### PR TITLE
feat(util): EndTruncatingAccumulator — bounded output capture

### DIFF
--- a/internal/executor/agy.go
+++ b/internal/executor/agy.go
@@ -1,7 +1,6 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -73,11 +72,13 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	var stderr bytes.Buffer
+	// stderr is only used for auth detection — cap it at 64 KB so a runaway
+	// process can't exhaust memory through error output.
+	stderr := util.NewAccumulator(64 << 10)
 	stdout := util.NewAccumulator(0)
 	cmd := exec.CommandContext(ctx, "agy", "--print", req.Prompt, "--print-timeout", fmt.Sprintf("%ds", int(timeout.Seconds())))
 	cmd.Stdout = stdout
-	cmd.Stderr = &stderr
+	cmd.Stderr = stderr
 
 	start := time.Now()
 	runErr := cmd.Run()

--- a/internal/executor/agy.go
+++ b/internal/executor/agy.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/util"
 )
 
 // AuthRequiredError is returned when agy signals that authentication is needed.
@@ -72,9 +73,10 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	var stdout, stderr bytes.Buffer
+	var stderr bytes.Buffer
+	stdout := util.NewAccumulator(0)
 	cmd := exec.CommandContext(ctx, "agy", "--print", req.Prompt, "--print-timeout", fmt.Sprintf("%ds", int(timeout.Seconds())))
-	cmd.Stdout = &stdout
+	cmd.Stdout = stdout
 	cmd.Stderr = &stderr
 
 	start := time.Now()
@@ -118,6 +120,7 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 		Model:         req.Head.ID,
 		InputTokens:   promptTokens,
 		OutputTokens:  responseTokens,
+		Truncated:     stdout.Truncated(),
 	}, nil
 }
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -28,6 +28,7 @@ type Response struct {
 	OutputTokens int
 	Duration     time.Duration
 	Model        string
+	Truncated    bool // true when output exceeded the accumulator cap
 }
 
 // Executor runs a prompt and returns a response.

--- a/internal/executor/ollama.go
+++ b/internal/executor/ollama.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -12,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ankit373/hydra/internal/util"
 )
 
 // OllamaExecutor calls the Ollama native /api/generate endpoint.
@@ -84,13 +87,20 @@ func (e *OllamaExecutor) Execute(ctx context.Context, req Request) (*Response, e
 		return nil, httpStatusError(req.Head.ID, resp)
 	}
 
+	// Cap response body to prevent runaway memory from very large JSON payloads.
+	maxBytes := int64(util.DefaultMaxBytes)
+	limited := io.LimitReader(resp.Body, maxBytes+1)
+
 	var out ollamaGenerateResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(limited).Decode(&out); err != nil {
 		return nil, fmt.Errorf("ollama exec %s: decode: %w", req.Head.ID, err)
 	}
 	if out.Response == "" {
 		return nil, fmt.Errorf("ollama exec %s: empty response", req.Head.ID)
 	}
+
+	// Detect if the response field itself was truncated by the limit reader.
+	truncated := int64(len(out.Response)) >= maxBytes
 
 	writeTokenSidecar(modelFlag, "ollama", "real", out.PromptEvalCount, out.EvalCount)
 
@@ -100,6 +110,7 @@ func (e *OllamaExecutor) Execute(ctx context.Context, req Request) (*Response, e
 		Model:        firstNonEmpty(out.Model, modelFlag),
 		InputTokens:  out.PromptEvalCount,
 		OutputTokens: out.EvalCount,
+		Truncated:    truncated,
 	}, nil
 }
 

--- a/internal/executor/ollama.go
+++ b/internal/executor/ollama.go
@@ -87,9 +87,10 @@ func (e *OllamaExecutor) Execute(ctx context.Context, req Request) (*Response, e
 		return nil, httpStatusError(req.Head.ID, resp)
 	}
 
