### PR TITLE
feat(trust): SPRT optimal-stopping ensemble core (Phase 2a)

### DIFF
--- a/internal/trust/sprt.go
+++ b/internal/trust/sprt.go
@@ -1,0 +1,182 @@
+package trust
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// correlationDiscount caps the evidence from a model family that has already
+// voted: two heads backed by the same base model are not independent, so a
+// repeat vote counts for half. Prevents false agreement from inflating Λ.
+const correlationDiscount = 0.5
+
+// Target configures an SPRT run. The domain used for calibration lookups comes
+// from the Task, not here, so there is exactly one source of truth for it.
+type Target struct {
+	Confidence float64 // desired P(correct), e.g. 0.95 → α = 1-conf
+	MaxCostUSD float64 // hard spend ceiling; 0 = no limit
+}
+
+// Source is the minimal view of a head that SPRT needs. Kept independent of
+// provider.Head so the trust package stays a low-level dependency; callers
+// (swarm/dispatch) adapt their heads to this in Phase 2b.
+type Source struct {
+	ID         string // calibration key, e.g. "model:claude-sonnet"
+	Family     string // base-model family, for the correlation discount ("" = independent)
+	EstCostUSD float64
+}
+
+// Answer is what a source returned for the task.
+type Answer struct {
+	Text    string
+	CostUSD float64 // actual cost if known; falls back to Source.EstCostUSD
+}
+
+// Executor runs one source against a task. Production wraps the swarm executor;
+// tests inject a deterministic fake.
+type Executor interface {
+	Execute(ctx context.Context, src Source, task Task) (Answer, error)
+}
+
+// Decision is how an SPRT run ended.
+type Decision int
+
+const (
+	// DecisionAccept: Λ crossed the accept threshold A at the target confidence.
+	DecisionAccept Decision = iota
+	// DecisionStoppedOnBudget: ran out of budget/heads before reaching A — the
+	// residual uncertainty is where a human oracle (review) should be spent.
+	DecisionStoppedOnBudget
+)
+
+func (d Decision) String() string {
+	if d == DecisionAccept {
+		return "accept"
+	}
+	return "stopped_on_budget"
+}
+
+// Evidence is one entry in the LLR ledger — a single source's calibrated
+// contribution to the running log-odds that the candidate is correct.
+type Evidence struct {
+	Source      string  `json:"source"`
+	Agreed      bool    `json:"agreed"` // matched the candidate at the time
+	LLR         float64 `json:"llr"`    // calibrated contribution (nats), after any discount
+	Candidate   string  `json:"candidate"`
+	LambdaAfter float64 `json:"lambda_after"`
+	CostUSD     float64 `json:"cost_usd"`
+}
+
+// Result is the outcome of Run.
+type Result struct {
+	Candidate  string     `json:"candidate"`
+	Confidence float64    `json:"confidence"` // σ(Λ)
+	Decision   Decision   `json:"decision"`
+	Lambda     float64    `json:"lambda"`
+	SpentUSD   float64    `json:"spent_usd"`
+	Samples    int        `json:"samples"`
+	Ledger     []Evidence `json:"ledger"`
+}
+
+// Run executes the sequential probability ratio test: it samples sources in
+// decreasing evidence-per-dollar order, accumulating the calibrated
+// log-likelihood ratio Λ that the current candidate answer is correct, and
+// stops as soon as Λ crosses the Wald accept threshold A (target confidence) or
+// runs out of budget. A source that disagrees with the candidate pushes Λ down;
+// if Λ crosses the reject threshold B the run pivots to that source's answer
+// (destructive interference collapses to the better branch).
+func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *Calibrator, t Target) (*Result, error) {
+	if len(sources) == 0 {
+		return nil, fmt.Errorf("sprt: no sources provided")
+	}
+	alpha := 1 - t.Confidence
+	if alpha <= 0 || alpha >= 1 {
+		return nil, fmt.Errorf("sprt: confidence must be in (0,1), got %v", t.Confidence)
+	}
+	// Symmetric Wald thresholds (α = β for v1).
+	A := math.Log((1 - alpha) / alpha)
+	B := -A
+
+	// Sample most-evidence-per-dollar first.
+	order := append([]Source(nil), sources...)
+	sort.SliceStable(order, func(i, j int) bool {
+		return evidencePerCost(cal, order[i], task.Domain) > evidencePerCost(cal, order[j], task.Domain)
+	})
+
+	res := &Result{Decision: DecisionStoppedOnBudget}
+	var lambda float64
+	candidate := ""
+	familySeen := map[string]bool{}
+
+	for _, src := range order {
+		cost := src.EstCostUSD
+		if t.MaxCostUSD > 0 && res.SpentUSD+cost > t.MaxCostUSD {
+			break // next sample would blow the budget
+		}
+		ans, err := exec.Execute(ctx, src, task)
+		if err != nil {
+			continue // a dead head is not evidence — skip it
+		}
+		if ans.CostUSD > 0 {
+			cost = ans.CostUSD
+		}
+		res.SpentUSD += cost
+		res.Samples++
+
+		if candidate == "" {
+			candidate = ans.Text // first answer seeds the candidate
+		}
+		agreed := normalizeAnswer(ans.Text) == normalizeAnswer(candidate)
+
+		llr := cal.LLR(src.ID, task.Domain, agreed)
+		if src.Family != "" && familySeen[src.Family] {
+			llr *= correlationDiscount
+		}
+		familySeen[src.Family] = true
+
+		lambda += llr
+		res.Ledger = append(res.Ledger, Evidence{
+			Source: src.ID, Agreed: agreed, LLR: llr,
+			Candidate: candidate, LambdaAfter: lambda, CostUSD: cost,
+		})
+
+		if lambda >= A {
+			res.Decision = DecisionAccept
+			break
+		}
+		if lambda <= B {
+			// The weight of evidence says the candidate is wrong. Collapse to the
+			// disagreeing answer and re-seed Λ with this source asserting it.
+			candidate = ans.Text
+			lambda = cal.LLR(src.ID, task.Domain, true)
+			// The pivoting source's own vote now supports the new candidate.
+			res.Ledger[len(res.Ledger)-1].Candidate = candidate
+			res.Ledger[len(res.Ledger)-1].LambdaAfter = lambda
+		}
+	}
+
+	res.Candidate = candidate
+	res.Lambda = lambda
+	res.Confidence = sigmoid(lambda)
+	return res, nil
+}
+
+// evidencePerCost ranks sources by diagnostic power per dollar. Zero-cost
+// sources (local) sort by raw D.
+func evidencePerCost(cal *Calibrator, src Source, domain string) float64 {
+	d := cal.D(src.ID, domain)
+	if src.EstCostUSD <= 0 {
+		return d * 1e6 // effectively free → sample first
+	}
+	return d / src.EstCostUSD
+}
+
+// normalizeAnswer defines answer equality for agreement detection. v1 is a
+// conservative trim; semantic/structural equivalence is future work.
+func normalizeAnswer(s string) string { return strings.TrimSpace(s) }
+
+// sigmoid maps the log-odds Λ back to a probability for display.
+func sigmoid(x float64) float64 { return 1 / (1 + math.Exp(-x)) }

