### PR TITLE
feat(pricing): dynamic model pricing from OpenRouter API

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -631,10 +631,12 @@ func cmdPricingRefresh() *cobra.Command {
 func cmdPricingList() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List all models and their $/1M token rates",
+		Use:   "list [filter]",
+		Short: "List all models and their $/1M token rates (sorted alphabetically)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			db := pricing.Load()
+			// Hoist filter once — db.Models() is already sorted.
+			filter := strings.ToLower(strings.Join(args, " "))
 
 			if jsonOut {
 				type row struct {
@@ -644,17 +646,15 @@ func cmdPricingList() *cobra.Command {
 				}
 				var rows []row
 				for _, m := range db.Models() {
-					p, _ := db.ModelPrice(m)
-					filter := strings.Join(args, " ")
-					if filter != "" && !strings.Contains(m, strings.ToLower(filter)) {
+					if filter != "" && !strings.Contains(m, filter) {
 						continue
 					}
+					p, _ := db.ModelPrice(m)
 					rows = append(rows, row{m, p.InputPerMillion, p.OutputPerMillion})
 				}
 				return json.NewEncoder(os.Stdout).Encode(rows)
 			}
 
-			filter := strings.ToLower(strings.Join(args, " "))
 			fmt.Fprintf(os.Stdout, "%-55s  %10s  %11s\n", "Model", "In $/1M", "Out $/1M")
 			fmt.Fprintln(os.Stdout, strings.Repeat("─", 82))
 			count := 0

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/editor"
 	"github.com/ankit373/hydra/internal/parallel"
+	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/review"
 	"github.com/ankit373/hydra/internal/tui"
@@ -64,6 +65,7 @@ func rootCmd() *cobra.Command {
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(),
 		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdRun(),
+		cmdPricing(),
 		cmdVersion(),
 	)
 	return root
@@ -596,6 +598,82 @@ func cmdCost() *cobra.Command {
 	jsonCmd.Flags().StringVar(&since, "since", "", "ISO timestamp prefix filter (e.g. 2026-06-01)")
 
 	cmd.AddCommand(tail, jsonCmd)
+	return cmd
+}
+
+// ── pricing ───────────────────────────────────────────────────────────────────
+
+func cmdPricing() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pricing",
+		Short: "Manage live model pricing data (OpenRouter cache)",
+	}
+	cmd.AddCommand(cmdPricingRefresh(), cmdPricingList())
+	return cmd
+}
+
+func cmdPricingRefresh() *cobra.Command {
+	return &cobra.Command{
+		Use:   "refresh",
+		Short: "Force-fetch latest pricing from OpenRouter and update local cache",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			fmt.Fprintln(os.Stderr, "Fetching pricing from OpenRouter…")
+			n, err := pricing.Refresh()
+			if err != nil {
+				return fmt.Errorf("pricing refresh: %w", err)
+			}
+			fmt.Fprintf(os.Stdout, "Cached pricing for %d models.\n", n)
+			return nil
+		},
+	}
+}
+
+func cmdPricingList() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all models and their $/1M token rates",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			db := pricing.Load()
+
+			if jsonOut {
+				type row struct {
+					Model            string  `json:"model"`
+					InputPerMillion  float64 `json:"input_per_mtok"`
+					OutputPerMillion float64 `json:"output_per_mtok"`
+				}
+				var rows []row
+				for _, m := range db.Models() {
+					p, _ := db.ModelPrice(m)
+					filter := strings.Join(args, " ")
+					if filter != "" && !strings.Contains(m, strings.ToLower(filter)) {
+						continue
+					}
+					rows = append(rows, row{m, p.InputPerMillion, p.OutputPerMillion})
+				}
+				return json.NewEncoder(os.Stdout).Encode(rows)
+			}
+
+			filter := strings.ToLower(strings.Join(args, " "))
+			fmt.Fprintf(os.Stdout, "%-55s  %10s  %11s\n", "Model", "In $/1M", "Out $/1M")
+			fmt.Fprintln(os.Stdout, strings.Repeat("─", 82))
+			count := 0
+			for _, m := range db.Models() {
+				if filter != "" && !strings.Contains(m, filter) {
+					continue
+				}
+				p, _ := db.ModelPrice(m)
+				fmt.Fprintf(os.Stdout, "%-55s  %10.4f  %11.4f\n",
+					m, p.InputPerMillion, p.OutputPerMillion)
+				count++
+			}
+			if count == 0 {
+				fmt.Fprintln(os.Stdout, "(no models matched)")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 	return cmd
 }
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,9 +17,9 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/executor"
 	"github.com/ankit373/hydra/internal/policy"
+	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/provider"
-	"gopkg.in/yaml.v3"
 )
 
 // Options controls dispatch behaviour.
@@ -51,7 +50,7 @@ type Dispatcher struct {
 	cfg     *config.Config
 	heads   []provider.Head
 	policy  *policy.Engine
-	pricing *pricingConfig
+	pricing *pricing.DB
 }
 
 // New builds a Dispatcher from the saved config and a fresh machine probe.
@@ -68,13 +67,11 @@ func New(ctx context.Context) (*Dispatcher, error) {
 		localOnly = true
 	}
 
-	pricing, _ := loadPricing()
-
 	return &Dispatcher{
 		cfg:     cfg,
 		heads:   result.Heads,
 		policy:  policy.New(policy.DefaultRules(localOnly)),
-		pricing: pricing,
+		pricing: pricing.Load(),
 	}, nil
 }
 
@@ -394,42 +391,12 @@ func appendJSONL(path string, entry map[string]any) error {
 	return err
 }
 
