### PR TITLE
feat(stats): hydra stats — per-model/tier/day analytics + swarm winner rate

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -65,7 +65,7 @@ func rootCmd() *cobra.Command {
 	}
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(),
-		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdRun(),
+		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(), cmdRun(),
 		cmdPricing(),
 		cmdVersion(),
 	)
@@ -734,6 +734,137 @@ func cmdCost() *cobra.Command {
 	jsonCmd.Flags().StringVar(&since, "since", "", "ISO timestamp prefix filter (e.g. 2026-06-01)")
 
 	cmd.AddCommand(tail, jsonCmd)
+	return cmd
+}
+
+// ── stats ─────────────────────────────────────────────────────────────────────
+
+func cmdStats() *cobra.Command {
+	var (
+		days      int
+		byModel   bool
+		byTier    bool
+		byDay     bool
+		swarmOnly bool
+		sessionID string
+		jsonOut   bool
+	)
+
+	printJSON := func(v any) {
+		raw, _ := json.MarshalIndent(v, "", "  ")
+		fmt.Println(string(raw))
+	}
+
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "Spend analytics — model, tier, day, and swarm breakdowns",
+		Long: `hydra stats shows cost.jsonl summaries with rich grouping options.
+
+Examples:
+  hydra stats                  # today summary
+  hydra stats --days 7         # last 7 days, grouped by model
+  hydra stats --model          # all-time by model
+  hydra stats --tier           # all-time by tier
+  hydra stats --day            # all-time by day
+  hydra stats --swarm          # swarm-only stats + winner rate
+  hydra stats --session <id>   # single session/task breakdown
+  hydra stats --json           # machine-readable output`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			all, err := cost.LoadAll()
+			if err != nil {
+				return err
+			}
+
+			// Session filter takes priority.
+			if sessionID != "" {
+				var rows []cost.Row
+				for _, r := range all {
+					if r.TaskID == sessionID || r.RunID == sessionID {
+						rows = append(rows, r)
+					}
+				}
+				if len(rows) == 0 {
+					return fmt.Errorf("no entries found for session %q", sessionID)
+				}
+				groups := cost.ByModel(rows)
+				if jsonOut {
+					printJSON(groups)
+					return nil
+				}
+				cost.RenderStatsTable(fmt.Sprintf("session %s", sessionID), groups)
+				return nil
+			}
+
+			rows := cost.FilterDays(all, days)
+
+			period := "all time"
+			if days > 0 {
+				period = fmt.Sprintf("last %d days", days)
+			} else if days == 0 && !byModel && !byTier && !byDay && !swarmOnly {
+				// Default: today
+				rows = cost.FilterDays(all, 1)
+				period = "today"
+			}
+
+			if swarmOnly {
+				s := cost.SwarmStats(rows)
+				if jsonOut {
+					printJSON(s)
+					return nil
+				}
+				cost.RenderSwarmStats(s)
+				return nil
+			}
+
+			if byDay {
+				groups := cost.ByDay(rows)
+				if jsonOut {
+					printJSON(groups)
+					return nil
+				}
+				cost.RenderStatsTable(period+" · by day", groups)
+				return nil
+			}
+
+			if byTier {
+				groups := cost.GroupBy(rows, func(r cost.Row) string {
+					if r.Tier == 0 {
+						return "unknown"
+					}
+					return fmt.Sprintf("tier-%d", r.Tier)
+				})
+				if jsonOut {
+					printJSON(groups)
+					return nil
+				}
+				cost.RenderStatsTable(period+" · by tier", groups)
+				return nil
+			}
+
+			// Default grouping: by model.
+			groups := cost.ByModel(rows)
+			if jsonOut {
+				printJSON(groups)
+				return nil
+			}
+			cost.RenderStatsTable(period+" · by model", groups)
+
+			// Append swarm summary if any swarm rows exist.
+			s := cost.SwarmStats(rows)
+			if s.Runs > 0 {
+				cost.RenderSwarmStats(s)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&days, "days", 0, "show last N days (0 = today by default)")
+	cmd.Flags().BoolVar(&byModel, "model", false, "group by model (default grouping)")
+	cmd.Flags().BoolVar(&byTier, "tier", false, "group by tier")
+	cmd.Flags().BoolVar(&byDay, "day", false, "group by calendar day")
+	cmd.Flags().BoolVar(&swarmOnly, "swarm", false, "swarm-only stats: winner rate, avg wall time, mode breakdown")
+	cmd.Flags().StringVar(&sessionID, "session", "", "filter to a single task_id or run_id")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
 	return cmd
 }
 