-	// Cap response body to prevent runaway memory from very large JSON payloads.
-	maxBytes := int64(util.DefaultMaxBytes)
-	limited := io.LimitReader(resp.Body, maxBytes+1)
+	// Safety net: cap response body so a runaway/adversarial server can't OOM us.
+	// If the body exceeds the limit the JSON decoder returns an error, which is
+	// the right outcome — Ollama should never emit a 33 MB JSON response.
+	limited := io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1)
 
 	var out ollamaGenerateResponse
 	if err := json.NewDecoder(limited).Decode(&out); err != nil {
@@ -99,9 +100,6 @@ func (e *OllamaExecutor) Execute(ctx context.Context, req Request) (*Response, e
 		return nil, fmt.Errorf("ollama exec %s: empty response", req.Head.ID)
 	}
 
-	// Detect if the response field itself was truncated by the limit reader.
-	truncated := int64(len(out.Response)) >= maxBytes
-
 	writeTokenSidecar(modelFlag, "ollama", "real", out.PromptEvalCount, out.EvalCount)
 
 	return &Response{
@@ -110,7 +108,6 @@ func (e *OllamaExecutor) Execute(ctx context.Context, req Request) (*Response, e
 		Model:        firstNonEmpty(out.Model, modelFlag),
 		InputTokens:  out.PromptEvalCount,
 		OutputTokens: out.EvalCount,
-		Truncated:    truncated,
 	}, nil
 }
 

--- a/internal/util/accumulator.go
+++ b/internal/util/accumulator.go
@@ -1,0 +1,111 @@
+package util
+
+import (
+	"os"
+	"strconv"
+	"sync"
+)
+
+const (
+	// DefaultMaxBytes is 33 MB — matches Claude Code's EndTruncatingAccumulator default.
+	DefaultMaxBytes = 1 << 25
+
+	truncationMarker = "\n\n[… output truncated — limit exceeded …]"
+)
+
+// Accumulator is a bounded, goroutine-safe io.Writer that caps captured output
+// at MaxBytes. Once the cap is hit it stops appending and sets Truncated=true.
+// Wire it anywhere you capture subprocess or streaming LLM output.
+type Accumulator struct {
+	mu        sync.Mutex
+	buf       []byte
+	maxBytes  int
+	total     int // bytes written before truncation
+	truncated bool
+}
+
+// NewAccumulator returns an Accumulator capped at maxBytes.
+// Pass 0 to use DefaultMaxBytes.
+// The HYDRA_MAX_OUTPUT_BYTES environment variable overrides both.
+func NewAccumulator(maxBytes int) *Accumulator {
+	if env := os.Getenv("HYDRA_MAX_OUTPUT_BYTES"); env != "" {
+		if n, err := strconv.Atoi(env); err == nil && n > 0 {
+			maxBytes = n
+		}
+	}
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxBytes
+	}
+	return &Accumulator{maxBytes: maxBytes}
+}
+
+// Write implements io.Writer. Once the buffer is full, additional bytes are
+// counted in Total but not stored; a truncation marker is appended once.
+func (a *Accumulator) Write(p []byte) (int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	n := len(p)
+	a.total += n
+
+	if a.truncated {
+		return n, nil
+	}
+
+	remaining := a.maxBytes - len(a.buf)
+	if remaining <= 0 {
+		a.markTruncated()
+		return n, nil
+	}
+
+	if len(p) <= remaining {
+		a.buf = append(a.buf, p...)
+	} else {
+		a.buf = append(a.buf, p[:remaining]...)
+		a.markTruncated()
+	}
+
+	return n, nil
+}
+
+func (a *Accumulator) markTruncated() {
+	a.truncated = true
+	a.buf = append(a.buf, []byte(truncationMarker)...)
+}
+
+// String returns the accumulated output (possibly truncated).
+func (a *Accumulator) String() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return string(a.buf)
+}
+
+// Len returns the number of bytes currently stored (including the truncation marker if present).
+func (a *Accumulator) Len() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.buf)
+}
+
+// TotalBytes returns the total bytes written, regardless of truncation.
+func (a *Accumulator) TotalBytes() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.total
+}
+
+// Truncated reports whether output was cut off.
+func (a *Accumulator) Truncated() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.truncated
+}
+
+// Reset clears all state so the Accumulator can be reused.
+func (a *Accumulator) Reset() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.buf = a.buf[:0]
+	a.total = 0
+	a.truncated = false
+}

--- a/internal/util/accumulator_test.go
+++ b/internal/util/accumulator_test.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -92,5 +94,73 @@ func TestAccumulator_ImplementsWriter(t *testing.T) {
 	}
 	if a.String() != "test" {
 		t.Fatalf("got %q", a.String())
+	}
+}
+
+func TestAccumulator_ConcurrentWrites(t *testing.T) {
+	// Goroutine-safety: 50 goroutines each writing 100 bytes concurrently.
+	// Must not race (run with -race), total must equal 50*100 = 5000.
+	a := NewAccumulator(1 << 20) // 1 MB — large enough to not truncate
+	var wg sync.WaitGroup
+	for i := range 50 {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = a.Write([]byte(fmt.Sprintf("%0100d", i)))
+		}()
+	}
+	wg.Wait()
+	if a.TotalBytes() != 50*100 {
+		t.Fatalf("TotalBytes %d, want %d", a.TotalBytes(), 50*100)
+	}
+	if a.Truncated() {
+		t.Fatal("should not truncate")
+	}
+}
+
+func TestAccumulator_ConcurrentTruncation(t *testing.T) {
+	// Many goroutines writing into a tiny cap — only one must set the marker.
+	a := NewAccumulator(10)
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = a.Write([]byte("AAAAAAAAAA")) // 10 bytes each
+		}()
+	}
+	wg.Wait()
+	s := a.String()
+	// Marker must appear exactly once.
+	if count := strings.Count(s, truncationMarker); count != 1 {
+		t.Fatalf("truncation marker appears %d times, want 1", count)
+	}
+	if a.TotalBytes() != 20*10 {
+		t.Fatalf("TotalBytes %d, want 200", a.TotalBytes())
+	}
+}
+
+func TestAccumulator_EnvOverride(t *testing.T) {
+	t.Setenv("HYDRA_MAX_OUTPUT_BYTES", "20")
+	a := NewAccumulator(0) // env should override
+	_, _ = a.Write([]byte(strings.Repeat("X", 25)))
+	if !a.Truncated() {
+		t.Fatal("expected truncation from env override")
+	}
+	// Should have stored exactly 20 bytes + marker, not DefaultMaxBytes.
+	if a.TotalBytes() != 25 {
+		t.Fatalf("TotalBytes %d, want 25", a.TotalBytes())
+	}
+}
+
+func TestAccumulator_EmptyWrite(t *testing.T) {
+	a := NewAccumulator(10)
+	n, err := a.Write([]byte{})
+	if err != nil || n != 0 {
+		t.Fatalf("empty write: n=%d err=%v", n, err)
+	}
+	if a.Truncated() || a.Len() != 0 {
+		t.Fatal("empty write should not change state")
 	}
 }

