### PR TITLE
feat(ledger): local MCP accountability ledger + policy gate (Phase 6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ internal/graph/         ← Code dependency graph (graph.json) → blast radius 
 internal/a2a/           ← Causal agent handoffs: vector clocks + concurrent-edit conflict detection.
 internal/optimal/       ← Optimal parallel-agent count n*=√((1-s)/k) (Amdahl+coordination, Law 4).
 internal/entropy/       ← Context signal density (gzip proxy) → useful_tokens=L·ρ; compaction governor (Law 5).
+internal/ledger/        ← MCP accountability ledger: record + policy-gate what agents touch. `hydra mcp`.
 internal/pricing/       ← Live pricing DB (OpenRouter fetch + 24h cache + tier fallback).
 internal/policy/        ← PII detection + local-only enforcement.
 internal/{cost,budget}/ ← Spend reporting (est/actual labeling) + token-budget governor.
@@ -682,6 +683,7 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/a2a` | Agent-to-agent handoffs with vector clocks: causal ordering (before/after/concurrent) + `ConflictsWith` (concurrent + overlapping files). Backs `last_handoff.json` and `--a2a`. |
 | `internal/optimal` | Optimal parallel-agent count `n*=√((1−s)/k)` and speedup (Amdahl + coordination, Manifesto Law 4). Drives `hydra graph parallel`. |
 | `internal/entropy` | Context signal density ρ (gzip-ratio proxy) → `useful_tokens = L·ρ` + a compaction governor (Manifesto Law 5). Drives `hydra context entropy`. |
+| `internal/ledger` | Local MCP accountability ledger: append-only access events + glob allow/deny `Policy.Decide` gate (records every decision). Drives `hydra mcp check\|record\|log\|report`. |
 | `internal/tui` | Bubble Tea TUI: init wizard, install flow |
 | `internal/review` | Code review subcommand |
 | `internal/editor` | Editor integration |

--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ hydra graph blast <file>                # a file's blast radius + the confidence
 hydra graph parallel <files...>         # optimal number of parallel agents (Law 4)
 hydra context entropy <file|->          # signal density + useful tokens + compact hint
 
+# Accountability
+hydra mcp check <tool> --agent A --resource R --action write  # gate + record an access
+hydra mcp log --denied                  # what got blocked
+hydra mcp report                        # allowed/denied by agent and tool
+
 # Editing & batch
 hydra edit --file ... --prompt "..."    # scoped, validated, rollback-safe file edit
 hydra review ...                        # code review / approve / reject / QA
@@ -452,8 +457,8 @@ For Ollama models, add a family pattern:
 | **Optimal parallelism** — `n* = √((1−s)/k)` from graph coupling (Law 4) | ✅ Shipped |
 | **Causal A2A handoffs** — vector clocks, concurrent-edit conflict detection | ✅ Shipped |
 | **Context-entropy governor** — compact on falling signal density, not length | ✅ Shipped |
+| **MCP accountability ledger** — record + gate what every agent touches | ✅ Shipped |
 | Outcome auto-wiring (tests / review / revert → calibration) | 🔨 Building |
-| Local MCP accountability ledger | 📋 Planned |
 | Pluggable verification-oracle interface | 📋 Planned |
 | MCP server registry + central security agent | 📋 [#9](https://github.com/ankit373/hydra/issues/9)/[#10](https://github.com/ankit373/hydra/issues/10) |
 | Web UI + real-time cost dashboard | 📋 [#11](https://github.com/ankit373/hydra/issues/11)/[#12](https://github.com/ankit373/hydra/issues/12) |
@@ -464,8 +469,8 @@ See the full [Hydra Roadmap project board](https://github.com/users/ankit373/pro
 
 Hydra started by answering *which model is cheapest for this task?* It's evolving to answer a harder question: ***how sure are we the answer is right, and what's the least attention we can spend to be that sure?***
 
-- **Today** — calibration measures each source's real diagnostic power; SPRT samples adaptively to a target confidence; the defect-cost model prices what a wrong answer costs; and graph-aware routing reads a code dependency graph so an edit's **blast radius** raises the confidence bar where a mistake is expensive.
-- **Next** — a local MCP ledger records what every model was actually allowed to touch and did; a verification-oracle interface lets test-runners and compilers act as first-class, high-`D` evidence sources; outcomes (tests/review/revert) auto-train calibration.
+- **Today** — calibration measures each source's real diagnostic power; SPRT samples adaptively to a target confidence; the defect-cost model prices what a wrong answer costs; graph-aware routing reads a code dependency graph so an edit's **blast radius** raises the confidence bar where a mistake is expensive; and a local **accountability ledger** records — and can gate — what every agent was allowed to touch and did.
+- **Next** — a verification-oracle interface lets test-runners and compilers act as first-class, high-`D` evidence sources; outcomes (tests/review/revert) auto-train calibration.
 
 The design principle throughout: **no single vendor is privileged** — Hydra routes *across* providers and *away* from expensive ones, optimizing verified correctness per unit of human attention.
 

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ankit373/hydra/internal/editor"
 	"github.com/ankit373/hydra/internal/entropy"
 	"github.com/ankit373/hydra/internal/graph"
+	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/optimal"
 	"github.com/ankit373/hydra/internal/parallel"
 	"github.com/ankit373/hydra/internal/pricing"
@@ -73,7 +74,7 @@ func rootCmd() *cobra.Command {
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(),
 		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(),
-		cmdPricing(), cmdTrust(), cmdGraph(), cmdContext(),
+		cmdPricing(), cmdTrust(), cmdGraph(), cmdContext(), cmdMCP(),
 		cmdVersion(),
 	)
 	return root
@@ -474,6 +475,123 @@ func cmdDispatch() *cobra.Command {
 	cmd.Flags().StringVar(&domain, "domain", "", "calibration domain for --confidence (default: \"default\")")
 	cmd.Flags().StringVar(&file, "file", "", "target file — raises the confidence bar by its code blast radius")
 	cmd.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph used with --file")
+	return cmd
+}
+
+// cmdMCP is the local MCP accountability ledger + policy gate.
+func cmdMCP() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Local accountability ledger: record and gate what agents touch",
+	}
+
+	// check: evaluate the policy for an access and record the decision.
+	var chkAgent, chkResource, chkAction, policyPath string
+	check := &cobra.Command{
+		Use:   "check <tool>",
+		Short: "Evaluate the policy for a tool/resource access and record it",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			pol, err := ledger.LoadPolicy(policyPath)
+			if err != nil {
+				return err
+			}
+			decision, err := ledger.Check(ledger.DefaultPath(), pol,
+				chkAgent, args[0], chkResource, ledger.Action(chkAction))
+			if err != nil {
+				return err
+			}
+			fmt.Printf("  %s  %s %s/%s (%s)\n", strings.ToUpper(string(decision)),
+				chkAgent, args[0], chkResource, chkAction)
+			if decision == ledger.Deny {
+				os.Exit(3) // non-zero so callers can gate on it
+			}
+			return nil
+		},
+	}
+	check.Flags().StringVar(&chkAgent, "agent", "", "agent making the access")
+	check.Flags().StringVar(&chkResource, "resource", "", "resource being accessed")
+	check.Flags().StringVar(&chkAction, "action", "read", "read|write|exec|network")
+	check.Flags().StringVar(&policyPath, "policy", ledger.DefaultPolicyPath(), "path to the access policy JSON")
+
+	// record: append an event directly (for external tools reporting access).
+	var recAgent, recTool, recResource, recAction, recDecision string
+	record := &cobra.Command{
+		Use:   "record",
+		Short: "Append an access event to the ledger",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return ledger.Record(ledger.DefaultPath(), ledger.Event{
+				Agent: recAgent, Tool: recTool, Resource: recResource,
+				Action: ledger.Action(recAction), Decision: ledger.Decision(recDecision),
+			})
+		},
+	}
+	record.Flags().StringVar(&recAgent, "agent", "", "agent")
+	record.Flags().StringVar(&recTool, "tool", "", "tool")
+	record.Flags().StringVar(&recResource, "resource", "", "resource")
+	record.Flags().StringVar(&recAction, "action", "read", "read|write|exec|network")
+	record.Flags().StringVar(&recDecision, "decision", "allow", "allow|deny")
+
+	// log: list events, optionally filtered.
+	var logAgent string
+	var logDenied bool
+	logCmd := &cobra.Command{
+		Use:   "log",
+		Short: "List ledger events (newest last)",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			events, err := ledger.Load(ledger.DefaultPath())
+			if err != nil {
+				return err
+			}
+			events = ledger.Filter(events, logAgent, logDenied)
+			if len(events) == 0 {
+				fmt.Println("  (no matching ledger events)")
+				return nil
+			}
+			for _, e := range events {
+				fmt.Printf("  %s  %-6s  %-12s %s/%s %s\n", e.TS, strings.ToUpper(string(e.Decision)),
+					e.Agent, e.Tool, e.Resource, dimStyle.Render(string(e.Action)))
+			}
+			return nil
+		},
+	}
+	logCmd.Flags().StringVar(&logAgent, "agent", "", "filter to one agent")
+	logCmd.Flags().BoolVar(&logDenied, "denied", false, "only show denied accesses")
+
+	// report: aggregate summary.
+	var repJSON bool
+	report := &cobra.Command{
+		Use:   "report",
+		Short: "Accountability summary: allowed/denied, by agent and tool",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			events, err := ledger.Load(ledger.DefaultPath())
+			if err != nil {
+				return err
+			}
+			s := ledger.Summarize(events)
+			if repJSON {
+				return json.NewEncoder(os.Stdout).Encode(s)
+			}
+			fmt.Printf("\n  ledger events   %d  (%d allowed · %d denied)\n", s.Total, s.Allowed, s.Denied)
+			if len(s.ByAgent) > 0 {
+				fmt.Println("  by agent:")
+				for _, kc := range ledger.SortedCounts(s.ByAgent) {
+					fmt.Printf("    %-20s %d\n", kc.Key, kc.Count)
+				}
+			}
+			if len(s.ByTool) > 0 {
+				fmt.Println("  by tool:")
+				for _, kc := range ledger.SortedCounts(s.ByTool) {
+					fmt.Printf("    %-20s %d\n", kc.Key, kc.Count)
+				}
+			}
+			fmt.Println()
+			return nil
+		},
+	}
+	report.Flags().BoolVar(&repJSON, "json", false, "machine-readable JSON output")
+
+	cmd.AddCommand(check, record, logCmd, report)
 	return cmd
 }
 

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -1,0 +1,268 @@
+// Package ledger is Hydra's local MCP accountability ledger: an append-only
+// record of what every agent was allowed to touch and did. A policy gate decides
+// allow/deny for each tool/resource access and writes the decision to the ledger,
+// so there is always a local, queryable trail — the accountability half of
+// multi-model safety.
+package ledger
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Action is the kind of access an agent attempts against a resource.
+type Action string
+
+const (
+	Read    Action = "read"
+	Write   Action = "write"
+	Exec    Action = "exec"
+	Network Action = "network"
+)
+
+// Decision is the gate's verdict.
+type Decision string
+
+const (
+	Allow Decision = "allow"
+	Deny  Decision = "deny"
+)
+
+// Event is one recorded access attempt.
+type Event struct {
+	TS       string   `json:"ts"`
+	Agent    string   `json:"agent"`
+	Tool     string   `json:"tool"`
+	Resource string   `json:"resource"`
+	Action   Action   `json:"action"`
+	Decision Decision `json:"decision"`
+	Reason   string   `json:"reason,omitempty"`
+}
+
+// DefaultPath is where the ledger lives (~/.hydra/mcp_ledger.jsonl).
+func DefaultPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".hydra", "mcp_ledger.jsonl")
+}
+
+// Record appends one event, stamping TS if blank.
+func Record(path string, e Event) error {
+	if e.TS == "" {
+		e.TS = time.Now().UTC().Format(time.RFC3339)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	raw, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(f, string(raw))
+	return err
+}
+
+// Load reads all events; a missing ledger yields no events.
+func Load(path string) ([]Event, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var events []Event
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e Event
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			continue
+		}
+		events = append(events, e)
+	}
+	return events, sc.Err()
+}
+
+// Rule is one allow/deny rule. Empty fields (and "*") match anything; Resource
+// is matched as a glob (path.Match semantics via filepath.Match).
+type Rule struct {
+	Agent    string   `json:"agent,omitempty"`
+	Tool     string   `json:"tool,omitempty"`
+	Resource string   `json:"resource,omitempty"`
+	Action   Action   `json:"action,omitempty"`
+	Decision Decision `json:"decision"`
+}
+
+// Policy is an ordered rule set with a default decision. First matching rule wins.
+type Policy struct {
+	Rules   []Rule   `json:"rules"`
+	Default Decision `json:"default"`
+}
+
+// Decide evaluates an access against the policy, returning the decision and a
+// human-readable reason. A zero Default is treated as Allow (Hydra records
+// everything but blocks nothing unless a rule says so).
+func (p Policy) Decide(agent, tool, resource string, action Action) (Decision, string) {
+	for i, r := range p.Rules {
+		if r.matches(agent, tool, resource, action) {
+			return r.Decision, fmt.Sprintf("rule %d (%s %s/%s)", i, r.Decision, ruleOr(r.Tool), ruleOr(r.Resource))
+		}
+	}
+	def := p.Default
+	if def == "" {
+		def = Allow
+	}
+	return def, "default"
+}
+
+func (r Rule) matches(agent, tool, resource string, action Action) bool {
+	return fieldMatch(r.Agent, agent) &&
+		fieldMatch(r.Tool, tool) &&
+		globMatch(r.Resource, resource) &&
+		(r.Action == "" || r.Action == action)
+}
+
+// fieldMatch: empty or "*" matches anything; otherwise exact.
+func fieldMatch(pattern, v string) bool {
+	return pattern == "" || pattern == "*" || pattern == v
+}
+
+// globMatch: empty or "*" matches anything; otherwise filepath.Match glob. A
+// malformed pattern falls back to exact comparison rather than erroring.
+func globMatch(pattern, v string) bool {
+	if pattern == "" || pattern == "*" {
+		return true
+	}
+	ok, err := filepath.Match(pattern, v)
+	if err != nil {
+		return pattern == v
+	}
+	return ok
+}
+
+func ruleOr(s string) string {
+	if s == "" {
+		return "*"
+	}
+	return s
+}
+
+// DefaultPolicyPath is where the access policy lives (~/.hydra/mcp_policy.json).
+func DefaultPolicyPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".hydra", "mcp_policy.json")
+}
+
+// LoadPolicy reads a policy file. A missing file yields a default-allow policy
+// (Hydra records everything but blocks nothing until rules are defined).
+func LoadPolicy(path string) (Policy, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Policy{Default: Allow}, nil
+		}
+		return Policy{}, err
+	}
+	var p Policy
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return Policy{}, err
+	}
+	if p.Default == "" {
+		p.Default = Allow
+	}
+	return p, nil
+}
+
+// Check evaluates the policy AND records the resulting event to the ledger —
+// the accountability gate. It returns the decision.
+func Check(path string, p Policy, agent, tool, resource string, action Action) (Decision, error) {
+	decision, reason := p.Decide(agent, tool, resource, action)
+	err := Record(path, Event{
+		Agent: agent, Tool: tool, Resource: resource,
+		Action: action, Decision: decision, Reason: reason,
+	})
+	return decision, err
+}
+
+// Summary is the aggregate accountability report.
+type Summary struct {
+	Total   int            `json:"total"`
+	Allowed int            `json:"allowed"`
+	Denied  int            `json:"denied"`
+	ByAgent map[string]int `json:"by_agent"`
+	ByTool  map[string]int `json:"by_tool"`
+}
+
+// Summarize aggregates events for `hydra mcp report`.
+func Summarize(events []Event) Summary {
+	s := Summary{ByAgent: map[string]int{}, ByTool: map[string]int{}}
+	for _, e := range events {
+		s.Total++
+		switch e.Decision {
+		case Allow:
+			s.Allowed++
+		case Deny:
+			s.Denied++
+		}
+		s.ByAgent[e.Agent]++
+		s.ByTool[e.Tool]++
+	}
+	return s
+}
+
+// Filter returns events matching a non-empty agent and/or only denials.
+func Filter(events []Event, agent string, deniedOnly bool) []Event {
+	var out []Event
+	for _, e := range events {
+		if agent != "" && e.Agent != agent {
+			continue
+		}
+		if deniedOnly && e.Decision != Deny {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// SortedCounts returns key/count pairs sorted by count descending, for stable
+// report rendering.
+func SortedCounts(m map[string]int) []struct {
+	Key   string
+	Count int
+} {
+	out := make([]struct {
+		Key   string
+		Count int
+	}, 0, len(m))
+	for k, v := range m {
+		out = append(out, struct {
+			Key   string
+			Count int
+		}{k, v})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -1,0 +1,121 @@
+package ledger
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPolicy_Decide_FirstMatchWins(t *testing.T) {
+	p := Policy{
+		Rules: []Rule{
+			{Agent: "untrusted", Decision: Deny},
+			{Tool: "fs", Resource: "/etc/*", Action: Write, Decision: Deny},
+			{Tool: "fs", Resource: "/repo/*", Decision: Allow},
+		},
+		Default: Deny,
+	}
+
+	tests := []struct {
+		name                    string
+		agent, tool, resource   string
+		action                  Action
+		want                    Decision
+	}{
+		{"untrusted agent denied outright", "untrusted", "fs", "/repo/a.go", Read, Deny},
+		{"write to /etc denied by rule", "svc", "fs", "/etc/passwd", Write, Deny},
+		{"read of /etc: write-rule skipped, no allow rule → default deny", "svc", "fs", "/etc/passwd", Read, Deny},
+		{"repo write allowed", "svc", "fs", "/repo/a.go", Write, Allow},
+		{"repo read allowed", "svc", "fs", "/repo/a.go", Read, Allow},
+		{"unmatched falls to default deny", "svc", "network", "example.com", Network, Deny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := p.Decide(tt.agent, tt.tool, tt.resource, tt.action)
+			if got != tt.want {
+				t.Errorf("Decide = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPolicy_DefaultAllowWhenUnset(t *testing.T) {
+	var p Policy // no rules, zero default
+	if got, _ := p.Decide("a", "t", "r", Read); got != Allow {
+		t.Errorf("empty policy default = %v, want allow", got)
+	}
+}
+
+func TestGlobMatch(t *testing.T) {
+	p := Policy{Rules: []Rule{{Resource: "secrets/*.key", Decision: Deny}}, Default: Allow}
+	if d, _ := p.Decide("a", "fs", "secrets/prod.key", Read); d != Deny {
+		t.Error("glob secrets/*.key should match secrets/prod.key")
+	}
+	if d, _ := p.Decide("a", "fs", "src/main.go", Read); d != Allow {
+		t.Error("non-matching resource should hit default allow")
+	}
+}
+
+func TestCheck_RecordsDecision(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	p := Policy{Rules: []Rule{{Tool: "fs", Resource: "/etc/*", Decision: Deny}}, Default: Allow}
+
+	if d, err := Check(path, p, "agentA", "fs", "/etc/hosts", Write); err != nil || d != Deny {
+		t.Fatalf("Check = %v (err %v), want deny", d, err)
+	}
+	if d, err := Check(path, p, "agentA", "fs", "/repo/x.go", Write); err != nil || d != Allow {
+		t.Fatalf("Check = %v (err %v), want allow", d, err)
+	}
+
+	events, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("ledger has %d events, want 2 (every check is recorded)", len(events))
+	}
+	if events[0].Decision != Deny || events[0].TS == "" {
+		t.Errorf("first event should be a timestamped deny: %+v", events[0])
+	}
+}
+
+func TestLoad_MissingIsEmpty(t *testing.T) {
+	events, err := Load(filepath.Join(t.TempDir(), "nope.jsonl"))
+	if err != nil {
+		t.Fatalf("missing ledger should not error: %v", err)
+	}
+	if events != nil {
+		t.Errorf("missing ledger should be nil, got %v", events)
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	events := []Event{
+		{Agent: "a", Tool: "fs", Decision: Allow},
+		{Agent: "a", Tool: "fs", Decision: Deny},
+		{Agent: "b", Tool: "net", Decision: Allow},
+	}
+	s := Summarize(events)
+	if s.Total != 3 || s.Allowed != 2 || s.Denied != 1 {
+		t.Errorf("totals = %+v, want 3/2/1", s)
+	}
+	if s.ByAgent["a"] != 2 || s.ByTool["fs"] != 2 {
+		t.Errorf("breakdowns wrong: %+v", s)
+	}
+}
+
+func TestFilter(t *testing.T) {
+	events := []Event{
+		{Agent: "a", Decision: Allow},
+		{Agent: "a", Decision: Deny},
+		{Agent: "b", Decision: Deny},
+	}
+	if got := Filter(events, "a", false); len(got) != 2 {
+		t.Errorf("Filter(agent=a) = %d, want 2", len(got))
+	}
+	if got := Filter(events, "", true); len(got) != 2 {
+		t.Errorf("Filter(deniedOnly) = %d, want 2", len(got))
+	}
+	if got := Filter(events, "a", true); len(got) != 1 {
+		t.Errorf("Filter(agent=a, denied) = %d, want 1", len(got))
+	}
+}


### PR DESCRIPTION
## Summary
The accountability half of multi-model safety: a local, append-only ledger of what every agent was allowed to touch and did, plus a glob-rule policy gate that records its own decisions.

## What's in this PR — `internal/ledger`
- **Ledger** (`~/.hydra/mcp_ledger.jsonl`) — timestamped access events: agent, tool, resource, action (read/write/exec/network), decision (allow/deny), reason.
- **`Policy.Decide`** — ordered glob allow/deny rules, first-match wins, configurable default (unset → allow: record everything, block nothing until rules exist).
- **`Check`** — evaluates the policy *and* records the decision, so nothing accesses a resource without leaving a trail.
- **`Summarize` / `Filter` / `SortedCounts`** back `report` and `log`.
- **`hydra mcp check | record | log | report`**; `check` exits `3` on deny so shell callers can gate on it.

## Verified
```
$ hydra mcp check fs --agent svc --resource /etc/passwd --action write   # DENY (exit 3)
$ hydra mcp check fs --agent svc --resource /repo/x.go  --action write   # ALLOW
$ hydra mcp report      # 3 events (1 allowed · 2 denied), by agent + by tool
```

## Tests
- glob rules, first-match precedence, default-allow; every `check` recorded (allow & deny); `Summarize`/`Filter`; missing ledger → empty. `go test ./... -race` green.

> Scope: this is the observability + gating layer. A full MCP server registry / enforcing proxy remains on the v2 roadmap.

Docs: README (roadmap → shipped, arc prose, command list), CLAUDE.md (layout + package map).

Closes #107