### PR TITLE
ci: add Go build/vet/test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  go:
+    name: Go build & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./... -race
+
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds the missing Go job to CI. Until now CI never compiled or tested the Go core.

- `go vet ./...`, `go build ./...`, `go test ./... -race`
- Pinned to `go-version-file: go.mod`

Verified locally: vet/build/test -race all pass.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)