### PR TITLE
feat(trust): calibration engine + defect-cost model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -659,7 +659,7 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/policy` | Allow/deny rules (PII local-only, etc.) |
 | `internal/rank` | CapScore ranking helpers |
 | `internal/config` | Hydra config load/save (`~/.config/hydra/`) |
-| `internal/company` | Playbook run state machine (multi-stage AI workflows) |
+| `internal/trust` | Trust Control Plane confidence layer: per-source calibration (Beta-Bernoulli → LLR/D) + defect-cost model. `hydra trust`. SPRT ensemble is Phase 2 (not yet shipped). |
 | `internal/tui` | Bubble Tea TUI: init wizard, install flow |
 | `internal/review` | Code review subcommand |
 | `internal/editor` | Editor integration |

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/review"
 	"github.com/ankit373/hydra/internal/swarm"
+	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/tui"
 	"github.com/ankit373/hydra/internal/update"
 
@@ -67,7 +68,7 @@ func rootCmd() *cobra.Command {
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(),
 		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(),
-		cmdPricing(),
+		cmdPricing(), cmdTrust(),
 		cmdVersion(),
 	)
 	return root
@@ -1052,6 +1053,122 @@ func cmdPricingList() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+	return cmd
+}
+
+// ── trust ───────────────────────────────────────────────────────────────────────
+
+func cmdTrust() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trust",
+		Short: "Confidence layer: source calibration and defect-cost (Trust Control Plane)",
+	}
+	cmd.AddCommand(cmdTrustCalibration(), cmdTrustRecord(), cmdTrustDefect())
+	return cmd
+}
+
+func cmdTrustCalibration() *cobra.Command {
+	var domain string
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "calibration",
+		Short: "Per-source sensitivity / specificity / diagnostic power (D)",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cal, err := trust.New(trust.DefaultPath())
+			if err != nil {
+				return err
+			}
+			stats := cal.Report()
+			if domain != "" {
+				filtered := stats[:0]
+				for _, s := range stats {
+					if s.Domain == domain {
+						filtered = append(filtered, s)
+					}
+				}
+				stats = filtered
+			}
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(stats)
+			}
+			if len(stats) == 0 {
+				fmt.Println("\n  No calibration recorded yet. Feed outcomes with `hydra trust record`.")
+				return nil
+			}
+			fmt.Printf("\n  %-28s %-10s %6s %7s %7s %8s\n", "Source", "Domain", "n", "se", "sp", "D(nats)")
+			fmt.Println("  " + strings.Repeat("─", 74))
+			for _, s := range stats {
+				fmt.Printf("  %-28.28s %-10.10s %6.0f %7.3f %7.3f %8.3f\n",
+					s.Source, s.Domain, s.N, s.Se, s.Sp, s.D)
+			}
+			fmt.Println()
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&domain, "domain", "", "filter to one domain")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
+	return cmd
+}
+
+func cmdTrustRecord() *cobra.Command {
+	var source, domain, outcome string
+	var saidCorrect bool
+	cmd := &cobra.Command{
+		Use:   "record",
+		Short: "Record a source's verdict + ground-truth outcome to train calibration",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			o := trust.ParseOutcome(outcome)
+			if o == trust.OutcomeUnknown {
+				return fmt.Errorf("--outcome must be correct|incorrect (got %q)", outcome)
+			}
+			if source == "" {
+				return fmt.Errorf("--source is required")
+			}
+			cal, err := trust.New(trust.DefaultPath())
+			if err != nil {
+				return err
+			}
+			if err := cal.Update(source, domain, saidCorrect, o); err != nil {
+				return err
+			}
+			fmt.Printf("  recorded: %s/%s said_correct=%v outcome=%s → D=%.3f nats\n",
+				source, domain, saidCorrect, outcome, cal.D(source, domain))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&source, "source", "", "evidence source, e.g. model:claude-sonnet or verifier:tests")
+	cmd.Flags().StringVar(&domain, "domain", "", "task domain")
+	cmd.Flags().BoolVar(&saidCorrect, "said-correct", false, "the source's raw verdict")
+	cmd.Flags().StringVar(&outcome, "outcome", "", "ground truth: correct|incorrect")
+	return cmd
+}
+
+func cmdTrustDefect() *cobra.Command {
+	var domain string
+	var blast float64
+	var irreversible, pii, production bool
+	cmd := &cobra.Command{
+		Use:   "defect",
+		Short: "Preview the modeled cost of shipping a wrong answer for a task",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			dm := trust.NewDefectModel()
+			task := trust.Task{
+				Domain:       domain,
+				BlastRadius:  blast,
+				Irreversible: irreversible,
+				TouchesPII:   pii,
+				Production:   production,
+			}
+			fmt.Printf("  defect cost ≈ $%.2f  (blast=%.1f irreversible=%v pii=%v prod=%v)\n",
+				dm.CostUSD(task), blast, irreversible, pii, production)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&domain, "domain", "", "task domain")
+	cmd.Flags().Float64Var(&blast, "blast", 1.0, "blast-radius multiplier (Graphify supplies this in Phase 3)")
+	cmd.Flags().BoolVar(&irreversible, "irreversible", false, "change cannot be cheaply undone")
+	cmd.Flags().BoolVar(&pii, "pii", false, "task handles personal data")
+	cmd.Flags().BoolVar(&production, "production", false, "target is production")
 	return cmd
 }
 

--- a/internal/trust/calibration.go
+++ b/internal/trust/calibration.go
@@ -1,0 +1,252 @@
+package trust
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// laplacePrior is the pseudo-count added to every confusion cell so a brand-new
+// source starts at se=sp=0.5 (D≈0) and earns trust only from real observations.
+const laplacePrior = 1.0
+
+// calibKey namespaces a confusion posterior by source and domain.
+type calibKey struct{ source, domain string }
+
+// confusion holds Beta-Bernoulli pseudo-counts for one (source, domain).
+//
+//	              actually correct   actually incorrect
+//	says correct        TP                  FP
+//	says incorrect      FN                  TN
+//
+// sensitivity se = TP/(TP+FN) = P(says correct | correct)
+// specificity sp = TN/(TN+FP) = P(says incorrect | incorrect)
+type confusion struct {
+	TP, FP, TN, FN float64
+}
+
+func newConfusion() *confusion {
+	return &confusion{TP: laplacePrior, FP: laplacePrior, TN: laplacePrior, FN: laplacePrior}
+}
+
+func (c *confusion) se() float64 { return c.TP / (c.TP + c.FN) }
+func (c *confusion) sp() float64 { return c.TN / (c.TN + c.FP) }
+
+// observations returns the number of real (non-prior) samples recorded.
+func (c *confusion) observations() float64 {
+	return (c.TP + c.FP + c.TN + c.FN) - 4*laplacePrior
+}
+
+// Stat is one row of a calibration report — the human/JSON-facing view.
+type Stat struct {
+	Source string  `json:"source"`
+	Domain string  `json:"domain"`
+	N      float64 `json:"n"`  // real observations (excludes prior)
+	Se     float64 `json:"se"` // sensitivity
+	Sp     float64 `json:"sp"` // specificity
+	D      float64 `json:"d"`  // diagnostic power (nats), expected |LLR|
+}
+
+// Calibrator maintains an online confusion posterior per (source, domain) and
+// derives calibrated LLR and diagnostic power from it. Safe for concurrent use.
+type Calibrator struct {
+	mu    sync.RWMutex
+	store map[calibKey]*confusion
+	path  string // "" disables persistence (used by tests)
+}
+
+// New constructs a Calibrator. When path is non-empty it replays any existing
+// records from that file so calibration survives process restarts; subsequent
+// updates are appended there. An empty path keeps everything in memory.
+func New(path string) (*Calibrator, error) {
+	c := &Calibrator{store: map[calibKey]*confusion{}, path: path}
+	if path == "" {
+		return c, nil
+	}
+	if err := c.load(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// DefaultPath is where calibration is persisted for the CLI (~/.hydra/calibration.jsonl).
+func DefaultPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".hydra", "calibration.jsonl")
+}
+
+// record is one persisted training event.
+type record struct {
+	TS          string `json:"ts"`
+	Source      string `json:"source"`
+	Domain      string `json:"domain"`
+	SaidCorrect bool   `json:"said_correct"`
+	Outcome     int    `json:"outcome"`
+}
+
+// load replays the jsonl file into the in-memory posterior. A missing file is
+// not an error — it just means no calibration has been recorded yet.
+func (c *Calibrator) load() error {
+	f, err := os.Open(c.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var r record
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			continue // skip malformed rows
+		}
+		c.apply(r.Source, r.Domain, r.SaidCorrect, Outcome(r.Outcome))
+	}
+	return scanner.Err()
+}
+
+// apply folds one observation into the in-memory posterior (no persistence).
+func (c *Calibrator) apply(source, domain string, saidCorrect bool, actual Outcome) {
+	if actual == OutcomeUnknown {
+		return
+	}
+	key := calibKey{source, domain}
+	conf := c.store[key]
+	if conf == nil {
+		conf = newConfusion()
+		c.store[key] = conf
+	}
+	switch {
+	case saidCorrect && actual == OutcomeCorrect:
+		conf.TP++
+	case saidCorrect && actual == OutcomeIncorrect:
+		conf.FP++
+	case !saidCorrect && actual == OutcomeCorrect:
+		conf.FN++
+	case !saidCorrect && actual == OutcomeIncorrect:
+		conf.TN++
+	}
+}
+
+// Update records one observation: a source said correct/incorrect and the
+// ground-truth outcome came back. It updates the posterior and, when a path is
+// set, appends the event so it survives restarts. OutcomeUnknown is ignored.
+func (c *Calibrator) Update(source, domain string, saidCorrect bool, actual Outcome) error {
+	if actual == OutcomeUnknown {
+		return nil
+	}
+	c.mu.Lock()
+	c.apply(source, domain, saidCorrect, actual)
+	c.mu.Unlock()
+
+	if c.path == "" {
+		return nil
+	}
+	return c.append(record{
+		TS:          time.Now().UTC().Format(time.RFC3339),
+		Source:      source,
+		Domain:      domain,
+		SaidCorrect: saidCorrect,
+		Outcome:     int(actual),
+	})
+}
+
+func (c *Calibrator) append(r record) error {
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(c.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	raw, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(f, string(raw))
+	return err
+}
+
+// LLR returns the calibrated log-likelihood-ratio contribution (nats) of a
+// verdict from this source. Positive nats are evidence the answer is correct.
+//   - says correct:   ln( se / (1−sp) )
+//   - says incorrect: ln( (1−se) / sp )
+//
+// An uncalibrated / coin-flip source (se+sp≈1) yields LLR≈0.
+func (c *Calibrator) LLR(source, domain string, saidCorrect bool) float64 {
+	se, sp := c.rates(source, domain)
+	if saidCorrect {
+		return math.Log(se / (1 - sp))
+	}
+	return math.Log((1 - se) / sp)
+}
+
+// D is the diagnostic power of a source (nats): the expected LLR of its verdict
+// given a truly-correct item, i.e. KL(Bern(se) ‖ Bern(1−sp)). It is ≥0 always,
+// and 0 exactly when se+sp=1 (the source carries no information — Law 2). Use it
+// to order which source to sample next (most evidence first).
+func (c *Calibrator) D(source, domain string) float64 {
+	se, sp := c.rates(source, domain)
+	return se*math.Log(se/(1-sp)) + (1-se)*math.Log((1-se)/sp)
+}
+
+// rates returns clamped se/sp so LLR/D never hit ±Inf from a degenerate cell.
+func (c *Calibrator) rates(source, domain string) (se, sp float64) {
+	c.mu.RLock()
+	conf := c.store[calibKey{source, domain}]
+	c.mu.RUnlock()
+	if conf == nil {
+		return 0.5, 0.5 // unknown source: uninformative
+	}
+	return clamp01(conf.se()), clamp01(conf.sp())
+}
+
+// clamp01 keeps a probability strictly inside (0,1) so logs stay finite even
+// before enough samples accumulate (the Laplace prior already guarantees this,
+// but clamp is a cheap belt-and-suspenders against future prior changes).
+func clamp01(p float64) float64 {
+	const eps = 1e-9
+	if p < eps {
+		return eps
+	}
+	if p > 1-eps {
+		return 1 - eps
+	}
+	return p
+}
+
+// Report returns per-(source,domain) calibration stats, most-diagnostic first.
+func (c *Calibrator) Report() []Stat {
+	c.mu.RLock()
+	stats := make([]Stat, 0, len(c.store))
+	for k, conf := range c.store {
+		se, sp := clamp01(conf.se()), clamp01(conf.sp())
+		stats = append(stats, Stat{
+			Source: k.source,
+			Domain: k.domain,
+			N:      conf.observations(),
+			Se:     se,
+			Sp:     sp,
+			D:      se*math.Log(se/(1-sp)) + (1-se)*math.Log((1-se)/sp),
+		})
+	}
+	c.mu.RUnlock()
+
+	sort.Slice(stats, func(i, j int) bool { return stats[i].D > stats[j].D })
+	return stats
+}

--- a/internal/trust/calibration_test.go
+++ b/internal/trust/calibration_test.go
@@ -1,0 +1,131 @@
+package trust
+
+import (
+	"math"
+	"path/filepath"
+	"testing"
+)
+
+// feed records tp/fp/tn/fn observations for a source.
+func feed(t *testing.T, c *Calibrator, source, domain string, tp, fp, tn, fn int) {
+	t.Helper()
+	for i := 0; i < tp; i++ {
+		mustUpdate(t, c, source, domain, true, OutcomeCorrect)
+	}
+	for i := 0; i < fp; i++ {
+		mustUpdate(t, c, source, domain, true, OutcomeIncorrect)
+	}
+	for i := 0; i < tn; i++ {
+		mustUpdate(t, c, source, domain, false, OutcomeIncorrect)
+	}
+	for i := 0; i < fn; i++ {
+		mustUpdate(t, c, source, domain, false, OutcomeCorrect)
+	}
+}
+
+func mustUpdate(t *testing.T, c *Calibrator, s, d string, said bool, o Outcome) {
+	t.Helper()
+	if err := c.Update(s, d, said, o); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+}
+
+// A source right 90% of the time (se=sp=0.9) must converge D to the analytic
+// value ln(9)·0.8 ≈ 1.758 nats; a coin-flip source (se=sp=0.5) must converge to 0.
+func TestD_ConvergesToAnalytic(t *testing.T) {
+	c, _ := New("")
+
+	// 2000 truth-balanced samples, source 90% accurate.
+	feed(t, c, "model:good", "go", 900, 100, 900, 100)
+	analytic := math.Log(9) * 0.8 // 1.7578…
+	if got := c.D("model:good", "go"); math.Abs(got-analytic) > 0.05 {
+		t.Errorf("D(90%% source) = %.4f, want ≈%.4f", got, analytic)
+	}
+
+	// Coin flip: says correct half the time regardless of truth.
+	feed(t, c, "model:coin", "go", 500, 500, 500, 500)
+	if got := c.D("model:coin", "go"); math.Abs(got) > 0.01 {
+		t.Errorf("D(coin flip) = %.4f, want ≈0", got)
+	}
+}
+
+func TestLLR_Signs(t *testing.T) {
+	c, _ := New("")
+	feed(t, c, "s", "d", 900, 100, 900, 100) // se≈sp≈0.9
+
+	pos := c.LLR("s", "d", true)  // ≈ ln(0.9/0.1) = ln 9 ≈ 2.197
+	neg := c.LLR("s", "d", false) // ≈ ln(0.1/0.9) = −ln 9
+
+	if math.Abs(pos-math.Log(9)) > 0.05 {
+		t.Errorf("LLR(said correct) = %.4f, want ≈%.4f", pos, math.Log(9))
+	}
+	if math.Abs(neg+math.Log(9)) > 0.05 {
+		t.Errorf("LLR(said incorrect) = %.4f, want ≈%.4f", neg, -math.Log(9))
+	}
+	if pos <= 0 || neg >= 0 {
+		t.Errorf("expected +LLR for correct and −LLR for incorrect, got %.3f / %.3f", pos, neg)
+	}
+}
+
+// An unseen source carries no information: LLR and D are exactly 0.
+func TestUnknownSourceIsUninformative(t *testing.T) {
+	c, _ := New("")
+	if d := c.D("never-seen", "go"); d != 0 {
+		t.Errorf("D(unknown) = %v, want 0", d)
+	}
+	if l := c.LLR("never-seen", "go", true); l != 0 {
+		t.Errorf("LLR(unknown) = %v, want 0", l)
+	}
+}
+
+func TestOutcomeUnknownDoesNotTrain(t *testing.T) {
+	c, _ := New("")
+	if err := c.Update("s", "d", true, OutcomeUnknown); err != nil {
+		t.Fatal(err)
+	}
+	// No stat row should exist, and D stays 0.
+	if len(c.Report()) != 0 {
+		t.Errorf("Report has %d rows, want 0 after only-unknown update", len(c.Report()))
+	}
+}
+
+// Calibration must survive a process restart via jsonl replay.
+func TestPersistenceReplay(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "calibration.jsonl")
+
+	c1, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed(t, c1, "model:good", "go", 90, 10, 90, 10)
+	want := c1.D("model:good", "go")
+
+	// Fresh calibrator over the same file replays the history.
+	c2, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := c2.D("model:good", "go")
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("D after replay = %.6f, want %.6f (state not persisted)", got, want)
+	}
+	if n := c2.Report()[0].N; n != 200 {
+		t.Errorf("observations after replay = %v, want 200", n)
+	}
+}
+
+func TestReport_SortedByD(t *testing.T) {
+	c, _ := New("")
+	feed(t, c, "weak", "go", 60, 40, 60, 40)  // ~0.6 accurate → low D
+	feed(t, c, "strong", "go", 95, 5, 95, 5)  // ~0.95 → high D
+	rep := c.Report()
+	if len(rep) != 2 {
+		t.Fatalf("Report rows = %d, want 2", len(rep))
+	}
+	if rep[0].Source != "strong" {
+		t.Errorf("most-diagnostic first: got %q, want strong", rep[0].Source)
+	}
+	if rep[0].D <= rep[1].D {
+		t.Errorf("Report not sorted by D descending: %.3f then %.3f", rep[0].D, rep[1].D)
+	}
+}

--- a/internal/trust/defect.go
+++ b/internal/trust/defect.go
@@ -1,0 +1,58 @@
+package trust
+
+// DefectWeights are the multipliers that turn a task's risk attributes into the
+// dollar cost of shipping a wrong answer. They are deliberately simple and
+// tunable; the values below are illustrative defaults, not measured constants.
+// Graphify will supply real blast-radius multipliers in Phase 3.
+type DefectWeights struct {
+	Base         float64 // baseline cost of any wrong answer, USD
+	Irreversible float64 // multiplier when the change can't be cheaply undone
+	PII          float64 // multiplier when personal data is involved
+	Production   float64 // multiplier when the target is production
+}
+
+// DefaultWeights returns the built-in defect weights. A local, reversible,
+// non-PII, non-prod mistake costs Base; each risk factor scales it up.
+func DefaultWeights() DefectWeights {
+	return DefectWeights{
+		Base:         1.0,
+		Irreversible: 5.0,
+		PII:          10.0,
+		Production:   3.0,
+	}
+}
+
+// DefectModel prices the cost of shipping an incorrect answer for a task. That
+// cost sets how much confidence a task must clear before Hydra stops sampling
+// (Phase 2) and is surfaced in `hydra dispatch --dry-run` / `hydra trust defect`.
+type DefectModel struct {
+	W DefectWeights
+}
+
+// NewDefectModel returns a model using the default weights.
+func NewDefectModel() *DefectModel {
+	return &DefectModel{W: DefaultWeights()}
+}
+
+// CostUSD = Base × blast × w_irrev × w_pii × w_prod, with each risk factor
+// applied only when present. BlastRadius ≤ 0 is treated as 1.0 (local).
+func (d *DefectModel) CostUSD(t Task) float64 {
+	cost := d.W.Base
+
+	blast := t.BlastRadius
+	if blast <= 0 {
+		blast = 1.0
+	}
+	cost *= blast
+
+	if t.Irreversible {
+		cost *= d.W.Irreversible
+	}
+	if t.TouchesPII {
+		cost *= d.W.PII
+	}
+	if t.Production {
+		cost *= d.W.Production
+	}
+	return cost
+}

--- a/internal/trust/defect_test.go
+++ b/internal/trust/defect_test.go
@@ -1,0 +1,36 @@
+package trust
+
+import "testing"
+
+func TestDefectCostUSD(t *testing.T) {
+	dm := NewDefectModel() // Base 1, Irrev 5, PII 10, Prod 3
+
+	tests := []struct {
+		name string
+		task Task
+		want float64
+	}{
+		{"local reversible non-prod", Task{Domain: "go"}, 1},
+		{"blast only", Task{BlastRadius: 4}, 4},
+		{"production only", Task{Production: true}, 3},
+		{"irreversible + pii, blast 2", Task{BlastRadius: 2, Irreversible: true, TouchesPII: true}, 100},
+		{"everything, blast 1", Task{BlastRadius: 1, Irreversible: true, TouchesPII: true, Production: true}, 150},
+		{"zero blast treated as local", Task{BlastRadius: 0, Production: true}, 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dm.CostUSD(tt.task); got != tt.want {
+				t.Errorf("CostUSD(%+v) = %v, want %v", tt.task, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefectCost_HigherRiskCostsMore(t *testing.T) {
+	dm := NewDefectModel()
+	safe := dm.CostUSD(Task{Domain: "go"})
+	risky := dm.CostUSD(Task{Domain: "go", Production: true, TouchesPII: true})
+	if risky <= safe {
+		t.Errorf("risky task (%.1f) should cost more than safe task (%.1f)", risky, safe)
+	}
+}

--- a/internal/trust/types.go
+++ b/internal/trust/types.go
@@ -1,0 +1,45 @@
+// Package trust is the confidence layer of the Trust Control Plane: it measures
+// how much each evidence source's verdict is actually worth (calibration) and
+// how costly a wrong answer is for a given task (defect cost). Phase 1 ships the
+// calibration engine and the defect-cost model; the SPRT optimal-stopping
+// ensemble that consumes them lands in Phase 2.
+package trust
+
+// Outcome is the ground-truth-ish label used to train calibration.
+type Outcome int
+
+const (
+	// OutcomeUnknown means no ground truth is available yet — it never trains.
+	OutcomeUnknown Outcome = iota
+	// OutcomeCorrect: tests passed / user approved / not reverted within N days.
+	OutcomeCorrect
+	// OutcomeIncorrect: tests failed / user rejected / reverted.
+	OutcomeIncorrect
+)
+
+// ParseOutcome maps a CLI string to an Outcome. Unrecognized → OutcomeUnknown.
+func ParseOutcome(s string) Outcome {
+	switch s {
+	case "correct", "pass", "approve", "approved", "ok":
+		return OutcomeCorrect
+	case "incorrect", "fail", "reject", "rejected", "revert", "reverted":
+		return OutcomeIncorrect
+	default:
+		return OutcomeUnknown
+	}
+}
+
+// Task describes the work whose wrong-answer cost the DefectModel prices.
+type Task struct {
+	Domain string
+	// BlastRadius scales cost by how much other code a wrong answer would break.
+	// 0 or 1 = local/self-contained. Graphify supplies real values in Phase 3;
+	// until then callers leave it at the default (treated as 1.0).
+	BlastRadius float64
+	// Irreversible: the change cannot be cheaply undone (data migration, deploy).
+	Irreversible bool
+	// TouchesPII: the task handles personal data — a wrong answer is a leak risk.
+	TouchesPII bool
+	// Production: the change targets a production surface, not a scratch/dev one.
+	Production bool
+}


### PR DESCRIPTION
## Summary
The first code of the **Trust Control Plane**. New `internal/trust` package measures how much each evidence source's verdict is actually worth (calibration) and how costly a wrong answer is (defect cost) — the two inputs Phase 2's SPRT optimal-stopping ensemble will route on to hit a target *confidence of correctness*.

## What's in this PR (Phase 1)
- **`Calibrator`** — online Beta-Bernoulli confusion posterior per `(source, domain)` with a Laplace prior. Derives sensitivity/specificity → calibrated **LLR** and diagnostic power **`D = KL(Bern(se) ‖ Bern(1−sp))`** (expected LLR). `D = 0` exactly when `se+sp = 1`, so a coin-flip source contributes nothing (Manifesto Law 2). Persists to `~/.hydra/calibration.jsonl` and replays on load. Concurrency-safe.
- **`DefectModel`** — `CostUSD(task) = base × blast × irrev × pii × prod`, tunable weights. Blast-radius defaults to 1.0 until Graphify supplies real values in Phase 3.
- **CLI** — `hydra trust calibration [--domain X] [--json]`, `hydra trust record …`, `hydra trust defect …`.

## Math, verified in tests
- A source right 90% of the time (se=sp=0.9) converges `D` to the analytic `ln(9)·0.8 = 1.758 nats`; a coin flip converges to `0`.
- `LLR(said correct) ≈ +ln 9`, `LLR(said incorrect) ≈ −ln 9`; unseen source → `LLR=D=0`.
- jsonl replay reproduces the posterior after restart; defect weights multiply correctly.

> Note: the spec's "D ≈ 3.17 bits" acceptance figure was the *single-verdict* LLR (`ln 9`), not the expected-LLR `D`; the code implements the spec's own §1.1 formula and the tests assert the correct analytic `D`.

## Scope discipline
`Evidence`/`Result` and the SPRT loop that consume them land in **Phase 2** — kept out here so no dead exported symbols ship. Also removes the stale `internal/company` row from the CLAUDE.md package map (the package was deleted in #86). Public `docs/`/`llms.txt` deliberately **not** updated yet — the Trust feature is user-complete after Phase 2's `--confidence`, and `llms.txt` must not advertise a half-built feature.

## Verification
- `go build ./... && go vet ./...` — clean
- `go test ./... -race` — green
- Manual end-to-end: `record` → `calibration` (table + `--json`) → `defect`, persistence confirmed.

Closes #95