### PR TITLE
fix(executor): route env-key API providers to HTTPExecutor

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -41,7 +41,7 @@ func Supports(h provider.Head) bool {
 	if h.Source == "registry" {
 		return true // agy heads — AgyExecutor handles them
 	}
-	if h.Source == "port" || h.Endpoint != "" {
+	if h.Source == "port" || h.Source == "env" || h.Endpoint != "" {
 		return SupportsHTTP(h)
 	}
 	if _, ok := cliTemplates[h.Provider]; ok {
@@ -54,8 +54,12 @@ func Supports(h provider.Head) bool {
 // For selects the correct Executor for a given Head.
 //   - registry source (agy tiers): AgyExecutor → calls dispatch/agy.sh
 //   - ollama source: OllamaExecutor → native /api/generate
-//   - port source / explicit endpoint: HTTPExecutor → OpenAI-compatible REST
+//   - env source / port source / explicit endpoint: HTTPExecutor → per-provider REST
 //   - everything else: CLIExecutor → subprocess
+//
+// env-key heads (Source=="env") carry no Executable — they are API providers
+// (anthropic, openai, groq, …). HTTPExecutor.Execute dispatches on Head.Provider
+// and already has an adapter for each, so env heads route to HTTP, not CLI.
 func For(h provider.Head) Executor {
 	if h.Source == "registry" {
 		return &AgyExecutor{}
@@ -63,7 +67,7 @@ func For(h provider.Head) Executor {
 	if h.Source == "ollama" || h.Provider == "ollama" {
 		return &OllamaExecutor{}
 	}
-	if h.Source == "port" || h.Endpoint != "" {
+	if h.Source == "port" || h.Source == "env" || h.Endpoint != "" {
 		return &HTTPExecutor{}
 	}
 	return &CLIExecutor{}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,0 +1,85 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+func TestFor_SelectsExecutorBySource(t *testing.T) {
+	cases := []struct {
+		name string
+		head provider.Head
+		want interface{}
+	}{
+		{"registry → agy", provider.Head{Source: "registry", Provider: "anthropic"}, &AgyExecutor{}},
+		{"ollama source → ollama", provider.Head{Source: "ollama", ID: "ollama/qwen2.5"}, &OllamaExecutor{}},
+		{"ollama provider → ollama", provider.Head{Provider: "ollama", ID: "qwen2.5"}, &OllamaExecutor{}},
+		{"env → http", provider.Head{Source: "env", Provider: "anthropic", ID: "env/anthropic"}, &HTTPExecutor{}},
+		{"env openai → http", provider.Head{Source: "env", Provider: "openai", ID: "env/openai"}, &HTTPExecutor{}},
+		{"port → http", provider.Head{Source: "port", Endpoint: "http://localhost:1234"}, &HTTPExecutor{}},
+		{"explicit endpoint → http", provider.Head{Source: "cli", Endpoint: "http://x"}, &HTTPExecutor{}},
+		{"cli → cli", provider.Head{Source: "cli", Provider: "anthropic", Executable: "/usr/bin/claude"}, &CLIExecutor{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := For(tc.head)
+			if typeName(got) != typeName(tc.want) {
+				t.Fatalf("For(%+v) = %T, want %T", tc.head, got, tc.want)
+			}
+		})
+	}
+}
+
+// Regression guard for issue #75: an env-key head must NOT route to CLIExecutor
+// (it has no Executable, so a CLI exec would always fail).
+func TestFor_EnvHeadNeverRoutesToCLI(t *testing.T) {
+	for _, prov := range []string{"anthropic", "openai", "google", "groq", "mistral", "cohere", "bedrock"} {
+		h := provider.Head{Source: "env", Provider: prov, ID: "env/" + prov}
+		if _, isCLI := For(h).(*CLIExecutor); isCLI {
+			t.Fatalf("env head %q routed to CLIExecutor; want HTTPExecutor", h.ID)
+		}
+	}
+}
+
+func TestSupports_EnvHeadsGateOnKey(t *testing.T) {
+	// anthropic gates on ANTHROPIC_API_KEY (SupportsHTTP checks apiKeyFor directly).
+	head := provider.Head{Source: "env", Provider: "anthropic", ID: "env/anthropic"}
+
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	if Supports(head) {
+		t.Fatal("Supports(env/anthropic) = true with no key; want false")
+	}
+
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	if !Supports(head) {
+		t.Fatal("Supports(env/anthropic) = false with key set; want true")
+	}
+}
+
+func TestSupports_NonEnvUnchanged(t *testing.T) {
+	if !Supports(provider.Head{Source: "registry", Provider: "anthropic"}) {
+		t.Fatal("registry head should be supported")
+	}
+	if !Supports(provider.Head{Source: "cli", Provider: "anthropic", Executable: "/usr/bin/claude"}) {
+		t.Fatal("cli head with known template should be supported")
+	}
+	if Supports(provider.Head{Source: "cli", Provider: "unknown-tool", ID: "unknown-tool"}) {
+		t.Fatal("cli head with no template should not be supported")
+	}
+}
+
+func typeName(v interface{}) string {
+	switch v.(type) {
+	case *AgyExecutor:
+		return "agy"
+	case *OllamaExecutor:
+		return "ollama"
+	case *HTTPExecutor:
+		return "http"
+	case *CLIExecutor:
+		return "cli"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
## Summary
Makes Hydra's ~14 advertised API providers **actually executable**, not just discoverable.

## Problem
env-discovered heads (`Source=="env"`: anthropic, openai, groq, together, bedrock, …) carry no `Executable` and no `Endpoint`. `executor.For()` only routed `port`/`Endpoint` heads to `HTTPExecutor`, so env heads fell through to `CLIExecutor` and failed for lack of a binary. The entire per-provider adapter set in `http.go` (871 lines) was unreachable — real execution was limited to agy + Ollama + CLI-on-PATH + LM Studio.

## Fix (surgical — the adapters already exist)
`HTTPExecutor.Execute` already dispatches on `Head.Provider` with an adapter for every env provider, so the fix is only the routing gate:
- `For()`: `Source=="env"` → `HTTPExecutor`
- `Supports()`: `Source=="env"` → `SupportsHTTP(h)`

## Tests
New `internal/executor/executor_test.go`:
- `For()` selection across registry/ollama/env/port/endpoint/cli
- `Supports()` env gating on API key
- regression guard: env heads never route to `CLIExecutor`

## Verification
- `go build ./...` ✅
- `go test ./...` ✅ (executor tests pass; no regressions)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)