### PR TITLE
fix(#45): security audit — critical/high/medium/dead-code fixes

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -647,7 +647,9 @@ func cmdRunStart() *cobra.Command {
 				NeedsDesignSystem: needsDS,
 				ParentRun:         parentID,
 			})
-			_ = dryRun // DryRun not in StartOptions; caller can inspect stdout
+			if dryRun {
+				fmt.Fprintln(os.Stderr, "warning: --dry-run not yet implemented for run start; run will be created normally")
+			}
 			if err != nil {
 				return err
 			}
@@ -704,9 +706,9 @@ func cmdRunComplete() *cobra.Command {
 				}
 				findings = append(findings, severity+": "+finding)
 			}
-			_ = output
 			state, err := company.Complete(args[0], args[1], company.CompleteOptions{
 				Findings: findings,
+				Output:   output,
 			})
 			if err != nil {
 				return err
@@ -851,10 +853,10 @@ func cmdRunPrune() *cobra.Command {
 		Use:   "prune",
 		Short: "Remove old completed runs",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			_ = keepMin
 			pruned, kept, err := company.Prune(workspace, company.PruneOptions{
 				OlderThan: olderThan,
 				DryRun:    dryRun,
+				KeepMin:   keepMin,
 			})
 			if err != nil {
 				return err

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -30,18 +30,23 @@ import (
 )
 
 func main() {
-	// Non-blocking update check — prints notification after command output.
-	updateAvailable := update.Check()
+	// Fire update check in the background — never blocks startup.
+	updateCh := update.CheckAsync()
 
 	if err := rootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}
 
-	if updateAvailable != "" {
-		fmt.Fprintf(os.Stderr, "\n  %s  hydra %s is available → brew upgrade hydra\n",
-			lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("✦"),
-			updateAvailable,
-		)
+	select {
+	case latest := <-updateCh:
+		if latest != "" {
+			fmt.Fprintf(os.Stderr, "\n  %s  hydra %s is available → brew upgrade hydra\n",
+				lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("✦"),
+				latest,
+			)
+		}
+	default:
+		// Check still in flight — skip notification rather than block.
 	}
 }
 
@@ -75,12 +80,7 @@ func cmdVersion() *cobra.Command {
 			fmt.Printf("  commit:  %s\n", build.Commit)
 			fmt.Printf("  built:   %s\n", build.Date)
 			fmt.Printf("  by:      %s\n", build.BuiltBy)
-			if latest := update.Check(); latest != "" {
-				fmt.Printf("\n  %s  %s is available → brew upgrade hydra\n",
-					lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render("✦"),
-					latest,
-				)
-			}
+			// Update notice is printed by main() after Execute returns.
 		},
 	}
 }

--- a/dispatch/agy.sh
+++ b/dispatch/agy.sh
@@ -23,9 +23,17 @@ fi
 AGY_TIMEOUT="${AGY_TIMEOUT:-300}"  # default 5 min, override via env
 
 SETTINGS="$HOME/.gemini/antigravity-cli/settings.json"
-AUTH_FILE="${HYDRA_AUTH_FILE:-$HOME/hydra/logs/auth_required.json}"
+HYDRA_DIR="${HYDRA_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+# AUTH_FILE must align with the path route.sh reads — use $HYDRA_DIR/logs/
+AUTH_FILE="${HYDRA_AUTH_FILE:-$HYDRA_DIR/logs/auth_required.json}"
 
-# Swap model in settings.json, restore on exit
+# ── Settings swap with flock to prevent concurrent corruption ────────────────
+# When parallel.sh invokes multiple agy.sh instances concurrently, each must
+# hold an exclusive lock for the full read-modify-run-restore cycle.
+LOCK_FILE="${SETTINGS}.hydra.lock"
+exec 9>"$LOCK_FILE"
+flock -x 9
+
 original_model=$(jq -r '.model // empty' "$SETTINGS" 2>/dev/null || true)
 restore_settings() {
   if [[ -n "$original_model" ]]; then
@@ -33,13 +41,15 @@ restore_settings() {
   else
     jq 'del(.model)' "$SETTINGS" > "${SETTINGS}.tmp" && mv "${SETTINGS}.tmp" "$SETTINGS"
   fi
+  flock -u 9
 }
 trap restore_settings EXIT
 
 jq --arg m "$model_flag" '.model = $m' "$SETTINGS" > "${SETTINGS}.tmp" && mv "${SETTINGS}.tmp" "$SETTINGS"
 
 # Capture stdout and stderr separately — auth errors come on stderr before any output
-stderr_output=$(mktemp)
+stderr_output=$(mktemp -t hydra-agy-stderr.XXXXXX)
+trap 'rm -f "$stderr_output"; restore_settings' EXIT
 output=$(agy --print "$prompt" --print-timeout "${AGY_TIMEOUT}s" 2>"$stderr_output")
 exit_code=$?
 stderr_content=$(cat "$stderr_output"); rm -f "$stderr_output"
@@ -70,9 +80,11 @@ if [[ -n "${HYDRA_TOKEN_SIDECAR:-}" ]]; then
   prompt_chars=${#prompt}
   response_chars=${#output}
   factor=4
-  if [[ -f "$HOME/hydra/registry/pricing.yaml" ]]; then
-    f=$(yq -r '.estimate_factor // 4' "$HOME/hydra/registry/pricing.yaml" 2>/dev/null || echo 4)
-    [[ "$f" =~ ^[0-9]+$ ]] && factor="$f"
+  pricing_file="$HYDRA_DIR/registry/pricing.yaml"
+  if [[ -f "$pricing_file" ]]; then
+    f=$(yq -r '.estimate_factor // 4' "$pricing_file" 2>/dev/null || echo 4)
+    # Require a strictly positive integer to avoid division by zero
+    [[ "$f" =~ ^[1-9][0-9]*$ ]] && factor="$f"
   fi
   prompt_tokens=$(( prompt_chars / factor ))
   response_tokens=$(( response_chars / factor ))

--- a/dispatch/company.sh
+++ b/dispatch/company.sh
@@ -852,7 +852,7 @@ cmd_ticket_comment() {
         err "gh CLI not installed — cannot comment on github ticket"
         exit 1
       fi
-      gh issue comment "$ref" --body "$body" >/dev/null
+      gh issue comment -- "$ref" --body "$body" >/dev/null
       log "run $run_id commented on $ref"
       echo "commented on $ref"
       ;;

--- a/dispatch/company.sh
+++ b/dispatch/company.sh
@@ -1095,9 +1095,16 @@ cmd_fanout_ships() {
   local parent_rd; parent_rd="$(find_run_dir "$parent")" || { err "parent run $parent not found"; exit 1; }
   local workspace; workspace="$(jq -r '.workspace' "$parent_rd/manifest.json")"
 
-  # Apply filter if provided, otherwise select all features
+  # Apply filter if provided, otherwise select all features.
+  # --filter accepts a raw jq expression and must be trusted input (orchestrator-supplied).
+  # Validate it contains only alphanumeric identifiers, dots, quotes, spaces, and comparison
+  # operators to prevent env/path/shell injections from attacker-controlled backlog files.
   local features
   if [[ -n "$filter" ]]; then
+    if ! [[ "$filter" =~ ^[A-Za-z0-9_.\ \"\'=!<>|]+$ ]]; then
+      err "fanout-ships: --filter contains unsafe characters: $filter"
+      exit 1
+    fi
     features="$(jq -c --argjson dummy null ".features // [] | map(select($filter))" "$backlog_file")"
   else
     features="$(jq -c '.features // []' "$backlog_file")"

--- a/dispatch/edit.sh
+++ b/dispatch/edit.sh
@@ -33,9 +33,10 @@ SCOPE="$HYDRA_DIR/dispatch/scope.sh"
 ROUTE="$HYDRA_DIR/dispatch/route.sh"
 
 mkdir -p "$LOG_DIR"
-log() { printf '[%s] edit: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG_FILE"; }
-err() { echo "❌ edit: $*" >&2; log "ERROR: $*"; }
+log()  { printf '[%s] edit: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG_FILE"; }
+err()  { echo "❌ edit: $*" >&2; log "ERROR: $*"; }
 info() { echo "🧷 edit: $*" >&2; log "INFO: $*"; }
+warn() { echo "⚠️  edit: $*" >&2; log "WARN: $*"; }
 
 emit_json() {
   # emit_json <status> <file> <workspace> <git_root> <enum> <added> <removed> <validator> <rolled_back> <error>
@@ -315,8 +316,8 @@ fi
 
 # ── Atomic write ──────────────────────────────────────────────────────────────
 
-TMP="${FILE}.hydra-tmp.$$"
 mkdir -p "$(dirname "$FILE")"
+TMP=$(mktemp "$(dirname "$FILE")/.hydra-tmp.XXXXXX")
 printf '%s\n' "$NEW_CONTENT" > "$TMP"
 mv "$TMP" "$FILE"
 info "wrote new content ($(wc -l < "$FILE" | tr -d ' ') lines)"
@@ -342,10 +343,13 @@ if [[ $VALIDATE -eq 1 && "${HYDRA_VALIDATE:-on}" != "off" ]]; then
   fi
 
   if [[ -n "$vtmpl" ]]; then
-    cmd="${vtmpl//\{file\}/$FILE}"
-    info "validating: $cmd"
+    # Build the command as an array — never use eval. Replace the {file} placeholder
+    # with the actual path as a separate, quoted argument to prevent shell injection.
+    IFS=' ' read -ra vcmd <<< "${vtmpl//\{file\}/}"
+    vcmd+=("$FILE")
+    info "validating: ${vcmd[*]}"
     set +e
-    vout=$(eval "$cmd" 2>&1)
+    vout=$("${vcmd[@]}" 2>&1)
     vrc=$?
     set -e
 

--- a/dispatch/edit.sh
+++ b/dispatch/edit.sh
@@ -70,28 +70,11 @@ done
 [[ "$FILE" != /* ]] && err "--file must be absolute: $FILE" && exit 1
 
 # ── Load policy (if provided) ────────────────────────────────────────────────
-# Policy flags become POL_* env-style locals. Phase 1 reads but mostly no-ops;
-# Phase 2 features (sr_blocks, atomic, agentic, auto_commit, etc.) hook here.
+# Only the two fields that are actively consumed in Phase 1 are parsed.
+# Phase 2 fields (atomic, auto_commit, test_loop, etc.) are added here when implemented.
 
 POL_EDIT_MODE="rewrite"
-POL_ATOMIC="false"
-POL_AUTO_COMMIT="false"
-POL_TRACK_TOKENS="true"
-POL_VALIDATORS="[]"
-POL_MAX_RETRIES=1
-POL_ESCALATE_ON_FAIL="true"
-POL_RUBBER_DUCK="false"
-POL_DIFF_CAP_PCT=90
-POL_VALIDATE_STRICT="false"
 POL_USE_REPO_MAP="false"
-POL_USE_WORKTREE="false"
-POL_TEST_LOOP="false"
-POL_LINT_LOOP="false"
-POL_DEDUP_FILE_READS="true"
-POL_PROMPT_CACHE="true"
-POL_DEFENSIVE="false"
-POL_MAX_COST_USD=0
-POL_MAX_WALL_SECONDS=600
 POL_MATCHED_RULES="[]"
 
 if [[ -n "$POLICY_JSON" ]]; then
@@ -101,27 +84,10 @@ if [[ -n "$POLICY_JSON" ]]; then
   if ! jq empty "$POLICY_JSON" >/dev/null 2>&1; then
     err "--policy file is not valid JSON: $POLICY_JSON"; exit 1
   fi
-  POL_EDIT_MODE=$(jq -r       '.edit_mode             // "rewrite"'   "$POLICY_JSON")
-  POL_ATOMIC=$(jq -r          '.atomic                // false | tostring' "$POLICY_JSON")
-  POL_AUTO_COMMIT=$(jq -r     '.auto_commit           // false | tostring' "$POLICY_JSON")
-  POL_TRACK_TOKENS=$(jq -r    '.track_tokens          // true  | tostring' "$POLICY_JSON")
-  POL_VALIDATORS=$(jq -c      '.validators            // []'              "$POLICY_JSON")
-  POL_MAX_RETRIES=$(jq -r     '.max_retries           // 1'               "$POLICY_JSON")
-  POL_ESCALATE_ON_FAIL=$(jq -r '.escalate_on_fail     // true  | tostring' "$POLICY_JSON")
-  POL_RUBBER_DUCK=$(jq -r     '.rubber_duck           // false | tostring' "$POLICY_JSON")
-  POL_DIFF_CAP_PCT=$(jq -r    '.diff_size_cap_pct     // 90'              "$POLICY_JSON")
-  POL_VALIDATE_STRICT=$(jq -r '.validate_strict       // false | tostring' "$POLICY_JSON")
-  POL_USE_REPO_MAP=$(jq -r    '.use_repo_map          // false | tostring' "$POLICY_JSON")
-  POL_USE_WORKTREE=$(jq -r    '.use_worktree          // false | tostring' "$POLICY_JSON")
-  POL_TEST_LOOP=$(jq -r       '.test_loop             // false | tostring' "$POLICY_JSON")
-  POL_LINT_LOOP=$(jq -r       '.lint_loop             // false | tostring' "$POLICY_JSON")
-  POL_DEDUP_FILE_READS=$(jq -r '.dedup_file_reads     // true  | tostring' "$POLICY_JSON")
-  POL_PROMPT_CACHE=$(jq -r    '.prompt_cache          // true  | tostring' "$POLICY_JSON")
-  POL_DEFENSIVE=$(jq -r       '.defensive             // false | tostring' "$POLICY_JSON")
-  POL_MAX_COST_USD=$(jq -r    '.max_cost_usd          // 0'                "$POLICY_JSON")
-  POL_MAX_WALL_SECONDS=$(jq -r '.max_wall_seconds     // 600'              "$POLICY_JSON")
-  POL_MATCHED_RULES=$(jq -c   '.matched_rules         // []'              "$POLICY_JSON")
-  info "policy loaded: mode=$POL_EDIT_MODE atomic=$POL_ATOMIC commit=$POL_AUTO_COMMIT repo_map=$POL_USE_REPO_MAP strict=$POL_VALIDATE_STRICT rules=$(echo "$POL_MATCHED_RULES" | jq -r 'join(",")')"
+  POL_EDIT_MODE=$(jq -r    '.edit_mode   // "rewrite"'       "$POLICY_JSON")
+  POL_USE_REPO_MAP=$(jq -r '.use_repo_map // false | tostring' "$POLICY_JSON")
+  POL_MATCHED_RULES=$(jq -c '.matched_rules // []'            "$POLICY_JSON")
+  info "policy loaded: mode=$POL_EDIT_MODE repo_map=$POL_USE_REPO_MAP rules=$(echo "$POL_MATCHED_RULES" | jq -r 'join(",")')"
 fi
 
 # Honor policy edit_mode if it was set and --mode wasn't explicitly given.
@@ -174,6 +140,16 @@ cleanup_our_backup() {
   [[ $WE_CREATED_BACKUP -eq 1 && -f "$BACKUP" ]] && rm -f "$BACKUP"
 }
 
+# ── Per-invocation markers ────────────────────────────────────────────────────
+# UUID markers prevent injection: if the file content or prompt contains the
+# literal marker string, a fixed marker would break extraction. A fresh UUID
+# per invocation makes collision cryptographically impossible.
+_mid=$(cat /proc/sys/kernel/random/uuid 2>/dev/null \
+       || uuidgen 2>/dev/null \
+       || od -A n -t x -N 16 /dev/urandom | tr -d ' \n')
+MARKER_START="<<<HYDRA_EDIT_START_${_mid}>>>"
+MARKER_END="<<<HYDRA_EDIT_END_${_mid}>>>"
+
 # ── Build edit prompt ─────────────────────────────────────────────────────────
 # Strict markers so we can extract the new file content unambiguously.
 
@@ -215,15 +191,15 @@ Instruction:
 $PROMPT
 
 Current file content:
-<<<HYDRA_FILE_START>>>
+$MARKER_START
 $current_block
-<<<HYDRA_FILE_END>>>
+$MARKER_END
 
 Now output the COMPLETE new file content (every line, not a diff, not a
 snippet) between these exact markers and nothing else:
-<<<HYDRA_FILE_START>>>
+$MARKER_START
 (new content here)
-<<<HYDRA_FILE_END>>>
+$MARKER_END
 EOF
 )
 
@@ -248,11 +224,11 @@ fi
 
 extract_between() {
   # Strict: content between START and END markers (exclusive).
-  echo "$1" | awk '
+  echo "$1" | awk -v ms="$MARKER_START" -v me="$MARKER_END" '
     BEGIN { inside=0; printed=0 }
-    /<<<HYDRA_FILE_END>>>/ && inside==1 { inside=0; printed=1; exit }
+    $0 == me && inside==1 { inside=0; printed=1; exit }
     inside==1 { print }
-    /<<<HYDRA_FILE_START>>>/ && printed==0 { inside=1 }
+    $0 == ms && printed==0 { inside=1 }
   '
 }
 
@@ -263,15 +239,15 @@ extract_lenient() {
   # - END missing   → everything from line after START to EOF
   local text="$1"
   local has_start has_end
-  has_start=$(echo "$text" | grep -c '<<<HYDRA_FILE_START>>>' || true)
-  has_end=$(echo "$text"   | grep -c '<<<HYDRA_FILE_END>>>'   || true)
+  has_start=$(echo "$text" | grep -cF "$MARKER_START" || true)
+  has_end=$(echo "$text"   | grep -cF "$MARKER_END"   || true)
 
   if [[ "$has_start" -gt 0 && "$has_end" -gt 0 ]]; then
     extract_between "$text"
   elif [[ "$has_end" -gt 0 ]]; then
-    echo "$text" | awk '/<<<HYDRA_FILE_END>>>/ { exit } { print }'
+    echo "$text" | awk -v me="$MARKER_END" '$0 == me { exit } { print }'
   elif [[ "$has_start" -gt 0 ]]; then
-    echo "$text" | awk 'p { print } /<<<HYDRA_FILE_START>>>/ { p=1 }'
+    echo "$text" | awk -v ms="$MARKER_START" 'p { print } $0 == ms { p=1 }'
   else
     echo ""
   fi
@@ -298,8 +274,8 @@ NEW_CONTENT=$(echo "$NEW_CONTENT" | awk '
   }
 ')
 
-# Marker leakage check — abort if any HYDRA marker survives in the body
-if echo "$NEW_CONTENT" | grep -q "<<<HYDRA_FILE_"; then
+# Marker leakage check — abort if our unique markers survive in the extracted body
+if echo "$NEW_CONTENT" | grep -qF "$MARKER_START" || echo "$NEW_CONTENT" | grep -qF "$MARKER_END"; then
   err "marker leakage detected in new content — rejecting"
   cleanup_our_backup
   emit_json "fail" "$FILE" "$WORKSPACE" "$GIT_ROOT" "$ENUM" 0 0 "false" "false" "marker_leakage"

--- a/dispatch/ollama.sh
+++ b/dispatch/ollama.sh
@@ -16,19 +16,25 @@ prompt="${2:-}"
 
 OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
 
+# Validate OLLAMA_HOST: only allow http://localhost*, http://127.*, or https://*
+if [[ ! "$OLLAMA_HOST" =~ ^https?://(localhost|127\.|::1) ]] && [[ ! "$OLLAMA_HOST" =~ ^https:// ]]; then
+  echo "❌ ollama.sh: OLLAMA_HOST must be a loopback address or https — got: $OLLAMA_HOST" >&2
+  exit 1
+fi
+
 # ── Health check ──────────────────────────────────────────────────────────────
-if ! curl -sf "$OLLAMA_HOST/" > /dev/null 2>&1; then
+if ! curl -sf --max-redirs 0 "$OLLAMA_HOST/" > /dev/null 2>&1; then
   echo "⚠️  Ollama not running. Starting..." >&2
   ollama serve &>/dev/null &
   sleep 3
-  if ! curl -sf "$OLLAMA_HOST/" > /dev/null 2>&1; then
+  if ! curl -sf --max-redirs 0 "$OLLAMA_HOST/" > /dev/null 2>&1; then
     echo "❌ Ollama failed to start. Is it installed?" >&2
     exit 1
   fi
 fi
 
 # ── Dispatch ──────────────────────────────────────────────────────────────────
-response=$(curl -sf "$OLLAMA_HOST/api/generate" \
+response=$(curl -sf --max-redirs 0 "$OLLAMA_HOST/api/generate" \
   -H "Content-Type: application/json" \
   -d "$(jq -n \
     --arg model "$model_flag" \

--- a/dispatch/route.sh
+++ b/dispatch/route.sh
@@ -71,16 +71,16 @@ tier_pool() { model_field "$1" token_pool; }
 
 # Check if a pool is marked exhausted in state.json
 pool_exhausted() {
-  [[ -f "$STATE_FILE" ]] && jq -e ".exhausted_pools | index(\"$1\") != null" "$STATE_FILE" > /dev/null 2>&1
+  [[ -f "$STATE_FILE" ]] && jq -e --arg p "$1" '(.exhausted_pools // []) | index($p) != null' "$STATE_FILE" > /dev/null 2>&1
 }
 
 # Mark a pool as exhausted
 mark_pool_exhausted() {
   mkdir -p "$LOG_DIR"
   if [[ -f "$STATE_FILE" ]]; then
-    jq ".exhausted_pools += [\"$1\"]" "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+    jq --arg p "$1" '.exhausted_pools = ((.exhausted_pools // []) + [$p])' "$STATE_FILE" > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
   else
-    echo "{\"exhausted_pools\":[\"$1\"],\"claude_pct\":0}" > "$STATE_FILE"
+    jq -n --arg p "$1" '{"exhausted_pools":[$p],"claude_pct":0}' > "$STATE_FILE"
   fi
   warn "Pool '$1' marked exhausted. Will skip all tiers in this pool."
 }
@@ -107,6 +107,7 @@ apply_tier_downgrade() {
   local tier="$1" mode="$2"
   local downgrade=0
   case "$mode" in
+    warning)   downgrade=1 ;;
     critical)  downgrade=2 ;;
     emergency) downgrade=3 ;;
   esac
@@ -291,7 +292,7 @@ for try_tier in "${tiers_to_try[@]}"; do
   # Token-tracking sidecar — executor writes counts here, we read after
   HYDRA_TOKEN_SIDECAR=$(mktemp -t hydra-tokens.XXXXXX.json)
   export HYDRA_TOKEN_SIDECAR
-  call_start_ns=$(date +%s%N 2>/dev/null || python3 -c 'import time;print(int(time.time()*1e9))')
+  call_start_ns=$(date +%s%N 2>/dev/null || python3 -c 'import time;print(int(time.time()*1e9))' 2>/dev/null || echo 0)
 
   set +e
   case "$executor" in
@@ -310,46 +311,56 @@ for try_tier in "${tiers_to_try[@]}"; do
   esac
   set -e
 
-  call_end_ns=$(date +%s%N 2>/dev/null || python3 -c 'import time;print(int(time.time()*1e9))')
+  call_end_ns=$(date +%s%N 2>/dev/null || python3 -c 'import time;print(int(time.time()*1e9))' 2>/dev/null || echo 0)
+  [[ "$call_start_ns" =~ ^[0-9]+$ ]] || call_start_ns=0
+  [[ "$call_end_ns"   =~ ^[0-9]+$ ]] || call_end_ns=0
   wall_ms=$(( (call_end_ns - call_start_ns) / 1000000 ))
 
-  # ── Log token cost (best-effort; never fails the call) ─────────────────────
-  if [[ -s "$HYDRA_TOKEN_SIDECAR" ]] && jq empty "$HYDRA_TOKEN_SIDECAR" 2>/dev/null; then
-    sidecar=$(cat "$HYDRA_TOKEN_SIDECAR")
-    pricing_file="$HYDRA_DIR/registry/pricing.yaml"
-    in_price=0; out_price=0
-    if [[ -f "$pricing_file" ]]; then
-      in_price=$(yq -r ".tiers.\"$try_tier\".input_per_million // 0"  "$pricing_file" 2>/dev/null || echo 0)
-      out_price=$(yq -r ".tiers.\"$try_tier\".output_per_million // 0" "$pricing_file" 2>/dev/null || echo 0)
-    fi
-    p_tok=$(echo "$sidecar" | jq -r '.prompt_tokens   // 0')
-    r_tok=$(echo "$sidecar" | jq -r '.response_tokens // 0')
-    cost=$(awk -v p="$p_tok" -v r="$r_tok" -v pi="$in_price" -v po="$out_price" \
-      'BEGIN{ printf "%.6f", (p/1000000)*pi + (r/1000000)*po }')
+  # ── Log token cost (best-effort; a logging failure must never abort a dispatch) ──
+  {
+    if [[ -s "$HYDRA_TOKEN_SIDECAR" ]] && jq empty "$HYDRA_TOKEN_SIDECAR" 2>/dev/null; then
+      sidecar=$(cat "$HYDRA_TOKEN_SIDECAR")
+      pricing_file="$HYDRA_DIR/registry/pricing.yaml"
+      in_price=0; out_price=0
+      if [[ -f "$pricing_file" ]]; then
+        in_price=$(yq -r ".tiers.\"$try_tier\".input_per_million // 0"  "$pricing_file" 2>/dev/null || echo 0)
+        out_price=$(yq -r ".tiers.\"$try_tier\".output_per_million // 0" "$pricing_file" 2>/dev/null || echo 0)
+      fi
+      p_tok=$(echo "$sidecar" | jq -r '.prompt_tokens   // 0')
+      r_tok=$(echo "$sidecar" | jq -r '.response_tokens // 0')
+      cost=$(awk -v p="$p_tok" -v r="$r_tok" -v pi="$in_price" -v po="$out_price" \
+        'BEGIN{ printf "%.6f", (p/1000000)*pi + (r/1000000)*po }')
 
-    cost_log="$LOG_DIR/cost.jsonl"
-    jq -n -c \
-      --arg ts        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-      --argjson tier  "$try_tier" \
-      --arg enum      "${enum_key:-}" \
-      --arg model     "$model_name" \
-      --arg executor  "$executor" \
-      --arg pool      "$pool" \
-      --argjson prompt_tokens   "$p_tok" \
-      --argjson response_tokens "$r_tok" \
-      --argjson est_cost_usd    "$cost" \
-      --argjson wall_ms         "$wall_ms" \
-      --argjson sidecar         "$sidecar" \
-      --arg task_id   "${HYDRA_TASK_ID:-}" \
-      --arg run_id    "${HYDRA_RUN_ID:-}" \
-      '{ ts: $ts, tier: $tier, enum: $enum, model: $model,
-         executor: $executor, pool: $pool,
-         prompt_tokens: $prompt_tokens, response_tokens: $response_tokens,
-         est_cost_usd: $est_cost_usd, wall_ms: $wall_ms,
-         source: $sidecar.source, task_id: $task_id, run_id: $run_id }' \
-      >> "$cost_log"
-  fi
-  rm -f "$HYDRA_TOKEN_SIDECAR"
+      # Ensure numeric values before --argjson to prevent jq parse errors
+      [[ "$p_tok"   =~ ^[0-9]+$           ]] || p_tok=0
+      [[ "$r_tok"   =~ ^[0-9]+$           ]] || r_tok=0
+      [[ "$cost"    =~ ^[0-9]+\.?[0-9]*$  ]] || cost=0
+      [[ "$wall_ms" =~ ^-?[0-9]+$         ]] || wall_ms=0
+
+      cost_log="$LOG_DIR/cost.jsonl"
+      jq -n -c \
+        --arg ts        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --argjson tier  "$try_tier" \
+        --arg enum      "${enum_key:-}" \
+        --arg model     "$model_name" \
+        --arg executor  "$executor" \
+        --arg pool      "$pool" \
+        --argjson prompt_tokens   "$p_tok" \
+        --argjson response_tokens "$r_tok" \
+        --argjson est_cost_usd    "$cost" \
+        --argjson wall_ms         "$wall_ms" \
+        --argjson sidecar         "$sidecar" \
+        --arg task_id   "${HYDRA_TASK_ID:-}" \
+        --arg run_id    "${HYDRA_RUN_ID:-}" \
+        '{ ts: $ts, tier: $tier, enum: $enum, model: $model,
+           executor: $executor, pool: $pool,
+           prompt_tokens: $prompt_tokens, response_tokens: $response_tokens,
+           est_cost_usd: $est_cost_usd, wall_ms: $wall_ms,
+           source: $sidecar.source, task_id: $task_id, run_id: $run_id }' \
+        >> "$cost_log"
+    fi
+    rm -f "${HYDRA_TOKEN_SIDECAR:-}"
+  } || { rm -f "${HYDRA_TOKEN_SIDECAR:-}"; true; }
 
   if [[ $exit_code -eq 0 && -n "$output" ]]; then
     echo "$output"

--- a/internal/company/company.go
+++ b/internal/company/company.go
@@ -307,7 +307,9 @@ func Next(runID string) (*NextResult, error) {
 	})
 	state.Status = "in_progress"
 	state.UpdatedAt = now
-	_ = writeJSON(filepath.Join(rd, "state.json"), state)
+	if err := writeJSON(filepath.Join(rd, "state.json"), state); err != nil {
+		return nil, fmt.Errorf("Next: persist state: %w", err)
+	}
 
 	return &NextResult{
 		RunID:       runID,
@@ -326,6 +328,7 @@ type CompleteOptions struct {
 	Status   string   // ok | fail | skipped
 	Findings []string // severity strings
 	Note     string
+	Output   string   // result/output text from this stage
 }
 
 // Complete marks a stage done and advances state.
@@ -374,7 +377,9 @@ func Complete(runID, stageName string, opts CompleteOptions) (*State, error) {
 			state.Status = "blocked"
 			state.BlockingFindings = &BlockingFindings{Stage: stageName, Findings: intersection}
 			state.UpdatedAt = now
-			_ = writeJSON(filepath.Join(rd, "state.json"), state)
+			if err := writeJSON(filepath.Join(rd, "state.json"), state); err != nil {
+				return nil, fmt.Errorf("Complete: persist blocked state: %w", err)
+			}
 			_ = Ledger(manifest.Workspace)
 			return state, nil
 		}
@@ -385,7 +390,9 @@ func Complete(runID, stageName string, opts CompleteOptions) (*State, error) {
 	state.CurrentStage++
 	state.Status = "pending"
 	state.UpdatedAt = now
-	_ = writeJSON(filepath.Join(rd, "state.json"), state)
+	if err := writeJSON(filepath.Join(rd, "state.json"), state); err != nil {
+		return nil, fmt.Errorf("Complete: persist state: %w", err)
+	}
 	_ = Ledger(manifest.Workspace)
 
 	return state, nil
@@ -784,6 +791,7 @@ type PruneOptions struct {
 	OlderThan          string // e.g. "30d"
 	IncludeCompleted   bool
 	DryRun             bool
+	KeepMin            int // minimum runs to retain regardless of age
 }
 
 // Prune deletes finished runs older than a threshold.
@@ -839,6 +847,12 @@ func Prune(workspace string, opts PruneOptions) (pruned, kept int, err error) {
 			continue
 		}
 		if updatedAt.After(cutoff) {
+			kept++
+			continue
+		}
+
+		// Respect KeepMin: once we've already kept >= KeepMin, allow pruning.
+		if opts.KeepMin > 0 && kept < opts.KeepMin {
 			kept++
 			continue
 		}
@@ -1057,7 +1071,7 @@ func writeJSON(path string, v any) error {
 		return err
 	}
 	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, raw, 0o644); err != nil {
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
 		return err
 	}
 	return os.Rename(tmp, path)
@@ -1194,7 +1208,12 @@ func removeFromIndex(indexPath, runID string) error {
 			lines = append(lines, line)
 		}
 	}
-	return os.WriteFile(indexPath, []byte(strings.Join(lines, "\n")+"\n"), 0o600)
+	// Write atomically so concurrent processes never see a partial index.
+	tmp := indexPath + ".tmp"
+	if err := os.WriteFile(tmp, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, indexPath)
 }
 
 func parseDuration(s string) int64 {
@@ -1242,7 +1261,8 @@ func gzipFile(src, dst string) error {
 		return err
 	}
 	defer in.Close()
-	out, err := os.Create(dst)
+	// O_EXCL prevents a symlink attack if dst already exists.
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o600)
 	if err != nil {
 		return err
 	}

--- a/internal/company/company.go
+++ b/internal/company/company.go
@@ -897,10 +897,10 @@ func Children(parentRunID string) ([]ChildRun, error) {
 			continue
 		}
 		cs, _ := readState(crd)
-		cur, total := 0, len(cm.Stages)
-		if cs != nil {
-			cur = cs.CurrentStage
+		if cs == nil {
+			continue
 		}
+		cur, total := cs.CurrentStage, len(cm.Stages)
 		result = append(result, ChildRun{
 			RunID:    e.Name(),
 			Playbook: cm.Playbook,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -41,7 +42,7 @@ func Dir() string {
 //  3. ~/.hydra (standalone install copies scripts here)
 func ScriptHome() string {
 	if h := os.Getenv("HYDRA_HOME"); h != "" {
-		return h
+		return filepath.Clean(h)
 	}
 	// Walk up from executable looking for dispatch/route.sh (dev / repo layout).
 	if exe, err := os.Executable(); err == nil {
@@ -74,15 +75,24 @@ func Load() (*Config, error) {
 	return &cfg, nil
 }
 
-// Save writes cfg to the config file, creating the directory if needed.
+// Save writes cfg to the config file atomically (temp file + rename).
 func Save(cfg *Config) error {
 	if err := os.MkdirAll(Dir(), 0o700); err != nil {
 		return err
 	}
-	f, err := os.Create(Path())
+	tmp, err := os.CreateTemp(Dir(), ".config-*.toml")
 	if err != nil {
+		return fmt.Errorf("config save: %w", err)
+	}
+	tmpName := tmp.Name()
+	if err := toml.NewEncoder(tmp).Encode(cfg); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
 		return err
 	}
-	defer f.Close()
-	return toml.NewEncoder(f).Encode(cfg)
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, Path())
 }

--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -61,8 +61,7 @@ type SummaryResult struct {
 
 // LoadAll reads all rows from cost.jsonl.
 func LoadAll() ([]Row, error) {
-	path := costLogPath()
-	return loadRows(path, "")
+	return loadRows(costLogPath())
 }
 
 // Summary returns today + all-time totals and last 5 recent rows.
@@ -199,18 +198,27 @@ func Tail(n int) ([]Row, error) {
 	return out, nil
 }
 
-// JSON returns raw rows, optionally filtered by since (ISO timestamp prefix).
+// JSON returns raw rows, optionally filtered by since (RFC3339 timestamp).
+// Uses time.Parse for comparison so timezone offsets are handled correctly.
 func JSON(since string) ([]Row, error) {
-	if since == "" {
-		return LoadAll()
-	}
 	all, err := LoadAll()
 	if err != nil {
 		return nil, err
 	}
+	if since == "" {
+		return all, nil
+	}
+	sinceT, err := time.Parse(time.RFC3339, since)
+	if err != nil {
+		return nil, fmt.Errorf("cost: invalid since timestamp %q: %w", since, err)
+	}
 	var out []Row
 	for _, r := range all {
-		if r.TS >= since {
+		t, err := time.Parse(time.RFC3339, r.TS)
+		if err != nil {
+			continue
+		}
+		if !t.Before(sinceT) {
 			out = append(out, r)
 		}
 	}
@@ -274,7 +282,7 @@ func costLogPath() string {
 	return filepath.Join(config.Dir(), "logs", "cost.jsonl")
 }
 
-func loadRows(path, since string) ([]Row, error) {
+func loadRows(path string) ([]Row, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -294,9 +302,6 @@ func loadRows(path, since string) ([]Row, error) {
 		var r Row
 		if err := json.Unmarshal([]byte(line), &r); err != nil {
 			continue // skip malformed rows
-		}
-		if since != "" && r.TS < since {
-			continue
 		}
 		rows = append(rows, r)
 	}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -471,3 +471,33 @@ func truncate(s string, n int) string {
 	}
 	return s[:n] + "…"
 }
+
+// EnumToTier maps a routing enum key (e.g. "SIMPLE") to a tier number string.
+// Single source of truth — editor and parallel both delegate here.
+func EnumToTier(enum string) string {
+	const (
+		GRUNT    = "10"
+		TRIVIAL  = "9"
+		SIMPLE   = "8"
+		STANDARD = "7"
+		MODERATE = "6"
+		COMPLEX  = "5"
+		HARD     = "4"
+		VERY_HARD = "3"
+		EXPERT   = "2"
+		CORE     = "1"
+	)
+	switch enum {
+	case "GRUNT":     return GRUNT
+	case "TRIVIAL":   return TRIVIAL
+	case "SIMPLE":    return SIMPLE
+	case "STANDARD":  return STANDARD
+	case "MODERATE":  return MODERATE
+	case "COMPLEX":   return COMPLEX
+	case "HARD":      return HARD
+	case "VERY_HARD": return VERY_HARD
+	case "EXPERT":    return EXPERT
+	case "CORE":      return CORE
+	default:          return ""
+	}
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ankit373/hydra/internal/config"
@@ -41,6 +42,9 @@ type Result struct {
 	Retries   int
 	*executor.Response
 }
+
+// stateMu protects concurrent read-modify-write on state.json across goroutines.
+var stateMu sync.Mutex
 
 // Dispatcher holds resolved config and the probed head list.
 type Dispatcher struct {
@@ -294,6 +298,9 @@ func (d *Dispatcher) selectHeads(tierHint string, localOnly bool) []provider.Hea
 // syncStateJSON updates ~/.hydra/logs/state.json after a successful dispatch
 // so the Ink UI (ui/) reflects Go dispatcher activity.
 func (d *Dispatcher) syncStateJSON(r *Result) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
 	stateDir := filepath.Join(config.Dir(), "logs")
 	statePath := filepath.Join(stateDir, "state.json")
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -156,13 +156,21 @@ snippet) between these exact markers and nothing else:
 
 	// ── Atomic write ──────────────────────────────────────────────────────────
 	_ = os.MkdirAll(filepath.Dir(req.File), 0o755)
-	tmp := fmt.Sprintf("%s.hydra-tmp.%d", req.File, os.Getpid())
-	if err := os.WriteFile(tmp, []byte(newContent+"\n"), 0o644); err != nil {
+	tmpF, err := os.CreateTemp(filepath.Dir(req.File), ".hydra-tmp.*")
+	if err != nil {
 		cleanupBackup()
 		return failResult(req, "write_failed: "+err.Error()), nil
 	}
-	if err := os.Rename(tmp, req.File); err != nil {
-		_ = os.Remove(tmp)
+	tmpPath := tmpF.Name()
+	if _, werr := fmt.Fprint(tmpF, newContent+"\n"); werr != nil {
+		_ = tmpF.Close()
+		_ = os.Remove(tmpPath)
+		cleanupBackup()
+		return failResult(req, "write_failed: "+werr.Error()), nil
+	}
+	_ = tmpF.Close()
+	if err := os.Rename(tmpPath, req.File); err != nil {
+		_ = os.Remove(tmpPath)
 		cleanupBackup()
 		return failResult(req, "rename_failed: "+err.Error()), nil
 	}
@@ -179,8 +187,7 @@ snippet) between these exact markers and nothing else:
 		}
 
 		if vtmpl != "" {
-			cmd := strings.ReplaceAll(vtmpl, "{file}", req.File)
-			vout, vrc := runCmd(cmd)
+			vout, vrc := runValidatorCmd(vtmpl, req.File)
 			if vrc != 0 {
 				validatorPassed = false
 				rollback(req.File, origContent, origExisted, resolved.GitRoot, backup)
@@ -337,12 +344,20 @@ func rollback(file, origContent string, origExisted bool, gitRoot, backup string
 	_ = os.WriteFile(file, []byte(origContent), 0o644)
 }
 
-func runCmd(cmd string) (output string, exitCode int) {
-	parts := strings.Fields(cmd)
+// runValidatorCmd executes a validator template safely.
+// Splits around {file} so paths containing spaces are never fragmented by Fields.
+func runValidatorCmd(vtmpl, file string) (output string, exitCode int) {
+	var parts []string
+	if idx := strings.Index(vtmpl, "{file}"); idx >= 0 {
+		parts = append(strings.Fields(vtmpl[:idx]), file)
+		parts = append(parts, strings.Fields(vtmpl[idx+len("{file}"):])...)
+	} else {
+		parts = strings.Fields(vtmpl)
+	}
 	if len(parts) == 0 {
 		return "", 0
 	}
-	c := exec.Command(parts[0], parts[1:]...) //nolint:gosec
+	c := exec.Command(parts[0], parts[1:]...)
 	out, err := c.CombinedOutput()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -427,24 +442,4 @@ func writeLastEdit(file, enum, ws string, added, removed int) error {
 	return os.WriteFile(path, raw, 0o600)
 }
 
-// enumToTier maps routing enum keys to tier numbers (from routing.yaml).
-// Used when routing.yaml can't be loaded at runtime.
-var enumTiers = map[string]string{
-	"GRUNT":     "10",
-	"TRIVIAL":   "9",
-	"SIMPLE":    "8",
-	"STANDARD":  "7",
-	"MODERATE":  "6",
-	"COMPLEX":   "5",
-	"HARD":      "4",
-	"VERY_HARD": "3",
-	"EXPERT":    "2",
-	"CORE":      "1",
-}
-
-func enumToTier(enum string) string {
-	if t, ok := enumTiers[enum]; ok {
-		return t
-	}
-	return ""
-}
+func enumToTier(enum string) string { return dispatch.EnumToTier(enum) }

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
-	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/workspace"
 )
 
@@ -82,18 +81,6 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 			_ = os.Remove(backup)
 		}
 	}
-
-	// ── Policy ────────────────────────────────────────────────────────────────
-	var fp policy.FilePolicy
-	eng, pErr := policy.LoadFilePolicy(config.ScriptHome())
-	if pErr == nil {
-		fp = eng.Decide(policy.Spec{
-			File:          req.File,
-			FileExtension: fileExt(req.File),
-			Workspace:     wsName,
-		})
-	}
-	_ = fp // Phase 1: snapshot flags; Phase 2 will consume them
 
 	// ── Build prompt ──────────────────────────────────────────────────────────
 	var ctxNote string
@@ -403,8 +390,8 @@ func diffStats(file, origContent, gitRoot, backup string, origExisted bool) (add
 	if origExisted {
 		origLines = strings.Count(origContent, "\n")
 	}
-	added = max(0, newLines-origLines)
-	removed = max(0, origLines-newLines)
+	added = max(0, newLines-origLines)   //nolint:builtin — uses Go 1.21+ built-in
+	removed = max(0, origLines-newLines) //nolint:builtin
 	return
 }
 
@@ -413,12 +400,6 @@ func readFileLines(path string) string {
 	return string(raw)
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
 
 func firstLine(s string) string {
 	lines := strings.SplitN(strings.TrimSpace(s), "\n", 2)

--- a/internal/executor/agy.go
+++ b/internal/executor/agy.go
@@ -58,7 +58,10 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 
 	timeout := 300 * time.Second
 	if t := os.Getenv("AGY_TIMEOUT"); t != "" {
-		if d, err := time.ParseDuration(t + "s"); err == nil {
+		if d, err := time.ParseDuration(t); err == nil {
+			timeout = d
+		} else if d, err := time.ParseDuration(t + "s"); err == nil {
+			// Bare integer seconds (e.g. "300") — treat as seconds.
 			timeout = d
 		}
 	}
@@ -79,7 +82,7 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 
 	// Auth detection: check stderr + first 3 lines of stdout only.
 	// Never scan full output — model responses may contain auth strings.
-	firstLines := strings.Join(strings.SplitN(outStr, "\n", 4)[:min3(strings.Count(outStr, "\n")+1, 3)], "\n")
+	firstLines := strings.Join(strings.SplitN(outStr, "\n", 4)[:min(strings.Count(outStr, "\n")+1, 3)], "\n")
 	authSignal := stderrStr + "\n" + firstLines
 
 	if authSignalRe.MatchString(authSignal) {
@@ -192,10 +195,3 @@ func writeAuthRequired(pool, modelFlag, authURL string) {
 	_ = os.WriteFile(filepath.Join(logDir, "auth_required.json"), data, 0o600)
 }
 
-
-func min3(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/internal/executor/agy.go
+++ b/internal/executor/agy.go
@@ -46,6 +46,10 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 	}
 
 	settingsPath := agySitesPath()
+
+	// Recover from a prior SIGKILL that left settings.json in a swapped state.
+	recoverAgySwap(settingsPath)
+
 	originalModel, err := swapAgyModel(settingsPath, modelFlag)
 	if err != nil {
 		// Settings file might not exist yet — proceed without swapping.
@@ -123,30 +127,48 @@ func agySitesPath() string {
 	return filepath.Join(home, ".gemini", "antigravity-cli", "settings.json")
 }
 
+// agyOrigSuffix is the sentinel backup written before any settings.json swap.
+// If the process is SIGKILLed mid-swap, recoverAgySwap restores it on next run.
+const agyOrigSuffix = ".hydra-orig"
+
 // swapAgyModel writes modelFlag into settings.json and returns the original model.
+// It writes a sentinel backup first so recoverAgySwap() can undo a partial swap
+// caused by SIGKILL between os.Rename and the defer restoreAgyModel.
 func swapAgyModel(settingsPath, modelFlag string) (string, error) {
 	raw, err := os.ReadFile(settingsPath)
 	if err != nil {
 		return "", err
 	}
+	// Write sentinel before any mutation — must survive SIGKILL.
+	if err := os.WriteFile(settingsPath+agyOrigSuffix, raw, 0o600); err != nil {
+		return "", err
+	}
 	var m map[string]interface{}
 	if err := json.Unmarshal(raw, &m); err != nil {
+		_ = os.Remove(settingsPath + agyOrigSuffix)
 		return "", err
 	}
 	original, _ := m["model"].(string)
 	m["model"] = modelFlag
 	updated, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
+		_ = os.Remove(settingsPath + agyOrigSuffix)
 		return "", err
 	}
 	tmp := settingsPath + ".hydra-tmp"
 	if err := os.WriteFile(tmp, updated, 0o600); err != nil {
+		_ = os.Remove(settingsPath + agyOrigSuffix)
 		return "", err
 	}
-	return original, os.Rename(tmp, settingsPath)
+	if err := os.Rename(tmp, settingsPath); err != nil {
+		_ = os.Remove(settingsPath + agyOrigSuffix)
+		_ = os.Remove(tmp)
+		return "", err
+	}
+	return original, nil
 }
 
-// restoreAgyModel writes back the original model (or deletes the key if empty).
+// restoreAgyModel writes back the original model and removes the sentinel.
 func restoreAgyModel(settingsPath, originalModel string) {
 	raw, err := os.ReadFile(settingsPath)
 	if err != nil {
@@ -169,7 +191,27 @@ func restoreAgyModel(settingsPath, originalModel string) {
 	if err := os.WriteFile(tmp, updated, 0o600); err != nil {
 		return
 	}
-	_ = os.Rename(tmp, settingsPath)
+	if err := os.Rename(tmp, settingsPath); err == nil {
+		_ = os.Remove(settingsPath + agyOrigSuffix)
+	}
+}
+
+// recoverAgySwap detects a stale sentinel left by a prior SIGKILL and restores
+// settings.json to its pre-swap state. No-ops when no sentinel exists.
+func recoverAgySwap(settingsPath string) {
+	orig, err := os.ReadFile(settingsPath + agyOrigSuffix)
+	if err != nil {
+		return
+	}
+	tmp := settingsPath + ".hydra-tmp"
+	if err := os.WriteFile(tmp, orig, 0o600); err != nil {
+		return
+	}
+	if err := os.Rename(tmp, settingsPath); err != nil {
+		_ = os.Remove(tmp)
+		return
+	}
+	_ = os.Remove(settingsPath + agyOrigSuffix)
 }
 
 // writeAuthRequired writes logs/auth_required.json so the TUI can surface it.

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ankit373/hydra/internal/provider"
@@ -76,8 +78,18 @@ type tokenSidecar struct {
 
 // writeTokenSidecar writes token usage to HYDRA_TOKEN_SIDECAR if set.
 func writeTokenSidecar(model, executorName, source string, prompt, response int) {
-	path := os.Getenv("HYDRA_TOKEN_SIDECAR")
-	if path == "" {
+	raw := os.Getenv("HYDRA_TOKEN_SIDECAR")
+	if raw == "" {
+		return
+	}
+	// Reject paths with traversal components or path separators in the basename.
+	clean := filepath.Clean(raw)
+	if !filepath.IsAbs(clean) || strings.Contains(filepath.Base(clean), "..") {
+		return
+	}
+	// Only allow writes inside os.TempDir to prevent arbitrary file writes.
+	tmpDir := filepath.Clean(os.TempDir())
+	if !strings.HasPrefix(clean, tmpDir+string(filepath.Separator)) {
 		return
 	}
 	data, _ := json.Marshal(tokenSidecar{
@@ -87,5 +99,5 @@ func writeTokenSidecar(model, executorName, source string, prompt, response int)
 		PromptTokens:   prompt,
 		ResponseTokens: response,
 	})
-	_ = os.WriteFile(path, data, 0o644)
+	_ = os.WriteFile(clean, data, 0o600)
 }

--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -421,7 +421,6 @@ func (e *HTTPExecutor) executeBedrock(ctx context.Context, req Request) (*Respon
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("x-amz-content-sha256", sha256Hex(raw))
 	if err := signAWSRequest(httpReq, raw, bedrockRegion(), "bedrock"); err != nil {
 		return nil, fmt.Errorf("http exec %s: %w", req.Head.ID, err)
 	}
@@ -493,7 +492,8 @@ func (e *HTTPExecutor) executeReplicate(ctx context.Context, req Request) (*Resp
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 
-	for pred.Status == "starting" || pred.Status == "processing" {
+	const maxPollIter = 150 // 150 × 2s = 5 min ceiling
+	for i := 0; i < maxPollIter && (pred.Status == "starting" || pred.Status == "processing"); i++ {
 		if pred.URLs.Get == "" {
 			break
 		}

--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -244,12 +244,13 @@ func (e *HTTPExecutor) executeGemini(ctx context.Context, req Request) (*Respons
 		return nil, err
 	}
 
-	u := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s", url.PathEscape(model), url.QueryEscape(apiKeyFor("google")))
+	u := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", url.PathEscape(model))
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(raw))
 	if err != nil {
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-goog-api-key", apiKeyFor("google"))
 
 	start := time.Now()
 	resp, err := e.httpClient().Do(httpReq)
@@ -534,6 +535,9 @@ type replicatePrediction struct {
 }
 
 func (e *HTTPExecutor) getReplicatePrediction(ctx context.Context, headID, getURL string) (replicatePrediction, error) {
+	if !strings.HasPrefix(getURL, "https://api.replicate.com/") {
+		return replicatePrediction{}, fmt.Errorf("http exec %s: unexpected Replicate poll URL %q", headID, getURL)
+	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, getURL, nil)
 	if err != nil {
 		return replicatePrediction{}, err
@@ -666,7 +670,7 @@ func joinCohereBlocks(blocks []struct {
 }
 
 func httpStatusError(headID string, resp *http.Response) error {
-	b, _ := io.ReadAll(resp.Body)
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	return fmt.Errorf("http exec %s: status %d — %s", headID, resp.StatusCode, string(b))
 }
 

--- a/internal/executor/ollama.go
+++ b/internal/executor/ollama.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
+	"strings"
+	"sync"
 	"time"
 )
 
@@ -100,18 +103,29 @@ func (e *OllamaExecutor) Execute(ctx context.Context, req Request) (*Response, e
 	}, nil
 }
 
+// ollamaServeOnce ensures at most one `ollama serve` process is started by Hydra.
+var ollamaServeOnce sync.Once
+
 // ensureRunning checks Ollama health and attempts auto-start if down.
 func (e *OllamaExecutor) ensureRunning(host string) error {
 	if e.isHealthy(host) {
 		return nil
 	}
 
-	// Attempt to start ollama serve in background.
-	ollamaCmd := exec.Command("ollama", "serve")
-	ollamaCmd.Stdout = nil
-	ollamaCmd.Stderr = nil
-	if err := ollamaCmd.Start(); err != nil {
-		return fmt.Errorf("ollama not running and could not start: %w", err)
+	var startErr error
+	ollamaServeOnce.Do(func() {
+		cmd := exec.Command("ollama", "serve")
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+		if err := cmd.Start(); err != nil {
+			startErr = fmt.Errorf("ollama not running and could not start: %w", err)
+			return
+		}
+		// Reap the child when it exits so it doesn't become a zombie.
+		go func() { _ = cmd.Wait() }()
+	})
+	if startErr != nil {
+		return startErr
 	}
 
 	// Wait up to 3 seconds for it to become healthy.
@@ -142,8 +156,18 @@ func (e *OllamaExecutor) isHealthy(host string) bool {
 }
 
 func ollamaHost() string {
-	if h := os.Getenv("OLLAMA_HOST"); h != "" {
-		return h
+	h := os.Getenv("OLLAMA_HOST")
+	if h == "" {
+		return "http://localhost:11434"
 	}
-	return "http://localhost:11434"
+	u, err := url.Parse(h)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return "http://localhost:11434"
+	}
+	// Only allow loopback targets unless the scheme is https.
+	host := u.Hostname()
+	if u.Scheme == "http" && !strings.HasPrefix(host, "127.") && host != "localhost" && host != "::1" {
+		return "http://localhost:11434"
+	}
+	return h
 }

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -256,13 +256,21 @@ snippet) between these exact markers and nothing else:
 
 	// Atomic write
 	_ = os.MkdirAll(filepath.Dir(file), 0o755)
-	tmp := fmt.Sprintf("%s.hydra-tmp.%d", file, os.Getpid())
-	if err := os.WriteFile(tmp, []byte(newContent+"\n"), 0o644); err != nil {
+	tmpF, err := os.CreateTemp(filepath.Dir(file), ".hydra-tmp.*")
+	if err != nil {
 		cleanupBackup()
 		return failEdit(task, "write_failed: "+err.Error())
 	}
-	if err := os.Rename(tmp, file); err != nil {
-		_ = os.Remove(tmp)
+	tmpPath := tmpF.Name()
+	if _, werr := fmt.Fprint(tmpF, newContent+"\n"); werr != nil {
+		_ = tmpF.Close()
+		_ = os.Remove(tmpPath)
+		cleanupBackup()
+		return failEdit(task, "write_failed: "+werr.Error())
+	}
+	_ = tmpF.Close()
+	if err := os.Rename(tmpPath, file); err != nil {
+		_ = os.Remove(tmpPath)
 		cleanupBackup()
 		return failEdit(task, "rename_failed: "+err.Error())
 	}
@@ -279,8 +287,7 @@ snippet) between these exact markers and nothing else:
 			vtmpl = tscTemplate(resolved.GitRoot)
 		}
 		if vtmpl != "" {
-			cmd := strings.ReplaceAll(vtmpl, "{file}", file)
-			if rc := runValidate(cmd); rc != 0 {
+			if rc := runValidate(vtmpl, file); rc != 0 {
 				rollback(file, origContent, origExisted, resolved.GitRoot, backup)
 				return mustMarshal(EditResult{
 					Label: task.Label, Enum: task.Enum, Mode: "edit",
@@ -429,12 +436,20 @@ func rollback(file, origContent string, origExisted bool, gitRoot, backup string
 	_ = os.WriteFile(file, []byte(origContent), 0o644)
 }
 
-func runValidate(cmd string) int {
-	parts := strings.Fields(cmd)
+// runValidate splits the validator template around {file} to prevent
+// paths-with-spaces from being fragmented by strings.Fields.
+func runValidate(vtmpl, file string) int {
+	var parts []string
+	if idx := strings.Index(vtmpl, "{file}"); idx >= 0 {
+		parts = append(strings.Fields(vtmpl[:idx]), file)
+		parts = append(parts, strings.Fields(vtmpl[idx+len("{file}"):])...)
+	} else {
+		parts = strings.Fields(vtmpl)
+	}
 	if len(parts) == 0 {
 		return 0
 	}
-	c := exec.Command(parts[0], parts[1:]...) //nolint:gosec
+	c := exec.Command(parts[0], parts[1:]...)
 	if err := c.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return exitErr.ExitCode()
@@ -489,15 +504,4 @@ func diffStats(file, origContent, gitRoot, backup string, origExisted bool) (add
 	return
 }
 
-var enumTiers = map[string]string{
-	"GRUNT": "10", "TRIVIAL": "9", "SIMPLE": "8", "STANDARD": "7",
-	"MODERATE": "6", "COMPLEX": "5", "HARD": "4", "VERY_HARD": "3",
-	"EXPERT": "2", "CORE": "1",
-}
-
-func enumToTier(enum string) string {
-	if t, ok := enumTiers[enum]; ok {
-		return t
-	}
-	return ""
-}
+func enumToTier(enum string) string { return dispatch.EnumToTier(enum) }

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -4,8 +4,16 @@ package policy
 
 import (
 	"regexp"
-	"strings"
 )
+
+// piiPatterns are compiled once at package init to avoid per-call allocations.
+var piiPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\b\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b`),                              // SSN
+	regexp.MustCompile(`\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b`),                        // credit card
+	regexp.MustCompile(`\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`),           // email (fixed: [A-Za-z] not [A-Z|a-z])
+	regexp.MustCompile(`(?i)\b(password|secret|api[-_]?key|token|private[-_]?key)\s*[:=]\s*\S+`), // credentials
+	regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`),                         // IP address
+}
 
 // Action is what the engine tells the dispatcher to do.
 type Action struct {
@@ -55,33 +63,12 @@ func (e *Engine) Evaluate(req Request) Action {
 // information. This is a fast heuristic; replace with Presidio via sidecar for
 // production-grade detection.
 func ContainsPII(req Request) bool {
-	patterns := []*regexp.Regexp{
-		regexp.MustCompile(`\b\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b`), // SSN
-		regexp.MustCompile(`\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b`), // credit card
-		regexp.MustCompile(`\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Z|a-z]{2,}\b`), // email
-		regexp.MustCompile(`(?i)\b(password|secret|api[-_]?key|token|private[-_]?key)\s*[:=]\s*\S+`), // credentials
-		regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`), // IP address
-	}
-	lower := strings.ToLower(req.Prompt)
-	_ = lower
-	for _, p := range patterns {
+	for _, p := range piiPatterns {
 		if p.MatchString(req.Prompt) {
 			return true
 		}
 	}
 	return false
-}
-
-// HasTag returns a condition function that matches when req has the given tag.
-func HasTag(tag string) func(Request) bool {
-	return func(req Request) bool {
-		for _, t := range req.Tags {
-			if t == tag {
-				return true
-			}
-		}
-		return false
-	}
 }
 
 // ── Default rule set ──────────────────────────────────────────────────────────

--- a/internal/policy/file_policy.go
+++ b/internal/policy/file_policy.go
@@ -150,8 +150,7 @@ func matchCondition(key string, val interface{}, spec Spec) bool {
 	case "eq":
 		return fmt.Sprintf("%v", specVal) == fmt.Sprintf("%v", val)
 	case "ne":
-		sv := fmt.Sprintf("%v", specVal)
-		return sv != "" && sv != fmt.Sprintf("%v", val)
+		return fmt.Sprintf("%v", specVal) != fmt.Sprintf("%v", val)
 	case "gt", "lt", "gte", "lte":
 		sn := toFloat(specVal)
 		vn := toFloat(val)
@@ -257,7 +256,10 @@ func toFloat(v interface{}) float64 {
 		if n { return 1 }
 		return 0
 	case string:
-		f, _ := strconv.ParseFloat(n, 64)
+		f, err := strconv.ParseFloat(n, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "policy: non-numeric value %q treated as 0\n", n)
+		}
 		return f
 	}
 	return 0

--- a/internal/provider/agy/provider.go
+++ b/internal/provider/agy/provider.go
@@ -8,6 +8,7 @@ package agy
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -16,6 +17,13 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/provider"
 )
+
+// agiTierScores maps registry tier numbers to capability scores.
+// Declared once to avoid a map allocation on every Discover call.
+var agiTierScores = map[int]int{
+	2: 92, 3: 88, 4: 82, 5: 80,
+	6: 78, 7: 72, 8: 70, 9: 68,
+}
 
 func init() {
 	provider.Register(&Provider{})
@@ -46,7 +54,8 @@ func (p *Provider) Discover(_ context.Context) ([]provider.Head, error) {
 		} `yaml:"models"`
 	}
 	if err := yaml.Unmarshal(data, &reg); err != nil {
-		return nil, nil // malformed YAML — don't crash, just skip
+		log.Printf("agy provider: malformed models.yaml at %s: %v — no agy heads available", registryPath, err)
+		return nil, nil
 	}
 
 	var heads []provider.Head
@@ -73,11 +82,7 @@ func (p *Provider) Discover(_ context.Context) ([]provider.Head, error) {
 // tierScore maps the registry tier number to a Go capability score.
 // Tier 2 = Opus Thinking (highest); tier 9 = Flash Low (lowest agy tier).
 func tierScore(tier int) int {
-	scores := map[int]int{
-		2: 92, 3: 88, 4: 82, 5: 80,
-		6: 78, 7: 72, 8: 70, 9: 68,
-	}
-	if s, ok := scores[tier]; ok {
+	if s, ok := agiTierScores[tier]; ok {
 		return s
 	}
 	return 60

--- a/internal/provider/port/provider.go
+++ b/internal/provider/port/provider.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -70,19 +71,25 @@ type ollamaService struct{}
 func (s *ollamaService) port() int { return 11434 }
 
 func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]provider.Head, error) {
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:11434/api/tags", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:11434/api/tags", nil)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ollama probe: unexpected status %d", resp.StatusCode)
+	}
 
 	var payload struct {
 		Models []struct {
 			Name string `json:"name"`
 		} `json:"models"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
 		return nil, err
 	}
 
@@ -109,19 +116,25 @@ type lmStudioService struct{}
 func (s *lmStudioService) port() int { return 1234 }
 
 func (s *lmStudioService) probe(ctx context.Context, caps *capabilities.DB) ([]provider.Head, error) {
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:1234/v1/models", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:1234/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("lmstudio probe: unexpected status %d", resp.StatusCode)
+	}
 
 	var payload struct {
 		Data []struct {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -14,9 +14,6 @@ func Register(p Provider) { global.add(p) }
 // All returns every registered provider.
 func All() []Provider { return global.all() }
 
-// Get returns a specific provider by ID.
-func Get(id string) (Provider, error) { return global.get(id) }
-
 // Registry is a thread-safe map of Providers.
 // The global instance is used by default; tests may construct their own.
 type Registry struct {

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -177,14 +177,11 @@ func Reject(file string) (*RejectResult, error) {
 
 	gitRoot := resolved.GitRoot
 	if gitRoot != "" {
-		tracked, _ := exec.Command("git", "-C", gitRoot, "ls-files", "--error-unmatch", file).CombinedOutput()
-		if len(tracked) > 0 || tracked != nil {
-			if err := exec.Command("git", "-C", gitRoot, "ls-files", "--error-unmatch", file).Run(); err == nil {
-				if err := exec.Command("git", "-C", gitRoot, "checkout", "--", file).Run(); err != nil {
-					return nil, fmt.Errorf("git checkout failed: %w", err)
-				}
-				return &RejectResult{Status: "rejected", File: file, Method: "git_checkout"}, nil
+		if err := exec.Command("git", "-C", gitRoot, "ls-files", "--error-unmatch", file).Run(); err == nil {
+			if err := exec.Command("git", "-C", gitRoot, "checkout", "--", file).Run(); err != nil {
+				return nil, fmt.Errorf("git checkout failed: %w", err)
 			}
+			return &RejectResult{Status: "rejected", File: file, Method: "git_checkout"}, nil
 		}
 		// Untracked new file
 		if fileExists(file) {

--- a/internal/sysinfo/history.go
+++ b/internal/sysinfo/history.go
@@ -23,16 +23,23 @@ type memorySample struct {
 	WiredGB float64   `json:"wired_gb"`
 }
 
-// historyPath returns ~/.hydra/memory_history.jsonl
+// historyPath returns ~/.hydra/memory_history.jsonl, or "" if the home dir is unavailable.
 func historyPath() string {
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
 	return filepath.Join(home, ".hydra", historyFile)
 }
+
 
 // recordSample appends the current reading to the history file if enough time
 // has passed since the last sample. Silently ignores write errors.
 func recordSample(s *Specs) {
 	path := historyPath()
+	if path == "" {
+		return
+	}
 
 	// Don't spam: skip if we wrote recently.
 	if info, err := os.Stat(path); err == nil {
@@ -64,6 +71,9 @@ func recordSample(s *Specs) {
 // loadRecentSamples reads the last historyDays worth of samples.
 func loadRecentSamples() []memorySample {
 	path := historyPath()
+	if path == "" {
+		return nil
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil

--- a/internal/sysinfo/sysinfo.go
+++ b/internal/sysinfo/sysinfo.go
@@ -19,7 +19,11 @@ const (
 )
 
 func (p Pressure) String() string {
-	return [...]string{"low", "moderate", "high"}[p]
+	names := [...]string{"low", "moderate", "high"}
+	if p < 0 || int(p) >= len(names) {
+		return "unknown"
+	}
+	return names[p]
 }
 
 // Specs describes the hardware and current memory state relevant to AI model selection.
@@ -79,12 +83,6 @@ func (s *Specs) bestFreeEstimate() float64 {
 	}
 	// Nothing known — be conservative.
 	return s.TotalRAMGB * 0.55
-}
-
-// UsingHistoricalData reports whether recommendations are based on historical
-// averages (true) or just the current snapshot (false).
-func (s *Specs) UsingHistoricalData() bool {
-	return s.History != nil && s.History.Reliable
 }
 
 // MemoryNote returns a human-readable explanation of the effective value.

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ankit373/hydra/internal/build"
@@ -30,9 +31,28 @@ type state struct {
 	LatestVersion string    `json:"latest_version"`
 }
 
-// Check returns the latest version string if an update is available,
-// or empty string if up-to-date, disabled, non-TTY, or a dev build.
+var (
+	checkOnce   sync.Once
+	checkResult string
+)
+
+// Check returns the latest version if an update is available, empty otherwise.
+// Safe to call multiple times — the network fetch runs at most once per process.
 func Check() string {
+	checkOnce.Do(func() { checkResult = doCheck() })
+	return checkResult
+}
+
+// CheckAsync fires Check in a goroutine and returns a buffered channel.
+// The channel delivers exactly one value (the version string or "").
+// Drain with a select/default to avoid blocking if the check hasn't returned.
+func CheckAsync() <-chan string {
+	ch := make(chan string, 1)
+	go func() { ch <- Check() }()
+	return ch
+}
+
+func doCheck() string {
 	if os.Getenv("HYDRA_NO_UPDATE_CHECK") != "" || os.Getenv("CI") != "" {
 		return ""
 	}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -6,7 +6,6 @@ package workspace
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -168,26 +167,13 @@ func GitRoot(path string) string {
 	return ""
 }
 
-// GitRootCmd uses git rev-parse for accuracy when git is available.
-func GitRootCmd(path string) string {
-	dir := path
-	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
-		dir = filepath.Dir(dir)
-	}
-	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return GitRoot(path)
-	}
-	return strings.TrimSpace(string(out))
-}
-
 // find returns the workspace whose root contains path.
 // Respects HYDRA_WORKSPACE override.
 func (r *Registry) find(path string) (Workspace, error) {
 	if override := os.Getenv("HYDRA_WORKSPACE"); override != "" {
 		for _, ws := range r.workspaces {
 			if ws.Name == override {
-				if !strings.HasPrefix(path, ws.Root) {
+				if path != ws.Root && !strings.HasPrefix(path, ws.Root+"/") {
 					return Workspace{}, fmt.Errorf("HYDRA_WORKSPACE=%s root (%s) does not contain %s", override, ws.Root, path)
 				}
 				return ws, nil

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -63,9 +63,13 @@ func Load(hydraHome string) (*Registry, error) {
 
 	r := &Registry{validators: make(map[string]string)}
 	for name, e := range rf.Workspaces {
+		root := filepath.Clean(e.Root)
+		if !filepath.IsAbs(root) {
+			return nil, fmt.Errorf("workspace %q: root %q must be an absolute path", name, e.Root)
+		}
 		r.workspaces = append(r.workspaces, Workspace{
 			Name:         name,
-			Root:         e.Root,
+			Root:         root,
 			Git:          e.Git,
 			AllowedGlobs: e.AllowedGlobs,
 			DeniedGlobs:  e.DeniedGlobs,


### PR DESCRIPTION
## Summary

Resolves all critical, high, and medium findings from the full codebase security audit (issue #45). Also removes identified dead code.

### Critical
- **`dispatch/edit.sh`** — Removed `eval` entirely. Validator command built as a proper bash array (`read -ra vcmd`); `$FILE` passed as a separate quoted positional arg.

### High — Security
- **`executor.go`** — `HYDRA_TOKEN_SIDECAR` path validated (absolute, within `os.TempDir`, no `..`); file written `0o600`
- **`http.go`** — Replicate poll URL validated against `https://api.replicate.com/` (SSRF); Gemini key moved to `x-goog-api-key` header; HTTP error body reads capped at 4096 via `io.LimitReader`
- **`agy.go`** — `AGY_TIMEOUT` parsing fixed (`5m` no longer becomes `5ms`)
- **`agy.sh`** — `flock` exclusive lock wraps settings.json swap cycle; `AUTH_FILE` path aligned with `route.sh`
- **`route.sh`** — All pool names use `jq --arg`; missing `warning` tier-downgrade case added; cost-logging block wrapped in `|| true`

### High — Bug Risk
- **`company.go`** — Nil guard before `cs.Status` dereference in `Children()`

### Medium
- **`dispatch.go`** — `stateMu` mutex on `syncStateJSON`
- **`config.go`** — Atomic config write (temp+rename); `HYDRA_HOME` normalized
- **`workspace.go`** — `HasPrefix` with trailing `/` prevents path traversal
- **`policy/engine.go`** — PII regexes compiled once; email regex fixed `[A-Za-z]`
- **`ollama.go`** — `OLLAMA_HOST` validated (loopback-only); zombie processes fixed via `sync.Once`
- **`port/provider.go`** — HTTP status checked; body capped with `io.LimitReader`
- **`ollama.sh`** — `OLLAMA_HOST` validated; `--max-redirs 0`
- **`edit.sh`** — `warn()` defined; `mktemp` for atomic write temp file
- **`review.go`** — Removed always-true `tracked != nil` condition

### Dead Code Removed
`GitRootCmd`, `UsingHistoricalData`, `HasTag`, `provider.Get`, `min3`, custom `max`, fp policy block in editor.go, unused `lower` var, stale imports

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [ ] Manual: concurrent agy dispatches confirm settings.json not corrupted
- [ ] Manual: validator with semicolons in template does not inject

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)