### PR TITLE
fix(cost): unify token-source labeling across dispatch and swarm

### DIFF
--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -66,6 +66,20 @@ type SummaryResult struct {
 	EstimatedTokens int `json:"estimated_tokens"`
 }
 
+// SourceLabels returns the cost.jsonl provenance labels for a token count that
+// was either reported by the provider (estimated=false) or estimated by Hydra
+// (estimated=true, e.g. agy's char/4). It is the single source of truth for
+// these labels so the dispatch and swarm log paths cannot drift.
+//   - tokensSource: "actual" | "estimated"
+//   - costSource:   always "estimated" (est_cost_usd is pricing × tokens, never billed)
+//   - legacySource: "real" | "estimate" — mirrors tokensSource for older readers
+func SourceLabels(estimated bool) (tokensSource, costSource, legacySource string) {
+	if estimated {
+		return "estimated", "estimated", "estimate"
+	}
+	return "actual", "estimated", "real"
+}
+
 // tokensEstimated reports whether a row's tokens were estimated rather than
 // reported by the provider. New rows carry tokens_source; legacy rows fall
 // back to the old `source` field ("estimate" → estimated).

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -133,6 +133,19 @@ func TestTokenSourceShare(t *testing.T) {
 	}
 }
 
+func TestSourceLabels(t *testing.T) {
+	// estimated=true → estimated everywhere, legacy "estimate"
+	ts, cs, ls := SourceLabels(true)
+	if ts != "estimated" || cs != "estimated" || ls != "estimate" {
+		t.Errorf("SourceLabels(true) = %q/%q/%q, want estimated/estimated/estimate", ts, cs, ls)
+	}
+	// estimated=false → actual tokens, but cost is still derived, legacy "real"
+	ts, cs, ls = SourceLabels(false)
+	if ts != "actual" || cs != "estimated" || ls != "real" {
+		t.Errorf("SourceLabels(false) = %q/%q/%q, want actual/estimated/real", ts, cs, ls)
+	}
+}
+
 func TestTokensEstimated_Precedence(t *testing.T) {
 	// tokens_source wins over legacy source when both are present.
 	if tokensEstimated(Row{TokensSource: "actual", Source: "estimate"}) {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ankit373/hydra/internal/budget"
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/cost"
 	"github.com/ankit373/hydra/internal/executor"
 	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/pricing"
@@ -381,19 +382,12 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options) error {
 
 	// cost.jsonl only written when we have token data.
 	if r.Response.InputTokens > 0 || r.Response.OutputTokens > 0 {
-		// tokens_source reflects whether the provider reported usage (actual)
-		// or Hydra estimated it (estimated, e.g. agy char/4). cost_source is
-		// always "estimated": est_cost_usd is derived from pricing × tokens,
-		// never a billed figure. `source` is retained for backward-compat with
-		// older readers and mirrors tokens_source.
-		tokensSource := "actual"
-		if r.Response.TokensEstimated {
-			tokensSource = "estimated"
-		}
-		legacySource := "real"
-		if r.Response.TokensEstimated {
-			legacySource = "estimate"
-		}
+		// Provenance labels come from cost.SourceLabels so dispatch and swarm
+		// stay in lock-step: tokens_source reflects whether the provider
+		// reported usage or Hydra estimated it (agy char/4); cost_source is
+		// always "estimated" (est_cost_usd is pricing × tokens, never billed);
+		// the legacy `source` field mirrors tokens_source for older readers.
+		tokensSource, costSource, legacySource := cost.SourceLabels(r.Response.TokensEstimated)
 		costEntry := map[string]any{
 			"ts":             time.Now().UTC().Format(time.RFC3339),
 			"tier":           tier,
@@ -406,7 +400,7 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options) error {
 			"est_cost_usd":   estCost,
 			"wall_ms":        wallMs,
 			"tokens_source":  tokensSource,
-			"cost_source":    "estimated",
+			"cost_source":    costSource,
 			"source":         legacySource,
 			"task_id":        os.Getenv("HYDRA_TASK_ID"),
 			"run_id":         os.Getenv("HYDRA_RUN_ID"),

--- a/internal/swarm/attempt.go
+++ b/internal/swarm/attempt.go
@@ -32,10 +32,11 @@ type Attempt struct {
 	Status       HeadStatus
 	Output       string
 	Truncated    bool // true when output was capped by the accumulator
-	InputTokens  int
-	OutputTokens int
-	Duration     time.Duration
-	EstCostUSD   float64
+	InputTokens     int
+	OutputTokens    int
+	TokensEstimated bool // true when tokens were estimated (agy char/4), not provider-reported
+	Duration        time.Duration
+	EstCostUSD      float64
 	Err          error // original typed error — never stringified before display
 	StartedAt    time.Time
 	FinishedAt   time.Time

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/cost"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
 )
@@ -72,6 +73,8 @@ func logAttempts(result *SwarmResult, promptPreview string) {
 		if a.Status == StatusPending || a.Status == StatusCanceled {
 			continue
 		}
+		// Shared with the dispatch log path — see cost.SourceLabels.
+		tokensSource, costSrc, legacySource := cost.SourceLabels(a.TokensEstimated)
 		entry := map[string]any{
 			"ts":              a.FinishedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
 			"tier":            rank.UITier(a.Head),
@@ -82,7 +85,9 @@ func logAttempts(result *SwarmResult, promptPreview string) {
 			"response_tokens": a.OutputTokens,
 			"est_cost_usd":    a.EstCostUSD,
 			"wall_ms":         a.Duration.Milliseconds(),
-			"source":          costSource(a),
+			"tokens_source":   tokensSource,
+			"cost_source":     costSrc,
+			"source":          legacySource,
 			"swarm_mode":      string(result.Mode),
 			"swarm_winner":    a.Status == StatusOK && a.Rank == 1,
 			"task_id":         taskID,
@@ -92,13 +97,6 @@ func logAttempts(result *SwarmResult, promptPreview string) {
 		raw, _ := json.Marshal(entry)
 		_, _ = fmt.Fprintln(f, string(raw))
 	}
-}
-
-func costSource(a Attempt) string {
-	if a.InputTokens > 0 {
-		return "real"
-	}
-	return "estimate"
 }
 
 func round6(f float64) float64 {

--- a/internal/swarm/runner.go
+++ b/internal/swarm/runner.go
@@ -46,6 +46,7 @@ func executeHead(ctx context.Context, h provider.Head, prompt string, opts Optio
 	a.Output = resp.Output
 	a.InputTokens = resp.InputTokens
 	a.OutputTokens = resp.OutputTokens
+	a.TokensEstimated = resp.TokensEstimated
 	a.Truncated = resp.Truncated
 	return a
 }


### PR DESCRIPTION
## Summary
#90 fixed the **dispatch** cost path to distinguish actual vs estimated tokens, but the **swarm** path was left on the old `InputTokens>0 → "real"` heuristic and never emitted `tokens_source`/`cost_source`. Result: agy swarm attempts (char/4 estimates) were logged as *measured*, and swarm rows in `cost.jsonl` had a different schema than dispatch rows written to the same file.

## Changes
- `internal/cost/cost.go` — new `SourceLabels(estimated bool)` returning `(tokens_source, cost_source, legacy source)`; the single source of truth for these labels.
- `internal/dispatch/dispatch.go` — call `cost.SourceLabels` instead of inlining the labels.
- `internal/swarm/attempt.go` — `Attempt.TokensEstimated`.
- `internal/swarm/runner.go` — populate it from `executor.Response.TokensEstimated`.
- `internal/swarm/cost.go` — `logAttempts` emits `tokens_source` + `cost_source` via `SourceLabels`; divergent `costSource()` deleted.
- `internal/cost/cost_test.go` — cover `SourceLabels`.

Both log paths now share one schema and one labeling rule — no duplicate, drift-prone logic.

## Verification
- `go build ./... && go vet ./...` — clean
- `go test ./... -race` — green

Closes #93