--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -31,6 +31,8 @@ type Row struct {
 	Source         string  `json:"source"`
 	TaskID         string  `json:"task_id"`
 	RunID          string  `json:"run_id"`
+	SwarmMode      string  `json:"swarm_mode"`
+	SwarmWinner    bool    `json:"swarm_winner"`
 }
 
 // Totals is an aggregate summary.
@@ -225,6 +227,83 @@ func JSON(since string) ([]Row, error) {
 	return out, nil
 }
 
+// FilterDays returns rows from the last n calendar days (UTC). n=0 returns all.
+func FilterDays(rows []Row, n int) []Row {
+	if n <= 0 {
+		return rows
+	}
+	cutoff := time.Now().UTC().AddDate(0, 0, -n).Format("2006-01-02")
+	var out []Row
+	for _, r := range rows {
+		if len(r.TS) >= 10 && r.TS[:10] >= cutoff {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// ByModel returns per-model totals sorted by cost descending.
+func ByModel(rows []Row) []GroupRow {
+	return groupBy(rows, func(r Row) string {
+		if r.Model == "" {
+			return "unknown"
+		}
+		return r.Model
+	})
+}
+
+// ByDay returns per-day totals sorted by date ascending.
+func ByDay(rows []Row) []GroupRow {
+	groups := groupBy(rows, func(r Row) string {
+		if len(r.TS) >= 10 {
+			return r.TS[:10]
+		}
+		return "unknown"
+	})
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Key < groups[j].Key })
+	return groups
+}
+
+// SwarmSummary holds swarm-specific aggregate stats.
+type SwarmSummary struct {
+	Runs       int     `json:"runs"`
+	WinnerRate float64 `json:"winner_rate"` // fraction 0-1
+	AvgWallMS  int64   `json:"avg_wall_ms"`
+	TotalCost  float64 `json:"total_cost_usd"`
+	ByMode     map[string]int `json:"by_mode"`
+}
+
+// SwarmStats returns aggregated stats for swarm-only rows.
+func SwarmStats(rows []Row) SwarmSummary {
+	var swarmRows []Row
+	for _, r := range rows {
+		if r.SwarmMode != "" {
+			swarmRows = append(swarmRows, r)
+		}
+	}
+	s := SwarmSummary{ByMode: map[string]int{}}
+	s.Runs = len(swarmRows)
+	if s.Runs == 0 {
+		return s
+	}
+	winners := 0
+	var totalWall int64
+	for _, r := range swarmRows {
+		if r.SwarmWinner {
+			winners++
+		}
+		totalWall += r.WallMS
+		s.TotalCost += r.EstCostUSD
+		if r.SwarmMode != "" {
+			s.ByMode[r.SwarmMode]++
+		}
+	}
+	s.WinnerRate = float64(winners) / float64(s.Runs)
+	s.AvgWallMS = totalWall / int64(s.Runs)
+	s.TotalCost = math.Round(s.TotalCost*1_000_000) / 1_000_000
+	return s
+}
+
 // ── Rendering ─────────────────────────────────────────────────────────────────
 
 // RenderSummary prints a human-readable summary.
@@ -261,6 +340,74 @@ func RenderTable(title string, rows []GroupRow) {
 			r.EstCostUSD, r.WallMS/1000)
 	}
 	fmt.Println()
