### PR TITLE
feat(trust): wire SPRT into dispatch — hydra dispatch --confidence (Phase 2b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,19 +21,20 @@ Never do work yourself that belongs to a lower tier. Never escalate work to your
 
 ## Directory Layout
 
-**The `hydra` Go CLI is the primary interface** (`cmd/hydra` + `internal/`). The `dispatch/*.sh`
-shell layer is **deprecated legacy** — route.sh is superseded by `hydra dispatch` and kept only
-for internal fallback (`HYDRA_INTERNAL=1`). Prefer the Go commands everywhere.
+**The `hydra` Go CLI is the entire interface** (`cmd/hydra` + `internal/`). The legacy
+`dispatch/*.sh` shell layer and the `internal/company` playbook engine have been **removed**
+(#86, #88) — there is no shell fallback and no `hydra run`. Everything is native Go.
 ```
 cmd/hydra/              ← CLI entry point (Cobra): dispatch, probe, status, cost, stats,
-                          swarm, edit, review, parallel, pricing, run, init.
+                          pricing, edit, review, parallel, trust, init.
 internal/dispatch/      ← Tier routing + fallback + policy + cost logging (the router).
-internal/executor/      ← Executors: agy, Ollama, HTTP (API providers), CLI subprocess.
+internal/executor/      ← Native executors: agy, Ollama, HTTP (API providers), CLI subprocess.
 internal/provider/      ← Discovery: cli / env (API keys) / port / agy.
-internal/swarm/         ← Swarm dispatch — fan-out to multiple heads (race/best/all + judge).
+internal/swarm/         ← Fan-out (race/best/all + judge) + SPRT adapter (swarm→trust).
+internal/trust/         ← Trust Control Plane: calibration (LLR/D) + defect-cost + SPRT ensemble.
 internal/pricing/       ← Live pricing DB (OpenRouter fetch + 24h cache + tier fallback).
 internal/policy/        ← PII detection + local-only enforcement.
-internal/{cost,budget}/ ← Spend reporting + token-budget (claude_pct) governor.
+internal/{cost,budget}/ ← Spend reporting (est/actual labeling) + token-budget governor.
 internal/util/          ← Shared utilities (Accumulator, etc).
 
 registry/routing.yaml   ← THE ENUM. Change tier assignments here only.
@@ -42,8 +43,6 @@ registry/models.yaml    ← Model definitions, token pools, fallback chains (fla
 registry/domains.yaml   ← Domain → enum key routing (references routing.yaml).
 registry/pricing.yaml   ← Static tier pricing fallback (used when offline).
 logs/                   ← Dispatch log + state.json (pool exhaustion, claude_pct).
-
-dispatch/*.sh           ← DEPRECATED legacy shell layer (route.sh, agy.sh, ollama.sh, …).
 ```
 
 ---
@@ -202,6 +201,13 @@ hydra dispatch --enum MODERATE --prompt "add auth" --a2a logs/last_handoff.json
 
 # Fan-out to multiple heads (swarm) and judge the best
 hydra dispatch --swarm --swarm-mode best --prompt "implement rate limiter"
+
+# Route to a target confidence of correctness (SPRT optimal-stopping ensemble)
+hydra dispatch --confidence 0.95 --prompt "is this migration safe for prod?"
+
+# Trust Control Plane: calibration, defect-cost, run stats, and the LLR ledger
+hydra trust calibration ; hydra trust record --source model:x --domain go --said-correct --outcome correct
+hydra trust defect --pii --production ; hydra trust stats ; hydra trust explain <task_hash>
 
 # System state / discovered heads / spend
 hydra status ; hydra probe ; hydra cost ; hydra stats
@@ -659,7 +665,7 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/policy` | Allow/deny rules (PII local-only, etc.) |
 | `internal/rank` | CapScore ranking helpers |
 | `internal/config` | Hydra config load/save (`~/.config/hydra/`) |
-| `internal/trust` | Trust Control Plane confidence layer: per-source calibration (Beta-Bernoulli → LLR/D) + defect-cost model. `hydra trust`. SPRT ensemble is Phase 2 (not yet shipped). |
+| `internal/trust` | Trust Control Plane confidence layer: per-source calibration (Beta-Bernoulli → LLR/D), defect-cost model, and the SPRT optimal-stopping ensemble (`trust.Run`). Drives `hydra dispatch --confidence` and `hydra trust calibration\|record\|defect\|stats\|explain`. |
 | `internal/tui` | Bubble Tea TUI: init wizard, install flow |
 | `internal/review` | Code review subcommand |
 | `internal/editor` | Editor integration |

--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ You have Claude Code for complex problems, Codex for code generation, Ollama run
 
 It discovers every AI model on your machine, assigns each a capability score, routes tasks to the right model by complexity and cost, enforces PII policy so sensitive data never leaves your machine, and logs every dispatch with token counts and cost — without any manual configuration.
 
+And it's growing into a **Trust Control Plane**: route not just to the cheapest model, but to a *target confidence of correctness* — sampling models adaptively and stopping the moment you're sure enough (see **Confidence Routing** under [Features](#features)).
+
 ```bash
-brew install --HEAD Formula/hydra.rb && hydra init
+brew install ankit373/hydra/hydra && hydra init
 ```
+
+> **Pure Go, single binary.** Hydra is one `hydra` CLI — the legacy shell layer is gone. Everything below runs through `hydra <command>`.
 
 ---
 
@@ -71,40 +75,61 @@ Hydra discovers and routes to all of these automatically — no plugins, no manu
 ## Architecture
 
 ```
-  ┌───────────────────────────────────────────────────────────────────┐
-  │                         hydra dispatch                            │
-  └───────────────────────────────┬───────────────────────────────────┘
-                                  │
-                    ┌─────────────▼──────────────┐
-                    │          Hydra              │
-                    │                             │
-                    │  ┌─────────────────────┐    │
-                    │  │   Policy Engine     │    │
-                    │  │  PII detection      │    │
-                    │  │  cost ceiling       │    │
-                    │  │  local-only routing │    │
-                    │  └──────────┬──────────┘    │
-                    │             │               │
-                    │  ┌──────────▼──────────┐    │
-                    │  │    Tier Router      │    │
-                    │  │  score → tier       │    │
-                    │  │  fallback chains    │    │
-                    │  └──────────┬──────────┘    │
-                    └────────┬────┴────────────────┘
-                             │
-           ┌─────────────────┼─────────────────┐
-           │                 │                 │
-    ┌──────▼──────┐   ┌──────▼──────┐   ┌──────▼──────┐
-    │  CLI Heads  │   │  API Heads  │   │ Local Heads │
-    │             │   │             │   │             │
-    │ Claude Code │   │   OpenAI    │   │   Ollama    │
-    │    Codex    │   │  Anthropic  │   │  LM Studio  │
-    │   Cursor    │   │    Groq     │   │             │
-    │    Kiro     │   │  Together   │   │             │
-    │  Windsurf   │   │   + more    │   │             │
-    └─────────────┘   └─────────────┘   └─────────────┘
-      score: 60–95      score: 70–95      score: 50–72
+  ┌───────────────────────────────────────────────────────────────────────┐
+  │   hydra dispatch  [--local | --swarm | --confidence 0.95]               │
+  └───────────────────────────────────┬─────────────────────────────────────┘
+                                       │
+                     ┌─────────────────▼─────────────────┐
+                     │  Policy Engine                     │  PII detection
+                     │  (blocks before any network call)  │  cost ceiling · local-only
+                     └─────────────────┬─────────────────┘
+                                       │
+                     ┌─────────────────▼─────────────────┐
+                     │  Router                            │  CapScore → tier
+                     │  score → tier → fallback chain     │  ~1.1 µs/dispatch
+                     └───┬───────────────┬───────────────┬─┘
+             single      │        swarm  │    confidence │  (SPRT)
+          ┌──────────────▼┐  ┌───────────▼──┐  ┌──────────▼───────────┐
+          │ best available│  │ race/best/all│  │ Trust Control Plane   │
+          │ head + fallbk │  │ + LLM judge  │  │ calibration → LLR/D    │
+          └──────┬────────┘  └──────┬───────┘  │ SPRT optimal-stopping  │
+                 │                  │          │ defect-cost model      │
+                 │                  │          └──────────┬────────────┘
+                 └──────────────────┴─────────────────────┘
+                                       │
+              ┌────────────────────────┼────────────────────────┐
+       ┌──────▼──────┐          ┌──────▼──────┐          ┌───────▼─────┐
+       │  CLI Heads  │          │  API Heads  │          │ Local Heads │
+       │ Claude Code │          │   OpenAI    │          │   Ollama    │
+       │   Codex     │          │  Anthropic  │          │  LM Studio  │
+       │  Cursor …   │          │  Groq … +12 │          │             │
+       └─────────────┘          └─────────────┘          └─────────────┘
+         score 60–95              score 70–95              score 50–72
+                                       │
+                     ┌─────────────────▼─────────────────┐
+                     │  Observability                     │  cost.jsonl (est/actual)
+                     │  cost + calibration + trust ledgers│  calibration.jsonl · trust.jsonl
+                     └────────────────────────────────────┘
 ```
+
+Every executor is **native Go** — `agy`, Ollama, per-provider HTTP (OpenAI-compatible + Anthropic/Gemini/Cohere/Azure/Bedrock/Replicate), and generic CLI. No shell scripts in the hot path.
+
+---
+
+## By the Numbers
+
+| Metric | Value | How it's measured |
+|---|---|---|
+| Routing overhead | **~1,130 ns / dispatch** | `go test -bench=BenchmarkRoutingPath` (Apple M1): policy eval + head selection + budget check |
+| Cost vs all-frontier | **75–85% lower** | typical coding session where most tasks are SIMPLE/STANDARD; see `hydra stats` for your own numbers |
+| Machine discovery | **< 2 s** for 13+ CLIs, 14 API providers, 2 local runtimes | concurrent PATH + env + port scan (`hydra probe`) |
+| Calibration convergence | a 90%-reliable source → **D ≈ 1.76 nats** diagnostic power | `internal/trust` table tests; a coin-flip source → **D ≈ 0** (contributes nothing) |
+| SPRT — easy tasks | **2.6 samples, −49% vs fixed-5**, 98.8% accuracy | 20k seeded synthetic trials, `TestSPRT_Law3` |
+| SPRT — blended workload | **3.8 samples, −24% vs fixed-5**, 98.2% accuracy | same suite; 71% easy / 29% hard task mix |
+| SPRT — hard tasks | **6.8 samples** (adaptively *more* than 5), 96.7% accuracy | fixed-N ensembles can't do this — SPRT spends where accuracy demands it |
+| Output capture | bounded at **33 MB** per subprocess | `internal/util.Accumulator` — no unbounded buffers |
+
+> **Methodology & honesty.** Routing overhead, discovery, calibration, and SPRT figures are **measured** by the test/benchmark suite (`go test ./...`, race-clean in CI). The SPRT numbers come from *synthetic* trials with known ground truth, not production traffic — they validate the algorithm (Wald sequential test), and land above the continuous theoretical `E[N]` (easy 1.33 / blended 2.48) because real evidence arrives in discrete steps. Cost-savings ranges are workload-dependent estimates; `hydra stats` reports your actual spend. As production `trust.jsonl` accumulates, `hydra trust stats` graduates these from *modeled* to *observed*.
 
 ---
 
@@ -178,7 +203,7 @@ $ hydra dispatch --prompt "process payment for card 4111-1111-1111-1111"
 
 ### 💰 Full Cost Visibility
 
-Every dispatch is logged to `~/.hydra/dispatch.jsonl` with model, tier, token counts, estimated cost, and fallback chain. Run `hydra stats` to see where your budget is going.
+Every dispatch is logged to `~/.hydra/cost.jsonl` with model, tier, token counts, estimated cost, and fallback chain. Costs are **honestly labeled**: `tokens_source` marks whether a provider reported real usage or Hydra estimated it, and `cost_source` is always `estimated` (pricing × tokens, never a billed figure). Run `hydra cost` or `hydra stats` to see where your budget is going.
 
 ```
 $ hydra cost
@@ -224,6 +249,40 @@ hydra dispatch --dry-run --prompt "write a SQL migration"
 hydra dispatch --local --prompt "write unit tests for this function"
 ```
 
+### 🐝 Swarm Dispatch
+
+Fan a single prompt out to multiple heads at once, then keep the best answer:
+
+```bash
+hydra dispatch --swarm --swarm-mode race "prompt"   # first success wins (latency)
+hydra dispatch --swarm --swarm-mode best "prompt"   # LLM judge picks the best answer
+hydra dispatch --swarm --swarm-mode all  "prompt"   # every answer, ranked by CapScore
+```
+
+`--swarm-max-heads`, `--swarm-max-cost` (pre-flight cost guard), and `--swarm-heads id1,id2` give you fine control over fan-out.
+
+### 🧭 Confidence Routing (Trust Control Plane)
+
+Most routers optimize *cost*. Hydra is growing a second axis: **verified correctness**. Instead of always firing a fixed number of models, `--confidence` runs a **sequential probability ratio test (SPRT)** — it samples models adaptively, in most-diagnostic-per-dollar order, and stops the moment the calibrated log-odds cross the target confidence.
+
+```bash
+hydra dispatch --confidence 0.95 --prompt "is this migration safe to run in prod?"
+```
+
+It leans on **per-source calibration** you build from real outcomes — each model/verifier earns a measured sensitivity, specificity, and *diagnostic power* `D`. A coin-flip source (`D≈0`) contributes nothing; a proven one lets a single vote go a long way.
+
+```bash
+hydra trust record --source model:claude-sonnet --domain go --said-correct --outcome correct
+hydra trust calibration          # per-source se / sp / D table
+hydra trust defect --pii --production   # modeled $ cost of shipping a wrong answer
+hydra trust stats                # samples saved vs fixed-N, achieved vs target confidence
+hydra trust explain <task_hash>  # the full LLR ledger for a past run — why it stopped
+```
+
+In synthetic benchmarks this cuts model calls **~49% on easy tasks** and **~24% on a blended workload** at ≥98% accuracy — while deliberately sampling *more* than a fixed swarm on genuinely hard tasks, which a fixed-N ensemble cannot do. Calibration is cold-start conservative: with no history, sources are treated as uninformative and Hydra falls back to sampling broadly.
+
+> The SPRT ensemble, calibration engine, and defect-cost model have shipped. Graph-aware (blast-radius) routing, a local MCP accountability ledger, and a pluggable verification-oracle interface are on the [roadmap](#roadmap).
+
 ---
 
 ## Comparison
@@ -234,11 +293,14 @@ hydra dispatch --local --prompt "write unit tests for this function"
 | Hardware-aware local model selection | ✅ | ❌ | ❌ | ❌ |
 | PII detection + local enforcement | ✅ | ❌ | ❌ | ❌ |
 | Fallback chains | ✅ | ❌ | ✅ | ✅ |
-| Per-dispatch cost logging | ✅ | ❌ | ✅ | ❌ |
+| Per-dispatch cost logging (est. vs actual labeled) | ✅ | ❌ | ✅ | ❌ |
 | Works with CLI tools (not just APIs) | ✅ | ✅ | ❌ | ❌ |
 | Zero config to start | ✅ | ✅ | ❌ | ❌ |
-| MCP server registry *(v2)* | 🔨 | ❌ | ❌ | ❌ |
-| Central security agent *(v2)* | 🔨 | ❌ | ❌ | ❌ |
+| Swarm dispatch (race / best / all) | ✅ | ❌ | ❌ | ❌ |
+| Route to a **confidence of correctness** (SPRT) | ✅ | ❌ | ❌ | ❌ |
+| Per-source calibration (sensitivity / specificity / D) | ✅ | ❌ | ❌ | ❌ |
+| MCP accountability ledger *(roadmap)* | 🔨 | ❌ | ❌ | ❌ |
+| Central security agent *(roadmap)* | 🔨 | ❌ | ❌ | ❌ |
 
 ---
 
@@ -274,13 +336,34 @@ The wizard scans your machine, ranks every model it finds, walks you through pic
 ### Core Commands
 
 ```bash
+# Discovery & state
 hydra init                              # first-run wizard
 hydra probe                             # scan and display all available models
-hydra status                            # live system state
+hydra status                            # live system state (heads, budget bars)
+
+# Dispatch
 hydra dispatch --prompt "..."           # route a prompt to the best model
 hydra dispatch --dry-run --prompt "..." # preview routing without executing
 hydra dispatch --local --prompt "..."   # local models only, no API calls
-hydra cost                              # cost summary by model and day
+hydra dispatch --swarm --swarm-mode best "..."   # fan out to many heads, judge best
+hydra dispatch --confidence 0.95 "..."  # SPRT: sample until this P(correct) is reached
+
+# Cost & pricing
+hydra cost                              # spend summary (est. vs actual labeled)
+hydra stats                             # rollup by model / tier / day
+hydra pricing list                      # live $/1M-token rates (OpenRouter + fallback)
+
+# Trust Control Plane
+hydra trust calibration                 # per-source sensitivity / specificity / D
+hydra trust record ...                  # feed an outcome to train calibration
+hydra trust defect ...                  # modeled cost of shipping a wrong answer
+hydra trust stats                       # samples saved, achieved vs target confidence
+hydra trust explain <task_hash>         # the LLR ledger for a past SPRT run
+
+# Editing & batch
+hydra edit --file ... --prompt "..."    # scoped, validated, rollback-safe file edit
+hydra review ...                        # code review / approve / reject / QA
+hydra parallel ...                      # fan independent tasks across heads
 ```
 
 ---
@@ -339,36 +422,36 @@ For Ollama models, add a family pattern:
 
 ## Roadmap
 
-| Feature | Release | Status |
-|---------|---------|--------|
-| Auto-discovery: CLI, API keys, local ports | v1.0 | ✅ Shipped |
-| Hardware-aware Ollama model selection | v1.0 | ✅ Shipped |
-| PII detection + local-only enforcement | v1.0 | ✅ Shipped |
-| Tier routing with automatic fallback chains | v1.0 | ✅ Shipped |
-| First-run TUI wizard (`hydra init`) | v1.0 | ✅ Shipped |
-| `hydra cost` — cost breakdown by model and day | v1.1 | ✅ Shipped |
-| Ollama model deduplication (binary vs models) | v1.1 | 🔨 Building |
-| MCP Server Registry | v2.0 | 📋 [#9](https://github.com/ankit373/hydra/issues/9) |
-| Per-model MCP access controls | v2.0 | 📋 [#10](https://github.com/ankit373/hydra/issues/10) |
-| Central security agent | v2.0 | 📋 [#10](https://github.com/ankit373/hydra/issues/10) |
-| Real-time cost dashboard | v2.0 | 📋 [#11](https://github.com/ankit373/hydra/issues/11) |
-| Swarm dispatch — parallel multi-model tasks | v2.0 | 📋 [#11](https://github.com/ankit373/hydra/issues/11) |
-| Web UI | v3.0 | 📋 [#12](https://github.com/ankit373/hydra/issues/12) |
-| Compliance reporting (SOC 2, GDPR) | v3.0 | 📋 Planned |
+| Feature | Status |
+|---------|--------|
+| Auto-discovery: CLI, API keys, local ports | ✅ Shipped |
+| Hardware-aware Ollama model selection | ✅ Shipped |
+| PII detection + local-only enforcement | ✅ Shipped |
+| Tier routing with automatic fallback chains | ✅ Shipped |
+| First-run TUI wizard (`hydra init`) | ✅ Shipped |
+| `hydra cost` / `hydra stats` — spend breakdown, est. vs actual | ✅ Shipped |
+| Dynamic live pricing (OpenRouter + 24h cache) | ✅ Shipped |
+| Swarm dispatch — race / best / all + LLM judge | ✅ Shipped |
+| **Per-source calibration** (Beta-Bernoulli → LLR / D) | ✅ Shipped |
+| **Defect-cost model** (`hydra trust defect`) | ✅ Shipped |
+| **SPRT confidence routing** (`hydra dispatch --confidence`) | ✅ Shipped |
+| Graph-aware routing (blast-radius → confidence) | 🔨 Building |
+| Outcome auto-wiring (tests / review / revert → calibration) | 🔨 Building |
+| Local MCP accountability ledger | 📋 Planned |
+| Pluggable verification-oracle interface | 📋 Planned |
+| MCP server registry + central security agent | 📋 [#9](https://github.com/ankit373/hydra/issues/9)/[#10](https://github.com/ankit373/hydra/issues/10) |
+| Web UI + real-time cost dashboard | 📋 [#11](https://github.com/ankit373/hydra/issues/11)/[#12](https://github.com/ankit373/hydra/issues/12) |
 
 See the full [Hydra Roadmap project board](https://github.com/users/ankit373/projects/2).
 
-### v2: Beyond Routing — The Full Control Plane
+### The arc: from cost router to Trust Control Plane
 
-The current layer answers: *which model handles this task?*
+Hydra started by answering *which model is cheapest for this task?* It's evolving to answer a harder question: ***how sure are we the answer is right, and what's the least attention we can spend to be that sure?***
 
-v2 extends the control plane to answer: *what is each model allowed to touch?*
+- **Today** — calibration measures each source's real diagnostic power; SPRT samples adaptively to a target confidence; the defect-cost model prices what a wrong answer costs.
+- **Next** — graph-aware routing uses code blast-radius to raise the confidence bar where a mistake is expensive; a local MCP ledger records what every model was actually allowed to touch and did; a verification-oracle interface lets test-runners and compilers act as first-class, high-`D` evidence sources.
 
-**MCP Server Registry** — a central inventory of every MCP server connected to your AI tools. Today there is no way to know which model is talking to which server, what operations it has been authorized, or what it has actually called. Hydra v2 changes that: one place to see, grant, and revoke access across every model.
-
-**Central Security Agent** — a policy enforcement point between your models and your MCP servers. Even if a model has filesystem or GitHub MCP access configured, the security agent can block writes, deletes, or network calls based on centrally-defined rules. Deny rules apply regardless of what the individual model thinks it is authorized to do.
-
-**Cost Dashboard** — real-time spend tracking with per-model and per-task-type breakdowns, budget alerts, and a local vs cloud ratio so you know exactly how much you are saving by running locally.
+The design principle throughout: **no single vendor is privileged** — Hydra routes *across* providers and *away* from expensive ones, optimizing verified correctness per unit of human attention.
 
 ---
 
@@ -376,26 +459,35 @@ v2 extends the control plane to answer: *what is each model allowed to touch?*
 
 ```
 hydra/
-├── cmd/hydra/                   # CLI entry point (Cobra)
+├── cmd/hydra/                   # CLI entry point (Cobra) — every subcommand
 ├── internal/
 │   ├── capabilities/            # Capability scoring — data.json, no hardcoded logic
 │   ├── config/                  # TOML config at ~/.hydra/config.toml
-│   ├── dispatch/                # Tier routing + fallback chains + cost logging
-│   ├── executor/                # CLI and HTTP executors for every head type
-│   ├── policy/                  # PII detection + routing enforcement
-│   ├── probe/                   # Concurrent multi-provider discovery
-│   ├── provider/                # CLI, env, and port discovery providers
+│   ├── dispatch/                # Tier routing + fallback chains + policy + cost logging
+│   ├── executor/                # Native executors: agy · Ollama · per-provider HTTP · CLI
+│   ├── provider/                # Discovery providers (self-register via init())
 │   │   ├── cli/                 # PATH scanner (13+ tools)
 │   │   ├── env/                 # API key scanner (14 providers)
-│   │   └── port/                # Local server scanner (Ollama, LM Studio)
-│   ├── rank/                    # Deduplication and capability ranking
+│   │   ├── port/                # Local server scanner (Ollama, LM Studio)
+│   │   └── agy/                 # Antigravity tier registry
+│   ├── probe/                   # Concurrent multi-provider discovery
+│   ├── policy/                  # PII detection + local-only enforcement
+│   ├── swarm/                   # Fan-out dispatch: race / best (LLM judge) / all + SPRT adapter
+│   ├── trust/                   # Trust Control Plane: calibration · defect-cost · SPRT ensemble
+│   ├── pricing/                 # Live cost DB (OpenRouter fetch + 24h cache + YAML fallback)
+│   ├── cost/                    # cost.jsonl reader + spend summaries + source labeling
+│   ├── budget/                  # Per-model token-budget governor (6 pressure modes)
+│   ├── rank/                    # Deduplication + CapScore ranking
+│   ├── editor/                  # Scoped, validated, rollback-safe file edits
+│   ├── parallel/                # Independent multi-task fan-out
+│   ├── review/                  # Code review / approve / reject / QA
+│   ├── util/                    # Shared utilities (bounded Accumulator, 33 MB cap)
 │   ├── sysinfo/                 # Hardware detection + 7-day memory history
+│   ├── build/ · update/         # Version stamping + startup update check
 │   └── tui/                     # Bubbletea init wizard + install guide
-├── dispatch/                    # Shell dispatch layer (agy + Ollama wrappers)
-├── registry/                    # Routing YAML, model definitions, policy config
-├── skills/                      # Skill prompts (delegate, escalate, rubber-duck)
-├── docs/                        # GitHub Pages (hydra.uvansa.com)
-└── Formula/hydra.rb             # Homebrew formula (auto-updated by goreleaser)
+├── registry/                    # routing.yaml (the enum) · models · domains · pricing · policy
+├── docs/                        # GitHub Pages (hydra.uvansa.com) — index.html, llms.txt
+└── Formula/hydra.rb             # Homebrew formula (auto-updated by GoReleaser)
 ```
 
 ---

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -318,6 +319,9 @@ func cmdDispatch() *cobra.Command {
 		swarmMaxHeads int
 		swarmMaxCost  float64
 		swarmJudge    string
+		// trust / SPRT flags
+		confidence float64
+		domain     string
 	)
 
 	cmd := &cobra.Command{
@@ -331,6 +335,26 @@ func cmdDispatch() *cobra.Command {
 			d, err := dispatch.New(ctx)
 			if err != nil {
 				return err
+			}
+
+			// ── SPRT confidence mode ──────────────────────────────────────
+			if confidence > 0 {
+				sw := swarm.New(d, d.Heads(), d)
+				res, err := sw.RunSPRT(ctx, prompt, swarm.Options{
+					TierHint:      tier,
+					MaxHeads:      swarmMaxHeads,
+					MaxEstCostUSD: swarmMaxCost,
+					LocalOnly:     localOnly,
+					System:        system,
+					Confidence:    confidence,
+					Domain:        domain,
+				})
+				if err != nil {
+					return err
+				}
+				printSPRTResult(res)
+				logTrustRun(res, prompt, domain)
+				return nil
 			}
 
 			// ── swarm mode ────────────────────────────────────────────────
@@ -422,7 +446,79 @@ func cmdDispatch() *cobra.Command {
 	cmd.Flags().IntVar(&swarmMaxHeads, "swarm-max-heads", 0, "max heads to fire (default 5)")
 	cmd.Flags().Float64Var(&swarmMaxCost, "swarm-max-cost", 0, "refuse swarm if preflight cost estimate exceeds this USD")
 	cmd.Flags().StringVar(&swarmJudge, "swarm-judge-tier", "", "tier for judge head in best mode (default: tier 1 / cortex)")
+	// trust / SPRT flags
+	cmd.Flags().Float64Var(&confidence, "confidence", 0, "route via SPRT ensemble until this P(correct) is reached, e.g. 0.95")
+	cmd.Flags().StringVar(&domain, "domain", "", "calibration domain for --confidence (default: \"default\")")
 	return cmd
+}
+
+// printSPRTResult renders an SPRT confidence run: the LLR ledger, the decision,
+// and the winning answer.
+func printSPRTResult(r *swarm.SPRTResult) {
+	sep := dimStyle.Render("  " + strings.Repeat("─", 60))
+	t := r.Trust
+
+	fmt.Println()
+	fmt.Printf("  %s [%s]\n\n", cortexStyle.Render("▶ SPRT"), dimStyle.Render(r.Domain))
+
+	fmt.Printf("  %-28s  %-9s  %8s  %10s\n", "SOURCE", "VERDICT", "LLR", "Λ AFTER")
+	fmt.Println(sep)
+	for _, e := range t.Ledger {
+		verdict := "agree"
+		if !e.Agreed {
+			verdict = "disagree"
+		}
+		fmt.Printf("  %-28.28s  %-9s  %+8.3f  %+10.3f\n", e.Source, verdict, e.LLR, e.LambdaAfter)
+	}
+	fmt.Println(sep)
+
+	fmt.Printf("\n  %s %s  ·  confidence %.1f%%  ·  %d samples  ·  $%.4f\n",
+		dimStyle.Render("Decision →"),
+		cortexStyle.Render(t.Decision.String()),
+		t.Confidence*100, t.Samples, t.SpentUSD,
+	)
+	fmt.Println()
+	if t.Candidate != "" {
+		fmt.Println(t.Candidate)
+		fmt.Println()
+	}
+}
+
+// logTrustRun appends the SPRT run to ~/.hydra/trust.jsonl (best-effort).
+func logTrustRun(r *swarm.SPRTResult, prompt, domain string) {
+	if domain == "" {
+		domain = "default"
+	}
+	models := make([]string, 0, len(r.Attempts))
+	seen := map[string]bool{}
+	for _, a := range r.Attempts {
+		if !seen[a.Head.ID] {
+			seen[a.Head.ID] = true
+			models = append(models, a.Head.ID)
+		}
+	}
+	_, costSource, _ := cost.SourceLabels(anyEstimated(r.Attempts))
+	_ = trust.LogRun(trust.DefaultLogPath(), trust.RunLog{
+		TaskHash:   trust.TaskHash(prompt),
+		Domain:     domain,
+		TargetConf: r.Target,
+		FinalConf:  r.Trust.Confidence,
+		Samples:    r.Trust.Samples,
+		Models:     models,
+		CostUSD:    r.Trust.SpentUSD,
+		CostSource: costSource,
+		Decision:   r.Trust.Decision.String(),
+		Ledger:     r.Trust.Ledger,
+	})
+}
+
+func anyEstimated(attempts []swarm.Attempt) bool {
+	for _, a := range attempts {
+		if a.TokensEstimated {
+			return true
+		}
+	}
+	return false
 }
 
 // printSwarmResult renders the swarm result to stdout.
@@ -1063,8 +1159,89 @@ func cmdTrust() *cobra.Command {
 		Use:   "trust",
 		Short: "Confidence layer: source calibration and defect-cost (Trust Control Plane)",
 	}
-	cmd.AddCommand(cmdTrustCalibration(), cmdTrustRecord(), cmdTrustDefect())
+	cmd.AddCommand(cmdTrustCalibration(), cmdTrustRecord(), cmdTrustDefect(),
+		cmdTrustStats(), cmdTrustExplain())
 	return cmd
+}
+
+func cmdTrustStats() *cobra.Command {
+	var days int
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "SPRT run rollup: samples saved vs fixed-N, auto-clear rate, achieved vs target confidence",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			runs, err := trust.LoadRuns(trust.DefaultLogPath())
+			if err != nil {
+				return err
+			}
+			if days > 0 {
+				cutoff := time.Now().UTC().AddDate(0, 0, -days).Format(time.RFC3339)
+				kept := runs[:0]
+				for _, r := range runs {
+					if r.TS >= cutoff {
+						kept = append(kept, r)
+					}
+				}
+				runs = kept
+			}
+			s := trust.Aggregate(runs, 5) // compare against a fixed-5 swarm
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(s)
+			}
+			if s.Runs == 0 {
+				fmt.Println("\n  No SPRT runs yet. Try `hydra dispatch --confidence 0.95 --prompt ...`.")
+				return nil
+			}
+			fmt.Printf("\n  Trust stats (%d runs)\n", s.Runs)
+			fmt.Println("  " + strings.Repeat("─", 52))
+			fmt.Printf("  mean samples        %.2f  (vs fixed-%d swarm)\n", s.MeanSamples, s.FixedSwarmN)
+			fmt.Printf("  samples saved       %.0f%%\n", s.SamplesSavedPct)
+			fmt.Printf("  auto-cleared        %.0f%%  (reached target without a human)\n", s.AutoClearedPct)
+			fmt.Printf("  confidence          target %.1f%% → achieved %.1f%%\n",
+				s.MeanTargetConf*100, s.MeanFinalConf*100)
+			fmt.Printf("  total spend         $%.4f\n\n", s.TotalCostUSD)
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&days, "days", 0, "only include runs from the last N days")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
+	return cmd
+}
+
+func cmdTrustExplain() *cobra.Command {
+	return &cobra.Command{
+		Use:   "explain <task_hash>",
+		Short: "Show the LLR ledger for a past SPRT run — why it stopped where it did",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			runs, err := trust.LoadRuns(trust.DefaultLogPath())
+			if err != nil {
+				return err
+			}
+			for i := len(runs) - 1; i >= 0; i-- { // newest match first
+				r := runs[i]
+				if r.TaskHash != args[0] {
+					continue
+				}
+				fmt.Printf("\n  task %s  ·  domain %s  ·  %s\n", r.TaskHash, r.Domain, r.TS)
+				fmt.Printf("  target %.1f%% → achieved %.1f%%  ·  %d samples  ·  %s\n\n",
+					r.TargetConf*100, r.FinalConf*100, r.Samples, r.Decision)
+				fmt.Printf("  %-28s  %-9s  %8s  %10s\n", "SOURCE", "VERDICT", "LLR", "Λ AFTER")
+				fmt.Println("  " + strings.Repeat("─", 60))
+				for _, e := range r.Ledger {
+					verdict := "agree"
+					if !e.Agreed {
+						verdict = "disagree"
+					}
+					fmt.Printf("  %-28.28s  %-9s  %+8.3f  %+10.3f\n", e.Source, verdict, e.LLR, e.LambdaAfter)
+				}
+				fmt.Println()
+				return nil
+			}
+			return fmt.Errorf("no run found with task_hash %q", args[0])
+		},
+	}
 }
 
 func cmdTrustCalibration() *cobra.Command {

--- a/docs/index.html
+++ b/docs/index.html
@@ -2423,6 +2423,16 @@
         </div>
       </div>
 
+      <div class="arch-card scroll-reveal" style="background: rgba(139,92,246,0.07); border: 1px solid rgba(139,92,246,0.25); border-radius: 16px; padding: 28px;">
+        <div style="font-size: 28px; margin-bottom: 14px;">🧭</div>
+        <h3 style="font-family: var(--font-display); font-size: 18px; color: var(--text-bright); margin: 0 0 10px;">Confidence Routing <span style="font-size: 11px; color: var(--accent-primary); border: 1px solid rgba(139,92,246,0.4); border-radius: 6px; padding: 1px 6px; vertical-align: middle;">NEW</span></h3>
+        <p style="color: var(--text-muted); font-size: 14px; line-height: 1.65; margin: 0 0 16px;">Instead of always firing a fixed number of models, <strong style="color: var(--text-main);">--confidence</strong> runs a sequential probability ratio test (SPRT): it samples models adaptively and stops the moment a target confidence of correctness is reached, using per-source calibration you build from real outcomes. Fewer calls on easy tasks; more only where accuracy demands it.</p>
+        <div class="code-snippet-box" style="margin: 0; padding: 10px 14px;">
+          <pre style="margin: 0; font-size: 12px; color: var(--accent-primary);">hydra dispatch --confidence 0.95 "prompt"
+hydra trust stats        # samples saved, achieved conf</pre>
+        </div>
+      </div>
+
       <div class="arch-card scroll-reveal" style="background: rgba(6,182,212,0.07); border: 1px solid rgba(6,182,212,0.25); border-radius: 16px; padding: 28px;">
         <div style="font-size: 28px; margin-bottom: 14px;">📊</div>
         <h3 style="font-family: var(--font-display); font-size: 18px; color: var(--text-bright); margin: 0 0 10px;">Cost Analytics</h3>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,6 +7,7 @@
 - **10-tier routing**: Claude Opus (tier 1, complex reasoning) down to Qwen3 via Ollama (tier 10, free local)
 - **~1µs routing overhead**: the Go routing engine (policy eval + head selection + budget check) adds ~1,130 ns per dispatch — benchmarked on Apple M1 via `go test -bench=BenchmarkRoutingPath`
 - **Swarm dispatch**: fan a single prompt to multiple models simultaneously — race (fastest), best (LLM-judged quality), or all (aggregate)
+- **Confidence routing**: `hydra dispatch --confidence 0.95` runs an SPRT (sequential probability ratio test) ensemble that samples models adaptively and stops as soon as a target confidence of correctness is reached, using per-source calibration (`hydra trust calibration`) you build up from real outcomes — fewer model calls on easy tasks, more only where accuracy demands it
 - **Token budget enforcement**: 6 pressure modes (Normal → Emergency) auto-downgrade tiers as context window fills
 - **Cost analytics**: `hydra stats` shows spend broken down by model, tier, and day
 - **Dynamic pricing**: live rates from OpenRouter API with 24h cache and static YAML offline fallback

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-24</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/llms.txt</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/pricing.md</loc>
-    <lastmod>2026-06-15</lastmod>
+    <lastmod>2026-07-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/internal/swarm/sprt.go
+++ b/internal/swarm/sprt.go
@@ -1,0 +1,117 @@
+package swarm
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/rank"
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+// SPRTResult wraps a trust.Run outcome with the executions it drove, so callers
+// can render both the decision (candidate, confidence, ledger) and the per-head
+// attempts.
+type SPRTResult struct {
+	Trust    *trust.Result
+	Attempts []Attempt
+	Domain   string
+	Prompt   string
+	Target   float64 // requested target confidence
+}
+
+// RunSPRT routes a prompt through the SPRT optimal-stopping ensemble: it samples
+// the selected heads adaptively, in most-diagnostic-per-dollar order, stopping as
+// soon as the calibrated confidence reaches opts.Confidence. It is the production
+// caller of trust.Run — the swarm executor is adapted to trust.Executor here.
+func (s *Swarm) RunSPRT(ctx context.Context, prompt string, opts Options) (*SPRTResult, error) {
+	if opts.Confidence <= 0 || opts.Confidence >= 1 {
+		return nil, fmt.Errorf("swarm sprt: confidence must be in (0,1), got %v", opts.Confidence)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, fmt.Errorf("swarm sprt: config load: %w", err)
+	}
+
+	selected, err := resolveSelector(opts, cfg).Select(s.heads, opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("swarm sprt: no heads available")
+	}
+
+	domain := opts.Domain
+	if domain == "" {
+		domain = "default"
+	}
+
+	cal, err := trust.New(trust.DefaultPath())
+	if err != nil {
+		return nil, fmt.Errorf("swarm sprt: calibration load: %w", err)
+	}
+
+	// Map heads → trust.Source, estimating per-call cost for ordering + budget.
+	estIn := len(prompt) / 4
+	sources := make([]trust.Source, 0, len(selected))
+	byID := make(map[string]provider.Head, len(selected))
+	for _, h := range selected {
+		var cost float64
+		if s.pricing != nil {
+			cost = s.pricing.EstimateCost(rank.UITier(h), estIn, estIn/2)
+		}
+		sources = append(sources, trust.Source{ID: h.ID, Family: h.Provider, EstCostUSD: cost})
+		byID[h.ID] = h
+	}
+
+	adapter := &sprtExecutor{swarm: s, prompt: prompt, opts: opts, byID: byID}
+	res, err := trust.Run(ctx, trust.Task{Domain: domain}, sources, adapter, cal, trust.Target{
+		Confidence: opts.Confidence,
+		MaxCostUSD: opts.MaxEstCostUSD,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Mark the winning attempt (the one whose output became the candidate).
+	for i := range adapter.attempts {
+		if adapter.attempts[i].Output == res.Candidate {
+			adapter.attempts[i].Rank = 1
+			break
+		}
+	}
+
+	return &SPRTResult{Trust: res, Attempts: adapter.attempts, Domain: domain, Prompt: prompt, Target: opts.Confidence}, nil
+}
+
+// sprtExecutor adapts the swarm's per-head execution to the trust.Executor
+// interface and records every attempt it makes.
+type sprtExecutor struct {
+	swarm    *Swarm
+	prompt   string
+	opts     Options
+	byID     map[string]provider.Head
+	attempts []Attempt
+}
+
+func (e *sprtExecutor) Execute(ctx context.Context, src trust.Source, _ trust.Task) (trust.Answer, error) {
+	h, ok := e.byID[src.ID]
+	if !ok {
+		return trust.Answer{}, fmt.Errorf("sprt: unknown source %q", src.ID)
+	}
+	a := executeHead(ctx, h, e.prompt, e.opts)
+
+	// Price the attempt so cost logging and the budget guard see real numbers.
+	if e.swarm.pricing != nil && a.Status == StatusOK {
+		a.EstCostUSD = round6(e.swarm.pricing.EstimateCost(rank.UITier(h), a.InputTokens, a.OutputTokens))
+	}
+	a.FinishedAt = time.Now()
+	e.attempts = append(e.attempts, a)
+
+	if a.Status != StatusOK {
+		return trust.Answer{}, fmt.Errorf("sprt: head %s failed: %s", h.ID, a.Status)
+	}
+	return trust.Answer{Text: a.Output, CostUSD: a.EstCostUSD}, nil
+}

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -44,6 +44,10 @@ type Options struct {
 	// Judge (ModeBest only).
 	JudgeTierHint string        // "" → use config.Cortex head
 	JudgeTimeout  time.Duration // 0 → 30 s
+
+	// SPRT mode (RunSPRT).
+	Confidence float64 // target P(correct); >0 selects the SPRT ensemble
+	Domain     string  // calibration domain ("" → "default")
 }
 
 // SwarmResult is the complete outcome of a swarm dispatch.

--- a/internal/trust/log.go
+++ b/internal/trust/log.go
@@ -1,0 +1,133 @@
+package trust
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// RunLog is one persisted SPRT run — the data the "By The Numbers" page
+// graduates from [MODEL] to [MEASURED], and what `hydra trust stats/explain` read.
+type RunLog struct {
+	TS         string     `json:"ts"`
+	TaskHash   string     `json:"task_hash"`
+	Domain     string     `json:"domain"`
+	TargetConf float64    `json:"target_conf"`
+	FinalConf  float64    `json:"final_conf"`
+	Samples    int        `json:"samples"`
+	Models     []string   `json:"models"`
+	CostUSD    float64    `json:"cost_usd"`
+	CostSource string     `json:"cost_source"` // from cost.SourceLabels
+	Decision   string     `json:"decision"`    // accept | stopped_on_budget
+	Ledger     []Evidence `json:"ledger,omitempty"`
+}
+
+// DefaultLogPath is where SPRT runs are persisted (~/.hydra/trust.jsonl).
+func DefaultLogPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".hydra", "trust.jsonl")
+}
+
+// TaskHash is a short stable identifier for a prompt, used to correlate a run
+// with `hydra trust explain <task_hash>`.
+func TaskHash(prompt string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(prompt))
+	return fmt.Sprintf("%08x", h.Sum32())
+}
+
+// LogRun appends one run to the trust log, stamping TS if the caller left it blank.
+func LogRun(path string, r RunLog) error {
+	if r.TS == "" {
+		r.TS = time.Now().UTC().Format(time.RFC3339)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	raw, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(f, string(raw))
+	return err
+}
+
+// LoadRuns reads all runs from the trust log. A missing file yields no runs.
+func LoadRuns(path string) ([]RunLog, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var runs []RunLog
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var r RunLog
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			continue
+		}
+		runs = append(runs, r)
+	}
+	return runs, scanner.Err()
+}
+
+// Stats is the aggregate view produced by `hydra trust stats`.
+type Stats struct {
+	Runs            int     `json:"runs"`
+	MeanSamples     float64 `json:"mean_samples"`
+	FixedSwarmN     int     `json:"fixed_swarm_n"` // baseline for comparison
+	SamplesSavedPct float64 `json:"samples_saved_pct"`
+	AutoClearedPct  float64 `json:"auto_cleared_pct"` // reached accept without a human
+	MeanTargetConf  float64 `json:"mean_target_conf"`
+	MeanFinalConf   float64 `json:"mean_final_conf"`
+	TotalCostUSD    float64 `json:"total_cost_usd"`
+}
+
+// Aggregate summarizes a set of runs against a fixed-N swarm baseline.
+func Aggregate(runs []RunLog, fixedN int) Stats {
+	s := Stats{FixedSwarmN: fixedN}
+	s.Runs = len(runs)
+	if s.Runs == 0 {
+		return s
+	}
+	var totSamples, accepted int
+	var totTarget, totFinal, totCost float64
+	for _, r := range runs {
+		totSamples += r.Samples
+		totTarget += r.TargetConf
+		totFinal += r.FinalConf
+		totCost += r.CostUSD
+		if r.Decision == DecisionAccept.String() {
+			accepted++
+		}
+	}
+	n := float64(s.Runs)
+	s.MeanSamples = float64(totSamples) / n
+	s.MeanTargetConf = totTarget / n
+	s.MeanFinalConf = totFinal / n
+	s.TotalCostUSD = totCost
+	s.AutoClearedPct = 100 * float64(accepted) / n
+	if fixedN > 0 {
+		s.SamplesSavedPct = 100 * (1 - s.MeanSamples/float64(fixedN))
+	}
+	return s
+}

--- a/internal/trust/log_test.go
+++ b/internal/trust/log_test.go
@@ -1,0 +1,94 @@
+package trust
+
+import (
+	"math"
+	"path/filepath"
+	"testing"
+)
+
+func TestTaskHash_StableAndDistinct(t *testing.T) {
+	if TaskHash("hello") != TaskHash("hello") {
+		t.Error("TaskHash not stable for identical input")
+	}
+	if TaskHash("hello") == TaskHash("world") {
+		t.Error("TaskHash collided on distinct inputs")
+	}
+	if len(TaskHash("x")) != 8 {
+		t.Errorf("TaskHash length = %d, want 8 hex chars", len(TaskHash("x")))
+	}
+}
+
+func TestLogRun_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trust.jsonl")
+
+	in := RunLog{
+		TaskHash: "abc123", Domain: "go", TargetConf: 0.95, FinalConf: 0.97,
+		Samples: 3, Models: []string{"a", "b"}, CostUSD: 0.012,
+		CostSource: "estimated", Decision: "accept",
+		Ledger: []Evidence{{Source: "a", Agreed: true, LLR: 2.2, LambdaAfter: 2.2}},
+	}
+	if err := LogRun(path, in); err != nil {
+		t.Fatal(err)
+	}
+	runs, err := LoadRuns(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("loaded %d runs, want 1", len(runs))
+	}
+	got := runs[0]
+	if got.TS == "" {
+		t.Error("LogRun should stamp TS when blank")
+	}
+	if got.TaskHash != "abc123" || got.Samples != 3 || got.Decision != "accept" {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	if len(got.Ledger) != 1 || got.Ledger[0].Source != "a" {
+		t.Errorf("ledger not preserved: %+v", got.Ledger)
+	}
+}
+
+func TestLoadRuns_MissingFile(t *testing.T) {
+	runs, err := LoadRuns(filepath.Join(t.TempDir(), "does-not-exist.jsonl"))
+	if err != nil {
+		t.Fatalf("missing file should not error, got %v", err)
+	}
+	if runs != nil {
+		t.Errorf("missing file should yield nil runs, got %v", runs)
+	}
+}
+
+func TestAggregate(t *testing.T) {
+	runs := []RunLog{
+		{Samples: 2, TargetConf: 0.95, FinalConf: 0.98, CostUSD: 0.01, Decision: "accept"},
+		{Samples: 4, TargetConf: 0.95, FinalConf: 0.96, CostUSD: 0.02, Decision: "accept"},
+		{Samples: 6, TargetConf: 0.95, FinalConf: 0.80, CostUSD: 0.03, Decision: "stopped_on_budget"},
+	}
+	s := Aggregate(runs, 5)
+
+	if s.Runs != 3 {
+		t.Errorf("runs = %d, want 3", s.Runs)
+	}
+	if math.Abs(s.MeanSamples-4.0) > 1e-9 { // (2+4+6)/3
+		t.Errorf("mean samples = %v, want 4", s.MeanSamples)
+	}
+	// mean 4 vs fixed-5 → 20% saved.
+	if math.Abs(s.SamplesSavedPct-20.0) > 1e-9 {
+		t.Errorf("samples saved = %v%%, want 20", s.SamplesSavedPct)
+	}
+	// 2 of 3 accepted → 66.7% auto-cleared.
+	if math.Abs(s.AutoClearedPct-200.0/3) > 1e-6 {
+		t.Errorf("auto-cleared = %v%%, want ≈66.7", s.AutoClearedPct)
+	}
+	if math.Abs(s.TotalCostUSD-0.06) > 1e-9 {
+		t.Errorf("total cost = %v, want 0.06", s.TotalCostUSD)
+	}
+}
+
+func TestAggregate_Empty(t *testing.T) {
+	s := Aggregate(nil, 5)
+	if s.Runs != 0 || s.MeanSamples != 0 {
+		t.Errorf("empty aggregate should be zero-valued, got %+v", s)
+	}
+}


### PR DESCRIPTION
## Summary
Completes the Trust Control Plane vertical slice: the Phase 2a SPRT engine is now reachable end-to-end via `hydra dispatch --confidence`, runs are logged and inspectable, and **all user-facing docs are updated to the current Go-only flow** (the shell layer is gone; Trust has shipped).

## Integration
- **`internal/swarm`** — `ModeSPRT` + `RunSPRT` + a swarm→`trust.Executor` adapter mapping selected heads to `trust.Source` (per-call cost from pricing, family from provider for the correlation discount) and recording every attempt. This is the production caller of `trust.Run`.
- **`cmd/hydra`** — `hydra dispatch --confidence 0.95 [--domain X]` routes through the SPRT ensemble and prints the LLR ledger + decision.
- **`internal/trust/log.go`** — `~/.hydra/trust.jsonl` schema (`task_hash`, target/final conf, samples, models, cost + `cost_source`, decision, ledger) + `Aggregate`.
- **`hydra trust stats`** (samples saved vs fixed-N, auto-clear rate, achieved vs target confidence) and **`hydra trust explain <task_hash>`** (the ledger).

## Docs — the flow entirely changed
- **README** — rewritten architecture diagram (policy → router → single/swarm/SPRT → heads → observability), a new **By the Numbers** section (measured routing overhead, calibration `D`, SPRT sample/accuracy figures with a methodology + honesty note), Swarm + Confidence-Routing feature sections, expanded command list, corrected comparison + roadmap, and a real package tree (no more `dispatch/*.sh`).
- **CLAUDE.md** — directory layout + quick reference reflect the native-Go-only flow, `internal/trust`, `--confidence`, and `hydra trust *`.
- **llms.txt / index.html / sitemap.xml** — confidence-routing capability added, lastmod bumped.

## Verification
- `go build ./... && go vet ./...` clean; `go test ./... -race` green.
- Manual: `trust stats` (table + `--json`), `trust explain` (ledger + clean error on unknown hash), and `--confidence`/`--domain` flags confirmed wired.

Closes #99