### PR TITLE
feat(#27): internal/parallel — fan-out dispatcher + hydra parallel subcommand

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -10,8 +10,11 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
+	"encoding/json"
+
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/parallel"
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/tui"
 
@@ -38,7 +41,7 @@ func rootCmd() *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	root.AddCommand(cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch())
+	root.AddCommand(cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(), cmdParallel())
 	return root
 }
 
@@ -211,6 +214,49 @@ func cmdDispatch() *cobra.Command {
 	cmd.Flags().BoolVarP(&localOnly, "local", "l", false, "force local heads only")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show selected head without executing")
 	cmd.Flags().StringVarP(&system, "system", "s", "", "system prompt")
+	return cmd
+}
+
+// ── parallel ──────────────────────────────────────────────────────────────────
+
+func cmdParallel() *cobra.Command {
+	var tasksFile string
+
+	cmd := &cobra.Command{
+		Use:   "parallel",
+		Short: "Fan N tasks out to N Hydra Heads simultaneously",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			raw, err := os.ReadFile(tasksFile)
+			if err != nil {
+				return fmt.Errorf("reading tasks file: %w", err)
+			}
+			var tasks []parallel.Task
+			if err := json.Unmarshal(raw, &tasks); err != nil {
+				return fmt.Errorf("invalid JSON in %s: %w", tasksFile, err)
+			}
+
+			ctx := context.Background()
+			results, err := parallel.Run(ctx, tasks)
+			if err != nil {
+				return err
+			}
+
+			out, _ := json.MarshalIndent(results, "", "  ")
+			fmt.Println(string(out))
+
+			// Exit non-zero if any task failed.
+			for _, r := range results {
+				var s struct{ Status string }
+				if json.Unmarshal(r.Raw(), &s) == nil && s.Status == "fail" {
+					os.Exit(1)
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&tasksFile, "tasks", "", "path to tasks JSON file (required)")
+	_ = cmd.MarkFlagRequired("tasks")
 	return cmd
 }
 

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -1,0 +1,503 @@
+// Package parallel fans N independent tasks out to N Hydra Heads simultaneously.
+// It is the Go port of dispatch/parallel.sh.
+package parallel
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/policy"
+	"github.com/ankit373/hydra/internal/workspace"
+)
+
+const (
+	markerStart = "<<<HYDRA_FILE_START>>>"
+	markerEnd   = "<<<HYDRA_FILE_END>>>"
+)
+
+// Task is one item in the input batch.
+// When File is non-empty the task is an edit task; otherwise a text dispatch.
+type Task struct {
+	Label    string `json:"label"`
+	Enum     string `json:"enum"`
+	Prompt   string `json:"prompt"`
+	File     string `json:"file,omitempty"`
+	Context  string `json:"context,omitempty"` // context file path for text tasks
+	Validate *bool  `json:"validate,omitempty"` // edit tasks only; nil = true
+}
+
+// TextResult is the result of a text dispatch task.
+type TextResult struct {
+	Label  string `json:"label"`
+	Enum   string `json:"enum"`
+	Mode   string `json:"mode"`
+	Status string `json:"status"`
+	Output string `json:"output"`
+	Error  string `json:"error,omitempty"`
+}
+
+// EditResult is the result of an edit task (matches editor.Result + label/enum/mode).
+type EditResult struct {
+	Label           string `json:"label"`
+	Enum            string `json:"enum"`
+	Mode            string `json:"mode"`
+	Status          string `json:"status"`
+	File            string `json:"file"`
+	Workspace       string `json:"workspace"`
+	GitRoot         string `json:"git_root"`
+	LinesAdded      int    `json:"lines_added"`
+	LinesRemoved    int    `json:"lines_removed"`
+	ValidatorPassed bool   `json:"validator_passed"`
+	RolledBack      bool   `json:"rolled_back"`
+	Error           string `json:"error,omitempty"`
+}
+
+// Result is a union type (either TextResult or EditResult) marshalled as JSON.
+type Result struct {
+	raw json.RawMessage
+}
+
+func (r Result) MarshalJSON() ([]byte, error) { return r.raw, nil }
+func (r Result) Raw() json.RawMessage          { return r.raw }
+
+// Run fans all tasks out as goroutines and collects results.
+// Returns non-nil error only for pre-flight failures; individual task errors
+// are captured in each result's Status/Error fields.
+func Run(ctx context.Context, tasks []Task) ([]Result, error) {
+	if len(tasks) == 0 {
+		return nil, fmt.Errorf("no tasks provided")
+	}
+
+	// Pre-flight: detect duplicate file targets.
+	seen := map[string]string{}
+	for _, t := range tasks {
+		if t.File == "" {
+			continue
+		}
+		if first, ok := seen[t.File]; ok {
+			return nil, fmt.Errorf("conflict: tasks %q and %q both target %s", first, t.Label, t.File)
+		}
+		seen[t.File] = t.Label
+	}
+
+	results := make([]Result, len(tasks))
+	var mu sync.Mutex
+
+	g, gctx := errgroup.WithContext(ctx)
+
+	for i, task := range tasks {
+		i, task := i, task
+		g.Go(func() error {
+			var raw json.RawMessage
+			if task.File != "" {
+				raw = runEditTask(gctx, task)
+			} else {
+				raw = runTextTask(gctx, task)
+			}
+			mu.Lock()
+			results[i] = Result{raw: raw}
+			mu.Unlock()
+			return nil // always nil — errors are captured in raw
+		})
+	}
+
+	_ = g.Wait()
+
+	_ = persistResults(results)
+	return results, nil
+}
+
+// runTextTask dispatches a prompt and returns the raw JSON result.
+func runTextTask(ctx context.Context, task Task) json.RawMessage {
+	d, err := dispatch.New(ctx)
+	if err != nil {
+		return failText(task, "dispatcher init: "+err.Error())
+	}
+
+	prompt := task.Prompt
+	if task.Context != "" {
+		if raw, err := os.ReadFile(task.Context); err == nil {
+			prompt = fmt.Sprintf("CONTEXT:\n%s\n\nTASK:\n%s", string(raw), task.Prompt)
+		}
+	}
+
+	result, err := d.Dispatch(ctx, prompt, dispatch.Options{
+		TierHint: enumToTier(task.Enum),
+	})
+	if err != nil {
+		return failText(task, err.Error())
+	}
+
+	return mustMarshal(TextResult{
+		Label:  task.Label,
+		Enum:   task.Enum,
+		Mode:   "text",
+		Status: "ok",
+		Output: result.Output,
+	})
+}
+
+// runEditTask performs an atomic file edit and returns the raw JSON result.
+// Self-contained port of the edit.sh flow so this package compiles on develop
+// before internal/editor merges. Once editor merges, this can delegate to editor.Edit.
+func runEditTask(ctx context.Context, task Task) json.RawMessage {
+	file := task.File
+	if !filepath.IsAbs(file) {
+		return failEdit(task, "file path must be absolute")
+	}
+	if task.Enum == "CORE" {
+		return failEdit(task, "CORE tier: use Claude's native Edit/Write directly")
+	}
+
+	// Scope check
+	reg, err := workspace.Load(config.ScriptHome())
+	if err != nil {
+		return failEdit(task, "workspace load: "+err.Error())
+	}
+	wsName, err := reg.Check(file)
+	if err != nil {
+		return failEdit(task, "scope_rejected: "+err.Error())
+	}
+	resolved, _ := reg.Resolve(file)
+
+	// Policy (Phase 1)
+	if eng, pErr := policy.LoadFilePolicy(config.ScriptHome()); pErr == nil {
+		_ = eng.Decide(policy.Spec{
+			File:          file,
+			FileExtension: fileExt(file),
+			Workspace:     wsName,
+		})
+	}
+
+	// Snapshot
+	origContent, origExisted := readFile(file)
+	backup := file + ".hydra-bak"
+	createdBackup := false
+	if resolved.GitRoot == "" && origExisted && !fileExists(backup) {
+		_ = os.WriteFile(backup, []byte(origContent), 0o644)
+		createdBackup = true
+	}
+	cleanupBackup := func() {
+		if createdBackup {
+			_ = os.Remove(backup)
+		}
+	}
+
+	// Build prompt
+	ctxNote := "The file currently exists. Modify it per the instruction below."
+	currentBlock := origContent
+	if !origExisted {
+		ctxNote = "The file does NOT yet exist. Create it per the instruction below."
+		currentBlock = "<empty — file does not exist yet>"
+	}
+	editPrompt := fmt.Sprintf(`You are editing a single file. Output ONLY the new file content between the
+markers. No prose. No explanations. No code fences (no `+"`"+`).
+
+File path: %s
+%s
+
+Instruction:
+%s
+
+Current file content:
+%s
+%s
+%s
+
+Now output the COMPLETE new file content (every line, not a diff, not a
+snippet) between these exact markers and nothing else:
+%s
+(new content here)
+%s`,
+		file, ctxNote, task.Prompt,
+		markerStart, currentBlock, markerEnd,
+		markerStart, markerEnd,
+	)
+
+	// Dispatch
+	d, err := dispatch.New(ctx)
+	if err != nil {
+		cleanupBackup()
+		return failEdit(task, "dispatcher init: "+err.Error())
+	}
+	dispResult, err := d.Dispatch(ctx, editPrompt, dispatch.Options{
+		TierHint: enumToTier(task.Enum),
+	})
+	if err != nil {
+		cleanupBackup()
+		return failEdit(task, "route_failed: "+err.Error())
+	}
+
+	// Parse
+	newContent := extractContent(dispResult.Output)
+	newContent = stripOuterFence(newContent)
+	if strings.Contains(newContent, markerStart) || strings.Contains(newContent, markerEnd) {
+		cleanupBackup()
+		return failEdit(task, "marker_leakage")
+	}
+	if newContent == "" {
+		cleanupBackup()
+		if origExisted {
+			return failEdit(task, "empty_replacement")
+		}
+		return failEdit(task, "marker_parse_failed")
+	}
+
+	// Atomic write
+	_ = os.MkdirAll(filepath.Dir(file), 0o755)
+	tmp := fmt.Sprintf("%s.hydra-tmp.%d", file, os.Getpid())
+	if err := os.WriteFile(tmp, []byte(newContent+"\n"), 0o644); err != nil {
+		cleanupBackup()
+		return failEdit(task, "write_failed: "+err.Error())
+	}
+	if err := os.Rename(tmp, file); err != nil {
+		_ = os.Remove(tmp)
+		cleanupBackup()
+		return failEdit(task, "rename_failed: "+err.Error())
+	}
+
+	// Validate
+	validate := true
+	if task.Validate != nil {
+		validate = *task.Validate
+	}
+	if validate {
+		ext := fileExt(file)
+		vtmpl := reg.ValidatorFor(ext)
+		if vtmpl == "" && (ext == "ts" || ext == "tsx") && resolved.GitRoot != "" {
+			vtmpl = tscTemplate(resolved.GitRoot)
+		}
+		if vtmpl != "" {
+			cmd := strings.ReplaceAll(vtmpl, "{file}", file)
+			if rc := runValidate(cmd); rc != 0 {
+				rollback(file, origContent, origExisted, resolved.GitRoot, backup)
+				return mustMarshal(EditResult{
+					Label: task.Label, Enum: task.Enum, Mode: "edit",
+					Status: "fail", File: file, Workspace: wsName, GitRoot: resolved.GitRoot,
+					RolledBack: true, Error: "validation_failed",
+				})
+			}
+		}
+	}
+
+	added, removed := diffStats(file, origContent, resolved.GitRoot, backup, origExisted)
+	return mustMarshal(EditResult{
+		Label: task.Label, Enum: task.Enum, Mode: "edit",
+		Status: "ok", File: file, Workspace: wsName, GitRoot: resolved.GitRoot,
+		LinesAdded: added, LinesRemoved: removed, ValidatorPassed: true,
+	})
+}
+
+// persistResults writes results to logs/last_parallel.json.
+func persistResults(results []Result) error {
+	path := filepath.Join(config.Dir(), "logs", "last_parallel.json")
+	_ = os.MkdirAll(filepath.Dir(path), 0o700)
+	all := make([]json.RawMessage, len(results))
+	for i, r := range results {
+		all[i] = r.raw
+	}
+	raw, err := json.MarshalIndent(all, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, raw, 0o600)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func failText(task Task, errMsg string) json.RawMessage {
+	return mustMarshal(TextResult{Label: task.Label, Enum: task.Enum, Mode: "text", Status: "fail", Error: errMsg})
+}
+
+func failEdit(task Task, errMsg string) json.RawMessage {
+	return mustMarshal(EditResult{Label: task.Label, Enum: task.Enum, Mode: "edit", Status: "fail", File: task.File, Error: errMsg})
+}
+
+func mustMarshal(v any) json.RawMessage {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+func readFile(path string) (content string, existed bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	return string(raw), true
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func fileExt(path string) string {
+	ext := filepath.Ext(path)
+	if len(ext) > 0 {
+		return ext[1:]
+	}
+	return ""
+}
+
+func extractContent(raw string) string {
+	hasStart := strings.Contains(raw, markerStart)
+	hasEnd := strings.Contains(raw, markerEnd)
+	switch {
+	case hasStart && hasEnd:
+		return extractBetween(raw)
+	case hasEnd && !hasStart:
+		lines := strings.Split(raw, "\n")
+		var out []string
+		for _, l := range lines {
+			if strings.Contains(l, markerEnd) {
+				break
+			}
+			out = append(out, l)
+		}
+		return strings.Join(out, "\n")
+	case hasStart && !hasEnd:
+		parts := strings.SplitN(raw, markerStart, 2)
+		if len(parts) == 2 {
+			return strings.TrimPrefix(parts[1], "\n")
+		}
+	}
+	return ""
+}
+
+func extractBetween(raw string) string {
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	var out []string
+	inside, printed := false, false
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !printed && strings.Contains(line, markerStart) {
+			inside = true
+			continue
+		}
+		if inside && strings.Contains(line, markerEnd) {
+			printed = true
+			break
+		}
+		if inside {
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+func stripOuterFence(s string) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) == 0 {
+		return s
+	}
+	start, end := 0, len(lines)-1
+	if strings.HasPrefix(lines[0], "```") {
+		start = 1
+	}
+	if end > start && lines[end] == "```" {
+		end--
+	}
+	return strings.Join(lines[start:end+1], "\n")
+}
+
+func rollback(file, origContent string, origExisted bool, gitRoot, backup string) {
+	if gitRoot != "" {
+		if exec.Command("git", "-C", gitRoot, "ls-files", "--error-unmatch", file).Run() == nil {
+			_ = exec.Command("git", "-C", gitRoot, "checkout", "--", file).Run()
+			return
+		}
+	}
+	if fileExists(backup) {
+		_ = os.Rename(backup, file)
+		return
+	}
+	if !origExisted {
+		_ = os.Remove(file)
+		return
+	}
+	_ = os.WriteFile(file, []byte(origContent), 0o644)
+}
+
+func runValidate(cmd string) int {
+	parts := strings.Fields(cmd)
+	if len(parts) == 0 {
+		return 0
+	}
+	c := exec.Command(parts[0], parts[1:]...) //nolint:gosec
+	if err := c.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+		return 1
+	}
+	return 0
+}
+
+func tscTemplate(gitRoot string) string {
+	tsc := filepath.Join(gitRoot, "node_modules", ".bin", "tsc")
+	if !fileExists(tsc) {
+		return ""
+	}
+	if fileExists(filepath.Join(gitRoot, "tsconfig.json")) {
+		return tsc + " --noEmit -p " + gitRoot + "/tsconfig.json"
+	}
+	return tsc + " --noEmit --allowJs --skipLibCheck --target es2022 --lib es2022,dom {file}"
+}
+
+func diffStats(file, origContent, gitRoot, backup string, origExisted bool) (added, removed int) {
+	if gitRoot != "" {
+		out, err := exec.Command("git", "-C", gitRoot, "diff", "--numstat", "--", file).Output()
+		if err == nil {
+			line := strings.TrimSpace(string(out))
+			fmt.Sscanf(line, "%d\t%d", &added, &removed)
+			return
+		}
+	}
+	if fileExists(backup) {
+		out, _ := exec.Command("diff", "-u", backup, file).CombinedOutput()
+		for _, l := range strings.Split(string(out), "\n") {
+			if strings.HasPrefix(l, "+") && !strings.HasPrefix(l, "+++") {
+				added++
+			} else if strings.HasPrefix(l, "-") && !strings.HasPrefix(l, "---") {
+				removed++
+			}
+		}
+		return
+	}
+	newContent, _ := os.ReadFile(file)
+	newLines := strings.Count(string(newContent), "\n")
+	origLines := 0
+	if origExisted {
+		origLines = strings.Count(origContent, "\n")
+	}
+	if newLines > origLines {
+		added = newLines - origLines
+	} else {
+		removed = origLines - newLines
+	}
+	return
+}
+
+var enumTiers = map[string]string{
+	"GRUNT": "10", "TRIVIAL": "9", "SIMPLE": "8", "STANDARD": "7",
+	"MODERATE": "6", "COMPLEX": "5", "HARD": "4", "VERY_HARD": "3",
+	"EXPERT": "2", "CORE": "1",
+}
+
+func enumToTier(enum string) string {
+	if t, ok := enumTiers[enum]; ok {
+		return t
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
Full Go port of `dispatch/parallel.sh` (284 lines):

- **Pre-flight**: rejects batches where two tasks target the same file (would race)
- **Text tasks**: dispatch via `internal/dispatch` with optional context file injection
- **Edit tasks**: inline atomic editor — scope check, `.hydra-bak` snapshot, marker-based prompt, strict+lenient marker extraction, atomic rename write, validator, rollback on failure, diff stats
- **Fan-out**: `errgroup` — all tasks run concurrently; errors captured in result objects, never abort the group
- **Persistence**: `logs/last_parallel.json` after every run (feeds `hydra review summary`)
- **Exit**: 0 if all ok; 1 if any task status = fail
- **CLI**: `hydra parallel --tasks <tasks.json>`

Closes #27

## Test plan
- [ ] `go build ./...` passes
- [ ] `hydra parallel --help` shows flags
- [ ] Duplicate file conflict returns pre-flight error
- [ ] Empty tasks file returns error