+}
+
+// RenderStatsTable prints the polished stats-command table with comma-formatted numbers.
+func RenderStatsTable(period string, rows []GroupRow) {
+	sep := strings.Repeat("─", 71)
+	fmt.Printf("\nPeriod: %s\n\n", period)
+	fmt.Printf("  %-32s  %6s  %9s  %9s  %10s\n", "Model / Key", "Calls", "In Tok", "Out Tok", "Cost USD")
+	fmt.Println("  " + sep)
+	var totCalls, totIn, totOut int
+	var totCost float64
+	for _, r := range rows {
+		fmt.Printf("  %-32s  %6s  %9s  %9s  %10s\n",
+			truncLabel(r.Key, 32),
+			commaInt(r.Calls),
+			commaInt(r.PromptTokens),
+			commaInt(r.ResponseTokens),
+			fmt.Sprintf("$%.3f", r.EstCostUSD),
+		)
+		totCalls += r.Calls
+		totIn += r.PromptTokens
+		totOut += r.ResponseTokens
+		totCost += r.EstCostUSD
+	}
+	fmt.Println("  " + sep)
+	fmt.Printf("  %-32s  %6s  %9s  %9s  %10s\n",
+		"Total",
+		commaInt(totCalls),
+		commaInt(totIn),
+		commaInt(totOut),
+		fmt.Sprintf("$%.3f", totCost),
+	)
+	fmt.Println()
+}
+
+// RenderSwarmStats prints the swarm-specific summary.
+func RenderSwarmStats(s SwarmSummary) {
+	fmt.Printf("\nSwarm runs: %d  Winner rate: %.0f%%  Avg wall time: %.1fs  Total: $%.4f\n",
+		s.Runs, s.WinnerRate*100, float64(s.AvgWallMS)/1000, s.TotalCost)
+	if len(s.ByMode) > 0 {
+		fmt.Print("Modes:")
+		for mode, count := range s.ByMode {
+			fmt.Printf("  %s=%d", mode, count)
+		}
+		fmt.Println()
+	}
+	fmt.Println()
+}
+
+func commaInt(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if n < 1000 {
+		return s
+	}
+	result := ""
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			result += ","
+		}
+		result += string(c)
+	}
+	return result
+}
+
+func truncLabel(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
 }
 
 // RenderTail prints human-readable tail rows.
@@ -321,6 +468,9 @@ func aggregate(rows []Row) Totals {
 	t.EstCostUSD = math.Round(t.EstCostUSD*1_000_000) / 1_000_000
 	return t
 }
