### PR TITLE
feat(a2a,optimal): causal handoffs (vector clocks) + optimal parallelism n* (Phase 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,9 @@ internal/executor/      ← Native executors: agy, Ollama, HTTP (API providers),
 internal/provider/      ← Discovery: cli / env (API keys) / port / agy.
 internal/swarm/         ← Fan-out (race/best/all + judge) + SPRT adapter (swarm→trust).
 internal/trust/         ← Trust Control Plane: calibration (LLR/D) + defect-cost + SPRT ensemble.
-internal/graph/         ← Code dependency graph (graph.json) → blast radius → defect cost.
+internal/graph/         ← Code dependency graph (graph.json) → blast radius + coupling k.
+internal/a2a/           ← Causal agent handoffs: vector clocks + concurrent-edit conflict detection.
+internal/optimal/       ← Optimal parallel-agent count n*=√((1-s)/k) (Amdahl+coordination, Law 4).
 internal/pricing/       ← Live pricing DB (OpenRouter fetch + 24h cache + tier fallback).
 internal/policy/        ← PII detection + local-only enforcement.
 internal/{cost,budget}/ ← Spend reporting (est/actual labeling) + token-budget governor.
@@ -209,6 +211,10 @@ hydra dispatch --confidence 0.95 --prompt "is this migration safe for prod?"
 # Blast-radius aware: --file raises the confidence bar by the code graph
 hydra graph blast internal/auth/token.go
 hydra dispatch --confidence 0.90 --file internal/auth/token.go --prompt "rotate signing key"
+
+# Optimal parallelism (Law 4): how many agents to fan out for these files
+hydra graph parallel internal/a.go internal/b.go
+# A2A handoffs (last_handoff.json) now carry a vector clock for causal ordering.
 
 # Trust Control Plane: calibration, defect-cost, run stats, and the LLR ledger
 hydra trust calibration ; hydra trust record --source model:x --domain go --said-correct --outcome correct
@@ -671,7 +677,9 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/rank` | CapScore ranking helpers |
 | `internal/config` | Hydra config load/save (`~/.config/hydra/`) |
 | `internal/trust` | Trust Control Plane confidence layer: per-source calibration (Beta-Bernoulli → LLR/D), defect-cost model + `RequiredConfidence`, and the SPRT optimal-stopping ensemble (`trust.Run`). Drives `hydra dispatch --confidence` and `hydra trust calibration\|record\|defect\|stats\|explain`. |
-| `internal/graph` | Code dependency graph (`graph.json`, Graphify or any tree-sitter indexer) → transitive-dependent blast radius → `trust.Task.BlastRadius`. Drives `hydra graph blast` and `hydra dispatch --file`. |
+| `internal/graph` | Code dependency graph (`graph.json`, Graphify or any tree-sitter indexer) → transitive-dependent blast radius + coupling `k`. Drives `hydra graph blast\|parallel` and `hydra dispatch --file`. |
+| `internal/a2a` | Agent-to-agent handoffs with vector clocks: causal ordering (before/after/concurrent) + `ConflictsWith` (concurrent + overlapping files). Backs `last_handoff.json` and `--a2a`. |
+| `internal/optimal` | Optimal parallel-agent count `n*=√((1−s)/k)` and speedup (Amdahl + coordination, Manifesto Law 4). Drives `hydra graph parallel`. |
 | `internal/tui` | Bubble Tea TUI: init wizard, install flow |
 | `internal/review` | Code review subcommand |
 | `internal/editor` | Editor integration |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Every executor is **native Go** — `agy`, Ollama, per-provider HTTP (OpenAI-com
 | SPRT — easy tasks | **2.6 samples, −49% vs fixed-5**, 98.8% accuracy | 20k seeded synthetic trials, `TestSPRT_Law3` |
 | SPRT — blended workload | **3.8 samples, −24% vs fixed-5**, 98.2% accuracy | same suite; 71% easy / 29% hard task mix |
 | SPRT — hard tasks | **6.8 samples** (adaptively *more* than 5), 96.7% accuracy | fixed-N ensembles can't do this — SPRT spends where accuracy demands it |
+| Optimal parallelism | **6 agents** for independent work → **2** for same-subgraph edits | `n* = √((1−s)/k)`, Law 4; `k` from graph coupling (`internal/optimal`) |
 | Output capture | bounded at **33 MB** per subprocess | `internal/util.Accumulator` — no unbounded buffers |
 
 > **Methodology & honesty.** Routing overhead, discovery, calibration, and SPRT figures are **measured** by the test/benchmark suite (`go test ./...`, race-clean in CI). The SPRT numbers come from *synthetic* trials with known ground truth, not production traffic — they validate the algorithm (Wald sequential test), and land above the continuous theoretical `E[N]` (easy 1.33 / blended 2.48) because real evidence arrives in discrete steps. Cost-savings ranges are workload-dependent estimates; `hydra stats` reports your actual spend. As production `trust.jsonl` accumulates, `hydra trust stats` graduates these from *modeled* to *observed*.
@@ -368,6 +369,7 @@ hydra trust defect ...                  # modeled cost of shipping a wrong answe
 hydra trust stats                       # samples saved, achieved vs target confidence
 hydra trust explain <task_hash>         # the LLR ledger for a past SPRT run
 hydra graph blast <file>                # a file's blast radius + the confidence it demands
+hydra graph parallel <files...>         # optimal number of parallel agents (Law 4)
 
 # Editing & batch
 hydra edit --file ... --prompt "..."    # scoped, validated, rollback-safe file edit
@@ -445,6 +447,8 @@ For Ollama models, add a family pattern:
 | **Defect-cost model** (`hydra trust defect`) | ✅ Shipped |
 | **SPRT confidence routing** (`hydra dispatch --confidence`) | ✅ Shipped |
 | **Graph-aware routing** — blast-radius → defect cost → confidence | ✅ Shipped |
+| **Optimal parallelism** — `n* = √((1−s)/k)` from graph coupling (Law 4) | ✅ Shipped |
+| **Causal A2A handoffs** — vector clocks, concurrent-edit conflict detection | ✅ Shipped |
 | Outcome auto-wiring (tests / review / revert → calibration) | 🔨 Building |
 | Local MCP accountability ledger | 📋 Planned |
 | Pluggable verification-oracle interface | 📋 Planned |

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/editor"
 	"github.com/ankit373/hydra/internal/graph"
+	"github.com/ankit373/hydra/internal/optimal"
 	"github.com/ankit373/hydra/internal/parallel"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
@@ -516,7 +517,43 @@ func cmdGraph() *cobra.Command {
 	}
 	blast.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph (graph.json)")
 	blast.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
-	cmd.AddCommand(blast)
+
+	var parGraph string
+	var parJSON bool
+	var serial float64
+	parallelCmd := &cobra.Command{
+		Use:   "parallel <file> [file...]",
+		Short: "Optimal number of parallel agents for editing these files (Law 4)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			g, err := graph.Load(parGraph)
+			if err != nil {
+				return err
+			}
+			k := g.Coupling(args)
+			n, speedup := optimal.Agents(serial, k)
+			if parJSON {
+				return json.NewEncoder(os.Stdout).Encode(map[string]any{
+					"files": args, "serial_fraction": serial, "coordination_k": k,
+					"optimal_agents": n, "speedup": speedup,
+				})
+			}
+			fmt.Printf("\n  %s\n", cortexStyle.Render(fmt.Sprintf("%d file(s)", len(args))))
+			fmt.Printf("    coordination cost k    %.3f\n", k)
+			fmt.Printf("    optimal agents n*      %d\n", n)
+			fmt.Printf("    speedup S(n*)          %.2f×\n", speedup)
+			if speedup < 1 {
+				fmt.Printf("    %s\n", dimStyle.Render("→ heavily coupled — parallelism doesn't pay; edit serially"))
+			}
+			fmt.Println()
+			return nil
+		},
+	}
+	parallelCmd.Flags().StringVar(&parGraph, "graph", "graph.json", "path to the dependency graph (graph.json)")
+	parallelCmd.Flags().BoolVar(&parJSON, "json", false, "machine-readable JSON output")
+	parallelCmd.Flags().Float64Var(&serial, "serial", optimal.DefaultSerialFraction, "serial (non-parallelizable) work fraction s")
+
+	cmd.AddCommand(blast, parallelCmd)
 	return cmd
 }
 

--- a/internal/a2a/a2a.go
+++ b/internal/a2a/a2a.go
@@ -1,0 +1,195 @@
+// Package a2a models agent-to-agent handoffs with causal ordering. Each handoff
+// carries a vector clock so Hydra can tell whether two handoffs are sequential
+// (one happened-before the other) or concurrent — and, when concurrent, whether
+// they touch overlapping files and therefore conflict.
+package a2a
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Clock is a vector clock: agent ID → event counter.
+type Clock map[string]uint64
+
+// Tick returns a copy of the clock with the given agent's counter incremented.
+// The receiver is not mutated, so callers can keep prior snapshots.
+func (c Clock) Tick(agent string) Clock {
+	out := c.clone()
+	out[agent]++
+	return out
+}
+
+// Merge returns the component-wise maximum of two clocks — the causal history
+// known to an agent that has observed both.
+func (c Clock) Merge(o Clock) Clock {
+	out := c.clone()
+	for k, v := range o {
+		if v > out[k] {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func (c Clock) clone() Clock {
+	out := make(Clock, len(c))
+	for k, v := range c {
+		out[k] = v
+	}
+	return out
+}
+
+// Ordering is the causal relationship between two clocks.
+type Ordering int
+
+const (
+	Equal      Ordering = iota // identical histories
+	Before                     // c happened-before o
+	After                      // o happened-before c
+	Concurrent                 // neither — independent, possibly conflicting
+)
+
+func (o Ordering) String() string {
+	switch o {
+	case Equal:
+		return "equal"
+	case Before:
+		return "before"
+	case After:
+		return "after"
+	default:
+		return "concurrent"
+	}
+}
+
+// Compare classifies the causal relationship of c to o. c is Before o iff every
+// component of c is ≤ o and at least one is strictly less (and symmetrically for
+// After); if both directions show a strictly-greater component, they are
+// Concurrent.
+func (c Clock) Compare(o Clock) Ordering {
+	cLess, cGreater := false, false
+	for _, k := range unionKeys(c, o) {
+		switch {
+		case c[k] < o[k]:
+			cLess = true
+		case c[k] > o[k]:
+			cGreater = true
+		}
+	}
+	switch {
+	case !cLess && !cGreater:
+		return Equal
+	case cLess && !cGreater:
+		return Before
+	case cGreater && !cLess:
+		return After
+	default:
+		return Concurrent
+	}
+}
+
+func unionKeys(a, b Clock) []string {
+	seen := make(map[string]bool, len(a)+len(b))
+	var keys []string
+	for k := range a {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	for k := range b {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// Handoff is the structured context passed between agents. It is the typed form
+// of ~/.hydra/logs/last_handoff.json.
+type Handoff struct {
+	From        string   `json:"from"`
+	Model       string   `json:"model,omitempty"`
+	Task        string   `json:"task"`
+	Files       []string `json:"files,omitempty"`
+	Conventions string   `json:"conventions,omitempty"`
+	Context     string   `json:"context,omitempty"`
+	PriorOutput string   `json:"prior_output,omitempty"`
+	Clock       Clock    `json:"clock,omitempty"`
+}
+
+// Load reads a handoff from disk. A missing file returns a nil handoff and no
+// error so callers can treat "no prior handoff" as the empty causal history.
+func Load(path string) (*Handoff, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var h Handoff
+	if err := json.Unmarshal(raw, &h); err != nil {
+		return nil, err
+	}
+	return &h, nil
+}
+
+// Save writes the handoff atomically-ish (dir created, 0600).
+func (h *Handoff) Save(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, raw, 0o600)
+}
+
+// PromptBlock renders the handoff as the structured context block prepended to a
+// downstream agent's prompt.
+func (h *Handoff) PromptBlock(task string) string {
+	files := ""
+	for i, f := range h.Files {
+		if i > 0 {
+			files += ", "
+		}
+		files += f
+	}
+	return "A2A HANDOFF from: " + h.From +
+		"\nFiles in scope: " + files +
+		"\nConventions:\n" + h.Conventions +
+		"\nPrior output:\n" + h.PriorOutput +
+		"\nContext:\n" + h.Context +
+		"\n\nTASK:\n" + task
+}
+
+// ConflictsWith reports whether two handoffs are concurrent (neither
+// happened-before the other) AND touch at least one common file — the signature
+// of an unsynchronized edit collision.
+func (h *Handoff) ConflictsWith(o *Handoff) bool {
+	if h == nil || o == nil {
+		return false
+	}
+	if h.Clock.Compare(o.Clock) != Concurrent {
+		return false
+	}
+	return overlaps(h.Files, o.Files)
+}
+
+func overlaps(a, b []string) bool {
+	set := make(map[string]bool, len(a))
+	for _, f := range a {
+		set[f] = true
+	}
+	for _, f := range b {
+		if set[f] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/a2a/a2a_test.go
+++ b/internal/a2a/a2a_test.go
@@ -1,0 +1,113 @@
+package a2a
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestClock_TickIsImmutable(t *testing.T) {
+	c := Clock{"a": 1}
+	c2 := c.Tick("a")
+	if c["a"] != 1 {
+		t.Error("Tick mutated the receiver")
+	}
+	if c2["a"] != 2 {
+		t.Errorf("Tick(a) = %d, want 2", c2["a"])
+	}
+	if c.Tick("b")["b"] != 1 {
+		t.Error("Tick on a new agent should start at 1")
+	}
+}
+
+func TestClock_Merge(t *testing.T) {
+	a := Clock{"x": 3, "y": 1}
+	b := Clock{"y": 5, "z": 2}
+	m := a.Merge(b)
+	if m["x"] != 3 || m["y"] != 5 || m["z"] != 2 {
+		t.Errorf("Merge = %v, want {x:3 y:5 z:2}", m)
+	}
+}
+
+func TestClock_Compare(t *testing.T) {
+	tests := []struct {
+		name string
+		c, o Clock
+		want Ordering
+	}{
+		{"equal", Clock{"a": 1}, Clock{"a": 1}, Equal},
+		{"empty equal", Clock{}, Clock{}, Equal},
+		{"before", Clock{"a": 1}, Clock{"a": 2}, Before},
+		{"before new key", Clock{"a": 1}, Clock{"a": 1, "b": 1}, Before},
+		{"after", Clock{"a": 3}, Clock{"a": 1}, After},
+		{"concurrent", Clock{"a": 2, "b": 0}, Clock{"a": 1, "b": 1}, Concurrent},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.c.Compare(tt.o); got != tt.want {
+				t.Errorf("Compare(%v,%v) = %v, want %v", tt.c, tt.o, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConflictsWith(t *testing.T) {
+	// Concurrent clocks + overlapping files → conflict.
+	a := &Handoff{Files: []string{"auth.go", "user.go"}, Clock: Clock{"agentA": 1}}
+	b := &Handoff{Files: []string{"user.go", "api.go"}, Clock: Clock{"agentB": 1}}
+	if !a.ConflictsWith(b) {
+		t.Error("concurrent handoffs on overlapping files should conflict")
+	}
+
+	// Concurrent but disjoint files → no conflict.
+	c := &Handoff{Files: []string{"x.go"}, Clock: Clock{"agentA": 1}}
+	d := &Handoff{Files: []string{"y.go"}, Clock: Clock{"agentB": 1}}
+	if c.ConflictsWith(d) {
+		t.Error("disjoint files should not conflict even when concurrent")
+	}
+
+	// Causally ordered (before/after) + overlapping files → NOT a conflict.
+	e := &Handoff{Files: []string{"auth.go"}, Clock: Clock{"agentA": 1}}
+	f := &Handoff{Files: []string{"auth.go"}, Clock: Clock{"agentA": 2}}
+	if e.ConflictsWith(f) {
+		t.Error("sequential handoffs are ordered, not conflicting")
+	}
+}
+
+func TestHandoff_SaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "logs", "last_handoff.json")
+	in := &Handoff{
+		From: "hydra-tier-3", Task: "add auth", Files: []string{"auth.go"},
+		PriorOutput: "done", Clock: Clock{"hydra-tier-3": 1},
+	}
+	if err := in.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.From != "hydra-tier-3" || got.Clock["hydra-tier-3"] != 1 || len(got.Files) != 1 {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+}
+
+func TestLoad_MissingIsNil(t *testing.T) {
+	h, err := Load(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("missing handoff should not error: %v", err)
+	}
+	if h != nil {
+		t.Errorf("missing handoff should be nil, got %+v", h)
+	}
+}
+
+func TestPromptBlock(t *testing.T) {
+	h := &Handoff{From: "tier-2", Files: []string{"a.go", "b.go"}, PriorOutput: "x"}
+	block := h.PromptBlock("do the thing")
+	if !strings.Contains(block, "A2A HANDOFF from: tier-2") ||
+		!strings.Contains(block, "a.go, b.go") ||
+		!strings.Contains(block, "do the thing") {
+		t.Errorf("PromptBlock missing expected content:\n%s", block)
+	}
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -10,10 +10,10 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/ankit373/hydra/internal/a2a"
 	"github.com/ankit373/hydra/internal/budget"
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/cost"
@@ -201,42 +201,36 @@ func readClaudePct() int {
 
 // injectA2A reads a handoff JSON file and prepends a structured block to the prompt.
 func injectA2A(path, prompt string) (string, error) {
-	raw, err := os.ReadFile(path)
+	h, err := a2a.Load(path)
 	if err != nil {
 		return prompt, fmt.Errorf("a2a: %w", err)
 	}
-	var h struct {
-		From        string   `json:"from"`
-		Task        string   `json:"task"`
-		Files       []string `json:"files"`
-		Context     string   `json:"context"`
-		Conventions string   `json:"conventions"`
-		PriorOutput string   `json:"prior_output"`
+	if h == nil {
+		return prompt, nil // no handoff → prompt unchanged
 	}
-	if err := json.Unmarshal(raw, &h); err != nil {
-		return prompt, fmt.Errorf("a2a: %w", err)
-	}
-	block := fmt.Sprintf(
-		"A2A HANDOFF from: %s\nFiles in scope: %s\nConventions:\n%s\nPrior output:\n%s\nContext:\n%s\n\nTASK:\n%s",
-		h.From, strings.Join(h.Files, ", "), h.Conventions, h.PriorOutput, h.Context, h.Task,
-	)
-	return block + "\n\nADDITIONAL INSTRUCTION:\n" + prompt, nil
+	return h.PromptBlock(prompt) + "\n\nADDITIONAL INSTRUCTION:\n" + prompt, nil
 }
 
-// writeHandoff saves last_handoff.json after a successful dispatch.
+// writeHandoff saves last_handoff.json after a successful dispatch, advancing
+// the vector clock so downstream agents inherit this dispatch's causal history.
 func (d *Dispatcher) writeHandoff(r *Result, prompt string) error {
 	handoffPath := filepath.Join(config.Dir(), "logs", "last_handoff.json")
-	h := map[string]any{
-		"from":         fmt.Sprintf("hydra-tier-%d", rank.UITier(r.Head)),
-		"model":        r.Head.Name,
-		"task":         prompt,
-		"prior_output": r.Response.Output,
+
+	// Inherit the prior handoff's clock (if any) and tick for this agent.
+	var base a2a.Clock
+	if prior, err := a2a.Load(handoffPath); err == nil && prior != nil {
+		base = prior.Clock
 	}
-	raw, err := json.MarshalIndent(h, "", "  ")
-	if err != nil {
-		return err
+	from := fmt.Sprintf("hydra-tier-%d", rank.UITier(r.Head))
+
+	h := a2a.Handoff{
+		From:        from,
+		Model:       r.Head.Name,
+		Task:        prompt,
+		PriorOutput: r.Response.Output,
+		Clock:       base.Tick(from),
 	}
-	return os.WriteFile(handoffPath, raw, 0o600)
+	return h.Save(handoffPath)
 }
 
 // selectHeads returns heads to try, in order of preference.

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -111,29 +111,104 @@ func (g *Graph) DependentCount(nodeID string) int {
 	return len(g.transitiveDependents([]string{nodeID}))
 }
 
+// seedsForFile returns the node IDs declared in a file, matching by exact path
+// first and falling back to basename so callers may pass absolute or relative
+// paths.
+func (g *Graph) seedsForFile(file string) []string {
+	if g == nil || len(g.filesToNodes) == 0 {
+		return nil
+	}
+	if seeds := g.filesToNodes[file]; len(seeds) > 0 {
+		return seeds
+	}
+	base := filepath.Base(file)
+	var seeds []string
+	for f, ids := range g.filesToNodes {
+		if filepath.Base(f) == base {
+			seeds = append(seeds, ids...)
+		}
+	}
+	return seeds
+}
+
 // BlastRadiusForFile returns a defect-cost multiplier for editing a file:
 // 1 + log2(1 + transitive dependents) over all nodes declared in that file. A
 // leaf (or an unknown file, or no graph) yields 1.0; a widely-depended-on file
 // grows sub-linearly so one hub node doesn't produce an absurd multiplier.
 func (g *Graph) BlastRadiusForFile(file string) float64 {
-	if g == nil || len(g.filesToNodes) == 0 {
-		return 1.0
-	}
-	seeds := g.filesToNodes[file]
-	if len(seeds) == 0 {
-		// Try a basename match so callers can pass absolute or relative paths.
-		base := filepath.Base(file)
-		for f, ids := range g.filesToNodes {
-			if filepath.Base(f) == base {
-				seeds = append(seeds, ids...)
-			}
-		}
-	}
+	seeds := g.seedsForFile(file)
 	if len(seeds) == 0 {
 		return 1.0
 	}
 	count := len(g.transitiveDependents(seeds))
 	return 1.0 + math.Log2(1.0+float64(count))
+}
+
+// Coordination-cost bounds for Coupling, mapping graph overlap → the k used by
+// package optimal (independent work → kMin ⇒ n*≈6; fully-overlapping → kMax ⇒ n*≈2).
+const (
+	kMin = 0.02
+	kMax = 0.30
+)
+
+// Coupling returns the per-agent coordination cost k for editing a set of files
+// in parallel, derived from how much their impact sets (own nodes + transitive
+// dependents) overlap. Disjoint files → kMin (safe to parallelize widely);
+// files sharing the same subgraph → toward kMax (parallelism collapses). Fewer
+// than two files, or no graph, → kMin.
+func (g *Graph) Coupling(files []string) float64 {
+	if g == nil || len(files) < 2 {
+		return kMin
+	}
+	sets := make([]map[string]bool, len(files))
+	for i, f := range files {
+		sets[i] = g.affectedSet(f)
+	}
+	var sum float64
+	var pairs int
+	for i := 0; i < len(sets); i++ {
+		for j := i + 1; j < len(sets); j++ {
+			sum += jaccard(sets[i], sets[j])
+			pairs++
+		}
+	}
+	overlap := 0.0
+	if pairs > 0 {
+		overlap = sum / float64(pairs)
+	}
+	return kMin + overlap*(kMax-kMin)
+}
+
+// affectedSet is a file's own nodes plus everything that transitively depends on
+// them — the region of the graph an edit could perturb.
+func (g *Graph) affectedSet(file string) map[string]bool {
+	seeds := g.seedsForFile(file)
+	set := make(map[string]bool, len(seeds))
+	for _, s := range seeds {
+		set[s] = true
+	}
+	for n := range g.transitiveDependents(seeds) {
+		set[n] = true
+	}
+	return set
+}
+
+// jaccard is |A∩B| / |A∪B|; two empty sets have no overlap (0).
+func jaccard(a, b map[string]bool) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for k := range a {
+		if b[k] {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
 }
 
 // Dependents returns the direct dependents of a node (for `hydra graph blast`).

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -93,6 +93,42 @@ func TestLoad_MissingFileIsEmpty(t *testing.T) {
 	}
 }
 
+func TestCoupling(t *testing.T) {
+	// Two files whose impact sets are disjoint → minimal coordination cost.
+	disjoint := fromDoc(Doc{
+		Nodes: []Node{{ID: "x", File: "x.go"}, {ID: "y", File: "y.go"}},
+		Edges: nil, // no dependents, no overlap
+	})
+	if got := disjoint.Coupling([]string{"x.go", "y.go"}); math.Abs(got-kMin) > 1e-9 {
+		t.Errorf("disjoint Coupling = %v, want kMin=%v", got, kMin)
+	}
+
+	// Two files that share their entire dependent set → maximal coupling.
+	// hub1, hub2 both depended on by the same {a,b,c}.
+	shared := fromDoc(Doc{
+		Nodes: []Node{
+			{ID: "h1", File: "h1.go"}, {ID: "h2", File: "h2.go"},
+			{ID: "a", File: "a.go"}, {ID: "b", File: "b.go"}, {ID: "c", File: "c.go"},
+		},
+		Edges: []Edge{
+			{From: "a", To: "h1"}, {From: "b", To: "h1"}, {From: "c", To: "h1"},
+			{From: "a", To: "h2"}, {From: "b", To: "h2"}, {From: "c", To: "h2"},
+		},
+	})
+	k := shared.Coupling([]string{"h1.go", "h2.go"})
+	if k <= disjoint.Coupling([]string{"x.go", "y.go"}) {
+		t.Errorf("shared-subgraph coupling (%v) should exceed disjoint (%v)", k, disjoint.Coupling([]string{"x.go", "y.go"}))
+	}
+	if k < 0.10 { // {a,b,c} shared out of union {h1,a,b,c}∪{h2,a,b,c} → strong overlap
+		t.Errorf("shared coupling = %v, expected substantial overlap", k)
+	}
+
+	// Fewer than two files → kMin (nothing to coordinate).
+	if got := shared.Coupling([]string{"h1.go"}); got != kMin {
+		t.Errorf("single-file Coupling = %v, want kMin", got)
+	}
+}
+
 func TestLoad_RoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "graph.json")
 	data := `{"nodes":[{"id":"a","file":"a.go"},{"id":"b","file":"b.go"}],"edges":[{"from":"b","to":"a"}]}`

--- a/internal/optimal/optimal.go
+++ b/internal/optimal/optimal.go
@@ -1,0 +1,58 @@
+// Package optimal computes the provably-best number of parallel agents for a
+// task, per Manifesto Law 4. Over-spawning on tightly-coupled code is slower
+// than a smaller fleet: coordination cost grows linearly with agent count while
+// the parallelizable work shrinks.
+package optimal
+
+import "math"
+
+// DefaultSerialFraction is the share of work that cannot be parallelized (human
+// review, integration). Manifesto assumption: s = 0.2.
+const DefaultSerialFraction = 0.2
+
+// Agents returns the optimal parallel agent count n* and its speedup S(n*) for a
+// serial fraction s and per-agent coordination cost k, maximizing the
+// Amdahl-with-coordination model:
+//
+//	S(n) = 1 / ( s + (1-s)/n + k*n )
+//	n*   = sqrt( (1-s) / k )
+//	S(n*) = 1 / ( s + 2*sqrt( k*(1-s) ) )
+//
+// n* is rounded to the nearest whole agent and clamped to ≥1.
+func Agents(s, k float64) (nStar int, speedup float64) {
+	if k <= 0 {
+		// No coordination cost → parallelism only limited by the serial
+		// fraction; there is no finite optimum, so return a sensible large-ish
+		// cap and the Amdahl ceiling.
+		return 0, amdahlCeiling(s)
+	}
+	if s < 0 {
+		s = 0
+	}
+	if s > 1 {
+		s = 1
+	}
+	nReal := math.Sqrt((1 - s) / k)
+	nStar = int(math.Round(nReal))
+	if nStar < 1 {
+		nStar = 1
+	}
+	speedup = Speedup(s, k, float64(nStar))
+	return nStar, speedup
+}
+
+// Speedup evaluates S(n) for the given parameters.
+func Speedup(s, k, n float64) float64 {
+	if n <= 0 {
+		return 1
+	}
+	return 1 / (s + (1-s)/n + k*n)
+}
+
+// amdahlCeiling is the classic 1/s limit when coordination is free.
+func amdahlCeiling(s float64) float64 {
+	if s <= 0 {
+		return math.Inf(1)
+	}
+	return 1 / s
+}

--- a/internal/optimal/optimal_test.go
+++ b/internal/optimal/optimal_test.go
@@ -1,0 +1,81 @@
+package optimal
+
+import (
+	"math"
+	"testing"
+)
+
+// Manifesto Law 4 numbers (s = 0.2):
+//   independent  k=0.02 → n*≈6.3→6
+//   moderate     k=0.08 → n*≈3.2→3
+//   heavy        k=0.30 → n*≈1.6→2
+func TestAgents_MatchesLaw4(t *testing.T) {
+	cases := []struct {
+		name  string
+		k     float64
+		wantN int
+	}{
+		{"independent", 0.02, 6},
+		{"moderate", 0.08, 3},
+		{"heavy overlap", 0.30, 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			n, _ := Agents(DefaultSerialFraction, c.k)
+			if n != c.wantN {
+				t.Errorf("Agents(0.2, %v) n* = %d, want %d", c.k, n, c.wantN)
+			}
+		})
+	}
+
+	// Independent work has a real (>1) speedup; heavy coupling drives the
+	// absolute S(n*) below 1 — the model correctly says "don't parallelize this."
+	if _, s := Agents(0.2, 0.02); s <= 1 {
+		t.Errorf("independent speedup = %v, want > 1", s)
+	}
+	if _, s := Agents(0.2, 0.30); s >= 1 {
+		t.Errorf("heavy-overlap speedup = %v, want < 1 (parallelism doesn't pay)", s)
+	}
+}
+
+// n* must actually maximize S(n): S(n*) ≥ S(n*±1).
+func TestAgents_IsOptimum(t *testing.T) {
+	s, k := 0.2, 0.05
+	n, peak := Agents(s, k)
+	if lower := Speedup(s, k, float64(n-1)); n > 1 && lower > peak {
+		t.Errorf("S(n*-1)=%v > S(n*)=%v — not optimal", lower, peak)
+	}
+	if higher := Speedup(s, k, float64(n+1)); higher > peak {
+		t.Errorf("S(n*+1)=%v > S(n*)=%v — not optimal", higher, peak)
+	}
+}
+
+// More coordination cost ⇒ fewer optimal agents.
+func TestAgents_MonotoneInK(t *testing.T) {
+	nLow, _ := Agents(0.2, 0.02)
+	nHigh, _ := Agents(0.2, 0.30)
+	if nHigh >= nLow {
+		t.Errorf("heavier coupling should reduce n*: k=0.02→%d, k=0.30→%d", nLow, nHigh)
+	}
+}
+
+func TestSpeedup_PeakFormula(t *testing.T) {
+	s, k := 0.2, 0.08
+	_, got := Agents(s, k)
+	// closed form S(n*) = 1 / (s + 2*sqrt(k*(1-s)))
+	want := 1 / (s + 2*math.Sqrt(k*(1-s)))
+	// Agents rounds n*, so allow a small gap from the continuous peak.
+	if math.Abs(got-want) > 0.05 {
+		t.Errorf("S(n*) = %v, continuous peak = %v", got, want)
+	}
+}
+
+func TestAgents_ZeroK(t *testing.T) {
+	n, speedup := Agents(0.2, 0)
+	if n != 0 {
+		t.Errorf("k=0 has no finite optimum; want sentinel 0, got %d", n)
+	}
+	if speedup != 1/0.2 {
+		t.Errorf("k=0 speedup should be Amdahl ceiling 1/s = 5, got %v", speedup)
+	}
+}


### PR DESCRIPTION
## Summary
Two multi-agent capabilities from Manifesto Law 4 and the causal-A2A design: know *how many* agents to fan out, and know whether two handoffs are safely sequential or a concurrent collision.

## Optimal parallelism (`internal/optimal` + `graph.Coupling`)
`Agents(s, k)` maximizes `S(n) = 1/(s + (1−s)/n + k·n)` → `n* = √((1−s)/k)`. `k` (coordination cost) comes from how much the edited files' impact sets overlap in the dependency graph. Verified against the Manifesto numbers **exactly**:

```
$ hydra graph parallel helper.go cli.go      # disjoint
    coordination cost k    0.020
    optimal agents n*      6
    speedup S(n*)          2.21×
$ hydra graph parallel auth.go user.go        # shared subgraph
    coordination cost k    0.230
    optimal agents n*      2
    speedup S(n*)          0.94×
    → heavily coupled — parallelism doesn't pay; edit serially
```
Over-spawning on coupled code is *provably* slower — and Hydra computes it, honestly reporting sub-1.0 speedup when parallelism doesn't pay.

## Causal A2A (`internal/a2a`)
Vector-clock `Clock` (Tick / Merge / Compare → before / after / concurrent / equal) and a typed `Handoff`. `dispatch` now writes `last_handoff.json` through it, **advancing the clock each dispatch** so downstream agents inherit causal history. `ConflictsWith` flags **concurrent clocks touching overlapping files** — the signature of an unsynchronized edit collision.

## Tests
- vector-clock ordering (all four relations) + conflict detection + handoff round-trip + missing→nil;
- `Agents` vs Law 4 numbers, is-optimum (`S(n*) ≥ S(n*±1)`), monotone-in-k, peak-formula, zero-k ceiling;
- `graph.Coupling` disjoint→kMin, shared-subgraph→high.
- `go build/vet` clean; `go test ./... -race` green.

Docs: README (roadmap → shipped, By-the-Numbers row, command list), CLAUDE.md (layout + package map + quick reference).

Closes #103