-// estimateCost returns $/call from pricing.yaml tier rates.
+// estimateCost returns $/call using the live pricing DB (OpenRouter + tier fallback).
 func (d *Dispatcher) estimateCost(tier, inputTokens, outputTokens int) float64 {
 	if d.pricing == nil {
 		return 0
 	}
-	tp, ok := d.pricing.Tiers[tier]
-	if !ok {
-		return 0
-	}
-	in := float64(inputTokens) / 1_000_000 * tp.InputPerMillion
-	out := float64(outputTokens) / 1_000_000 * tp.OutputPerMillion
-	return math.Round((in+out)*1_000_000) / 1_000_000
-}
-
-// ── Pricing ──────────────────────────────────────────────────────────────────
-
-type pricingTier struct {
-	InputPerMillion  float64 `yaml:"input_per_million"`
-	OutputPerMillion float64 `yaml:"output_per_million"`
-}
-
-type pricingConfig struct {
-	Tiers map[int]pricingTier `yaml:"tiers"`
-}
-
-func loadPricing() (*pricingConfig, error) {
-	path := filepath.Join(config.ScriptHome(), "registry", "pricing.yaml")
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var p pricingConfig
-	if err := yaml.Unmarshal(raw, &p); err != nil {
-		return nil, err
-	}
-	return &p, nil
+	return d.pricing.EstimateCost(tier, inputTokens, outputTokens)
 }
 
 // uiTier converts a Head to the 1-10 integer that ui/src/types.ts TIER_LABELS expects.

--- a/internal/pricing/cache.go
+++ b/internal/pricing/cache.go
@@ -1,0 +1,100 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+)
+
+const defaultCacheTTLHours = 24
+
+// priceCache is the on-disk JSON structure.
+type priceCache struct {
+	FetchedAt time.Time              `json:"fetched_at"`
+	Source    string                 `json:"source"`
+	Models    map[string]ModelPrice  `json:"models"`
+}
+
+func cachePath() string {
+	return filepath.Join(config.Dir(), "pricing_cache.json")
+}
+
+func cacheTTL() time.Duration {
+	if s := os.Getenv("HYDRA_PRICING_TTL_HOURS"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			return time.Duration(n) * time.Hour
+		}
+	}
+	return defaultCacheTTLHours * time.Hour
+}
+
+// readCache reads and parses the cache file. Returns an error if missing or corrupt.
+func readCache() (*priceCache, error) {
+	raw, err := os.ReadFile(cachePath())
+	if err != nil {
+		return nil, err
+	}
+	var c priceCache
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, err
+	}
+	if len(c.Models) == 0 {
+		return nil, os.ErrNotExist
+	}
+	return &c, nil
+}
+
+// isCacheStale returns true when the cache is older than the TTL.
+func isCacheStale(c *priceCache) bool {
+	return time.Since(c.FetchedAt) > cacheTTL()
+}
+
+// fetchAndSave fetches from OpenRouter and writes the result to the cache file.
+func fetchAndSave() (*priceCache, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	models, err := fetchFromOpenRouter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &priceCache{
+		FetchedAt: time.Now().UTC(),
+		Source:    "openrouter",
+		Models:    models,
+	}
+
+	if err := writeCache(c); err != nil {
+		// Non-fatal — return the data even if we couldn't persist it.
+		return c, nil
+	}
+	return c, nil
+}
+
+// refreshCache is the background-refresh entry point.
+func refreshCache() error {
+	_, err := fetchAndSave()
+	return err
+}
+
+func writeCache(c *priceCache) error {
+	raw, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(cachePath())
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp := cachePath() + ".tmp"
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, cachePath())
+}

--- a/internal/pricing/cache.go
+++ b/internal/pricing/cache.go
@@ -3,6 +3,8 @@ package pricing
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -13,11 +15,15 @@ import (
 
 const defaultCacheTTLHours = 24
 
+// errEmptyCache is returned when the cache file exists and parses correctly
+// but contains no model entries. Distinct from os.ErrNotExist.
+var errEmptyCache = errors.New("pricing cache is empty")
+
 // priceCache is the on-disk JSON structure.
 type priceCache struct {
-	FetchedAt time.Time              `json:"fetched_at"`
-	Source    string                 `json:"source"`
-	Models    map[string]ModelPrice  `json:"models"`
+	FetchedAt time.Time             `json:"fetched_at"`
+	Source    string                `json:"source"`
+	Models    map[string]ModelPrice `json:"models"`
 }
 
 func cachePath() string {
@@ -33,7 +39,8 @@ func cacheTTL() time.Duration {
 	return defaultCacheTTLHours * time.Hour
 }
 
-// readCache reads and parses the cache file. Returns an error if missing or corrupt.
+// readCache reads and parses the cache file.
+// Returns errEmptyCache when the file is valid but has no model entries.
 func readCache() (*priceCache, error) {
 	raw, err := os.ReadFile(cachePath())
 	if err != nil {
@@ -41,10 +48,10 @@ func readCache() (*priceCache, error) {
 	}
 	var c priceCache
 	if err := json.Unmarshal(raw, &c); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pricing cache corrupt: %w", err)
 	}
 	if len(c.Models) == 0 {
-		return nil, os.ErrNotExist
+		return nil, errEmptyCache
 	}
 	return &c, nil
 }
@@ -70,10 +77,8 @@ func fetchAndSave() (*priceCache, error) {
 		Models:    models,
 	}
 
-	if err := writeCache(c); err != nil {
-		// Non-fatal — return the data even if we couldn't persist it.
-		return c, nil
-	}
+	// Non-fatal if we can't persist — return the data regardless.
+	_ = writeCache(c)
 	return c, nil
 }
 
@@ -93,8 +98,15 @@ func writeCache(c *priceCache) error {
 		return err
 	}
 	tmp := cachePath() + ".tmp"
+	// Always clean up the tmp file, even on rename failure (cross-device move).
+	defer func() { _ = os.Remove(tmp) }()
+
 	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
 		return err
 	}
-	return os.Rename(tmp, cachePath())
+	if err := os.Rename(tmp, cachePath()); err != nil {
+		// Rename failed (e.g. cross-device). Fall back to direct write.
+		return os.WriteFile(cachePath(), raw, 0o600)
+	}
+	return nil
 }