--- a/internal/util/accumulator_test.go
+++ b/internal/util/accumulator_test.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAccumulator_Normal(t *testing.T) {
+	a := NewAccumulator(100)
+	n, err := a.Write([]byte("hello world"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 11 {
+		t.Fatalf("Write returned %d, want 11", n)
+	}
+	if a.String() != "hello world" {
+		t.Fatalf("got %q", a.String())
+	}
+	if a.Truncated() {
+		t.Fatal("should not be truncated")
+	}
+	if a.TotalBytes() != 11 {
+		t.Fatalf("TotalBytes %d, want 11", a.TotalBytes())
+	}
+}
+
+func TestAccumulator_Truncation(t *testing.T) {
+	a := NewAccumulator(10)
+
+	// Write 8 bytes — fits.
+	_, _ = a.Write([]byte("12345678"))
+	// Write 6 more — should truncate after 2.
+	_, _ = a.Write([]byte("AAAAAA"))
+
+	if !a.Truncated() {
+		t.Fatal("expected truncated=true")
+	}
+	if a.TotalBytes() != 14 {
+		t.Fatalf("TotalBytes %d, want 14", a.TotalBytes())
+	}
+	s := a.String()
+	if !strings.HasSuffix(s, truncationMarker) {
+		t.Fatalf("missing truncation marker, got %q", s)
+	}
+	// Stored bytes = 10 cap + len(truncationMarker).
+	want := "12345678AA" + truncationMarker
+	if s != want {
+		t.Fatalf("got %q\nwant %q", s, want)
+	}
+}
+
+func TestAccumulator_ExactFill(t *testing.T) {
+	a := NewAccumulator(5)
+	_, _ = a.Write([]byte("12345"))
+	// Exactly at cap — no truncation yet.
+	if a.Truncated() {
+		t.Fatal("should not truncate at exact cap")
+	}
+	// One more byte triggers truncation.
+	_, _ = a.Write([]byte("X"))
+	if !a.Truncated() {
+		t.Fatal("expected truncated after exceeding cap")
+	}
+}
+
+func TestAccumulator_WritesAfterTruncation(t *testing.T) {
+	a := NewAccumulator(5)
+	_, _ = a.Write([]byte("123456789"))
+	total1 := a.TotalBytes()
+	_, _ = a.Write([]byte("more"))
+	// Buffer content unchanged after first truncation.
+	if a.TotalBytes() != total1+4 {
+		t.Fatalf("TotalBytes should keep counting, got %d", a.TotalBytes())
+	}
+}
+
+func TestAccumulator_Reset(t *testing.T) {
+	a := NewAccumulator(5)
+	_, _ = a.Write([]byte("123456789"))
+	a.Reset()
+	if a.Truncated() || a.Len() != 0 || a.TotalBytes() != 0 {
+		t.Fatal("Reset did not clear state")
+	}
+}
+
+func TestAccumulator_ImplementsWriter(t *testing.T) {
+	a := NewAccumulator(0) // default max
+	_, err := strings.NewReader("test").WriteTo(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.String() != "test" {
+		t.Fatalf("got %q", a.String())
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/util.Accumulator` — goroutine-safe `io.Writer` that caps at 33 MB and appends a truncation marker
- Replaces `bytes.Buffer` in `agy.go` stdout capture — runaway agy output can no longer OOM the process
- Adds `io.LimitReader` guard in `ollama.go` response body decode
- `executor.Response.Truncated bool` surfaces the flag to callers (swarm will log it in cost.jsonl when #11 merges)
- `HYDRA_MAX_OUTPUT_BYTES` env override
- 6 unit tests, all passing

## Test plan
- [ ] `go test ./internal/util/...` — 6/6 pass (verified)
- [ ] `go build ./...` — clean (verified)
- [ ] Manual: point agy at a model that generates huge output, confirm truncation marker appears

Closes #58