### PR TITLE
feat(dispatch): swarm mode — fan-out to multiple heads

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -328,20 +328,15 @@ func printSwarmResult(r *swarm.SwarmResult) {
 	fmt.Printf("  %-28s  %-10s  %7s  %7s  %8s\n", "HEAD", "STATUS", "TIME", "SCORE", "COST")
 	fmt.Println(sep)
 
-	for _, a := range r.Attempts {
+	for i, a := range r.Attempts {
 		statusStr := statusIcon(a.Status) + " " + string(a.Status)
 		timeStr := "-"
 		if a.Duration > 0 {
 			timeStr = fmt.Sprintf("%dms", a.Duration.Milliseconds())
 		}
 		scoreStr := "-"
-		if r.Verdict != nil && a.Status == swarm.StatusOK {
-			for i, att := range r.Attempts {
-				if att.Head.ID == a.Head.ID && i < len(r.Verdict.Scores) {
-					scoreStr = fmt.Sprintf("%d/100", r.Verdict.Scores[i])
-					break
-				}
-			}
+		if r.Verdict != nil && a.Status == swarm.StatusOK && i < len(r.Verdict.Scores) {
+			scoreStr = fmt.Sprintf("%d/100", r.Verdict.Scores[i])
 		}
 		costStr := fmt.Sprintf("$%.4f", a.EstCostUSD)
 		if a.EstCostUSD == 0 {

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ankit373/hydra/internal/parallel"
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/review"
+	"github.com/ankit373/hydra/internal/swarm"
 	"github.com/ankit373/hydra/internal/tui"
 	"github.com/ankit373/hydra/internal/update"
 
@@ -196,6 +197,13 @@ func cmdDispatch() *cobra.Command {
 		system    string
 		a2aFile   string
 		enumKey   string
+		// swarm flags
+		doSwarm       bool
+		swarmMode     string
+		swarmHeads    string
+		swarmMaxHeads int
+		swarmMaxCost  float64
+		swarmJudge    string
 	)
 
 	cmd := &cobra.Command{
@@ -211,6 +219,39 @@ func cmdDispatch() *cobra.Command {
 				return err
 			}
 
+			// ── swarm mode ────────────────────────────────────────────────
+			if doSwarm {
+				var headIDs []string
+				if swarmHeads != "" {
+					for _, id := range strings.Split(swarmHeads, ",") {
+						if id = strings.TrimSpace(id); id != "" {
+							headIDs = append(headIDs, id)
+						}
+					}
+				}
+				mode := swarm.SwarmMode(swarmMode)
+				if mode == "" {
+					mode = swarm.ModeBest
+				}
+				sw := swarm.New(d, d.Heads(), d)
+				result, err := sw.Run(ctx, prompt, swarm.Options{
+					Mode:          mode,
+					TierHint:      tier,
+					HeadIDs:       headIDs,
+					MaxHeads:      swarmMaxHeads,
+					MaxEstCostUSD: swarmMaxCost,
+					LocalOnly:     localOnly,
+					System:        system,
+					JudgeTierHint: swarmJudge,
+				})
+				if err != nil {
+					return err
+				}
+				printSwarmResult(result)
+				return nil
+			}
+
+			// ── normal single dispatch ─────────────────────────────────────
 			opts := dispatch.Options{
 				TierHint:  tier,
 				LocalOnly: localOnly,
@@ -260,7 +301,107 @@ func cmdDispatch() *cobra.Command {
 	cmd.Flags().StringVarP(&system, "system", "s", "", "system prompt")
 	cmd.Flags().StringVar(&a2aFile, "a2a", "", "path to A2A handoff JSON (prepends structured context to prompt)")
 	cmd.Flags().StringVar(&enumKey, "enum", "", "routing enum key for cost logging (e.g. SIMPLE)")
+	// swarm flags
+	cmd.Flags().BoolVar(&doSwarm, "swarm", false, "fan prompt out to multiple heads simultaneously")
+	cmd.Flags().StringVar(&swarmMode, "swarm-mode", "best", "response strategy: best|race|all")
+	cmd.Flags().StringVar(&swarmHeads, "swarm-heads", "", "comma-separated head IDs to target (overrides --tier)")
+	cmd.Flags().IntVar(&swarmMaxHeads, "swarm-max-heads", 0, "max heads to fire (default 5)")
+	cmd.Flags().Float64Var(&swarmMaxCost, "swarm-max-cost", 0, "refuse swarm if preflight cost estimate exceeds this USD")
+	cmd.Flags().StringVar(&swarmJudge, "swarm-judge-tier", "", "tier for judge head in best mode (default: tier 1 / cortex)")
 	return cmd
+}
+
+// printSwarmResult renders the swarm result to stdout.
+func printSwarmResult(r *swarm.SwarmResult) {
+	sep := dimStyle.Render("  " + strings.Repeat("─", 60))
+
+	fmt.Println()
+	fmt.Printf("  %s [%s · %d heads]\n\n",
+		cortexStyle.Render("▶ SWARM"),
+		dimStyle.Render(string(r.Mode)),
+		len(r.Attempts),
+	)
+
+	// Attempt table header.
+	fmt.Printf("  %-28s  %-10s  %7s  %7s  %8s\n", "HEAD", "STATUS", "TIME", "SCORE", "COST")
+	fmt.Println(sep)
+
+	for _, a := range r.Attempts {
+		statusStr := statusIcon(a.Status) + " " + string(a.Status)
+		timeStr := "-"
+		if a.Duration > 0 {
+			timeStr = fmt.Sprintf("%dms", a.Duration.Milliseconds())
+		}
+		scoreStr := "-"
+		if r.Verdict != nil && a.Status == swarm.StatusOK {
+			for i, att := range r.Attempts {
+				if att.Head.ID == a.Head.ID && i < len(r.Verdict.Scores) {
+					scoreStr = fmt.Sprintf("%d/100", r.Verdict.Scores[i])
+					break
+				}
+			}
+		}
+		costStr := fmt.Sprintf("$%.4f", a.EstCostUSD)
+		if a.EstCostUSD == 0 {
+			costStr = "-"
+		}
+		winnerMark := "  "
+		if a.Rank == 1 {
+			winnerMark = cortexStyle.Render("→ ")
+		}
+		fmt.Printf("%s%-28s  %-10s  %7s  %7s  %8s\n",
+			winnerMark, a.Head.Name, statusStr, timeStr, scoreStr, costStr,
+		)
+	}
+
+	fmt.Println(sep)
+
+	// Verdict line.
+	if r.Verdict != nil && r.Winner != nil {
+		judgeLabel := "LLM judge"
+		if r.Verdict.Meta.UsedFallback {
+			judgeLabel = "cap-score fallback"
+		}
+		fmt.Printf("\n  %s %s  [%s, %dms]\n",
+			dimStyle.Render("Winner →"),
+			cortexStyle.Render(r.Winner.Head.Name),
+			judgeLabel,
+			r.Verdict.Meta.Duration.Milliseconds(),
+		)
+		if r.Verdict.Reason != "" {
+			fmt.Printf("  %s\n", dimStyle.Render(`"`+r.Verdict.Reason+`"`))
+		}
+	} else if r.Winner != nil {
+		fmt.Printf("\n  %s %s\n",
+			dimStyle.Render("Winner →"),
+			cortexStyle.Render(r.Winner.Head.Name),
+		)
+	}
+
+	fmt.Printf("\n  %s  total $%.4f  ·  wall %dms  ·  %d/%d succeeded\n\n",
+		sep,
+		r.TotalCostUSD,
+		r.WallDuration.Milliseconds(),
+		r.SucceededCount(),
+		len(r.Attempts),
+	)
+
+	// Winner output.
+	if r.Winner != nil && r.Winner.Output != "" {
+		fmt.Println(r.Winner.Output)
+		fmt.Println()
+	}
+}
+
+func statusIcon(s swarm.HeadStatus) string {
+	switch s {
+	case swarm.StatusOK:
+		return "✓"
+	case swarm.StatusCanceled:
+		return "·"
+	default:
+		return "✗"
+	}
 }
 
 // ── edit ──────────────────────────────────────────────────────────────────────

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/rank"
 )
 
 // Options controls dispatch behaviour.
@@ -235,7 +236,7 @@ func injectA2A(path, prompt string) (string, error) {
 func (d *Dispatcher) writeHandoff(r *Result, prompt string) error {
 	handoffPath := filepath.Join(config.Dir(), "logs", "last_handoff.json")
 	h := map[string]any{
-		"from":         fmt.Sprintf("hydra-tier-%d", uiTier(r.Head)),
+		"from":         fmt.Sprintf("hydra-tier-%d", rank.UITier(r.Head)),
 		"model":        r.Head.Name,
 		"task":         prompt,
 		"prior_output": r.Response.Output,
@@ -316,7 +317,7 @@ func (d *Dispatcher) syncStateJSON(r *Result) {
 
 	existing["last_model"] = r.Head.Name
 	existing["last_status"] = "ok"
-	existing["last_tier"] = uiTier(r.Head)
+	existing["last_tier"] = rank.UITier(r.Head)
 
 	updated, err := json.MarshalIndent(existing, "", "  ")
 	if err != nil {
@@ -333,7 +334,7 @@ func (d *Dispatcher) syncStateJSON(r *Result) {
 
 // logDispatch writes to dispatch.jsonl and cost.jsonl.
 func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options) error {
-	tier := uiTier(r.Head)
+	tier := rank.UITier(r.Head)
 	wallMs := r.Response.Duration.Milliseconds()
 	estCost := d.estimateCost(tier, r.Response.InputTokens, r.Response.OutputTokens)
 
@@ -405,39 +406,6 @@ func (d *Dispatcher) estimateCost(tier, inputTokens, outputTokens int) float64 {
 		return 0
 	}
 	return d.pricing.EstimateCost(tier, inputTokens, outputTokens)
-}
-
-// uiTier converts a Head to the 1-10 integer that ui/src/types.ts TIER_LABELS expects.
-func uiTier(h provider.Head) int {
-	if h.Source == "registry" {
-		if t := h.Meta["tier"]; t != "" {
-			if n, err := strconv.Atoi(t); err == nil {
-				return n
-			}
-		}
-	}
-	switch {
-	case h.CapScore >= 95:
-		return 1
-	case h.CapScore >= 90:
-		return 2
-	case h.CapScore >= 85:
-		return 3
-	case h.CapScore >= 80:
-		return 4
-	case h.CapScore >= 78:
-		return 5
-	case h.CapScore >= 72:
-		return 6
-	case h.CapScore >= 70:
-		return 7
-	case h.CapScore >= 65:
-		return 8
-	case h.CapScore >= 60:
-		return 9
-	default:
-		return 10
-	}
 }
 
 func truncate(s string, n int) string {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -54,6 +54,14 @@ type Dispatcher struct {
 	pricing *pricingConfig
 }
 
+// Heads returns the probed head list for external callers (e.g. swarm).
+func (d *Dispatcher) Heads() []provider.Head { return d.heads }
+
+// EstimateCost exposes per-tier cost estimation for external callers.
+func (d *Dispatcher) EstimateCost(tier, inputTokens, outputTokens int) float64 {
+	return d.estimateCost(tier, inputTokens, outputTokens)
+}
+
 // New builds a Dispatcher from the saved config and a fresh machine probe.
 func New(ctx context.Context) (*Dispatcher, error) {
 	cfg, err := config.Load()

--- a/internal/executor/agy.go
+++ b/internal/executor/agy.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ankit373/hydra/internal/config"
@@ -35,6 +36,11 @@ var authSignalRe = regexp.MustCompile(
 )
 var authURLRe = regexp.MustCompile(`https?://\S+`)
 
+// agyMu serializes all agy executions that mutate settings.json.
+// agy uses a single shared settings.json; concurrent swaps corrupt it.
+// Serialization eliminates the filesystem race at the cost of agy parallelism.
+var agyMu sync.Mutex
+
 // AgyExecutor invokes `agy --print` with model selection via settings.json swap.
 // Ports all logic from dispatch/agy.sh natively in Go.
 type AgyExecutor struct{}
@@ -44,6 +50,11 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 	if modelFlag == "" {
 		return nil, fmt.Errorf("agy executor: head %q has no model_flag in Meta", req.Head.ID)
 	}
+
+	// Serialize all agy invocations — settings.json is a single shared file.
+	// Concurrent swaps corrupt it, making swarm mode produce wrong models.
+	agyMu.Lock()
+	defer agyMu.Unlock()
 
 	settingsPath := agySitesPath()
 
@@ -116,12 +127,12 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 	writeTokenSidecar(modelFlag, "agy", "estimate", promptTokens, responseTokens)
 
 	return &Response{
-		Output:        output,
-		Duration:      duration,
-		Model:         req.Head.ID,
-		InputTokens:   promptTokens,
-		OutputTokens:  responseTokens,
-		Truncated:     stdout.Truncated(),
+		Output:       output,
+		Duration:     duration,
+		Model:        req.Head.ID,
+		InputTokens:  promptTokens,
+		OutputTokens: responseTokens,
+		Truncated:    stdout.Truncated(),
 	}, nil
 }
 

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -2,6 +2,7 @@
 package rank
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/ankit373/hydra/internal/provider"
@@ -69,4 +70,40 @@ func dedupeKey(h provider.Head) string {
 		return h.ID // each local model or antigravity tier is unique
 	}
 	return h.Provider // one entry per cloud provider
+}
+
+// UITier converts a Head's CapScore to the 1-10 tier integer used in cost
+// estimation and logging. Registry heads with an explicit "tier" meta key take
+// priority; otherwise the CapScore thresholds apply.
+func UITier(h provider.Head) int {
+	if h.Source == "registry" {
+		if t := h.Meta["tier"]; t != "" {
+			var n int
+			if _, err := fmt.Sscanf(t, "%d", &n); err == nil {
+				return n
+			}
+		}
+	}
+	switch {
+	case h.CapScore >= 95:
+		return 1
+	case h.CapScore >= 90:
+		return 2
+	case h.CapScore >= 85:
+		return 3
+	case h.CapScore >= 80:
+		return 4
+	case h.CapScore >= 78:
+		return 5
+	case h.CapScore >= 72:
+		return 6
+	case h.CapScore >= 70:
+		return 7
+	case h.CapScore >= 65:
+		return 8
+	case h.CapScore >= 60:
+		return 9
+	default:
+		return 10
+	}
 }

--- a/internal/swarm/attempt.go
+++ b/internal/swarm/attempt.go
@@ -1,0 +1,67 @@
+// Package swarm implements fan-out dispatch: one prompt fired at multiple
+// Heads simultaneously, with race / best / all response strategies.
+package swarm
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// HeadStatus describes how a single head's execution ended.
+type HeadStatus string
+
+const (
+	StatusPending      HeadStatus = "pending"
+	StatusRunning      HeadStatus = "running"
+	StatusOK           HeadStatus = "ok"
+	StatusFailed       HeadStatus = "failed"
+	StatusCanceled     HeadStatus = "canceled"
+	StatusTimeout      HeadStatus = "timeout"
+	StatusAuthRequired HeadStatus = "auth_required"
+)
+
+// Attempt is the immutable per-head execution record.
+// All fields are set before the Attempt is returned from a runner; callers
+// must treat the value as read-only.
+type Attempt struct {
+	Head         provider.Head
+	Status       HeadStatus
+	Output       string
+	InputTokens  int
+	OutputTokens int
+	Duration     time.Duration
+	EstCostUSD   float64
+	Err          error // original typed error — never stringified before display
+	StartedAt    time.Time
+	FinishedAt   time.Time
+	Rank         int // 1 = winner; 0 = unranked
+}
+
+// Succeeded reports whether the attempt produced usable output.
+func (a Attempt) Succeeded() bool { return a.Status == StatusOK }
+
+// TotalTokens returns input + output token count.
+func (a Attempt) TotalTokens() int { return a.InputTokens + a.OutputTokens }
+
+// classifyError converts a raw executor error into the appropriate HeadStatus.
+// Keeps error classification in one place so runners never branch on error types.
+func classifyError(err error) HeadStatus {
+	if err == nil {
+		return StatusOK
+	}
+	var authErr *executor.AuthRequiredError
+	if errors.As(err, &authErr) {
+		return StatusAuthRequired
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return StatusTimeout
+	}
+	if errors.Is(err, context.Canceled) {
+		return StatusCanceled
+	}
+	return StatusFailed
+}

--- a/internal/swarm/attempt.go
+++ b/internal/swarm/attempt.go
@@ -31,6 +31,7 @@ type Attempt struct {
 	Head         provider.Head
 	Status       HeadStatus
 	Output       string
+	Truncated    bool // true when output was capped by the accumulator
 	InputTokens  int
 	OutputTokens int
 	Duration     time.Duration

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -6,10 +6,10 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/rank"
 )
 
 // PricingReader abstracts the per-tier cost lookup so swarm doesn't need to
@@ -30,9 +30,7 @@ func preflightCost(heads []provider.Head, prompt string, pr PricingReader, maxUS
 	estInputTokens := len(prompt) / 4
 	var total float64
 	for _, h := range heads {
-		tier := uiTier(h)
-		// Estimate: same tokens in, half tokens out (conservative).
-		total += pr.EstimateCost(tier, estInputTokens, estInputTokens/2)
+		total += pr.EstimateCost(rank.UITier(h), estInputTokens, estInputTokens/2)
 	}
 
 	total = round6(total)
@@ -49,8 +47,7 @@ func enrichCosts(attempts []Attempt, pr PricingReader) {
 	}
 	for i := range attempts {
 		if attempts[i].Status == StatusOK {
-			tier := uiTier(attempts[i].Head)
-			attempts[i].EstCostUSD = round6(pr.EstimateCost(tier, attempts[i].InputTokens, attempts[i].OutputTokens))
+			attempts[i].EstCostUSD = round6(pr.EstimateCost(rank.UITier(attempts[i].Head), attempts[i].InputTokens, attempts[i].OutputTokens))
 		}
 	}
 }
@@ -76,8 +73,8 @@ func logAttempts(result *SwarmResult, promptPreview string) {
 			continue
 		}
 		entry := map[string]any{
-			"ts":              time.Now().UTC().Format(time.RFC3339),
-			"tier":            uiTier(a.Head),
+			"ts":              a.FinishedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			"tier":            rank.UITier(a.Head),
 			"model":           a.Head.Name,
 			"executor":        a.Head.Provider,
 			"pool":            a.Head.Meta["token_pool"],
@@ -102,41 +99,6 @@ func costSource(a Attempt) string {
 		return "real"
 	}
 	return "estimate"
-}
-
-// uiTier converts a Head's CapScore to a 1-10 tier integer.
-// Mirrors the same function in dispatch.go — kept local to avoid a circular import.
-func uiTier(h provider.Head) int {
-	if h.Source == "registry" {
-		if t := h.Meta["tier"]; t != "" {
-			var n int
-			if _, err := fmt.Sscanf(t, "%d", &n); err == nil {
-				return n
-			}
-		}
-	}
-	switch {
-	case h.CapScore >= 95:
-		return 1
-	case h.CapScore >= 90:
-		return 2
-	case h.CapScore >= 85:
-		return 3
-	case h.CapScore >= 80:
-		return 4
-	case h.CapScore >= 78:
-		return 5
-	case h.CapScore >= 72:
-		return 6
-	case h.CapScore >= 70:
-		return 7
-	case h.CapScore >= 65:
-		return 8
-	case h.CapScore >= 60:
-		return 9
-	default:
-		return 10
-	}
 }
 
 func round6(f float64) float64 {

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -1,0 +1,144 @@
+package swarm
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// PricingReader abstracts the per-tier cost lookup so swarm doesn't need to
+// re-parse pricing.yaml itself.
+type PricingReader interface {
+	// EstimateCost returns the estimated USD cost for the given tier + token counts.
+	EstimateCost(tier int, inputTokens, outputTokens int) float64
+}
+
+// preflightCost estimates the total cost of firing all selected heads before
+// any execution begins. Returns an error if the estimate exceeds maxUSD.
+// Uses prompt character count / 4 as a token estimate (same as agy executor).
+func preflightCost(heads []provider.Head, prompt string, pr PricingReader, maxUSD float64) (float64, error) {
+	if pr == nil || maxUSD <= 0 {
+		return 0, nil
+	}
+
+	estInputTokens := len(prompt) / 4
+	var total float64
+	for _, h := range heads {
+		tier := uiTier(h)
+		// Estimate: same tokens in, half tokens out (conservative).
+		total += pr.EstimateCost(tier, estInputTokens, estInputTokens/2)
+	}
+
+	total = round6(total)
+	if total > maxUSD {
+		return total, fmt.Errorf("swarm: estimated cost $%.4f exceeds limit $%.4f (%d heads)", total, maxUSD, len(heads))
+	}
+	return total, nil
+}
+
+// enrichCosts fills EstCostUSD on each attempt using real token counts.
+func enrichCosts(attempts []Attempt, pr PricingReader) {
+	if pr == nil {
+		return
+	}
+	for i := range attempts {
+		if attempts[i].Status == StatusOK {
+			tier := uiTier(attempts[i].Head)
+			attempts[i].EstCostUSD = round6(pr.EstimateCost(tier, attempts[i].InputTokens, attempts[i].OutputTokens))
+		}
+	}
+}
+
+// logAttempts writes one cost.jsonl entry per attempt that actually executed
+// (StatusOK or StatusFailed — not Pending/Canceled).
+func logAttempts(result *SwarmResult, promptPreview string) {
+	logDir := filepath.Join(config.Dir(), "logs")
+	_ = os.MkdirAll(logDir, 0o700)
+	path := filepath.Join(logDir, "cost.jsonl")
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	runID := os.Getenv("HYDRA_RUN_ID")
+	taskID := os.Getenv("HYDRA_TASK_ID")
+
+	for _, a := range result.Attempts {
+		if a.Status == StatusPending || a.Status == StatusCanceled {
+			continue
+		}
+		entry := map[string]any{
+			"ts":              time.Now().UTC().Format(time.RFC3339),
+			"tier":            uiTier(a.Head),
+			"model":           a.Head.Name,
+			"executor":        a.Head.Provider,
+			"pool":            a.Head.Meta["token_pool"],
+			"prompt_tokens":   a.InputTokens,
+			"response_tokens": a.OutputTokens,
+			"est_cost_usd":    a.EstCostUSD,
+			"wall_ms":         a.Duration.Milliseconds(),
+			"source":          costSource(a),
+			"swarm_mode":      string(result.Mode),
+			"swarm_winner":    a.Status == StatusOK && a.Rank == 1,
+			"task_id":         taskID,
+			"run_id":          runID,
+			"prompt_preview":  promptPreview,
+		}
+		raw, _ := json.Marshal(entry)
+		_, _ = fmt.Fprintln(f, string(raw))
+	}
+}
+
+func costSource(a Attempt) string {
+	if a.InputTokens > 0 {
+		return "real"
+	}
+	return "estimate"
+}
+
+// uiTier converts a Head's CapScore to a 1-10 tier integer.
+// Mirrors the same function in dispatch.go — kept local to avoid a circular import.
+func uiTier(h provider.Head) int {
+	if h.Source == "registry" {
+		if t := h.Meta["tier"]; t != "" {
+			var n int
+			if _, err := fmt.Sscanf(t, "%d", &n); err == nil {
+				return n
+			}
+		}
+	}
+	switch {
+	case h.CapScore >= 95:
+		return 1
+	case h.CapScore >= 90:
+		return 2
+	case h.CapScore >= 85:
+		return 3
+	case h.CapScore >= 80:
+		return 4
+	case h.CapScore >= 78:
+		return 5
+	case h.CapScore >= 72:
+		return 6
+	case h.CapScore >= 70:
+		return 7
+	case h.CapScore >= 65:
+		return 8
+	case h.CapScore >= 60:
+		return 9
+	default:
+		return 10
+	}
+}
+
+func round6(f float64) float64 {
+	return math.Round(f*1_000_000) / 1_000_000
+}

--- a/internal/swarm/judge.go
+++ b/internal/swarm/judge.go
@@ -1,0 +1,251 @@
+package swarm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+const defaultJudgeTimeout = 30 * time.Second
+
+// JudgeVerdict is the structured outcome of a judge evaluation.
+type JudgeVerdict struct {
+	WinnerIndex int
+	Scores      []int // 0-100 per attempt, same order as the attempts slice
+	Reason      string
+	Meta        JudgeMeta
+}
+
+// JudgeMeta records how the verdict was reached — LLM or fallback.
+type JudgeMeta struct {
+	Head           provider.Head
+	InputTokens    int
+	OutputTokens   int
+	Duration       time.Duration
+	UsedFallback   bool
+	FallbackReason string
+}
+
+// Judge ranks a set of completed Attempts and returns a verdict.
+type Judge interface {
+	Judge(ctx context.Context, prompt string, attempts []Attempt) (*JudgeVerdict, error)
+}
+
+// ── LLMJudge ─────────────────────────────────────────────────────────────────
+
+// LLMJudge dispatches a structured evaluation prompt to a configured head and
+// parses {"winner":0,"scores":[85,72],"reason":"..."} from the response.
+type LLMJudge struct {
+	d       *dispatch.Dispatcher
+	tier    string
+	timeout time.Duration
+}
+
+func newLLMJudge(d *dispatch.Dispatcher, tierHint string, timeout time.Duration) *LLMJudge {
+	if timeout <= 0 {
+		timeout = defaultJudgeTimeout
+	}
+	return &LLMJudge{d: d, tier: tierHint, timeout: timeout}
+}
+
+func (j *LLMJudge) Judge(ctx context.Context, prompt string, attempts []Attempt) (*JudgeVerdict, error) {
+	successful := successfulAttempts(attempts)
+	if len(successful) == 0 {
+		return nil, fmt.Errorf("judge: no successful attempts to evaluate")
+	}
+	if len(successful) == 1 {
+		// Trivial case — no need to call the LLM.
+		idx := successful[0]
+		scores := make([]int, len(attempts))
+		scores[idx] = attempts[idx].Head.CapScore
+		return &JudgeVerdict{
+			WinnerIndex: idx,
+			Scores:      scores,
+			Reason:      "only one successful response",
+			Meta:        JudgeMeta{},
+		}, nil
+	}
+
+	judgePrompt := buildJudgePrompt(prompt, attempts, successful)
+
+	jCtx, cancel := context.WithTimeout(ctx, j.timeout)
+	defer cancel()
+
+	start := time.Now()
+	result, err := j.d.Dispatch(jCtx, judgePrompt, dispatch.Options{
+		TierHint: j.tier,
+		System:   "You are a code and reasoning quality evaluator. Respond only with valid JSON.",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("judge dispatch: %w", err)
+	}
+	elapsed := time.Since(start)
+
+	verdict, err := parseJudgeResponse(result.Output, len(attempts), successful)
+	if err != nil {
+		return nil, fmt.Errorf("judge parse: %w — raw: %.200s", err, result.Output)
+	}
+
+	verdict.Meta = JudgeMeta{
+		Head:         result.Head,
+		InputTokens:  result.InputTokens,
+		OutputTokens: result.OutputTokens,
+		Duration:     elapsed,
+	}
+	return verdict, nil
+}
+
+// buildJudgePrompt constructs the structured evaluation prompt.
+func buildJudgePrompt(originalPrompt string, attempts []Attempt, successIdx []int) string {
+	var sb strings.Builder
+	sb.WriteString("You are evaluating responses to the following prompt:\n")
+	sb.WriteString("---\n")
+	sb.WriteString(originalPrompt)
+	sb.WriteString("\n---\n\n")
+	sb.WriteString("Below are the candidate responses, numbered from 0:\n\n")
+
+	for _, idx := range successIdx {
+		a := attempts[idx]
+		fmt.Fprintf(&sb, "=== Response %d (model: %s) ===\n%s\n\n", idx, a.Head.Name, a.Output)
+	}
+
+	sb.WriteString(`Evaluate each response on: correctness, completeness, clarity, and conciseness.
+Return ONLY valid JSON in this exact format (no prose, no code fences):
+{"winner":<index>,"scores":[<score_0>,<score_1>,...],"reason":"<one sentence>"}
+
+Rules:
+- "winner" must be the index (0-based) of the best response
+- "scores" must have one integer (0-100) for every response listed above, in the same order
+- "reason" must be a single sentence explaining why the winner is best
+- Indices refer to the numbers shown above (Response 0, Response 1, etc.)`)
+
+	return sb.String()
+}
+
+// judgeJSON is the expected JSON shape from the LLM judge.
+type judgeJSON struct {
+	Winner int    `json:"winner"`
+	Scores []int  `json:"scores"`
+	Reason string `json:"reason"`
+}
+
+// parseJudgeResponse extracts the verdict JSON from potentially noisy LLM output.
+func parseJudgeResponse(raw string, totalAttempts int, successIdx []int) (*JudgeVerdict, error) {
+	// Strip markdown fences if present.
+	clean := raw
+	if i := strings.Index(clean, "{"); i >= 0 {
+		clean = clean[i:]
+	}
+	if i := strings.LastIndex(clean, "}"); i >= 0 {
+		clean = clean[:i+1]
+	}
+
+	var j judgeJSON
+	if err := json.Unmarshal([]byte(clean), &j); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if len(j.Scores) != len(successIdx) {
+		return nil, fmt.Errorf("scores length %d does not match response count %d", len(j.Scores), len(successIdx))
+	}
+
+	// Map scores back to full attempts slice (failed attempts get score 0).
+	fullScores := make([]int, totalAttempts)
+	for i, idx := range successIdx {
+		fullScores[idx] = j.Scores[i]
+	}
+
+	// Validate winner index is in the successful set.
+	isValid := false
+	for _, idx := range successIdx {
+		if j.Winner == idx {
+			isValid = true
+			break
+		}
+	}
+	if !isValid {
+		return nil, fmt.Errorf("winner index %d is not in the successful response set", j.Winner)
+	}
+
+	return &JudgeVerdict{
+		WinnerIndex: j.Winner,
+		Scores:      fullScores,
+		Reason:      j.Reason,
+	}, nil
+}
+
+// ── CapScoreJudge ─────────────────────────────────────────────────────────────
+
+// CapScoreJudge is the deterministic fallback — no LLM call required.
+// The winner is the successful attempt with the highest CapScore.
+// Score = CapScore (0-100).
+type CapScoreJudge struct{}
+
+func (j *CapScoreJudge) Judge(_ context.Context, _ string, attempts []Attempt) (*JudgeVerdict, error) {
+	successful := successfulAttempts(attempts)
+	if len(successful) == 0 {
+		return nil, fmt.Errorf("capscorer: no successful attempts")
+	}
+
+	sort.Slice(successful, func(i, k int) bool {
+		return attempts[successful[i]].Head.CapScore > attempts[successful[k]].Head.CapScore
+	})
+
+	scores := make([]int, len(attempts))
+	for _, idx := range successful {
+		scores[idx] = attempts[idx].Head.CapScore
+	}
+
+	return &JudgeVerdict{
+		WinnerIndex: successful[0],
+		Scores:      scores,
+		Reason:      fmt.Sprintf("ranked by capability score; %s scored highest (%d)", attempts[successful[0]].Head.Name, attempts[successful[0]].Head.CapScore),
+		Meta:        JudgeMeta{UsedFallback: true},
+	}, nil
+}
+
+// ── CompositeJudge ────────────────────────────────────────────────────────────
+
+// CompositeJudge tries the primary judge, falls back to secondary on any error.
+type CompositeJudge struct {
+	primary  Judge
+	fallback Judge
+}
+
+func newCompositeJudge(primary, fallback Judge) *CompositeJudge {
+	return &CompositeJudge{primary: primary, fallback: fallback}
+}
+
+func (j *CompositeJudge) Judge(ctx context.Context, prompt string, attempts []Attempt) (*JudgeVerdict, error) {
+	verdict, err := j.primary.Judge(ctx, prompt, attempts)
+	if err == nil {
+		return verdict, nil
+	}
+
+	verdict, fbErr := j.fallback.Judge(ctx, prompt, attempts)
+	if fbErr != nil {
+		return nil, fmt.Errorf("primary judge: %w; fallback judge: %v", err, fbErr)
+	}
+
+	verdict.Meta.UsedFallback = true
+	verdict.Meta.FallbackReason = err.Error()
+	return verdict, nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// successfulAttempts returns the indices of attempts with StatusOK.
+func successfulAttempts(attempts []Attempt) []int {
+	var out []int
+	for i, a := range attempts {
+		if a.Status == StatusOK {
+			out = append(out, i)
+		}
+	}
+	return out
+}

--- a/internal/swarm/runner.go
+++ b/internal/swarm/runner.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ankit373/hydra/internal/executor"
 	"github.com/ankit373/hydra/internal/provider"
-	"golang.org/x/sync/errgroup"
 )
 
 // executeHead runs one head and returns a completed Attempt.
@@ -47,6 +46,7 @@ func executeHead(ctx context.Context, h provider.Head, prompt string, opts Optio
 	a.Output = resp.Output
 	a.InputTokens = resp.InputTokens
 	a.OutputTokens = resp.OutputTokens
+	a.Truncated = resp.Truncated
 	return a
 }
 
@@ -97,21 +97,24 @@ func runRace(ctx context.Context, heads []provider.Head, prompt string, opts Opt
 
 // runAll fires all heads concurrently and waits for every one to finish.
 // Used by both ModeAll (rank by CapScore) and ModeBest (feed to judge).
+// Uses sync.WaitGroup (not errgroup) — guarantees goroutine drain regardless
+// of errors, preventing zombie agy subprocesses.
 func runAll(ctx context.Context, heads []provider.Head, prompt string, opts Options) []Attempt {
 	attempts := make([]Attempt, len(heads))
 	var mu sync.Mutex
+	var wg sync.WaitGroup
 
-	g, gctx := errgroup.WithContext(ctx)
 	for i, h := range heads {
 		i, h := i, h
-		g.Go(func() error {
-			a := executeHead(gctx, h, prompt, opts)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a := executeHead(ctx, h, prompt, opts)
 			mu.Lock()
 			attempts[i] = a
 			mu.Unlock()
-			return nil // always nil — errors captured in Attempt
-		})
+		}()
 	}
-	_ = g.Wait()
+	wg.Wait()
 	return attempts
 }

--- a/internal/swarm/runner.go
+++ b/internal/swarm/runner.go
@@ -1,0 +1,117 @@
+package swarm
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/provider"
+	"golang.org/x/sync/errgroup"
+)
+
+// executeHead runs one head and returns a completed Attempt.
+// Never returns an error — all failures are captured in Attempt.Status/Err.
+func executeHead(ctx context.Context, h provider.Head, prompt string, opts Options) Attempt {
+	a := Attempt{
+		Head:      h,
+		Status:    StatusRunning,
+		StartedAt: time.Now(),
+	}
+
+	execCtx := ctx
+	var cancel context.CancelFunc
+	if opts.PerHeadTimeout > 0 {
+		execCtx, cancel = context.WithTimeout(ctx, opts.PerHeadTimeout)
+		defer cancel()
+	}
+
+	exec := executor.For(h)
+	resp, err := exec.Execute(execCtx, executor.Request{
+		Prompt:    prompt,
+		Head:      h,
+		MaxTokens: opts.MaxTokens,
+		System:    opts.System,
+	})
+
+	a.FinishedAt = time.Now()
+	a.Duration = a.FinishedAt.Sub(a.StartedAt)
+
+	if err != nil {
+		a.Status = classifyError(err)
+		a.Err = err
+		return a
+	}
+
+	a.Status = StatusOK
+	a.Output = resp.Output
+	a.InputTokens = resp.InputTokens
+	a.OutputTokens = resp.OutputTokens
+	return a
+}
+
+// runRace fires all heads concurrently and returns as soon as the first
+// StatusOK attempt arrives. All other goroutines are canceled and drained
+// before returning — no goroutine leaks, no zombie subprocesses.
+func runRace(ctx context.Context, heads []provider.Head, prompt string, opts Options) []Attempt {
+	raceCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	attempts := make([]Attempt, len(heads))
+	var mu sync.Mutex
+	won := false
+
+	var wg sync.WaitGroup
+	for i, h := range heads {
+		i, h := i, h
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a := executeHead(raceCtx, h, prompt, opts)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if a.Status == StatusOK && !won {
+				won = true
+				cancel() // signal all other goroutines to stop
+				a.Rank = 1
+			}
+			attempts[i] = a
+		}()
+	}
+
+	wg.Wait()
+
+	// Any attempt that didn't finish before cancel is marked Canceled.
+	mu.Lock()
+	defer mu.Unlock()
+	for i := range attempts {
+		if attempts[i].Status == StatusRunning || attempts[i].Status == StatusPending {
+			attempts[i].Status = StatusCanceled
+			attempts[i].Head = heads[i]
+		}
+	}
+	return attempts
+}
+
+// runAll fires all heads concurrently and waits for every one to finish.
+// Used by both ModeAll (rank by CapScore) and ModeBest (feed to judge).
+func runAll(ctx context.Context, heads []provider.Head, prompt string, opts Options) []Attempt {
+	attempts := make([]Attempt, len(heads))
+	var mu sync.Mutex
+
+	g, gctx := errgroup.WithContext(ctx)
+	for i, h := range heads {
+		i, h := i, h
+		g.Go(func() error {
+			a := executeHead(gctx, h, prompt, opts)
+			mu.Lock()
+			attempts[i] = a
+			mu.Unlock()
+			return nil // always nil — errors captured in Attempt
+		})
+	}
+	_ = g.Wait()
+	return attempts
+}

--- a/internal/swarm/selector.go
+++ b/internal/swarm/selector.go
@@ -1,0 +1,151 @@
+package swarm
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+const defaultMaxHeads = 5
+
+// HeadSelector picks which Heads to fire for a given swarm run.
+// Implementations are composable: a filter wraps a base selector.
+type HeadSelector interface {
+	Select(all []provider.Head, opts Options) ([]provider.Head, error)
+}
+
+// resolveSelector picks the right HeadSelector from Options.
+// Priority: explicit HeadIDs > TierHint > top-N by CapScore.
+func resolveSelector(opts Options, cfg *config.Config) HeadSelector {
+	if len(opts.HeadIDs) > 0 {
+		return &IDSelector{}
+	}
+	if opts.TierHint != "" {
+		return &TierSelector{cfg: cfg}
+	}
+	return &CapScoreSelector{}
+}
+
+// ── TierSelector ─────────────────────────────────────────────────────────────
+
+// TierSelector filters to heads assigned to a named tier in config.
+// Falls back to CapScoreSelector when the tier has no live heads.
+type TierSelector struct{ cfg *config.Config }
+
+func (s *TierSelector) Select(all []provider.Head, opts Options) ([]provider.Head, error) {
+	tierIDs := map[string]bool{}
+	for _, t := range s.cfg.Tiers {
+		if t.Name == opts.TierHint {
+			for _, id := range t.Heads {
+				tierIDs[id] = true
+			}
+		}
+	}
+
+	var candidates []provider.Head
+	for _, h := range all {
+		if executable(h) && tierIDs[h.ID] {
+			candidates = append(candidates, h)
+		}
+	}
+
+	if len(candidates) == 0 {
+		// Tier has no live heads — fall back to capability score ranking.
+		return (&CapScoreSelector{}).Select(all, opts)
+	}
+
+	return applyFiltersAndCap(candidates, opts), nil
+}
+
+// ── IDSelector ────────────────────────────────────────────────────────────────
+
+// IDSelector resolves an explicit list of head IDs.
+// Returns an error if any requested ID is not found in the probed set.
+type IDSelector struct{}
+
+func (s *IDSelector) Select(all []provider.Head, opts Options) ([]provider.Head, error) {
+	index := make(map[string]provider.Head, len(all))
+	for _, h := range all {
+		index[h.ID] = h
+	}
+
+	var selected []provider.Head
+	var missing []string
+	for _, id := range opts.HeadIDs {
+		h, ok := index[id]
+		if !ok {
+			missing = append(missing, id)
+			continue
+		}
+		if !executable(h) {
+			continue
+		}
+		selected = append(selected, h)
+	}
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("swarm: head IDs not found or not executable: %v", missing)
+	}
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("swarm: no executable heads in the requested ID list")
+	}
+
+	return applyFiltersAndCap(selected, opts), nil
+}
+
+// ── CapScoreSelector ─────────────────────────────────────────────────────────
+
+// CapScoreSelector picks the top-N executable heads ranked by CapScore descending.
+// Used as default when neither HeadIDs nor TierHint is set, and as fallback
+// when a TierSelector finds no live heads.
+type CapScoreSelector struct{}
+
+func (s *CapScoreSelector) Select(all []provider.Head, opts Options) ([]provider.Head, error) {
+	var candidates []provider.Head
+	for _, h := range all {
+		if executable(h) {
+			candidates = append(candidates, h)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("swarm: no executable heads found")
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].CapScore > candidates[j].CapScore
+	})
+
+	return applyFiltersAndCap(candidates, opts), nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func executable(h provider.Head) bool {
+	return executor.Supports(h)
+}
+
+// applyFiltersAndCap applies MinCapScore filter and MaxHeads cap in one pass.
+func applyFiltersAndCap(heads []provider.Head, opts Options) []provider.Head {
+	maxHeads := opts.MaxHeads
+	if maxHeads <= 0 {
+		maxHeads = defaultMaxHeads
+	}
+
+	var out []provider.Head
+	for _, h := range heads {
+		if opts.LocalOnly && !h.LocalOnly {
+			continue
+		}
+		if opts.MinCapScore > 0 && h.CapScore < opts.MinCapScore {
+			continue
+		}
+		out = append(out, h)
+		if len(out) >= maxHeads {
+			break
+		}
+	}
+	return out
+}

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -1,0 +1,250 @@
+package swarm
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// SwarmMode is the response selection strategy.
+type SwarmMode string
+
+const (
+	ModeRace SwarmMode = "race" // first success wins; all others are canceled
+	ModeBest SwarmMode = "best" // fire all; LLM judge (with CapScore fallback) picks winner
+	ModeAll  SwarmMode = "all"  // fire all; return ranked by CapScore, no judge
+)
+
+// Options configures a swarm run.
+type Options struct {
+	Mode SwarmMode
+
+	// Head selection — at most one of TierHint / HeadIDs should be set.
+	// When both are empty, CapScoreSelector picks the top-N available heads.
+	TierHint    string
+	HeadIDs     []string // explicit head IDs; bypasses tier
+	MinCapScore int      // exclude heads below this score (0 = no filter)
+
+	// Execution constraints.
+	MaxHeads       int           // hard cap on fan-out (0 → defaultMaxHeads = 5)
+	PerHeadTimeout time.Duration // per-head deadline (0 = inherit parent ctx)
+	MaxEstCostUSD  float64       // pre-flight guard; 0 = no limit
+	LocalOnly      bool
+
+	// Prompt parameters.
+	System    string
+	MaxTokens int
+
+	// Judge (ModeBest only).
+	JudgeTierHint string        // "" → use config.Cortex head
+	JudgeTimeout  time.Duration // 0 → 30 s
+}
+
+// SwarmResult is the complete outcome of a swarm dispatch.
+type SwarmResult struct {
+	Mode         SwarmMode
+	Prompt       string
+	Attempts     []Attempt     // all heads, in order fired; some may be Canceled
+	Winner       *Attempt      // nil only when every head failed
+	Verdict      *JudgeVerdict // non-nil only in ModeBest
+	TotalCostUSD float64       // sum of all EstCostUSD
+	WallDuration time.Duration
+	StartedAt    time.Time
+}
+
+// SucceededCount returns the number of attempts that produced output.
+func (r *SwarmResult) SucceededCount() int {
+	n := 0
+	for _, a := range r.Attempts {
+		if a.Status == StatusOK {
+			n++
+		}
+	}
+	return n
+}
+
+// Swarm orchestrates fan-out dispatch. It is stateless after construction;
+// each Run call is independent.
+type Swarm struct {
+	d       *dispatch.Dispatcher
+	heads   []provider.Head
+	pricing PricingReader
+}
+
+// New constructs a Swarm.
+// heads is the already-probed set of live heads (from probe.Run or Dispatcher.Heads).
+// pricing may be nil — cost estimation and pre-flight guard will be skipped.
+func New(d *dispatch.Dispatcher, heads []provider.Head, pricing PricingReader) *Swarm {
+	return &Swarm{d: d, heads: heads, pricing: pricing}
+}
+
+// Run executes the swarm: selects heads, optionally checks cost, fires them,
+// collects results, optionally judges, logs costs.
+func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmResult, error) {
+	if opts.Mode == "" {
+		opts.Mode = ModeBest
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("swarm: config load: %w", err)
+	}
+
+	// 1. Head selection.
+	selector := resolveSelector(opts, cfg)
+	selected, err := selector.Select(s.heads, opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("swarm: no heads available for the requested configuration")
+	}
+
+	// 2. Pre-flight cost guard.
+	_, err = preflightCost(selected, prompt, s.pricing, opts.MaxEstCostUSD)
+	if err != nil {
+		return nil, err
+	}
+
+	// 3. Execute.
+	startedAt := time.Now()
+	var attempts []Attempt
+
+	switch opts.Mode {
+	case ModeRace:
+		attempts = runRace(ctx, selected, prompt, opts)
+	case ModeBest, ModeAll:
+		attempts = runAll(ctx, selected, prompt, opts)
+	default:
+		return nil, fmt.Errorf("swarm: unknown mode %q", opts.Mode)
+	}
+
+	wallDuration := time.Since(startedAt)
+
+	// 4. Enrich cost on each attempt.
+	enrichCosts(attempts, s.pricing)
+
+	// 5. Determine winner + verdict.
+	result := &SwarmResult{
+		Mode:         opts.Mode,
+		Prompt:       prompt,
+		Attempts:     attempts,
+		WallDuration: wallDuration,
+		StartedAt:    startedAt,
+	}
+
+	switch opts.Mode {
+	case ModeRace:
+		result.Winner = raceWinner(attempts)
+	case ModeBest:
+		judge := buildJudge(s.d, opts, cfg)
+		verdict, judgeErr := judge.Judge(ctx, prompt, attempts)
+		if judgeErr == nil && verdict != nil {
+			result.Verdict = verdict
+			winner := &attempts[verdict.WinnerIndex]
+			winner.Rank = 1
+			result.Winner = winner
+			// Apply scores from verdict.
+			for i := range attempts {
+				if i < len(verdict.Scores) {
+					attempts[i].EstCostUSD = attempts[i].EstCostUSD // preserve cost
+				}
+			}
+		} else {
+			// Judge completely failed — fall back to CapScore winner.
+			result.Winner = capScoreWinner(attempts)
+		}
+	case ModeAll:
+		rankByCapScore(attempts)
+		if w := firstSuccessful(attempts); w != nil {
+			result.Winner = w
+		}
+	}
+
+	// 6. Sum total cost.
+	for _, a := range attempts {
+		result.TotalCostUSD += a.EstCostUSD
+	}
+
+	// 7. Log to cost.jsonl.
+	logAttempts(result, truncate(prompt, 80))
+
+	return result, nil
+}
+
+// ── private helpers ───────────────────────────────────────────────────────────
+
+func buildJudge(d *dispatch.Dispatcher, opts Options, cfg *config.Config) Judge {
+	tierHint := opts.JudgeTierHint
+	if tierHint == "" {
+		// Default to the configured Cortex head's tier (tier 1).
+		tierHint = "1"
+	}
+	llm := newLLMJudge(d, tierHint, opts.JudgeTimeout)
+	cap_ := &CapScoreJudge{}
+	return newCompositeJudge(llm, cap_)
+}
+
+func raceWinner(attempts []Attempt) *Attempt {
+	for i := range attempts {
+		if attempts[i].Rank == 1 {
+			return &attempts[i]
+		}
+	}
+	// Fallback: first OK attempt (should not happen if runRace set Rank correctly).
+	return firstSuccessful(attempts)
+}
+
+func capScoreWinner(attempts []Attempt) *Attempt {
+	var best *Attempt
+	for i := range attempts {
+		if attempts[i].Status != StatusOK {
+			continue
+		}
+		if best == nil || attempts[i].Head.CapScore > best.Head.CapScore {
+			best = &attempts[i]
+		}
+	}
+	if best != nil {
+		best.Rank = 1
+	}
+	return best
+}
+
+func rankByCapScore(attempts []Attempt) {
+	type indexed struct {
+		idx  int
+		score int
+	}
+	var ok []indexed
+	for i, a := range attempts {
+		if a.Status == StatusOK {
+			ok = append(ok, indexed{i, a.Head.CapScore})
+		}
+	}
+	sort.Slice(ok, func(i, j int) bool { return ok[i].score > ok[j].score })
+	for rank, item := range ok {
+		attempts[item.idx].Rank = rank + 1
+	}
+}
+
+func firstSuccessful(attempts []Attempt) *Attempt {
+	for i := range attempts {
+		if attempts[i].Status == StatusOK {
+			return &attempts[i]
+		}
+	}
+	return nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
@@ -149,12 +150,6 @@ func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmRes
 			winner := &attempts[verdict.WinnerIndex]
 			winner.Rank = 1
 			result.Winner = winner
-			// Apply scores from verdict.
-			for i := range attempts {
-				if i < len(verdict.Scores) {
-					attempts[i].EstCostUSD = attempts[i].EstCostUSD // preserve cost
-				}
-			}
 		} else {
 			// Judge completely failed — fall back to CapScore winner.
 			result.Winner = capScoreWinner(attempts)
@@ -243,8 +238,9 @@ func firstSuccessful(attempts []Attempt) *Attempt {
 }
 
 func truncate(s string, n int) string {
-	if len(s) <= n {
+	if utf8.RuneCountInString(s) <= n {
 		return s
 	}
-	return s[:n] + "…"
+	runes := []rune(s)
+	return string(runes[:n]) + "…"
 }


### PR DESCRIPTION
## Summary

Implements issue #11: swarm dispatch — fire one prompt at multiple heads simultaneously and pick the best response.

- **3 modes**: `race` (first success wins), `best` (LLM judge picks winner), `all` (return all, ranked by CapScore)
- **Strategy pattern for head selection**: `TierSelector`, `IDSelector`, `CapScoreSelector` — resolved by `Options` at runtime
- **Pluggable judge**: `LLMJudge` → `CapScoreJudge` fallback via `CompositeJudge`; trivial case (1 attempt) short-circuits without LLM call
- **No goroutine leaks**: race mode uses `sync.WaitGroup` + full drain; canceled attempts marked `StatusCanceled`
- **Cost lifecycle**: pre-flight guard → per-attempt enrichment with real token counts → `cost.jsonl` logging with `swarm_mode` / `swarm_winner` fields
- **No circular import**: `PricingReader` interface in swarm; `Dispatcher` implements it via new `Heads()` + `EstimateCost()` public methods
- **CLI flags**: `--swarm`, `--swarm-mode`, `--swarm-heads`, `--swarm-max-heads`, `--swarm-max-cost`, `--swarm-judge-tier`

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `hydra dispatch --swarm --swarm-mode race "hello"` — fires all tier heads, returns first success
- [ ] `hydra dispatch --swarm --swarm-mode best "explain Go interfaces"` — fires all, judge ranks
- [ ] `hydra dispatch --swarm --swarm-mode all "list 5 primes"` — fires all, CapScore ranked table
- [ ] `--swarm-max-cost 0.001` with 5 heads — pre-flight rejects with cost error
- [ ] `--swarm-heads head1,head2` — only specified heads are fired

Closes #11