### PR TITLE
fix(ci): goreleaser v2 — remove unsupported tap field from brews dependency

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -96,9 +96,6 @@ brews:
       - name: jq
       - name: yq
       - name: bun
-        tap:
-          owner: oven-sh
-          name: homebrew-bun
     install: |
       bin.install "hydra"
     test: |


### PR DESCRIPTION
## Summary
GoReleaser v2 removed the `tap` sub-field from `brews.dependencies`. Every push to develop was failing immediately with:
```
yaml: unmarshal errors:
  line 99: field tap not found in type config.t
```

Removes the 3-line `tap:` block from the `bun` dependency. Homebrew resolves the tap at install time — the field was purely informational.

## Changes
- `.goreleaser.yaml` — remove unsupported `tap:` sub-block from bun dependency

Closes #47