### PR TITLE
refactor: gate experimental 'run' playbook behind HYDRA_EXPERIMENTAL

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -67,10 +67,16 @@ func rootCmd() *cobra.Command {
 	}
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(),
-		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(), cmdRun(),
+		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(),
 		cmdPricing(),
 		cmdVersion(),
 	)
+	// `run` is the experimental playbook state machine — a separate, unproven
+	// subsystem kept off the default product surface. Opt in with HYDRA_EXPERIMENTAL=1.
+	// (Code is preserved, not deleted; this only unregisters the command by default.)
+	if os.Getenv("HYDRA_EXPERIMENTAL") != "" {
+		root.AddCommand(cmdRun())
+	}
 	return root
 }
 


### PR DESCRIPTION
## Summary
Phase 0.4 (non-destructive). Moves the experimental `run` playbook state machine off the default product surface for a single coherent CLI story.

- `cmdRun()` registered only when `HYDRA_EXPERIMENTAL` is set.
- Code preserved (no deletion). `dispatch/*.sh` already marked deprecated (#82).

## Verified
- default `hydra --help` omits `run`
- `HYDRA_EXPERIMENTAL=1 hydra --help` shows `run`
- `go build` / `go vet` / `go test` green

## Not done (deliberately)
Hard-deletion / extraction of `internal/company` + `dispatch/*.sh` to a separate repo — that's a separate explicit call.

Closes #83