+
+// GroupBy aggregates rows using an arbitrary key function, sorted by cost descending.
+func GroupBy(rows []Row, key func(Row) string) []GroupRow { return groupBy(rows, key) }
 
 func groupBy(rows []Row, key func(Row) string) []GroupRow {
 	m := map[string]*GroupRow{}

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -1,0 +1,134 @@
+package cost
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func makeRow(model string, tier int, inTok, outTok int, costUSD float64, wallMS int64, swarmMode string, swarmWinner bool) Row {
+	return Row{
+		TS:             time.Now().UTC().Format(time.RFC3339),
+		Tier:           tier,
+		Model:          model,
+		PromptTokens:   inTok,
+		ResponseTokens: outTok,
+		EstCostUSD:     costUSD,
+		WallMS:         wallMS,
+		SwarmMode:      swarmMode,
+		SwarmWinner:    swarmWinner,
+	}
+}
+
+func TestFilterDays_Zero(t *testing.T) {
+	rows := []Row{makeRow("m", 1, 100, 50, 0.01, 1000, "", false)}
+	got := FilterDays(rows, 0)
+	if len(got) != 1 {
+		t.Fatalf("FilterDays(0) should return all rows, got %d", len(got))
+	}
+}
+
+func TestFilterDays_Excludes_Old(t *testing.T) {
+	old := Row{TS: "2020-01-01T00:00:00Z", Model: "old"}
+	fresh := makeRow("fresh", 1, 0, 0, 0, 0, "", false)
+	got := FilterDays([]Row{old, fresh}, 1)
+	if len(got) != 1 || got[0].Model != "fresh" {
+		t.Fatalf("FilterDays should exclude old rows, got %v", got)
+	}
+}
+
+func TestByModel_Groups(t *testing.T) {
+	rows := []Row{
+		makeRow("claude", 1, 100, 50, 0.10, 500, "", false),
+		makeRow("claude", 1, 200, 80, 0.20, 600, "", false),
+		makeRow("qwen", 10, 50, 20, 0.00, 200, "", false),
+	}
+	groups := ByModel(rows)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 model groups, got %d", len(groups))
+	}
+	// Sorted by cost descending — claude first.
+	if groups[0].Key != "claude" {
+		t.Fatalf("expected claude first (highest cost), got %s", groups[0].Key)
+	}
+	if groups[0].Calls != 2 {
+		t.Fatalf("claude should have 2 calls, got %d", groups[0].Calls)
+	}
+	if groups[0].PromptTokens != 300 {
+		t.Fatalf("claude prompt tokens: want 300, got %d", groups[0].PromptTokens)
+	}
+}
+
+func TestByDay_Sorted(t *testing.T) {
+	rows := []Row{
+		{TS: "2026-06-14T10:00:00Z", Model: "a", EstCostUSD: 0.01},
+		{TS: "2026-06-12T10:00:00Z", Model: "b", EstCostUSD: 0.02},
+		{TS: "2026-06-13T10:00:00Z", Model: "c", EstCostUSD: 0.03},
+	}
+	groups := ByDay(rows)
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 day groups, got %d", len(groups))
+	}
+	// Must be ascending by date.
+	if groups[0].Key != "2026-06-12" || groups[1].Key != "2026-06-13" || groups[2].Key != "2026-06-14" {
+		t.Fatalf("days not sorted ascending: %v", groups)
+	}
+}
+
+func TestSwarmStats_Empty(t *testing.T) {
+	s := SwarmStats([]Row{makeRow("m", 1, 0, 0, 0, 0, "", false)})
+	if s.Runs != 0 {
+		t.Fatalf("no swarm rows should give Runs=0, got %d", s.Runs)
+	}
+}
+
+func TestSwarmStats_WinnerRate(t *testing.T) {
+	rows := []Row{
+		makeRow("a", 1, 100, 50, 0.01, 1000, "race", true),
+		makeRow("b", 2, 100, 50, 0.01, 800, "race", false),
+		makeRow("c", 3, 100, 50, 0.01, 1200, "race", false),
+		makeRow("d", 1, 100, 50, 0.01, 900, "best", true),
+	}
+	s := SwarmStats(rows)
+	if s.Runs != 4 {
+		t.Fatalf("want 4 swarm runs, got %d", s.Runs)
+	}
+	// 2 winners out of 4 runs = 0.5
+	if fmt.Sprintf("%.2f", s.WinnerRate) != "0.50" {
+		t.Fatalf("want winner rate 0.50, got %.2f", s.WinnerRate)
+	}
+	if s.ByMode["race"] != 3 || s.ByMode["best"] != 1 {
+		t.Fatalf("ByMode wrong: %v", s.ByMode)
+	}
+}
+
+func TestCommaInt(t *testing.T) {
+	cases := [][2]any{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1,000"},
+		{1234567, "1,234,567"},
+	}
+	for _, c := range cases {
+		got := commaInt(c[0].(int))
+		if got != c[1].(string) {
+			t.Errorf("commaInt(%d) = %q, want %q", c[0], got, c[1])
+		}
+	}
+}
+
+func TestGroupBy_Exported(t *testing.T) {
+	rows := []Row{
+		makeRow("a", 1, 0, 0, 0.5, 0, "", false),
+		makeRow("b", 2, 0, 0, 0.3, 0, "", false),
+		makeRow("a", 1, 0, 0, 0.2, 0, "", false),
+	}
+	groups := GroupBy(rows, func(r Row) string { return fmt.Sprintf("tier-%d", r.Tier) })
+	if len(groups) != 2 {
+		t.Fatalf("want 2 groups, got %d", len(groups))
+	}
+	// tier-1 has cost 0.7, tier-2 has 0.3 → tier-1 first
+	if groups[0].Key != "tier-1" {
+		t.Fatalf("expected tier-1 first (highest cost), got %s", groups[0].Key)
+	}
+}


### PR DESCRIPTION
## Summary
- `hydra stats` command with `--days`, `--model`, `--tier`, `--day`, `--swarm`, `--session`, `--json` flags
- `internal/cost`: `FilterDays`, `ByModel`, `ByDay`, `SwarmStats`, `GroupBy` (exported), `RenderStatsTable`, `RenderSwarmStats`
- `Row` struct extended with `SwarmMode`/`SwarmWinner` to match swarm cost log schema
- 8 tests, race-clean

## Usage
```
hydra stats               # today by model
hydra stats --days 7      # last 7 days
hydra stats --tier        # all-time by tier
hydra stats --swarm       # winner rate + mode breakdown
hydra stats --session ID  # filter to task_id or run_id
hydra stats --json        # machine-readable
```

Closes #54