--- a/internal/trust/sprt_test.go
+++ b/internal/trust/sprt_test.go
@@ -1,0 +1,223 @@
+package trust
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// calibrateSymmetric trains (id,domain) to se=sp≈p using n balanced samples.
+func calibrateSymmetric(c *Calibrator, id, domain string, p float64, n int) {
+	correct := int(p * float64(n))
+	wrong := n - correct
+	for i := 0; i < correct; i++ {
+		_ = c.Update(id, domain, true, OutcomeCorrect)   // TP
+		_ = c.Update(id, domain, false, OutcomeIncorrect) // TN
+	}
+	for i := 0; i < wrong; i++ {
+		_ = c.Update(id, domain, false, OutcomeCorrect)  // FN
+		_ = c.Update(id, domain, true, OutcomeIncorrect) // FP
+	}
+}
+
+// scriptExec returns a fixed answer sequence, one per Execute call.
+type scriptExec struct {
+	seq []string
+	i   int
+}
+
+func (s *scriptExec) Execute(_ context.Context, src Source, _ Task) (Answer, error) {
+	if s.i >= len(s.seq) {
+		return Answer{}, fmt.Errorf("script exhausted")
+	}
+	a := s.seq[s.i]
+	s.i++
+	return Answer{Text: a, CostUSD: src.EstCostUSD}, nil
+}
+
+func nSources(id string, n int, cost float64) []Source {
+	out := make([]Source, n)
+	for i := range out {
+		out[i] = Source{ID: id, EstCostUSD: cost}
+	}
+	return out
+}
+
+// The accept threshold is exactly the Wald A = ln((1-α)/α): k self-consistent
+// votes from a source with per-verdict LLR L accept iff k·L ≥ A.
+func TestSPRT_AcceptThreshold(t *testing.T) {
+	c, _ := New("")
+	calibrateSymmetric(c, "sim", "d", 0.9, 1000)
+	L := c.LLR("sim", "d", true)
+	A := math.Log(19) // α=0.05
+	wantSamples := int(math.Ceil(A / L))
+
+	exec := &scriptExec{seq: []string{"A", "A", "A", "A", "A"}}
+	res, err := Run(context.Background(), Task{Domain: "d"}, nSources("sim", 5, 1), exec, c, Target{Confidence: 0.95})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Decision != DecisionAccept {
+		t.Fatalf("decision = %v, want accept", res.Decision)
+	}
+	if res.Samples != wantSamples {
+		t.Errorf("samples = %d, want %d (ceil(A/L))", res.Samples, wantSamples)
+	}
+	if res.Candidate != "A" {
+		t.Errorf("candidate = %q, want A", res.Candidate)
+	}
+	if res.Confidence < 0.95 {
+		t.Errorf("confidence = %.4f, want ≥0.95", res.Confidence)
+	}
+}
+
+// When the weight of evidence turns against the seed answer, the run pivots to
+// the answer the disagreeing sources support.
+func TestSPRT_PivotsOnDisagreement(t *testing.T) {
+	c, _ := New("")
+	calibrateSymmetric(c, "sim", "d", 0.9, 1000)
+
+	exec := &scriptExec{seq: []string{"A", "B", "B", "B", "B", "B"}}
+	res, err := Run(context.Background(), Task{Domain: "d"}, nSources("sim", 6, 1), exec, c, Target{Confidence: 0.95})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Candidate != "B" {
+		t.Errorf("candidate = %q, want B after pivot", res.Candidate)
+	}
+	if res.Decision != DecisionAccept {
+		t.Errorf("decision = %v, want accept", res.Decision)
+	}
+}
+
+func TestSPRT_StopsOnBudget(t *testing.T) {
+	c, _ := New("")
+	calibrateSymmetric(c, "sim", "d", 0.9, 1000)
+
+	exec := &scriptExec{seq: []string{"A", "A", "A"}}
+	res, err := Run(context.Background(), Task{Domain: "d"}, nSources("sim", 3, 1),
+		exec, c, Target{Confidence: 0.95, MaxCostUSD: 1.5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Decision != DecisionStoppedOnBudget {
+		t.Errorf("decision = %v, want stopped_on_budget", res.Decision)
+	}
+	if res.Samples != 1 {
+		t.Errorf("samples = %d, want 1 (budget fits one $1 call under $1.5)", res.Samples)
+	}
+}
+
+// Sources are sampled most-diagnostic-first.
+func TestSPRT_SamplesHighestDFirst(t *testing.T) {
+	c, _ := New("")
+	calibrateSymmetric(c, "lo", "d", 0.6, 1000)
+	calibrateSymmetric(c, "mid", "d", 0.8, 1000)
+	calibrateSymmetric(c, "hi", "d", 0.95, 1000)
+
+	srcs := []Source{{ID: "lo", EstCostUSD: 1}, {ID: "mid", EstCostUSD: 1}, {ID: "hi", EstCostUSD: 1}}
+	exec := &scriptExec{seq: []string{"A", "A", "A"}}
+	res, err := Run(context.Background(), Task{Domain: "d"}, srcs, exec, c, Target{Confidence: 0.95})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Ledger[0].Source != "hi" {
+		t.Errorf("first sampled = %q, want hi (highest D)", res.Ledger[0].Source)
+	}
+}
+
+// Law 2 guard: an uninformative (coin-flip) source moves confidence essentially
+// nowhere — a fleet of them never reaches a decision and stays at σ(0)=0.5.
+func TestSPRT_MiscalibratedSourceContributesNothing(t *testing.T) {
+	c, _ := New("")
+	calibrateSymmetric(c, "coin", "d", 0.5, 1000)
+
+	seq := make([]string, 20)
+	for i := range seq {
+		seq[i] = "A"
+	}
+	res, err := Run(context.Background(), Task{Domain: "d"}, nSources("coin", 20, 1),
+		&scriptExec{seq: seq}, c, Target{Confidence: 0.95})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Decision != DecisionStoppedOnBudget {
+		t.Errorf("coin sources should never accept, got %v", res.Decision)
+	}
+	if math.Abs(res.Confidence-0.5) > 0.02 {
+		t.Errorf("confidence = %.4f, want ≈0.5 (coin carries no information)", res.Confidence)
+	}
+}
+
+// probExec answers `truth` with probability p, else `wrong` — a stochastic model.
+type probExec struct {
+	truth, wrong string
+	p            float64
+	rng          *rand.Rand
+}
+
+func (e *probExec) Execute(_ context.Context, src Source, _ Task) (Answer, error) {
+	if e.rng.Float64() < e.p {
+		return Answer{Text: e.truth, CostUSD: src.EstCostUSD}, nil
+	}
+	return Answer{Text: e.wrong, CostUSD: src.EstCostUSD}, nil
+}
+
+// Statistical acceptance (Manifesto Law 3): adaptive SPRT reaches target
+// confidence in far fewer samples than fixed-5 swarm, at ≥95% accuracy, and
+// spends more on harder tasks. Deterministic via a fixed seed.
+func TestSPRT_Law3_SamplesAndAccuracy(t *testing.T) {
+	const trials = 20000
+	rng := rand.New(rand.NewSource(42))
+
+	run := func(id string, p float64, pool int) (meanSamples, accuracy float64) {
+		c, _ := New("")
+		calibrateSymmetric(c, id, "d", p, 2000)
+		var totSamples, correct int
+		for i := 0; i < trials; i++ {
+			exec := &probExec{truth: "A", wrong: "B", p: p, rng: rng}
+			res, _ := Run(context.Background(), Task{Domain: "d"}, nSources(id, pool, 1), exec, c, Target{Confidence: 0.95})
+			totSamples += res.Samples
+			if res.Candidate == "A" {
+				correct++
+			}
+		}
+		return float64(totSamples) / trials, float64(correct) / trials
+	}
+
+	const fixedSwarm = 5.0
+	easyMean, easyAcc := run("easy", 0.90, 30)
+	hardMean, hardAcc := run("hard", 0.74, 30)
+	blendedMean := 0.71*easyMean + 0.29*hardMean
+	blendedAcc := 0.71*easyAcc + 0.29*hardAcc
+	t.Logf("easy(p=.90): mean=%.3f (%.0f%% fewer than fixed-5) acc=%.4f",
+		easyMean, 100*(1-easyMean/fixedSwarm), easyAcc)
+	t.Logf("hard(p=.74): mean=%.3f (SPRT samples MORE to hold accuracy) acc=%.4f", hardMean, hardAcc)
+	t.Logf("blended:     mean=%.3f (%.0f%% fewer than fixed-5) acc=%.4f",
+		blendedMean, 100*(1-blendedMean/fixedSwarm), blendedAcc)
+
+	// NOTE: these land above the Manifesto's *continuous* E[N] ([MODEL]: easy
+	// 1.33, blended 2.48) because evidence arrives in quantized ~2.19-nat steps —
+	// a single vote is below the accept threshold A=ln(19)=2.94, so an easy task
+	// needs ≥2 corroborating votes. That is faithful discrete SPRT, not a defect.
+
+	// Easy tasks clear in ≥40% fewer calls than a fixed-5 swarm (Law 3 headline).
+	if easyMean > 3.0 {
+		t.Errorf("easy mean samples = %.3f, want ≤3 (≥40%% fewer than fixed-5)", easyMean)
+	}
+	// The blended workload still beats fixed-5 outright.
+	if blendedMean >= fixedSwarm {
+		t.Errorf("blended mean samples = %.3f, want < %.0f (adaptive beats fixed)", blendedMean, fixedSwarm)
+	}
+	// SPRT spends more on harder tasks — that is the point, and fixed-N can't.
+	if hardMean <= easyMean {
+		t.Errorf("hard mean (%.3f) should exceed easy mean (%.3f)", hardMean, easyMean)
+	}
+	// Calibration guarantee: ~95% accuracy regardless of difficulty (Law 3).
+	if easyAcc < 0.95 || hardAcc < 0.95 || blendedAcc < 0.95 {
+		t.Errorf("accuracy below target: easy=%.4f hard=%.4f blended=%.4f, want ≥0.95",
+			easyAcc, hardAcc, blendedAcc)
+	}
+}


### PR DESCRIPTION
## Summary
The adaptive loop at the heart of the Trust Control Plane. It consumes Phase 1's per-source calibration to sample sources *only until confident enough*, replacing the always-fire-N swarm with a Wald **sequential probability ratio test**.

## What's in this PR (Phase 2a — the engine)
`internal/trust/sprt.go`:
- `Target{Confidence, MaxCostUSD}`, `Source{ID, Family, EstCostUSD}`, `Answer`, `Evidence` (the LLR ledger), `Result`, `Decision`, and an injected **`Executor`** interface — so `trust` stays a low-level package (no `provider`/`swarm` import); tests use a fake, the production adapter lands in 2b.
- Accumulate calibrated Λ = log-odds the candidate is correct; **accept at `A = ln((1−α)/α)`**, **pivot** to a disagreeing answer if Λ crosses `B = −A`. Sample most-`D`-per-dollar first; correlation discount for repeat votes from one model family; `σ(Λ)` → confidence.

## Manifesto Law 3, measured (seeded, 20k trials)
| workload | mean samples | vs fixed-5 | accuracy |
|---|---|---|---|
| easy (p=.90) | 2.56 | **−49%** | 98.8% |
| blended | 3.78 | **−24%** | 98.2% |
| hard (p=.74) | 6.77 | *+35% (by design)* | 96.7% |

Adaptive sampling beats fixed-5 on typical workloads at higher accuracy, and **spends more than 5 on hard tasks to hold accuracy — which fixed-N cannot** (Manifesto Law 3, verbatim).

> **Honest note:** these land above the Manifesto's *continuous* [MODEL] `E[N]` (easy 1.33, blended 2.48) because evidence arrives in quantized ~2.19-nat steps — one vote is below `A=ln(19)=2.94`, so an easy task needs ≥2 corroborating votes. That's faithful discrete SPRT, documented in the test. Phase 8 reconciles the homepage [MODEL] projection with these [MEASURED] numbers.

Also verified: exact accept threshold, pivot, budget stop, and the **Law 2 guard** — a coin-flip (`D≈0`) source shifts final confidence <2%.

## Verification
- `go vet ./...` clean; `go test ./... -race` green; no network deps.

Closes #97