### PR TITLE
test(swarm,editor,parallel): backfill unit tests for pure logic

### DIFF
--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -1,0 +1,106 @@
+package editor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractContent(t *testing.T) {
+	body := markerStart + "\nhello\nworld\n" + markerEnd
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"both markers", "prose\n" + body + "\ntrailing", "hello\nworld"},
+		{"end only", "hello\nworld\n" + markerEnd + "\njunk", "hello\nworld"},
+		{"start only", "prose\n" + markerStart + "\nhello\nworld", "hello\nworld"},
+		{"neither", "just some text", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractContent(tt.in); got != tt.want {
+				t.Errorf("extractContent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripOuterFence(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"fenced with lang", "```go\nx := 1\n```", "x := 1"},
+		{"fenced bare", "```\nx := 1\n```", "x := 1"},
+		{"no fence", "x := 1", "x := 1"},
+		{"open fence only", "```go\nx := 1", "x := 1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripOuterFence(tt.in); got != tt.want {
+				t.Errorf("stripOuterFence() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFileExt(t *testing.T) {
+	cases := map[string]string{
+		"foo.ts":       "ts",
+		"a.b.go":       "go",
+		"noext":        "",
+		"/abs/path.py": "py",
+	}
+	for in, want := range cases {
+		if got := fileExt(in); got != want {
+			t.Errorf("fileExt(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFirstLine(t *testing.T) {
+	if got := firstLine("  line1\nline2  "); got != "line1" {
+		t.Errorf("firstLine() = %q, want %q", got, "line1")
+	}
+	if got := firstLine(""); got != "" {
+		t.Errorf("firstLine(empty) = %q, want empty", got)
+	}
+}
+
+// runValidatorCmd must substitute {file} without fragmenting paths and must
+// surface the validator's exit code.
+func TestRunValidatorCmd(t *testing.T) {
+	dir := t.TempDir()
+	present := filepath.Join(dir, "present.txt")
+	if err := os.WriteFile(present, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	absent := filepath.Join(dir, "absent.txt")
+
+	if _, rc := runValidatorCmd("test -f {file}", present); rc != 0 {
+		t.Errorf("validator on existing file: rc = %d, want 0", rc)
+	}
+	if _, rc := runValidatorCmd("test -f {file}", absent); rc == 0 {
+		t.Errorf("validator on missing file: rc = 0, want non-zero")
+	}
+}
+
+// diffStats falls back to in-memory line counting when there is no git root
+// and no backup file.
+func TestDiffStats_InMemory(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(file, []byte("a\nb\nc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	added, removed := diffStats(file, "a\n", "", file+".no-backup", true)
+	if added != 2 || removed != 0 {
+		t.Errorf("diffStats grow: added=%d removed=%d, want 2/0", added, removed)
+	}
+
+	added, removed = diffStats(file, "a\nb\nc\nd\ne\n", "", file+".no-backup", true)
+	if added != 0 || removed != 2 {
+		t.Errorf("diffStats shrink: added=%d removed=%d, want 0/2", added, removed)
+	}
+}

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -1,0 +1,71 @@
+package parallel
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRun_EmptyBatch(t *testing.T) {
+	_, err := Run(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Run(nil) = nil error, want error")
+	}
+}
+
+// Run must reject a batch where two edit tasks target the same file, before
+// dispatching anything.
+func TestRun_DuplicateFileConflict(t *testing.T) {
+	tasks := []Task{
+		{Label: "a", Enum: "SIMPLE", File: "/abs/path/foo.go", Prompt: "x"},
+		{Label: "b", Enum: "SIMPLE", File: "/abs/path/foo.go", Prompt: "y"},
+	}
+	_, err := Run(context.Background(), tasks)
+	if err == nil {
+		t.Fatal("Run(duplicate file) = nil error, want conflict error")
+	}
+	if !strings.Contains(err.Error(), "conflict") {
+		t.Errorf("error = %q, want it to mention conflict", err.Error())
+	}
+}
+
+func TestExtractContent(t *testing.T) {
+	body := markerStart + "\nhello\nworld\n" + markerEnd
+	if got := extractContent("prose\n" + body + "\ntrailing"); got != "hello\nworld" {
+		t.Errorf("extractContent(both) = %q, want %q", got, "hello\nworld")
+	}
+	if got := extractContent("no markers here"); got != "" {
+		t.Errorf("extractContent(none) = %q, want empty", got)
+	}
+}
+
+func TestStripOuterFence(t *testing.T) {
+	if got := stripOuterFence("```ts\nconst x = 1\n```"); got != "const x = 1" {
+		t.Errorf("stripOuterFence() = %q, want %q", got, "const x = 1")
+	}
+}
+
+func TestFileExt(t *testing.T) {
+	if got := fileExt("main.go"); got != "go" {
+		t.Errorf("fileExt = %q, want go", got)
+	}
+	if got := fileExt("Makefile"); got != "" {
+		t.Errorf("fileExt(Makefile) = %q, want empty", got)
+	}
+}
+
+// Result marshals to its raw JSON verbatim.
+func TestResult_MarshalJSON(t *testing.T) {
+	r := Result{raw: json.RawMessage(`{"label":"a","status":"ok"}`)}
+	out, err := json.Marshal(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != `{"label":"a","status":"ok"}` {
+		t.Errorf("Marshal = %s, want raw passthrough", out)
+	}
+	if string(r.Raw()) != `{"label":"a","status":"ok"}` {
+		t.Errorf("Raw() mismatch")
+	}
+}

--- a/internal/swarm/swarm_test.go
+++ b/internal/swarm/swarm_test.go
@@ -1,0 +1,223 @@
+package swarm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// registryHead returns a head that executor.Supports() accepts (Source=="registry"),
+// so selector tests exercise real executability filtering without network.
+func registryHead(id, name string, cap int) provider.Head {
+	return provider.Head{ID: id, Name: name, Provider: "agy", Source: "registry", CapScore: cap}
+}
+
+// ── Attempt / SwarmResult ──────────────────────────────────────────────────────
+
+func TestAttempt_SucceededAndTokens(t *testing.T) {
+	a := Attempt{Status: StatusOK, InputTokens: 30, OutputTokens: 12}
+	if !a.Succeeded() {
+		t.Error("StatusOK should Succeed")
+	}
+	if a.TotalTokens() != 42 {
+		t.Errorf("TotalTokens = %d, want 42", a.TotalTokens())
+	}
+	if (Attempt{Status: StatusFailed}).Succeeded() {
+		t.Error("StatusFailed should not Succeed")
+	}
+}
+
+func TestSwarmResult_SucceededCount(t *testing.T) {
+	r := &SwarmResult{Attempts: []Attempt{
+		{Status: StatusOK}, {Status: StatusFailed}, {Status: StatusOK}, {Status: StatusCanceled},
+	}}
+	if got := r.SucceededCount(); got != 2 {
+		t.Errorf("SucceededCount = %d, want 2", got)
+	}
+}
+
+func TestSuccessfulAttempts(t *testing.T) {
+	got := successfulAttempts([]Attempt{{Status: StatusOK}, {Status: StatusFailed}, {Status: StatusOK}})
+	if len(got) != 2 || got[0] != 0 || got[1] != 2 {
+		t.Errorf("successfulAttempts = %v, want [0 2]", got)
+	}
+}
+
+// ── CapScoreJudge ──────────────────────────────────────────────────────────────
+
+func TestCapScoreJudge_PicksHighest(t *testing.T) {
+	attempts := []Attempt{
+		{Head: registryHead("a", "A", 70), Status: StatusOK},
+		{Head: registryHead("b", "B", 90), Status: StatusOK},
+		{Head: registryHead("c", "C", 50), Status: StatusFailed},
+	}
+	v, err := (&CapScoreJudge{}).Judge(context.Background(), "", attempts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.WinnerIndex != 1 {
+		t.Errorf("WinnerIndex = %d, want 1 (highest CapScore)", v.WinnerIndex)
+	}
+	if v.Scores[1] != 90 || v.Scores[0] != 70 {
+		t.Errorf("Scores = %v, want [70 90 0]", v.Scores)
+	}
+	if v.Scores[2] != 0 {
+		t.Errorf("failed attempt should score 0, got %d", v.Scores[2])
+	}
+}
+
+func TestCapScoreJudge_NoSuccess(t *testing.T) {
+	_, err := (&CapScoreJudge{}).Judge(context.Background(), "", []Attempt{{Status: StatusFailed}})
+	if err == nil {
+		t.Fatal("expected error when no attempt succeeded")
+	}
+}
+
+// ── CompositeJudge ─────────────────────────────────────────────────────────────
+
+type stubJudge struct {
+	verdict *JudgeVerdict
+	err     error
+}
+
+func (s stubJudge) Judge(context.Context, string, []Attempt) (*JudgeVerdict, error) {
+	return s.verdict, s.err
+}
+
+func TestCompositeJudge_PrimarySucceeds(t *testing.T) {
+	primary := stubJudge{verdict: &JudgeVerdict{WinnerIndex: 0}}
+	fallback := stubJudge{err: errors.New("should not be called")}
+	v, err := newCompositeJudge(primary, fallback).Judge(context.Background(), "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Meta.UsedFallback {
+		t.Error("UsedFallback should be false when primary succeeds")
+	}
+}
+
+func TestCompositeJudge_FallsBack(t *testing.T) {
+	primary := stubJudge{err: errors.New("primary boom")}
+	fallback := stubJudge{verdict: &JudgeVerdict{WinnerIndex: 2}}
+	v, err := newCompositeJudge(primary, fallback).Judge(context.Background(), "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !v.Meta.UsedFallback {
+		t.Error("UsedFallback should be true after fallback")
+	}
+	if v.Meta.FallbackReason != "primary boom" {
+		t.Errorf("FallbackReason = %q, want %q", v.Meta.FallbackReason, "primary boom")
+	}
+}
+
+func TestCompositeJudge_BothFail(t *testing.T) {
+	primary := stubJudge{err: errors.New("p")}
+	fallback := stubJudge{err: errors.New("f")}
+	if _, err := newCompositeJudge(primary, fallback).Judge(context.Background(), "", nil); err == nil {
+		t.Fatal("expected error when both judges fail")
+	}
+}
+
+// ── Cost ───────────────────────────────────────────────────────────────────────
+
+type fakePricing struct{ per float64 }
+
+func (f fakePricing) EstimateCost(_ int, _, _ int) float64 { return f.per }
+
+func TestPreflightCost(t *testing.T) {
+	heads := []provider.Head{registryHead("a", "A", 90), registryHead("b", "B", 80), registryHead("c", "C", 70)}
+	pr := fakePricing{per: 0.01}
+
+	total, err := preflightCost(heads, "some prompt", pr, 0.05)
+	if err != nil {
+		t.Fatalf("under budget should not error: %v", err)
+	}
+	if total != 0.03 {
+		t.Errorf("total = %v, want 0.03", total)
+	}
+
+	if _, err := preflightCost(heads, "some prompt", pr, 0.02); err == nil {
+		t.Error("over budget should error")
+	}
+
+	if total, err := preflightCost(heads, "p", nil, 0.05); err != nil || total != 0 {
+		t.Errorf("nil pricing: total=%v err=%v, want 0/nil", total, err)
+	}
+	if total, err := preflightCost(heads, "p", pr, 0); err != nil || total != 0 {
+		t.Errorf("no limit: total=%v err=%v, want 0/nil", total, err)
+	}
+}
+
+func TestEnrichCosts(t *testing.T) {
+	attempts := []Attempt{
+		{Head: registryHead("a", "A", 90), Status: StatusOK, InputTokens: 100, OutputTokens: 50},
+		{Head: registryHead("b", "B", 80), Status: StatusFailed},
+	}
+	enrichCosts(attempts, fakePricing{per: 0.02})
+	if attempts[0].EstCostUSD != 0.02 {
+		t.Errorf("OK attempt cost = %v, want 0.02", attempts[0].EstCostUSD)
+	}
+	if attempts[1].EstCostUSD != 0 {
+		t.Errorf("failed attempt cost = %v, want 0 (untouched)", attempts[1].EstCostUSD)
+	}
+}
+
+func TestRound6(t *testing.T) {
+	if got := round6(0.123456789); got != 0.123457 {
+		t.Errorf("round6 = %v, want 0.123457", got)
+	}
+}
+
+// ── Selectors ──────────────────────────────────────────────────────────────────
+
+func TestIDSelector(t *testing.T) {
+	all := []provider.Head{registryHead("h1", "H1", 90), registryHead("h2", "H2", 80), registryHead("h3", "H3", 70)}
+
+	got, err := (&IDSelector{}).Select(all, Options{HeadIDs: []string{"h1", "h3"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("selected %d heads, want 2", len(got))
+	}
+
+	if _, err := (&IDSelector{}).Select(all, Options{HeadIDs: []string{"h1", "missing"}}); err == nil {
+		t.Error("missing head ID should error")
+	}
+}
+
+func TestCapScoreSelector_SortsDescending(t *testing.T) {
+	all := []provider.Head{registryHead("lo", "Lo", 50), registryHead("hi", "Hi", 90), registryHead("mid", "Mid", 70)}
+	got, err := (&CapScoreSelector{}).Select(all, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0].ID != "hi" || got[1].ID != "mid" || got[2].ID != "lo" {
+		t.Errorf("order = %v, want hi>mid>lo", []string{got[0].ID, got[1].ID, got[2].ID})
+	}
+}
+
+func TestCapScoreSelector_NoExecutableHeads(t *testing.T) {
+	// A cli-sourced head with no known template is not executable.
+	all := []provider.Head{{ID: "x", Source: "cli", Provider: "unknown-vendor"}}
+	if _, err := (&CapScoreSelector{}).Select(all, Options{}); err == nil {
+		t.Error("expected error when no heads are executable")
+	}
+}
+
+func TestCapScoreSelector_MaxHeadsCap(t *testing.T) {
+	var all []provider.Head
+	for i, id := range []string{"a", "b", "c", "d"} {
+		all = append(all, registryHead(id, id, 90-i))
+	}
+	got, err := (&CapScoreSelector{}).Select(all, Options{MaxHeads: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Errorf("MaxHeads=2 returned %d heads", len(got))
+	}
+}


### PR DESCRIPTION
## Summary
`internal/swarm`, `internal/editor`, and `internal/parallel` had **zero test files**. This backfills focused unit tests over their deterministic, non-network logic — the parts most likely to regress silently, and the foundation Phase 2 (SPRT) builds on.

## Coverage added
- **editor** — `extractContent` (all four marker-presence cases), `stripOuterFence`, `fileExt`, `firstLine`, `runValidatorCmd` (`{file}` substitution + exit-code capture), `diffStats` in-memory line counting.
- **parallel** — `Run` pre-flight (empty batch → error, duplicate-file target → conflict error, both before any dispatch), marker/fence/ext helpers, `Result` raw-JSON passthrough.
- **swarm** — `Attempt.Succeeded`/`TotalTokens`, `SwarmResult.SucceededCount`, `successfulAttempts`, `CapScoreJudge` ranking + no-success error, `CompositeJudge` (primary-succeeds / falls-back-with-reason / both-fail), `preflightCost` + `enrichCosts` with a fake `PricingReader`, `round6`, `IDSelector` + `CapScoreSelector` (descending sort, `MaxHeads` cap, executability filter).

## Verification
- `go vet ./...` — clean
- `go test ./... -race` — green
- No network or real-subprocess dependencies (validator tests use `test -f`).

## Follow-up (filed separately)
Noticed while here: swarm's `logAttempts`/`costSource` still uses the pre-#90 `InputTokens>0 → "real"` heuristic and does not emit `tokens_source`/`cost_source`. Tracked in a separate issue — needs `TokensEstimated` plumbed through the runner into `Attempt`.

Closes #91