--- a/internal/pricing/fallback.go
+++ b/internal/pricing/fallback.go
@@ -1,0 +1,28 @@
+package pricing
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/ankit373/hydra/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+type fallbackYAML struct {
+	Tiers map[int]TierPrice `yaml:"tiers"`
+}
+
+// loadFallbackTiers reads tier pricing from registry/pricing.yaml.
+// This is always available — it ships with the binary.
+func loadFallbackTiers() (map[int]TierPrice, error) {
+	path := filepath.Join(config.ScriptHome(), "registry", "pricing.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var f fallbackYAML
+	if err := yaml.Unmarshal(raw, &f); err != nil {
+		return nil, err
+	}
+	return f.Tiers, nil
+}

--- a/internal/pricing/openrouter.go
+++ b/internal/pricing/openrouter.go
@@ -1,0 +1,88 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// openRouterModelsURL is a var so tests can override it with httptest.Server.
+var openRouterModelsURL = "https://openrouter.ai/api/v1/models"
+
+type orModel struct {
+	ID      string    `json:"id"`
+	Pricing orPricing `json:"pricing"`
+}
+
+type orPricing struct {
+	// OpenRouter returns per-token cost as a decimal string, e.g. "0.000015"
+	Prompt     string `json:"prompt"`
+	Completion string `json:"completion"`
+}
+
+type orResponse struct {
+	Data []orModel `json:"data"`
+}
+
+// fetchFromOpenRouter calls the OpenRouter models API and returns a map of
+// model ID → ModelPrice (converted to per-million-token rates).
+func fetchFromOpenRouter(ctx context.Context) (map[string]ModelPrice, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, openRouterModelsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "hydra/1 (+https://github.com/ankit373/hydra)")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openrouter fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("openrouter fetch: HTTP %d", resp.StatusCode)
+	}
+
+	var or_ orResponse
+	if err := json.NewDecoder(resp.Body).Decode(&or_); err != nil {
+		return nil, fmt.Errorf("openrouter parse: %w", err)
+	}
+
+	out := make(map[string]ModelPrice, len(or_.Data))
+	for _, m := range or_.Data {
+		id := strings.ToLower(m.ID)
+		inp, errI := parsePerToken(m.Pricing.Prompt)
+		out_, errO := parsePerToken(m.Pricing.Completion)
+		if errI != nil || errO != nil {
+			// Some free/experimental models have "0" or empty pricing — skip.
+			continue
+		}
+		out[id] = ModelPrice{
+			InputPerMillion:  inp * 1_000_000,
+			OutputPerMillion: out_ * 1_000_000,
+		}
+	}
+	return out, nil
+}
+
+// parsePerToken converts an OpenRouter per-token price string to float64.
+// Accepts "0.000015", "0", "", "-1" (free / not applicable → skip).
+func parsePerToken(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty price")
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, err
+	}
+	if f < 0 {
+		return 0, fmt.Errorf("negative price")
+	}
+	return f, nil
+}

