### PR TITLE
feat(graph): blast-radius-aware confidence routing (Phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ internal/executor/      ← Native executors: agy, Ollama, HTTP (API providers),
 internal/provider/      ← Discovery: cli / env (API keys) / port / agy.
 internal/swarm/         ← Fan-out (race/best/all + judge) + SPRT adapter (swarm→trust).
 internal/trust/         ← Trust Control Plane: calibration (LLR/D) + defect-cost + SPRT ensemble.
+internal/graph/         ← Code dependency graph (graph.json) → blast radius → defect cost.
 internal/pricing/       ← Live pricing DB (OpenRouter fetch + 24h cache + tier fallback).
 internal/policy/        ← PII detection + local-only enforcement.
 internal/{cost,budget}/ ← Spend reporting (est/actual labeling) + token-budget governor.
@@ -204,6 +205,10 @@ hydra dispatch --swarm --swarm-mode best --prompt "implement rate limiter"
 
 # Route to a target confidence of correctness (SPRT optimal-stopping ensemble)
 hydra dispatch --confidence 0.95 --prompt "is this migration safe for prod?"
+
+# Blast-radius aware: --file raises the confidence bar by the code graph
+hydra graph blast internal/auth/token.go
+hydra dispatch --confidence 0.90 --file internal/auth/token.go --prompt "rotate signing key"
 
 # Trust Control Plane: calibration, defect-cost, run stats, and the LLR ledger
 hydra trust calibration ; hydra trust record --source model:x --domain go --said-correct --outcome correct
@@ -665,7 +670,8 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/policy` | Allow/deny rules (PII local-only, etc.) |
 | `internal/rank` | CapScore ranking helpers |
 | `internal/config` | Hydra config load/save (`~/.config/hydra/`) |
-| `internal/trust` | Trust Control Plane confidence layer: per-source calibration (Beta-Bernoulli → LLR/D), defect-cost model, and the SPRT optimal-stopping ensemble (`trust.Run`). Drives `hydra dispatch --confidence` and `hydra trust calibration\|record\|defect\|stats\|explain`. |
+| `internal/trust` | Trust Control Plane confidence layer: per-source calibration (Beta-Bernoulli → LLR/D), defect-cost model + `RequiredConfidence`, and the SPRT optimal-stopping ensemble (`trust.Run`). Drives `hydra dispatch --confidence` and `hydra trust calibration\|record\|defect\|stats\|explain`. |
+| `internal/graph` | Code dependency graph (`graph.json`, Graphify or any tree-sitter indexer) → transitive-dependent blast radius → `trust.Task.BlastRadius`. Drives `hydra graph blast` and `hydra dispatch --file`. |
 | `internal/tui` | Bubble Tea TUI: init wizard, install flow |
 | `internal/review` | Code review subcommand |
 | `internal/editor` | Editor integration |

--- a/README.md
+++ b/README.md
@@ -279,6 +279,14 @@ hydra trust stats                # samples saved vs fixed-N, achieved vs target 
 hydra trust explain <task_hash>  # the full LLR ledger for a past run — why it stopped
 ```
 
+**Blast-radius aware.** Point Hydra at a dependency graph (`graph.json` from [Graphify](https://github.com/safishamsi/graphify) or any tree-sitter indexer) and the confidence bar scales with how much code an edit could break — a fix to a hub everything imports demands far more certainty than a leaf helper:
+
+```bash
+hydra graph blast internal/auth/token.go        # 3 transitive dependents → demands 96.7%
+hydra dispatch --confidence 0.90 --file internal/auth/token.go "rotate the signing key"
+#   graph: blast radius 3.00 → demands confidence ≥ 96.7%  (raises the 0.90 floor)
+```
+
 In synthetic benchmarks this cuts model calls **~49% on easy tasks** and **~24% on a blended workload** at ≥98% accuracy — while deliberately sampling *more* than a fixed swarm on genuinely hard tasks, which a fixed-N ensemble cannot do. Calibration is cold-start conservative: with no history, sources are treated as uninformative and Hydra falls back to sampling broadly.
 
 > The SPRT ensemble, calibration engine, and defect-cost model have shipped. Graph-aware (blast-radius) routing, a local MCP accountability ledger, and a pluggable verification-oracle interface are on the [roadmap](#roadmap).
@@ -359,6 +367,7 @@ hydra trust record ...                  # feed an outcome to train calibration
 hydra trust defect ...                  # modeled cost of shipping a wrong answer
 hydra trust stats                       # samples saved, achieved vs target confidence
 hydra trust explain <task_hash>         # the LLR ledger for a past SPRT run
+hydra graph blast <file>                # a file's blast radius + the confidence it demands
 
 # Editing & batch
 hydra edit --file ... --prompt "..."    # scoped, validated, rollback-safe file edit
@@ -435,7 +444,7 @@ For Ollama models, add a family pattern:
 | **Per-source calibration** (Beta-Bernoulli → LLR / D) | ✅ Shipped |
 | **Defect-cost model** (`hydra trust defect`) | ✅ Shipped |
 | **SPRT confidence routing** (`hydra dispatch --confidence`) | ✅ Shipped |
-| Graph-aware routing (blast-radius → confidence) | 🔨 Building |
+| **Graph-aware routing** — blast-radius → defect cost → confidence | ✅ Shipped |
 | Outcome auto-wiring (tests / review / revert → calibration) | 🔨 Building |
 | Local MCP accountability ledger | 📋 Planned |
 | Pluggable verification-oracle interface | 📋 Planned |
@@ -448,8 +457,8 @@ See the full [Hydra Roadmap project board](https://github.com/users/ankit373/pro
 
 Hydra started by answering *which model is cheapest for this task?* It's evolving to answer a harder question: ***how sure are we the answer is right, and what's the least attention we can spend to be that sure?***
 
-- **Today** — calibration measures each source's real diagnostic power; SPRT samples adaptively to a target confidence; the defect-cost model prices what a wrong answer costs.
-- **Next** — graph-aware routing uses code blast-radius to raise the confidence bar where a mistake is expensive; a local MCP ledger records what every model was actually allowed to touch and did; a verification-oracle interface lets test-runners and compilers act as first-class, high-`D` evidence sources.
+- **Today** — calibration measures each source's real diagnostic power; SPRT samples adaptively to a target confidence; the defect-cost model prices what a wrong answer costs; and graph-aware routing reads a code dependency graph so an edit's **blast radius** raises the confidence bar where a mistake is expensive.
+- **Next** — a local MCP ledger records what every model was actually allowed to touch and did; a verification-oracle interface lets test-runners and compilers act as first-class, high-`D` evidence sources; outcomes (tests/review/revert) auto-train calibration.
 
 The design principle throughout: **no single vendor is privileged** — Hydra routes *across* providers and *away* from expensive ones, optimizing verified correctness per unit of human attention.
 

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ankit373/hydra/internal/cost"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/editor"
+	"github.com/ankit373/hydra/internal/graph"
 	"github.com/ankit373/hydra/internal/parallel"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
@@ -69,7 +70,7 @@ func rootCmd() *cobra.Command {
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(),
 		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(),
-		cmdPricing(), cmdTrust(),
+		cmdPricing(), cmdTrust(), cmdGraph(),
 		cmdVersion(),
 	)
 	return root
@@ -322,6 +323,8 @@ func cmdDispatch() *cobra.Command {
 		// trust / SPRT flags
 		confidence float64
 		domain     string
+		file       string
+		graphPath  string
 	)
 
 	cmd := &cobra.Command{
@@ -338,7 +341,24 @@ func cmdDispatch() *cobra.Command {
 			}
 
 			// ── SPRT confidence mode ──────────────────────────────────────
-			if confidence > 0 {
+			// Triggered by --confidence, or by --file (blast radius derives a
+			// target on its own). Blast radius raises the bar but never lowers a
+			// target the user explicitly asked for.
+			effectiveConf := confidence
+			if file != "" {
+				g, err := graph.Load(graphPath)
+				if err != nil {
+					return err
+				}
+				task := trust.Task{Domain: domain, BlastRadius: g.BlastRadiusForFile(file)}
+				derived := trust.NewDefectModel().RequiredConfidence(task)
+				fmt.Printf("  %s blast radius %.2f → demands confidence ≥ %.1f%%\n",
+					dimStyle.Render("graph:"), task.BlastRadius, derived*100)
+				if derived > effectiveConf {
+					effectiveConf = derived
+				}
+			}
+			if effectiveConf > 0 {
 				sw := swarm.New(d, d.Heads(), d)
 				res, err := sw.RunSPRT(ctx, prompt, swarm.Options{
 					TierHint:      tier,
@@ -346,7 +366,7 @@ func cmdDispatch() *cobra.Command {
 					MaxEstCostUSD: swarmMaxCost,
 					LocalOnly:     localOnly,
 					System:        system,
-					Confidence:    confidence,
+					Confidence:    effectiveConf,
 					Domain:        domain,
 				})
 				if err != nil {
@@ -449,6 +469,54 @@ func cmdDispatch() *cobra.Command {
 	// trust / SPRT flags
 	cmd.Flags().Float64Var(&confidence, "confidence", 0, "route via SPRT ensemble until this P(correct) is reached, e.g. 0.95")
 	cmd.Flags().StringVar(&domain, "domain", "", "calibration domain for --confidence (default: \"default\")")
+	cmd.Flags().StringVar(&file, "file", "", "target file — raises the confidence bar by its code blast radius")
+	cmd.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph used with --file")
+	return cmd
+}
+
+// cmdGraph inspects the code dependency graph Hydra uses for blast-radius routing.
+func cmdGraph() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "graph",
+		Short: "Inspect the code dependency graph used for blast-radius routing",
+	}
+	var graphPath string
+	var jsonOut bool
+	blast := &cobra.Command{
+		Use:   "blast <file>",
+		Short: "Show a file's blast radius (how much transitively depends on it)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			g, err := graph.Load(graphPath)
+			if err != nil {
+				return err
+			}
+			file := args[0]
+			radius := g.BlastRadiusForFile(file)
+			task := trust.Task{BlastRadius: radius}
+			dm := trust.NewDefectModel()
+
+			var deps int
+			for _, id := range g.NodesInFile(file) {
+				deps += g.DependentCount(id)
+			}
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(map[string]any{
+					"file": file, "blast_radius": radius, "transitive_dependents": deps,
+					"defect_cost_usd": dm.CostUSD(task), "required_confidence": dm.RequiredConfidence(task),
+				})
+			}
+			fmt.Printf("\n  %s\n", cortexStyle.Render(file))
+			fmt.Printf("    transitive dependents  %d\n", deps)
+			fmt.Printf("    blast radius           %.2f×\n", radius)
+			fmt.Printf("    defect cost            $%.2f\n", dm.CostUSD(task))
+			fmt.Printf("    demands confidence     %.1f%%\n\n", dm.RequiredConfidence(task)*100)
+			return nil
+		},
+	}
+	blast.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph (graph.json)")
+	blast.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
+	cmd.AddCommand(blast)
 	return cmd
 }
 
@@ -1321,14 +1389,27 @@ func cmdTrustRecord() *cobra.Command {
 }
 
 func cmdTrustDefect() *cobra.Command {
-	var domain string
+	var domain, file, graphPath string
 	var blast float64
 	var irreversible, pii, production bool
 	cmd := &cobra.Command{
 		Use:   "defect",
-		Short: "Preview the modeled cost of shipping a wrong answer for a task",
+		Short: "Preview the modeled cost of a wrong answer + the confidence it demands",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			dm := trust.NewDefectModel()
+
+			// --file derives blast radius from the code dependency graph,
+			// overriding --blast when a graph is available.
+			blastSource := "flag"
+			if file != "" {
+				g, err := graph.Load(graphPath)
+				if err != nil {
+					return err
+				}
+				blast = g.BlastRadiusForFile(file)
+				blastSource = "graph"
+			}
+
 			task := trust.Task{
 				Domain:       domain,
 				BlastRadius:  blast,
@@ -1336,13 +1417,17 @@ func cmdTrustDefect() *cobra.Command {
 				TouchesPII:   pii,
 				Production:   production,
 			}
-			fmt.Printf("  defect cost ≈ $%.2f  (blast=%.1f irreversible=%v pii=%v prod=%v)\n",
-				dm.CostUSD(task), blast, irreversible, pii, production)
+			fmt.Printf("  defect cost ≈ $%.2f  (blast=%.2f [%s] irreversible=%v pii=%v prod=%v)\n",
+				dm.CostUSD(task), blast, blastSource, irreversible, pii, production)
+			fmt.Printf("  → demands confidence ≥ %.1f%%  (use with: hydra dispatch --confidence %.3f)\n",
+				dm.RequiredConfidence(task)*100, dm.RequiredConfidence(task))
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&domain, "domain", "", "task domain")
-	cmd.Flags().Float64Var(&blast, "blast", 1.0, "blast-radius multiplier (Graphify supplies this in Phase 3)")
+	cmd.Flags().Float64Var(&blast, "blast", 1.0, "blast-radius multiplier (ignored when --file is set)")
+	cmd.Flags().StringVar(&file, "file", "", "derive blast radius from this file's dependents in the code graph")
+	cmd.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph (graph.json)")
 	cmd.Flags().BoolVar(&irreversible, "irreversible", false, "change cannot be cheaply undone")
 	cmd.Flags().BoolVar(&pii, "pii", false, "task handles personal data")
 	cmd.Flags().BoolVar(&production, "production", false, "target is production")

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,6 +8,7 @@
 - **~1µs routing overhead**: the Go routing engine (policy eval + head selection + budget check) adds ~1,130 ns per dispatch — benchmarked on Apple M1 via `go test -bench=BenchmarkRoutingPath`
 - **Swarm dispatch**: fan a single prompt to multiple models simultaneously — race (fastest), best (LLM-judged quality), or all (aggregate)
 - **Confidence routing**: `hydra dispatch --confidence 0.95` runs an SPRT (sequential probability ratio test) ensemble that samples models adaptively and stops as soon as a target confidence of correctness is reached, using per-source calibration (`hydra trust calibration`) you build up from real outcomes — fewer model calls on easy tasks, more only where accuracy demands it
+- **Blast-radius aware**: `hydra dispatch --file X` and `hydra graph blast X` read a code dependency graph (`graph.json`) so an edit to a widely-depended-on file demands higher confidence than a leaf — the defect-cost model holds expected leaked-defect cost roughly constant
 - **Token budget enforcement**: 6 pressure modes (Normal → Emergency) auto-downgrade tiers as context window fills
 - **Cost analytics**: `hydra stats` shows spend broken down by model, tier, and day
 - **Dynamic pricing**: live rates from OpenRouter API with 24h cache and static YAML offline fallback

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -1,0 +1,153 @@
+// Package graph reads a code dependency graph (graph.json, as produced by
+// Graphify or any tree-sitter indexer) and computes a file's blast radius — how
+// much other code transitively depends on it. Hydra feeds blast radius into the
+// defect-cost model so an edit to a widely-depended-on file demands higher
+// confidence than an edit to a leaf.
+package graph
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+)
+
+// Node is one vertex in the dependency graph.
+type Node struct {
+	ID   string `json:"id"`
+	File string `json:"file"`
+}
+
+// Edge is a directed dependency: From depends on To (From imports/calls To), so
+// a change to To can break From.
+type Edge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// Doc is the on-disk graph.json schema.
+type Doc struct {
+	Nodes []Node `json:"nodes"`
+	Edges []Edge `json:"edges"`
+}
+
+// Graph is an in-memory dependency graph with reverse adjacency for blast-radius
+// queries. The zero value (and a nil *Graph) is a valid empty graph.
+type Graph struct {
+	// dependents[x] = nodes that directly depend on x (i.e. break if x changes).
+	dependents map[string][]string
+	// filesToNodes maps a file path to the node IDs declared in it.
+	filesToNodes map[string][]string
+}
+
+// Load reads graph.json from path. A missing file yields an empty graph and no
+// error, so blast-radius queries degrade gracefully to 1.0.
+func Load(path string) (*Graph, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Graph{}, nil
+		}
+		return nil, err
+	}
+	var doc Doc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+	return fromDoc(doc), nil
+}
+
+// DefaultPath is where Hydra looks for the graph relative to a repo root.
+func DefaultPath(repoRoot string) string {
+	return filepath.Join(repoRoot, "graph.json")
+}
+
+func fromDoc(doc Doc) *Graph {
+	g := &Graph{
+		dependents:   make(map[string][]string),
+		filesToNodes: make(map[string][]string),
+	}
+	for _, n := range doc.Nodes {
+		if n.File != "" {
+			g.filesToNodes[n.File] = append(g.filesToNodes[n.File], n.ID)
+		}
+	}
+	for _, e := range doc.Edges {
+		// e.From depends on e.To → e.To has dependent e.From.
+		g.dependents[e.To] = append(g.dependents[e.To], e.From)
+	}
+	return g
+}
+
+// transitiveDependents returns every node that transitively depends on any node
+// in seeds (breadth-first over reverse edges), excluding the seeds themselves.
+func (g *Graph) transitiveDependents(seeds []string) map[string]bool {
+	seen := make(map[string]bool)
+	if g == nil || g.dependents == nil {
+		return seen
+	}
+	seedSet := make(map[string]bool, len(seeds))
+	for _, s := range seeds {
+		seedSet[s] = true
+	}
+	queue := append([]string(nil), seeds...)
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, dep := range g.dependents[cur] {
+			if seen[dep] || seedSet[dep] {
+				continue
+			}
+			seen[dep] = true
+			queue = append(queue, dep)
+		}
+	}
+	return seen
+}
+
+// DependentCount returns the number of nodes that transitively depend on the
+// given node ID (how many things break if it changes).
+func (g *Graph) DependentCount(nodeID string) int {
+	return len(g.transitiveDependents([]string{nodeID}))
+}
+
+// BlastRadiusForFile returns a defect-cost multiplier for editing a file:
+// 1 + log2(1 + transitive dependents) over all nodes declared in that file. A
+// leaf (or an unknown file, or no graph) yields 1.0; a widely-depended-on file
+// grows sub-linearly so one hub node doesn't produce an absurd multiplier.
+func (g *Graph) BlastRadiusForFile(file string) float64 {
+	if g == nil || len(g.filesToNodes) == 0 {
+		return 1.0
+	}
+	seeds := g.filesToNodes[file]
+	if len(seeds) == 0 {
+		// Try a basename match so callers can pass absolute or relative paths.
+		base := filepath.Base(file)
+		for f, ids := range g.filesToNodes {
+			if filepath.Base(f) == base {
+				seeds = append(seeds, ids...)
+			}
+		}
+	}
+	if len(seeds) == 0 {
+		return 1.0
+	}
+	count := len(g.transitiveDependents(seeds))
+	return 1.0 + math.Log2(1.0+float64(count))
+}
+
+// Dependents returns the direct dependents of a node (for `hydra graph blast`).
+func (g *Graph) Dependents(nodeID string) []string {
+	if g == nil {
+		return nil
+	}
+	return g.dependents[nodeID]
+}
+
+// NodesInFile returns the node IDs declared in a file.
+func (g *Graph) NodesInFile(file string) []string {
+	if g == nil {
+		return nil
+	}
+	return g.filesToNodes[file]
+}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -1,0 +1,109 @@
+package graph
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// a ← b ← c   and   a ← d   (arrows point from dependency to dependent)
+//   b depends on a; c depends on b; d depends on a.
+func sampleGraph() *Graph {
+	return fromDoc(Doc{
+		Nodes: []Node{
+			{ID: "a", File: "a.go"},
+			{ID: "b", File: "b.go"},
+			{ID: "c", File: "c.go"},
+			{ID: "d", File: "d.go"},
+		},
+		Edges: []Edge{
+			{From: "b", To: "a"},
+			{From: "c", To: "b"},
+			{From: "d", To: "a"},
+		},
+	})
+}
+
+func TestDependentCount_Transitive(t *testing.T) {
+	g := sampleGraph()
+	if got := g.DependentCount("a"); got != 3 { // b, c (via b), d
+		t.Errorf("DependentCount(a) = %d, want 3", got)
+	}
+	if got := g.DependentCount("b"); got != 1 { // c
+		t.Errorf("DependentCount(b) = %d, want 1", got)
+	}
+	if got := g.DependentCount("c"); got != 0 { // leaf
+		t.Errorf("DependentCount(c) = %d, want 0", got)
+	}
+}
+
+func TestBlastRadiusForFile(t *testing.T) {
+	g := sampleGraph()
+	// a.go: 3 transitive dependents → 1 + log2(4) = 3.0
+	if got := g.BlastRadiusForFile("a.go"); math.Abs(got-3.0) > 1e-9 {
+		t.Errorf("blast(a.go) = %v, want 3.0", got)
+	}
+	// c.go: leaf → 1 + log2(1) = 1.0
+	if got := g.BlastRadiusForFile("c.go"); math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("blast(c.go) = %v, want 1.0", got)
+	}
+	// a hub is riskier than a leaf.
+	if g.BlastRadiusForFile("a.go") <= g.BlastRadiusForFile("c.go") {
+		t.Error("hub file should have larger blast radius than a leaf")
+	}
+}
+
+func TestBlastRadius_BasenameMatch(t *testing.T) {
+	g := sampleGraph()
+	if got := g.BlastRadiusForFile("/repo/pkg/a.go"); math.Abs(got-3.0) > 1e-9 {
+		t.Errorf("basename match blast = %v, want 3.0", got)
+	}
+}
+
+func TestBlastRadius_UnknownAndEmpty(t *testing.T) {
+	g := sampleGraph()
+	if got := g.BlastRadiusForFile("nonexistent.go"); got != 1.0 {
+		t.Errorf("unknown file blast = %v, want 1.0", got)
+	}
+	var empty *Graph
+	if got := empty.BlastRadiusForFile("a.go"); got != 1.0 {
+		t.Errorf("nil graph blast = %v, want 1.0", got)
+	}
+}
+
+func TestCycleSafety(t *testing.T) {
+	g := fromDoc(Doc{
+		Nodes: []Node{{ID: "a", File: "a.go"}, {ID: "b", File: "b.go"}},
+		Edges: []Edge{{From: "a", To: "b"}, {From: "b", To: "a"}}, // mutual
+	})
+	// Must terminate; each depends on the other, so one transitive dependent each.
+	if got := g.DependentCount("a"); got != 1 {
+		t.Errorf("DependentCount(a) with cycle = %d, want 1", got)
+	}
+}
+
+func TestLoad_MissingFileIsEmpty(t *testing.T) {
+	g, err := Load(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("missing graph should not error: %v", err)
+	}
+	if got := g.BlastRadiusForFile("a.go"); got != 1.0 {
+		t.Errorf("empty graph blast = %v, want 1.0", got)
+	}
+}
+
+func TestLoad_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	data := `{"nodes":[{"id":"a","file":"a.go"},{"id":"b","file":"b.go"}],"edges":[{"from":"b","to":"a"}]}`
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	g, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := g.DependentCount("a"); got != 1 {
+		t.Errorf("loaded DependentCount(a) = %d, want 1", got)
+	}
+}

--- a/internal/trust/defect.go
+++ b/internal/trust/defect.go
@@ -22,16 +22,56 @@ func DefaultWeights() DefectWeights {
 	}
 }
 
+// defaultToleratedLeakUSD is the expected cost of leaked defects Hydra is
+// willing to tolerate per task. RequiredConfidence sets the error probability α
+// so that α × (defect cost) ≈ this constant: a mistake that costs 10× more must
+// be 10× less likely. The baseline task (defect cost = Base) yields α = 0.10, i.e.
+// a 90% target — matching the SPRT default.
+const defaultToleratedLeakUSD = 0.10
+
+// maxConfidence caps how sure Hydra will insist on being, so an enormous
+// blast radius can't demand an unreachable (α→0) target.
+const maxConfidence = 0.999
+
 // DefectModel prices the cost of shipping an incorrect answer for a task. That
 // cost sets how much confidence a task must clear before Hydra stops sampling
-// (Phase 2) and is surfaced in `hydra dispatch --dry-run` / `hydra trust defect`.
+// (RequiredConfidence) and is surfaced in `hydra dispatch --confidence --file`,
+// `hydra trust defect`, and `hydra dispatch --dry-run`.
 type DefectModel struct {
 	W DefectWeights
+	// ToleratedLeakUSD is the expected leaked-defect cost held constant by
+	// RequiredConfidence. Zero uses defaultToleratedLeakUSD.
+	ToleratedLeakUSD float64
 }
 
 // NewDefectModel returns a model using the default weights.
 func NewDefectModel() *DefectModel {
 	return &DefectModel{W: DefaultWeights()}
+}
+
+// RequiredConfidence maps a task's defect cost to the confidence-of-correctness
+// Hydra should demand before it stops sampling. It holds the *expected leaked
+// defect cost* constant: α = toleratedLeak / defectCost, so target = 1 − α. A
+// costlier mistake linearly lowers the tolerated error probability; the result
+// is clamped to [0.5, maxConfidence].
+func (d *DefectModel) RequiredConfidence(t Task) float64 {
+	leak := d.ToleratedLeakUSD
+	if leak <= 0 {
+		leak = defaultToleratedLeakUSD
+	}
+	cost := d.CostUSD(t)
+	if cost <= 0 {
+		return 0.5
+	}
+	alpha := leak / cost
+	target := 1 - alpha
+	if target > maxConfidence {
+		target = maxConfidence
+	}
+	if target < 0.5 {
+		target = 0.5
+	}
+	return target
 }
 
 // CostUSD = Base × blast × w_irrev × w_pii × w_prod, with each risk factor

--- a/internal/trust/defect_test.go
+++ b/internal/trust/defect_test.go
@@ -1,6 +1,9 @@
 package trust
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestDefectCostUSD(t *testing.T) {
 	dm := NewDefectModel() // Base 1, Irrev 5, PII 10, Prod 3
@@ -23,6 +26,39 @@ func TestDefectCostUSD(t *testing.T) {
 				t.Errorf("CostUSD(%+v) = %v, want %v", tt.task, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRequiredConfidence_HoldsLeakConstant(t *testing.T) {
+	dm := NewDefectModel() // tolerated leak $0.10
+
+	// Baseline task (defect cost = Base = 1) → α=0.10 → 90%.
+	if got := dm.RequiredConfidence(Task{}); math.Abs(got-0.90) > 1e-9 {
+		t.Errorf("RequiredConfidence(base) = %v, want 0.90", got)
+	}
+	// blast 2 → cost 2 → α=0.05 → 95%.
+	if got := dm.RequiredConfidence(Task{BlastRadius: 2}); math.Abs(got-0.95) > 1e-9 {
+		t.Errorf("RequiredConfidence(blast 2) = %v, want 0.95", got)
+	}
+	// The invariant: α × defect cost ≈ tolerated leak, for un-capped targets.
+	for _, blast := range []float64{1, 2, 5, 10} {
+		task := Task{BlastRadius: blast}
+		alpha := 1 - dm.RequiredConfidence(task)
+		if leak := alpha * dm.CostUSD(task); math.Abs(leak-0.10) > 1e-9 {
+			t.Errorf("blast %v: expected leaked cost α·C = %v, want 0.10", blast, leak)
+		}
+	}
+}
+
+func TestRequiredConfidence_CappedAtMax(t *testing.T) {
+	dm := NewDefectModel()
+	// Enormous defect cost (all flags + high blast) would demand α→0; capped.
+	got := dm.RequiredConfidence(Task{BlastRadius: 50, Irreversible: true, TouchesPII: true, Production: true})
+	if got > maxConfidence {
+		t.Errorf("RequiredConfidence = %v, want ≤ %v (capped)", got, maxConfidence)
+	}
+	if got < 0.99 {
+		t.Errorf("very costly task should still demand ≥0.99, got %v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
A one-line fix to a leaf helper and a one-line fix to a hub 200 modules import carry wildly different risk. Phase 3 makes Hydra route accordingly: it reads a code dependency graph, computes an edit's **blast radius**, and raises the demanded confidence where a mistake would cascade.

## What's in this PR
- **`internal/graph`** — reads `graph.json` (`{nodes,edges}`, from [Graphify](https://github.com/safishamsi/graphify) or any tree-sitter indexer) and computes blast radius = `1 + log2(1 + transitive reverse-dependents)`. Cycle-safe BFS; basename fallback for abs/rel paths; a missing graph degrades gracefully to `1.0` (today's behavior).
- **`trust.DefectModel.RequiredConfidence`** — a *principled* defect-cost → confidence map that holds the **expected leaked defect cost constant**: `α = tolerated_leak / defect_cost`, so a 10× costlier mistake demands a 10× lower error probability (capped at 0.999). The baseline task → 90%, matching the SPRT default.
- **Wiring** — `hydra graph blast <file>`, `hydra trust defect --file X`, and `hydra dispatch --confidence --file X` (blast radius raises the bar, never lowers a user's explicit target).

## Verified end-to-end
```
$ hydra graph blast auth.go        # 3 transitive dependents
    blast radius        3.00×
    demands confidence  96.7%
$ hydra graph blast helper.go      # leaf → 1.00× → 90.0%
$ hydra trust defect --file auth.go --production   # 3×3=9 → demands 98.9%
```

## Tests
- transitive blast radius (hub > leaf), cycle safety, graceful missing graph, JSON round-trip;
- `RequiredConfidence` invariant (α·C ≈ tolerated leak across blast levels) + the 0.999 cap.
- `go build/vet` clean, `go test ./... -race` green.

Docs updated: README (roadmap → shipped, arc prose, Confidence blast-radius example, command list), CLAUDE.md (layout + package map + quick reference), llms.txt.

Closes #101