### PR TITLE
feat(entropy): context signal-density governor (Phase 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ internal/trust/         ← Trust Control Plane: calibration (LLR/D) + defect-co
 internal/graph/         ← Code dependency graph (graph.json) → blast radius + coupling k.
 internal/a2a/           ← Causal agent handoffs: vector clocks + concurrent-edit conflict detection.
 internal/optimal/       ← Optimal parallel-agent count n*=√((1-s)/k) (Amdahl+coordination, Law 4).
+internal/entropy/       ← Context signal density (gzip proxy) → useful_tokens=L·ρ; compaction governor (Law 5).
 internal/pricing/       ← Live pricing DB (OpenRouter fetch + 24h cache + tier fallback).
 internal/policy/        ← PII detection + local-only enforcement.
 internal/{cost,budget}/ ← Spend reporting (est/actual labeling) + token-budget governor.
@@ -680,6 +681,7 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/graph` | Code dependency graph (`graph.json`, Graphify or any tree-sitter indexer) → transitive-dependent blast radius + coupling `k`. Drives `hydra graph blast\|parallel` and `hydra dispatch --file`. |
 | `internal/a2a` | Agent-to-agent handoffs with vector clocks: causal ordering (before/after/concurrent) + `ConflictsWith` (concurrent + overlapping files). Backs `last_handoff.json` and `--a2a`. |
 | `internal/optimal` | Optimal parallel-agent count `n*=√((1−s)/k)` and speedup (Amdahl + coordination, Manifesto Law 4). Drives `hydra graph parallel`. |
+| `internal/entropy` | Context signal density ρ (gzip-ratio proxy) → `useful_tokens = L·ρ` + a compaction governor (Manifesto Law 5). Drives `hydra context entropy`. |
 | `internal/tui` | Bubble Tea TUI: init wizard, install flow |
 | `internal/review` | Code review subcommand |
 | `internal/editor` | Editor integration |

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Every executor is **native Go** — `agy`, Ollama, per-provider HTTP (OpenAI-com
 | SPRT — blended workload | **3.8 samples, −24% vs fixed-5**, 98.2% accuracy | same suite; 71% easy / 29% hard task mix |
 | SPRT — hard tasks | **6.8 samples** (adaptively *more* than 5), 96.7% accuracy | fixed-N ensembles can't do this — SPRT spends where accuracy demands it |
 | Optimal parallelism | **6 agents** for independent work → **2** for same-subgraph edits | `n* = √((1−s)/k)`, Law 4; `k` from graph coupling (`internal/optimal`) |
+| Context signal density | useful tokens = `length × ρ`; a dense 100k window beats a noisy 1M | Law 5; ρ via gzip-ratio proxy (`internal/entropy`) — compact on falling ρ |
 | Output capture | bounded at **33 MB** per subprocess | `internal/util.Accumulator` — no unbounded buffers |
 
 > **Methodology & honesty.** Routing overhead, discovery, calibration, and SPRT figures are **measured** by the test/benchmark suite (`go test ./...`, race-clean in CI). The SPRT numbers come from *synthetic* trials with known ground truth, not production traffic — they validate the algorithm (Wald sequential test), and land above the continuous theoretical `E[N]` (easy 1.33 / blended 2.48) because real evidence arrives in discrete steps. Cost-savings ranges are workload-dependent estimates; `hydra stats` reports your actual spend. As production `trust.jsonl` accumulates, `hydra trust stats` graduates these from *modeled* to *observed*.
@@ -370,6 +371,7 @@ hydra trust stats                       # samples saved, achieved vs target conf
 hydra trust explain <task_hash>         # the LLR ledger for a past SPRT run
 hydra graph blast <file>                # a file's blast radius + the confidence it demands
 hydra graph parallel <files...>         # optimal number of parallel agents (Law 4)
+hydra context entropy <file|->          # signal density + useful tokens + compact hint
 
 # Editing & batch
 hydra edit --file ... --prompt "..."    # scoped, validated, rollback-safe file edit
@@ -449,6 +451,7 @@ For Ollama models, add a family pattern:
 | **Graph-aware routing** — blast-radius → defect cost → confidence | ✅ Shipped |
 | **Optimal parallelism** — `n* = √((1−s)/k)` from graph coupling (Law 4) | ✅ Shipped |
 | **Causal A2A handoffs** — vector clocks, concurrent-edit conflict detection | ✅ Shipped |
+| **Context-entropy governor** — compact on falling signal density, not length | ✅ Shipped |
 | Outcome auto-wiring (tests / review / revert → calibration) | 🔨 Building |
 | Local MCP accountability ledger | 📋 Planned |
 | Pluggable verification-oracle interface | 📋 Planned |

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/ankit373/hydra/internal/cost"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/editor"
+	"github.com/ankit373/hydra/internal/entropy"
 	"github.com/ankit373/hydra/internal/graph"
 	"github.com/ankit373/hydra/internal/optimal"
 	"github.com/ankit373/hydra/internal/parallel"
@@ -71,7 +73,7 @@ func rootCmd() *cobra.Command {
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(),
 		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(),
-		cmdPricing(), cmdTrust(), cmdGraph(),
+		cmdPricing(), cmdTrust(), cmdGraph(), cmdContext(),
 		cmdVersion(),
 	)
 	return root
@@ -472,6 +474,53 @@ func cmdDispatch() *cobra.Command {
 	cmd.Flags().StringVar(&domain, "domain", "", "calibration domain for --confidence (default: \"default\")")
 	cmd.Flags().StringVar(&file, "file", "", "target file — raises the confidence bar by its code blast radius")
 	cmd.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph used with --file")
+	return cmd
+}
+
+// cmdContext inspects context-window quality (signal density, useful tokens).
+func cmdContext() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Measure context-window quality — signal density, not just length",
+	}
+	var jsonOut bool
+	var minDensity float64
+	entropyCmd := &cobra.Command{
+		Use:   "entropy [file]",
+		Short: "Signal density + useful tokens of a file (or stdin), with a compact recommendation",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			var raw []byte
+			var err error
+			if len(args) == 1 && args[0] != "-" {
+				raw, err = os.ReadFile(args[0])
+			} else {
+				raw, err = io.ReadAll(os.Stdin)
+			}
+			if err != nil {
+				return err
+			}
+			rec := entropy.Governor{MinDensity: minDensity}.Assess(string(raw))
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(map[string]any{
+					"tokens": rec.Snap.Tokens, "density": rec.Snap.Density,
+					"useful_tokens": rec.Snap.UsefulTokens, "compact": rec.Compact, "reason": rec.Reason,
+				})
+			}
+			fmt.Printf("\n  tokens (est)     %d\n", rec.Snap.Tokens)
+			fmt.Printf("  signal density   %.1f%%\n", rec.Snap.Density*100)
+			fmt.Printf("  useful tokens    %.0f\n", rec.Snap.UsefulTokens)
+			if rec.Compact {
+				fmt.Printf("  %s %s\n\n", cortexStyle.Render("⚠ compact:"), rec.Reason)
+			} else {
+				fmt.Printf("  %s\n\n", dimStyle.Render("✓ "+rec.Reason))
+			}
+			return nil
+		},
+	}
+	entropyCmd.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
+	entropyCmd.Flags().Float64Var(&minDensity, "min-density", 0, "signal-density floor for the compact recommendation (default 0.35)")
+	cmd.AddCommand(entropyCmd)
 	return cmd
 }
 

--- a/internal/entropy/entropy.go
+++ b/internal/entropy/entropy.go
@@ -1,0 +1,111 @@
+// Package entropy measures the useful information in a context window, not just
+// its length. Manifesto Law 5: useful_tokens = length × signal_density. A big
+// noisy window can carry less usable context than a small dense one, so
+// compaction should trigger on falling signal density — not token count alone.
+package entropy
+
+import (
+	"bytes"
+	"compress/gzip"
+)
+
+// SignalDensity estimates ρ ∈ (0,1]: how information-dense a context is, using
+// the gzip compression ratio as a computable proxy for entropy per byte.
+// Redundant, boilerplate, or repetitive text compresses to a small fraction
+// (low ρ); varied, information-rich text resists compression (high ρ). Empty
+// input has no signal (0).
+func SignalDensity(text string) float64 {
+	if len(text) == 0 {
+		return 0
+	}
+	var buf bytes.Buffer
+	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	_, _ = zw.Write([]byte(text))
+	_ = zw.Close()
+
+	// gzip has a fixed header/footer (~18 bytes); subtract it so tiny inputs
+	// aren't scored as artificially dense.
+	const overhead = 18
+	compressed := buf.Len() - overhead
+	if compressed < 1 {
+		compressed = 1
+	}
+	ratio := float64(compressed) / float64(len(text))
+	if ratio > 1 {
+		ratio = 1
+	}
+	if ratio < 0 {
+		ratio = 0
+	}
+	return ratio
+}
+
+// TokenEstimate approximates token count as bytes/4 (the same heuristic the agy
+// executor uses). It is a proxy, not a real tokenizer.
+func TokenEstimate(text string) int { return len(text) / 4 }
+
+// UsefulTokens is length × signal density: the information actually carried by a
+// context, in token-equivalents.
+func UsefulTokens(text string) float64 {
+	return float64(TokenEstimate(text)) * SignalDensity(text)
+}
+
+// Snapshot captures a context window's size and quality at a point in time.
+type Snapshot struct {
+	Tokens       int     // estimated total tokens
+	Density      float64 // ρ
+	UsefulTokens float64 // Tokens × ρ
+}
+
+// Measure builds a Snapshot for a context string.
+func Measure(text string) Snapshot {
+	rho := SignalDensity(text)
+	return Snapshot{
+		Tokens:       TokenEstimate(text),
+		Density:      rho,
+		UsefulTokens: float64(TokenEstimate(text)) * rho,
+	}
+}
+
+// DefaultMinDensity is the signal-density floor below which a context is mostly
+// noise and should be compacted regardless of length.
+const DefaultMinDensity = 0.35
+
+// Governor decides when to recommend compaction based on signal density, not
+// just length.
+type Governor struct {
+	// MinDensity is the ρ floor; below it, compaction is recommended. Zero uses
+	// DefaultMinDensity.
+	MinDensity float64
+}
+
+// Recommendation is the governor's verdict for a context.
+type Recommendation struct {
+	Compact bool
+	Reason  string
+	Snap    Snapshot
+}
+
+// Assess evaluates a single context snapshot against the density floor.
+func (g Governor) Assess(text string) Recommendation {
+	floor := g.MinDensity
+	if floor <= 0 {
+		floor = DefaultMinDensity
+	}
+	snap := Measure(text)
+	if snap.Density < floor {
+		return Recommendation{
+			Compact: true,
+			Reason:  "signal density below floor — window is mostly redundant context",
+			Snap:    snap,
+		}
+	}
+	return Recommendation{Compact: false, Reason: "context is dense enough", Snap: snap}
+}
+
+// Regressed reports whether growing the context from prev to cur added length
+// but not useful information — i.e. the window got bigger and *less* useful, the
+// clearest signal to compact.
+func Regressed(prev, cur Snapshot) bool {
+	return cur.Tokens > prev.Tokens && cur.UsefulTokens <= prev.UsefulTokens
+}

--- a/internal/entropy/entropy_test.go
+++ b/internal/entropy/entropy_test.go
@@ -1,0 +1,99 @@
+package entropy
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// variedText returns n bytes of high-entropy printable content (deterministic).
+func variedText(n int) string {
+	rng := rand.New(rand.NewSource(1))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(32 + rng.Intn(95)) // printable ASCII
+	}
+	return string(b)
+}
+
+func TestSignalDensity_DenseVsRedundant(t *testing.T) {
+	redundant := strings.Repeat("the quick brown fox. ", 20000) // ~420 KB, highly repetitive
+	dense := variedText(40000)                                  // 40 KB, near-random
+
+	rRed := SignalDensity(redundant)
+	rDense := SignalDensity(dense)
+
+	if rRed >= rDense {
+		t.Errorf("redundant ρ (%.3f) should be far below dense ρ (%.3f)", rRed, rDense)
+	}
+	if rRed > 0.1 {
+		t.Errorf("repetitive text ρ = %.3f, expected < 0.1", rRed)
+	}
+	if rDense < 0.5 {
+		t.Errorf("varied text ρ = %.3f, expected > 0.5", rDense)
+	}
+}
+
+func TestSignalDensity_Empty(t *testing.T) {
+	if got := SignalDensity(""); got != 0 {
+		t.Errorf("SignalDensity(empty) = %v, want 0", got)
+	}
+}
+
+// Law 5: a bloated, low-density window carries fewer useful tokens than a much
+// smaller high-density one.
+func TestUsefulTokens_Law5Ordering(t *testing.T) {
+	bloated := strings.Repeat("boilerplate config line = true\n", 30000) // ~930 KB, tiny ρ
+	curated := variedText(50000)                                         // 50 KB, high ρ
+
+	if TokenEstimate(bloated) <= TokenEstimate(curated) {
+		t.Fatal("test setup: bloated should be far longer than curated")
+	}
+	if UsefulTokens(curated) <= UsefulTokens(bloated) {
+		t.Errorf("curated useful (%.0f) should exceed bloated useful (%.0f) despite being %d× shorter",
+			UsefulTokens(curated), UsefulTokens(bloated),
+			TokenEstimate(bloated)/TokenEstimate(curated))
+	}
+}
+
+func TestGovernor_Assess(t *testing.T) {
+	g := Governor{}
+	redundant := strings.Repeat("x = 1\n", 5000)
+	dense := variedText(20000)
+
+	if rec := g.Assess(redundant); !rec.Compact {
+		t.Errorf("low-density context should recommend compaction (ρ=%.3f)", rec.Snap.Density)
+	}
+	if rec := g.Assess(dense); rec.Compact {
+		t.Errorf("high-density context should not recommend compaction (ρ=%.3f)", rec.Snap.Density)
+	}
+}
+
+func TestRegressed(t *testing.T) {
+	prev := Snapshot{Tokens: 100, UsefulTokens: 80}
+	// Grew in length but useful tokens fell → regressed.
+	if !Regressed(prev, Snapshot{Tokens: 200, UsefulTokens: 75}) {
+		t.Error("bigger + less useful should be a regression")
+	}
+	// Grew and added useful info → not a regression.
+	if Regressed(prev, Snapshot{Tokens: 200, UsefulTokens: 120}) {
+		t.Error("bigger + more useful is not a regression")
+	}
+	// Shrank → not a regression by this definition.
+	if Regressed(prev, Snapshot{Tokens: 50, UsefulTokens: 40}) {
+		t.Error("shrinking is not a regression")
+	}
+}
+
+func TestMeasure(t *testing.T) {
+	snap := Measure(variedText(8000))
+	if snap.Tokens != 2000 { // 8000/4
+		t.Errorf("Tokens = %d, want 2000", snap.Tokens)
+	}
+	if snap.Density <= 0 || snap.Density > 1 {
+		t.Errorf("Density = %v, want (0,1]", snap.Density)
+	}
+	if snap.UsefulTokens <= 0 {
+		t.Errorf("UsefulTokens = %v, want > 0", snap.UsefulTokens)
+	}
+}


### PR DESCRIPTION
## Summary
Manifesto Law 5: a context window's value is `length × signal_density`, not length alone. A bloated 1M-token window at 8% density carries fewer useful tokens than a curated 100k window at 90%. This adds a computable signal-density measure and a governor that recommends compaction when density falls — the right trigger, instead of raw token count.

## What's in this PR — `internal/entropy`
- **`SignalDensity(text)`** — ρ via the gzip compression ratio, a computable entropy-per-byte proxy: repetitive/boilerplate context compresses to a small fraction (low ρ); varied, information-rich context resists compression (high ρ).
- **`UsefulTokens = tokens × ρ`**, `Measure` → `Snapshot`.
- **`Governor.Assess`** (compact when ρ is below a floor, default 0.35) and **`Regressed`** (context grew but useful tokens didn't — the clearest compact signal).
- **`hydra context entropy [file|-]`** reports density, useful tokens, and a compact recommendation.

## Verified
```
$ hydra context entropy bloated.txt        # 16000 tok, 0.3% density → ⚠ compact
$ hydra context entropy entropy.go          # 874 tok, 43.4% density → ✓ dense enough
```

## Tests
- dense text scores far higher ρ than repetitive; empty → 0;
- **Law 5 ordering**: a curated 50 KB window's useful tokens exceed a bloated 930 KB window's, despite being ~18× shorter;
- governor floor; regression detector (bigger-but-not-better).
- `go build/vet` clean; `go test ./... -race` green.

Docs: README (roadmap → shipped, By-the-Numbers row, command list), CLAUDE.md (layout + package map).

Closes #105