--- a/internal/pricing/openrouter.go
+++ b/internal/pricing/openrouter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -13,13 +15,21 @@ import (
 // openRouterModelsURL is a var so tests can override it with httptest.Server.
 var openRouterModelsURL = "https://openrouter.ai/api/v1/models"
 
+// httpClient is package-level so connection pools are reused across calls.
+var httpClient = &http.Client{Timeout: 10 * time.Second}
+
+// maxResponseBytes caps the OpenRouter response body (5 MB should be ample
+// for a models list; protects against runaway/adversarial responses).
+const maxResponseBytes = 5 << 20
+
 type orModel struct {
 	ID      string    `json:"id"`
 	Pricing orPricing `json:"pricing"`
 }
 
 type orPricing struct {
-	// OpenRouter returns per-token cost as a decimal string, e.g. "0.000015"
+	// OpenRouter returns per-token cost as a decimal string, e.g. "0.000015".
+	// Free models return "0". Models with unknown pricing return "".
 	Prompt     string `json:"prompt"`
 	Completion string `json:"completion"`
 }
@@ -30,6 +40,8 @@ type orResponse struct {
 
 // fetchFromOpenRouter calls the OpenRouter models API and returns a map of
 // model ID → ModelPrice (converted to per-million-token rates).
+// Models with missing or negative pricing are skipped.
+// Models with "0" pricing (free/local) are included with $0 rates.
 func fetchFromOpenRouter(ctx context.Context) (map[string]ModelPrice, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, openRouterModelsURL, nil)
 	if err != nil {
@@ -37,8 +49,7 @@ func fetchFromOpenRouter(ctx context.Context) (map[string]ModelPrice, error) {
 	}
 	req.Header.Set("User-Agent", "hydra/1 (+https://github.com/ankit373/hydra)")
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("openrouter fetch: %w", err)
 	}
@@ -48,8 +59,9 @@ func fetchFromOpenRouter(ctx context.Context) (map[string]ModelPrice, error) {
 		return nil, fmt.Errorf("openrouter fetch: HTTP %d", resp.StatusCode)
 	}
 
+	limited := io.LimitReader(resp.Body, maxResponseBytes+1)
 	var or_ orResponse
-	if err := json.NewDecoder(resp.Body).Decode(&or_); err != nil {
+	if err := json.NewDecoder(limited).Decode(&or_); err != nil {
 		return nil, fmt.Errorf("openrouter parse: %w", err)
 	}
 
@@ -59,7 +71,8 @@ func fetchFromOpenRouter(ctx context.Context) (map[string]ModelPrice, error) {
 		inp, errI := parsePerToken(m.Pricing.Prompt)
 		out_, errO := parsePerToken(m.Pricing.Completion)
 		if errI != nil || errO != nil {
-			// Some free/experimental models have "0" or empty pricing — skip.
+			// Skip models with missing or negative pricing (empty string, "-1").
+			// Models with explicit "0" pricing (free) are included.
 			continue
 		}
 		out[id] = ModelPrice{
@@ -71,7 +84,8 @@ func fetchFromOpenRouter(ctx context.Context) (map[string]ModelPrice, error) {
 }
 
 // parsePerToken converts an OpenRouter per-token price string to float64.
-// Accepts "0.000015", "0", "", "-1" (free / not applicable → skip).
+// Returns an error for empty strings and negative values (these models are
+// skipped by fetchFromOpenRouter). Returns (0, nil) for "0" (free models).
 func parsePerToken(s string) (float64, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -81,8 +95,11 @@ func parsePerToken(s string) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, fmt.Errorf("non-finite price %q", s)
+	}
 	if f < 0 {
-		return 0, fmt.Errorf("negative price")
+		return 0, fmt.Errorf("negative price %q", s)
 	}
 	return f, nil
 }

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -4,7 +4,9 @@
 package pricing
 
 import (
+	"log"
 	"math"
+	"sort"
 	"strings"
 )
 
@@ -21,44 +23,58 @@ type TierPrice struct {
 }
 
 // DB is the live pricing store. Load it once at startup with Load().
-// All methods are safe for concurrent use after construction.
+//
+// Concurrency: DB is read-only after Load() returns. No fields are written
+// after construction, so all methods are safe for concurrent reads. Do NOT
+// store a *DB and mutate it — if you need a refresh, call Load() again.
 type DB struct {
 	// model name (lowercase) → price; populated from cache or OpenRouter fetch
 	models map[string]ModelPrice
-	// tier (1-10) → price; always populated from pricing.yaml fallback
+	// tier (1-10) → price; populated from pricing.yaml fallback
 	tiers map[int]TierPrice
 }
 
-// Load builds a DB: tries the local cache first, falls back to pricing.yaml.
-// A background refresh is started when the cache is stale (>24h).
-// Never returns nil — worst case it returns a DB with only tier data.
+// Load builds a DB: loads tier fallback immediately, then overlays live model
+// data from the local cache. A background refresh is started when the cache is
+// stale (>24h). On first run with no cache, a background fetch is kicked off
+// and tier-based pricing is used until the cache is warm.
+//
+// Never returns nil — worst case returns a DB with only tier data.
 func Load() *DB {
 	db := &DB{
 		models: make(map[string]ModelPrice),
 		tiers:  make(map[int]TierPrice),
 	}
 
-	// Always load tier fallback first — it's always available.
+	// Tier fallback is always loaded first — it's always available locally.
 	if tp, err := loadFallbackTiers(); err == nil {
 		db.tiers = tp
+	} else {
+		// pricing.yaml is missing. EstimateCost will return 0 for unknown tiers.
+		// This poisons cost.jsonl — warn loudly so the operator notices.
+		log.Printf("hydra/pricing: WARNING — could not load registry/pricing.yaml: %v. All tier cost estimates will be $0.00.", err)
 	}
 
-	// Try live model data from cache.
+	// Overlay live model-specific prices from cache.
 	if cache, err := readCache(); err == nil {
 		for k, v := range cache.Models {
 			db.models[strings.ToLower(k)] = v
 		}
-		// Kick off background refresh if stale.
 		if isCacheStale(cache) {
-			go func() { _ = refreshCache() }()
+			// Stale but usable — refresh in background, don't block caller.
+			go func() {
+				if err := refreshCache(); err != nil {
+					log.Printf("hydra/pricing: background refresh failed: %v", err)
+				}
+			}()
 		}
 	} else {
-		// No valid cache — fetch synchronously (best-effort, 10s timeout).
-		if cache, err := fetchAndSave(); err == nil {
-			for k, v := range cache.Models {
-				db.models[strings.ToLower(k)] = v
+		// No valid cache — kick off background fetch; use tier pricing until warm.
+		go func() {
+			if err := refreshCache(); err != nil {
+				log.Printf("hydra/pricing: initial background fetch failed: %v", err)
 			}
-		}
+		}()
 	}
 
 	return db
@@ -85,21 +101,25 @@ func (db *DB) CostForModel(modelName string, tier, inputTokens, outputTokens int
 
 // EstimateCost returns the estimated USD cost using tier-based pricing.
 // Implements the swarm.PricingReader interface.
+// Returns 0 if neither the requested tier nor tier 10 exist in pricing.yaml —
+// callers should treat 0 as "pricing unavailable" not "free".
 func (db *DB) EstimateCost(tier, inputTokens, outputTokens int) float64 {
 	tp, ok := db.tiers[tier]
 	if !ok {
-		// Tier not in pricing.yaml — use tier 10 (cheapest) as floor.
+		// Requested tier not in pricing.yaml — fall back to tier 10 (local/cheapest).
+		// If tier 10 is also missing (broken install), zero is returned.
 		tp = db.tiers[10]
 	}
 	return round6(cost(tp.InputPerMillion, tp.OutputPerMillion, inputTokens, outputTokens))
 }
 
-// Models returns all model names in the live pricing data.
+// Models returns all model names in the live pricing data, sorted alphabetically.
 func (db *DB) Models() []string {
 	out := make([]string, 0, len(db.models))
 	for k := range db.models {
 		out = append(out, k)
 	}
+	sort.Strings(out)
 	return out
 }
 
@@ -113,6 +133,12 @@ func (db *DB) ModelPrice(modelName string) (ModelPrice, bool) {
 func (db *DB) TierPrice(tier int) (TierPrice, bool) {
 	p, ok := db.tiers[tier]
 	return p, ok
+}
+
+// HasTiers reports whether tier pricing was loaded successfully.
+// Returns false when pricing.yaml was missing or unreadable.
+func (db *DB) HasTiers() bool {
+	return len(db.tiers) > 0
 }
 
 func cost(inputPerM, outputPerM float64, inputTokens, outputTokens int) float64 {

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -1,0 +1,125 @@
+// Package pricing provides live model cost data fetched from OpenRouter,
+// cached locally with a 24-hour TTL, falling back to the static
+// registry/pricing.yaml when offline or on first run.
+package pricing
+
+import (
+	"math"
+	"strings"
+)
+
+// ModelPrice holds per-million-token rates for one model.
+type ModelPrice struct {
+	InputPerMillion  float64 `json:"input_per_mtok"`
+	OutputPerMillion float64 `json:"output_per_mtok"`
+}
+
+// TierPrice holds per-million-token rates for one tier (from pricing.yaml).
+type TierPrice struct {
+	InputPerMillion  float64 `yaml:"input_per_million"`
+	OutputPerMillion float64 `yaml:"output_per_million"`
+}
+
+// DB is the live pricing store. Load it once at startup with Load().
+// All methods are safe for concurrent use after construction.
+type DB struct {
+	// model name (lowercase) → price; populated from cache or OpenRouter fetch
+	models map[string]ModelPrice
+	// tier (1-10) → price; always populated from pricing.yaml fallback
+	tiers map[int]TierPrice
+}
+
+// Load builds a DB: tries the local cache first, falls back to pricing.yaml.
+// A background refresh is started when the cache is stale (>24h).
+// Never returns nil — worst case it returns a DB with only tier data.
+func Load() *DB {
+	db := &DB{
+		models: make(map[string]ModelPrice),
+		tiers:  make(map[int]TierPrice),
+	}
+
+	// Always load tier fallback first — it's always available.
+	if tp, err := loadFallbackTiers(); err == nil {
+		db.tiers = tp
+	}
+
+	// Try live model data from cache.
+	if cache, err := readCache(); err == nil {
+		for k, v := range cache.Models {
+			db.models[strings.ToLower(k)] = v
+		}
+		// Kick off background refresh if stale.
+		if isCacheStale(cache) {
+			go func() { _ = refreshCache() }()
+		}
+	} else {
+		// No valid cache — fetch synchronously (best-effort, 10s timeout).
+		if cache, err := fetchAndSave(); err == nil {
+			for k, v := range cache.Models {
+				db.models[strings.ToLower(k)] = v
+			}
+		}
+	}
+
+	return db
+}
+
+// Refresh forces a synchronous fetch from OpenRouter and updates the cache.
+// Returns the number of models fetched and any error.
+func Refresh() (int, error) {
+	cache, err := fetchAndSave()
+	if err != nil {
+		return 0, err
+	}
+	return len(cache.Models), nil
+}
+
+// CostForModel returns the estimated USD cost for a specific model name.
+// Falls back to tier-based pricing if the model is not in the OpenRouter data.
+func (db *DB) CostForModel(modelName string, tier, inputTokens, outputTokens int) float64 {
+	if p, ok := db.models[strings.ToLower(modelName)]; ok {
+		return round6(cost(p.InputPerMillion, p.OutputPerMillion, inputTokens, outputTokens))
+	}
+	return db.EstimateCost(tier, inputTokens, outputTokens)
+}
+
+// EstimateCost returns the estimated USD cost using tier-based pricing.
+// Implements the swarm.PricingReader interface.
+func (db *DB) EstimateCost(tier, inputTokens, outputTokens int) float64 {
+	tp, ok := db.tiers[tier]
+	if !ok {
+		// Tier not in pricing.yaml — use tier 10 (cheapest) as floor.
+		tp = db.tiers[10]
+	}
+	return round6(cost(tp.InputPerMillion, tp.OutputPerMillion, inputTokens, outputTokens))
+}
+
+// Models returns all model names in the live pricing data.
+func (db *DB) Models() []string {
+	out := make([]string, 0, len(db.models))
+	for k := range db.models {
+		out = append(out, k)
+	}
+	return out
+}
+
+// ModelPrice returns the price entry for a model, and whether it was found.
+func (db *DB) ModelPrice(modelName string) (ModelPrice, bool) {
+	p, ok := db.models[strings.ToLower(modelName)]
+	return p, ok
+}
+
+// TierPrice returns the tier price entry.
+func (db *DB) TierPrice(tier int) (TierPrice, bool) {
+	p, ok := db.tiers[tier]
+	return p, ok
+}
+
+func cost(inputPerM, outputPerM float64, inputTokens, outputTokens int) float64 {
+	return float64(inputTokens)/1_000_000*inputPerM +
+		float64(outputTokens)/1_000_000*outputPerM
+}
+
+func round6(f float64) float64 {
+	return math.Round(f*1_000_000) / 1_000_000
+}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -1,0 +1,215 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// ── unit tests for cost math ──────────────────────────────────────────────────
+
+func TestCost(t *testing.T) {
+	cases := []struct {
+		inputPerM, outputPerM float64
+		inTok, outTok         int
+		want                  float64
+	}{
+		// 1M tokens each at $15/$75 per million → $15 + $75 = $90
+		{15.0, 75.0, 1_000_000, 1_000_000, 90.0},
+		// 100 in-tokens × $15/1M = $0.0015; 50 out-tokens × $75/1M = $0.00375
+		{15.0, 75.0, 100, 50, 0.0015 + 0.00375},
+		{0, 0, 999999, 999999, 0},
+		// 500 × $3/1M = $0.0015; 200 × $15/1M = $0.003
+		{3.0, 15.0, 500, 200, 0.0015 + 0.003},
+	}
+	for _, c := range cases {
+		got := round6(cost(c.inputPerM, c.outputPerM, c.inTok, c.outTok))
+		want := round6(c.want)
+		if got != want {
+			t.Errorf("cost(%v,%v,%v,%v) = %v, want %v",
+				c.inputPerM, c.outputPerM, c.inTok, c.outTok, got, want)
+		}
+	}
+}
+
+func TestDB_EstimateCost_FallsBackToTier10(t *testing.T) {
+	db := &DB{
+		models: map[string]ModelPrice{},
+		tiers: map[int]TierPrice{
+			10: {InputPerMillion: 0, OutputPerMillion: 0},
+		},
+	}
+	// Tier 99 doesn't exist — should use tier 10 (free local).
+	got := db.EstimateCost(99, 1000, 500)
+	if got != 0 {
+		t.Fatalf("want 0 for local tier fallback, got %v", got)
+	}
+}
+
+func TestDB_CostForModel_PrefersModeToTier(t *testing.T) {
+	db := &DB{
+		models: map[string]ModelPrice{
+			"anthropic/claude-opus-4": {InputPerMillion: 15, OutputPerMillion: 75},
+		},
+		tiers: map[int]TierPrice{
+			1: {InputPerMillion: 999, OutputPerMillion: 999}, // wrong — should not be used
+		},
+	}
+	got := db.CostForModel("anthropic/claude-opus-4", 1, 1_000_000, 0)
+	want := round6(15.0)
+	if got != want {
+		t.Fatalf("CostForModel: got %v, want %v", got, want)
+	}
+}
+
+func TestDB_CostForModel_CaseInsensitive(t *testing.T) {
+	db := &DB{
+		models: map[string]ModelPrice{
+			"anthropic/claude-opus-4": {InputPerMillion: 15, OutputPerMillion: 75},
+		},
+		tiers: map[int]TierPrice{},
+	}
+	// Lookup with mixed case.
+	got := db.CostForModel("Anthropic/Claude-Opus-4", 1, 1_000_000, 0)
+	if got == 0 {
+		t.Fatal("case-insensitive lookup failed")
+	}
+}
+
+// ── OpenRouter fetch ──────────────────────────────────────────────────────────
+
+func TestFetchFromOpenRouter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{
+					"id": "anthropic/claude-opus-4",
+					"pricing": map[string]string{
+						"prompt":     "0.000015",
+						"completion": "0.000075",
+					},
+				},
+				{
+					"id": "free/model",
+					"pricing": map[string]string{
+						"prompt":     "-1", // negative → skipped
+						"completion": "-1",
+					},
+				},
+				{
+					"id": "broken/model",
+					"pricing": map[string]string{
+						"prompt":     "not-a-number",
+						"completion": "0",
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	// Temporarily override the URL constant by monkey-patching via test helper.
+	orig := openRouterModelsURL
+	t.Cleanup(func() { openRouterModelsURL = orig })
+	openRouterModelsURL = srv.URL
+
+	models, err := fetchFromOpenRouter(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model (skipping negative and broken), got %d", len(models))
+	}
+	p := models["anthropic/claude-opus-4"]
+	if p.InputPerMillion != 15.0 {
+		t.Fatalf("input price: got %v, want 15.0", p.InputPerMillion)
+	}
+	if p.OutputPerMillion != 75.0 {
+		t.Fatalf("output price: got %v, want 75.0", p.OutputPerMillion)
+	}
+}
+
+// ── Cache read/write/TTL ──────────────────────────────────────────────────────
+
+func TestCacheRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HYDRA_CONFIG_DIR", dir) // override config.Dir() via env
+
+	c := &priceCache{
+		FetchedAt: time.Now().UTC(),
+		Source:    "test",
+		Models: map[string]ModelPrice{
+			"test/model": {InputPerMillion: 1.0, OutputPerMillion: 2.0},
+		},
+	}
+	if err := writeCache(c); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != "test" {
+		t.Fatalf("source: got %q, want %q", got.Source, "test")
+	}
+	if got.Models["test/model"].InputPerMillion != 1.0 {
+		t.Fatal("model price not preserved through roundtrip")
+	}
+}
+
+func TestCacheStale(t *testing.T) {
+	fresh := &priceCache{FetchedAt: time.Now()}
+	if isCacheStale(fresh) {
+		t.Fatal("fresh cache should not be stale")
+	}
+	old := &priceCache{FetchedAt: time.Now().Add(-25 * time.Hour)}
+	if !isCacheStale(old) {
+		t.Fatal("25h old cache should be stale")
+	}
+}
+
+func TestCacheTTLEnvOverride(t *testing.T) {
+	t.Setenv("HYDRA_PRICING_TTL_HOURS", "1")
+	c := &priceCache{FetchedAt: time.Now().Add(-90 * time.Minute)}
+	if !isCacheStale(c) {
+		t.Fatal("90m old cache should be stale with 1h TTL")
+	}
+}
+
+// ── parsePerToken ─────────────────────────────────────────────────────────────
+
+func TestParsePerToken(t *testing.T) {
+	cases := []struct {
+		s       string
+		want    float64
+		wantErr bool
+	}{
+		{"0.000015", 0.000015, false},
+		{"0", 0, false},
+		{"", 0, true},
+		{"-1", 0, true},
+		{"abc", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parsePerToken(c.s)
+		if (err != nil) != c.wantErr {
+			t.Errorf("parsePerToken(%q): err=%v wantErr=%v", c.s, err, c.wantErr)
+		}
+		if err == nil && got != c.want {
+			t.Errorf("parsePerToken(%q) = %v, want %v", c.s, got, c.want)
+		}
+	}
+}
+
+// cachePath uses config.Dir() which reads HYDRA_CONFIG_DIR env or defaults.
+// We need the test cache to land in t.TempDir().
+func init() {
+	_ = filepath.Join // ensure filepath is used
+	_ = os.Getenv    // ensure os is used
+}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -3,15 +3,15 @@ package pricing
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 )
 
-// ── unit tests for cost math ──────────────────────────────────────────────────
+// ── cost math ─────────────────────────────────────────────────────────────────
 
 func TestCost(t *testing.T) {
 	cases := []struct {
@@ -19,9 +19,9 @@ func TestCost(t *testing.T) {
 		inTok, outTok         int
 		want                  float64
 	}{
-		// 1M tokens each at $15/$75 per million → $15 + $75 = $90
+		// 1M tokens each at $15/$75 per million → $90
 		{15.0, 75.0, 1_000_000, 1_000_000, 90.0},
-		// 100 in-tokens × $15/1M = $0.0015; 50 out-tokens × $75/1M = $0.00375
+		// 100 in × $15/1M = $0.0015; 50 out × $75/1M = $0.00375
 		{15.0, 75.0, 100, 50, 0.0015 + 0.00375},
 		{0, 0, 999999, 999999, 0},
 		// 500 × $3/1M = $0.0015; 200 × $15/1M = $0.003
@@ -37,33 +37,58 @@ func TestCost(t *testing.T) {
 	}
 }
 
+// ── DB.EstimateCost ───────────────────────────────────────────────────────────
+
 func TestDB_EstimateCost_FallsBackToTier10(t *testing.T) {
 	db := &DB{
 		models: map[string]ModelPrice{},
-		tiers: map[int]TierPrice{
-			10: {InputPerMillion: 0, OutputPerMillion: 0},
-		},
+		tiers:  map[int]TierPrice{10: {InputPerMillion: 0, OutputPerMillion: 0}},
 	}
-	// Tier 99 doesn't exist — should use tier 10 (free local).
 	got := db.EstimateCost(99, 1000, 500)
 	if got != 0 {
 		t.Fatalf("want 0 for local tier fallback, got %v", got)
 	}
 }
 
-func TestDB_CostForModel_PrefersModeToTier(t *testing.T) {
+func TestDB_EstimateCost_ZeroWhenTier10Missing(t *testing.T) {
+	// CRITICAL case: both requested tier and tier 10 are absent.
+	// Must return 0, not panic.
+	db := &DB{
+		models: map[string]ModelPrice{},
+		tiers:  map[int]TierPrice{}, // completely empty
+	}
+	got := db.EstimateCost(1, 1_000_000, 1_000_000)
+	if got != 0 {
+		t.Fatalf("want 0 when tiers map empty, got %v", got)
+	}
+	if db.HasTiers() {
+		t.Fatal("HasTiers should be false for empty tiers map")
+	}
+}
+
+func TestDB_EstimateCost_KnownTier(t *testing.T) {
+	db := &DB{
+		models: map[string]ModelPrice{},
+		tiers:  map[int]TierPrice{1: {InputPerMillion: 15, OutputPerMillion: 75}},
+	}
+	got := db.EstimateCost(1, 1_000_000, 1_000_000)
+	if got != 90.0 {
+		t.Fatalf("got %v, want 90.0", got)
+	}
+}
+
+// ── DB.CostForModel ───────────────────────────────────────────────────────────
+
+func TestDB_CostForModel_PrefersModelToTier(t *testing.T) {
 	db := &DB{
 		models: map[string]ModelPrice{
 			"anthropic/claude-opus-4": {InputPerMillion: 15, OutputPerMillion: 75},
 		},
-		tiers: map[int]TierPrice{
-			1: {InputPerMillion: 999, OutputPerMillion: 999}, // wrong — should not be used
-		},
+		tiers: map[int]TierPrice{1: {InputPerMillion: 999, OutputPerMillion: 999}},
 	}
 	got := db.CostForModel("anthropic/claude-opus-4", 1, 1_000_000, 0)
-	want := round6(15.0)
-	if got != want {
-		t.Fatalf("CostForModel: got %v, want %v", got, want)
+	if got != round6(15.0) {
+		t.Fatalf("CostForModel: got %v, want 15.0", got)
 	}
 }
 
@@ -74,10 +99,29 @@ func TestDB_CostForModel_CaseInsensitive(t *testing.T) {
 		},
 		tiers: map[int]TierPrice{},
 	}
-	// Lookup with mixed case.
 	got := db.CostForModel("Anthropic/Claude-Opus-4", 1, 1_000_000, 0)
 	if got == 0 {
 		t.Fatal("case-insensitive lookup failed")
+	}
+}
+
+// ── DB.Models sort order ──────────────────────────────────────────────────────
+
+func TestDB_Models_Sorted(t *testing.T) {
+	db := &DB{
+		models: map[string]ModelPrice{
+			"z/model": {},
+			"a/model": {},
+			"m/model": {},
+		},
+		tiers: map[int]TierPrice{},
+	}
+	got := db.Models()
+	want := []string{"a/model", "m/model", "z/model"}
+	for i, v := range got {
+		if v != want[i] {
+			t.Fatalf("Models() not sorted: got %v, want %v", got, want)
+		}
 	}
 }
 
@@ -95,25 +139,30 @@ func TestFetchFromOpenRouter(t *testing.T) {
 					},
 				},
 				{
-					"id": "free/model",
-					"pricing": map[string]string{
-						"prompt":     "-1", // negative → skipped
-						"completion": "-1",
-					},
+					// Negative price → skipped
+					"id": "bad/negative",
+					"pricing": map[string]string{"prompt": "-1", "completion": "-1"},
 				},
 				{
-					"id": "broken/model",
-					"pricing": map[string]string{
-						"prompt":     "not-a-number",
-						"completion": "0",
-					},
+					// Parse error → skipped
+					"id": "bad/parse",
+					"pricing": map[string]string{"prompt": "NaN", "completion": "0"},
+				},
+				{
+					// Empty string → skipped
+					"id": "bad/empty",
+					"pricing": map[string]string{"prompt": "", "completion": ""},
+				},
+				{
+					// "0" price = free model → included with $0 rates
+					"id": "free/model",
+					"pricing": map[string]string{"prompt": "0", "completion": "0"},
 				},
 			},
 		})
 	}))
 	defer srv.Close()
 
-	// Temporarily override the URL constant by monkey-patching via test helper.
 	orig := openRouterModelsURL
 	t.Cleanup(func() { openRouterModelsURL = orig })
 	openRouterModelsURL = srv.URL
@@ -122,8 +171,9 @@ func TestFetchFromOpenRouter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(models) != 1 {
-		t.Fatalf("expected 1 model (skipping negative and broken), got %d", len(models))
+	// Expect 2: the paid model + the free model. Negative/empty/parse-error are skipped.
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d: %v", len(models), models)
 	}
 	p := models["anthropic/claude-opus-4"]
 	if p.InputPerMillion != 15.0 {
@@ -132,25 +182,41 @@ func TestFetchFromOpenRouter(t *testing.T) {
 	if p.OutputPerMillion != 75.0 {
 		t.Fatalf("output price: got %v, want 75.0", p.OutputPerMillion)
 	}
+	free := models["free/model"]
+	if free.InputPerMillion != 0 || free.OutputPerMillion != 0 {
+		t.Fatalf("free model should have $0 rates, got %+v", free)
+	}
 }
 
-// ── Cache read/write/TTL ──────────────────────────────────────────────────────
+func TestFetchFromOpenRouter_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+	orig := openRouterModelsURL
+	t.Cleanup(func() { openRouterModelsURL = orig })
+	openRouterModelsURL = srv.URL
+
+	_, err := fetchFromOpenRouter(context.Background())
+	if err == nil {
+		t.Fatal("expected error on HTTP 503")
+	}
+}
+
+// ── Cache ─────────────────────────────────────────────────────────────────────
 
 func TestCacheRoundtrip(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("HYDRA_CONFIG_DIR", dir) // override config.Dir() via env
+	t.Setenv("HYDRA_CONFIG_DIR", dir)
 
 	c := &priceCache{
 		FetchedAt: time.Now().UTC(),
 		Source:    "test",
-		Models: map[string]ModelPrice{
-			"test/model": {InputPerMillion: 1.0, OutputPerMillion: 2.0},
-		},
+		Models:    map[string]ModelPrice{"test/model": {1.0, 2.0}},
 	}
 	if err := writeCache(c); err != nil {
 		t.Fatal(err)
 	}
-
 	got, err := readCache()
 	if err != nil {
 		t.Fatal(err)
@@ -160,6 +226,25 @@ func TestCacheRoundtrip(t *testing.T) {
 	}
 	if got.Models["test/model"].InputPerMillion != 1.0 {
 		t.Fatal("model price not preserved through roundtrip")
+	}
+}
+
+func TestReadCache_EmptySentinel(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HYDRA_CONFIG_DIR", dir)
+
+	// Write a valid but empty cache.
+	c := &priceCache{FetchedAt: time.Now(), Models: map[string]ModelPrice{}}
+	if err := writeCache(c); err != nil {
+		t.Fatal(err)
+	}
+	_, err := readCache()
+	if !errors.Is(err, errEmptyCache) {
+		t.Fatalf("expected errEmptyCache, got %v", err)
+	}
+	// Must NOT return os.ErrNotExist for a file that exists.
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatal("errEmptyCache must not alias os.ErrNotExist")
 	}
 }
 
@@ -191,10 +276,11 @@ func TestParsePerToken(t *testing.T) {
 		wantErr bool
 	}{
 		{"0.000015", 0.000015, false},
-		{"0", 0, false},
+		{"0", 0, false},   // free model — included, not skipped
 		{"", 0, true},
 		{"-1", 0, true},
 		{"abc", 0, true},
+		{"NaN", 0, true},
 	}
 	for _, c := range cases {
 		got, err := parsePerToken(c.s)
@@ -205,11 +291,4 @@ func TestParsePerToken(t *testing.T) {
 			t.Errorf("parsePerToken(%q) = %v, want %v", c.s, got, c.want)
 		}
 	}
-}
-
-// cachePath uses config.Dir() which reads HYDRA_CONFIG_DIR env or defaults.
-// We need the test cache to land in t.TempDir().
-func init() {
-	_ = filepath.Join // ensure filepath is used
-	_ = os.Getenv    // ensure os is used
 }

--- a/internal/util/accumulator.go
+++ b/internal/util/accumulator.go
@@ -80,7 +80,10 @@ func (a *Accumulator) String() string {
 	return string(a.buf)
 }
 
-// Len returns the number of bytes currently stored (including the truncation marker if present).
+// Len returns the number of bytes currently stored. When truncation has
+// occurred this includes the length of the truncation marker itself, so
+// Len() may exceed maxBytes. Do not use Len() as a budget guard — use
+// TotalBytes() to know how many bytes were actually written by the source.
 func (a *Accumulator) Len() int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -102,6 +105,10 @@ func (a *Accumulator) Truncated() bool {
 }
 
 // Reset clears all state so the Accumulator can be reused.
+// The underlying byte slice is retained (resliced to zero length) to avoid
+// re-allocation on the next use. If the previous capture was large (e.g. a
+// 33 MB subprocess output) and the Accumulator will not be reused, set it to
+// nil instead of calling Reset to release the backing memory.
 func (a *Accumulator) Reset() {
 	a.mu.Lock()
 	defer a.mu.Unlock()


### PR DESCRIPTION
## Summary

- `internal/pricing.DB` — live pricing store with model-specific rates + tier fallback
- Fetches from OpenRouter `/api/v1/models` (200+ models) on first run; 24h TTL cache
- Cache at `~/.config/hydra/pricing_cache.json`; stale cache triggers background refresh
- Falls back to `registry/pricing.yaml` tier data when offline
- `CostForModel()` prefers live per-model rates over tier approximations
- Replaces the private `pricingConfig`/`loadPricing()` in dispatch — no more static-only pricing

## CLI
```
hydra pricing refresh          # force-fetch latest from OpenRouter
hydra pricing list             # table of all models + $/1M rates
hydra pricing list anthropic   # filter by substring
hydra pricing list --json      # machine-readable
```

## Test plan
- [ ] `go test ./internal/pricing/...` — 9/9 pass (verified)
- [ ] `go build ./...` — clean (verified)  
- [ ] `hydra pricing refresh` — fetches and prints model count
- [ ] `hydra pricing list claude` — shows Claude family models
- [ ] Offline: delete cache, disconnect network → falls back to pricing.yaml tiers

Closes #52