### PR TITLE
feat(oracle): verification-oracle interface — verifiers as first-class evidence (Phase 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ internal/a2a/           ← Causal agent handoffs: vector clocks + concurrent-ed
 internal/optimal/       ← Optimal parallel-agent count n*=√((1-s)/k) (Amdahl+coordination, Law 4).
 internal/entropy/       ← Context signal density (gzip proxy) → useful_tokens=L·ρ; compaction governor (Law 5).
 internal/ledger/        ← MCP accountability ledger: record + policy-gate what agents touch. `hydra mcp`.
+internal/oracle/        ← Verification oracles (tests/compile/lint) as calibrated evidence sources. `hydra oracle`.
 internal/pricing/       ← Live pricing DB (OpenRouter fetch + 24h cache + tier fallback).
 internal/policy/        ← PII detection + local-only enforcement.
 internal/{cost,budget}/ ← Spend reporting (est/actual labeling) + token-budget governor.
@@ -684,6 +685,7 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/optimal` | Optimal parallel-agent count `n*=√((1−s)/k)` and speedup (Amdahl + coordination, Manifesto Law 4). Drives `hydra graph parallel`. |
 | `internal/entropy` | Context signal density ρ (gzip-ratio proxy) → `useful_tokens = L·ρ` + a compaction governor (Manifesto Law 5). Drives `hydra context entropy`. |
 | `internal/ledger` | Local MCP accountability ledger: append-only access events + glob allow/deny `Policy.Decide` gate (records every decision). Drives `hydra mcp check\|record\|log\|report`. |
+| `internal/oracle` | Verification oracles: `Oracle`/`CommandOracle` run tests/compile/lint (exit 0 = pass) and map the verdict to a calibrated LLR (`oracle.LLR`) — a high-`D` evidence source. Drives `hydra oracle verify`. |
 | `internal/tui` | Bubble Tea TUI: init wizard, install flow |
 | `internal/review` | Code review subcommand |
 | `internal/editor` | Editor integration |

--- a/README.md
+++ b/README.md
@@ -373,7 +373,8 @@ hydra graph blast <file>                # a file's blast radius + the confidence
 hydra graph parallel <files...>         # optimal number of parallel agents (Law 4)
 hydra context entropy <file|->          # signal density + useful tokens + compact hint
 
-# Accountability
+# Verification & accountability
+hydra oracle verify go test ./... --source verifier:go-test  # verifier as evidence + its LLR
 hydra mcp check <tool> --agent A --resource R --action write  # gate + record an access
 hydra mcp log --denied                  # what got blocked
 hydra mcp report                        # allowed/denied by agent and tool
@@ -458,8 +459,8 @@ For Ollama models, add a family pattern:
 | **Causal A2A handoffs** — vector clocks, concurrent-edit conflict detection | ✅ Shipped |
 | **Context-entropy governor** — compact on falling signal density, not length | ✅ Shipped |
 | **MCP accountability ledger** — record + gate what every agent touches | ✅ Shipped |
+| **Verification oracles** — tests/compile/lint as first-class evidence | ✅ Shipped |
 | Outcome auto-wiring (tests / review / revert → calibration) | 🔨 Building |
-| Pluggable verification-oracle interface | 📋 Planned |
 | MCP server registry + central security agent | 📋 [#9](https://github.com/ankit373/hydra/issues/9)/[#10](https://github.com/ankit373/hydra/issues/10) |
 | Web UI + real-time cost dashboard | 📋 [#11](https://github.com/ankit373/hydra/issues/11)/[#12](https://github.com/ankit373/hydra/issues/12) |
 
@@ -469,8 +470,8 @@ See the full [Hydra Roadmap project board](https://github.com/users/ankit373/pro
 
 Hydra started by answering *which model is cheapest for this task?* It's evolving to answer a harder question: ***how sure are we the answer is right, and what's the least attention we can spend to be that sure?***
 
-- **Today** — calibration measures each source's real diagnostic power; SPRT samples adaptively to a target confidence; the defect-cost model prices what a wrong answer costs; graph-aware routing reads a code dependency graph so an edit's **blast radius** raises the confidence bar where a mistake is expensive; and a local **accountability ledger** records — and can gate — what every agent was allowed to touch and did.
-- **Next** — a verification-oracle interface lets test-runners and compilers act as first-class, high-`D` evidence sources; outcomes (tests/review/revert) auto-train calibration.
+- **Today** — calibration measures each source's real diagnostic power; SPRT samples adaptively to a target confidence; the defect-cost model prices what a wrong answer costs; graph-aware routing reads a code dependency graph so an edit's **blast radius** raises the confidence bar where a mistake is expensive; a local **accountability ledger** records — and can gate — what every agent was allowed to touch and did; and **verification oracles** (tests, compilers, linters) act as first-class, high-`D` evidence sources whose verdict can outweigh a model's opinion.
+- **Next** — outcomes (tests/review/revert) auto-train calibration in the background, so `D` reflects reality without manual `hydra trust record`.
 
 The design principle throughout: **no single vendor is privileged** — Hydra routes *across* providers and *away* from expensive ones, optimizing verified correctness per unit of human attention.
 

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ankit373/hydra/internal/graph"
 	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/optimal"
+	"github.com/ankit373/hydra/internal/oracle"
 	"github.com/ankit373/hydra/internal/parallel"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
@@ -74,7 +75,7 @@ func rootCmd() *cobra.Command {
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(),
 		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(),
-		cmdPricing(), cmdTrust(), cmdGraph(), cmdContext(), cmdMCP(),
+		cmdPricing(), cmdTrust(), cmdGraph(), cmdContext(), cmdMCP(), cmdOracle(),
 		cmdVersion(),
 	)
 	return root
@@ -475,6 +476,70 @@ func cmdDispatch() *cobra.Command {
 	cmd.Flags().StringVar(&domain, "domain", "", "calibration domain for --confidence (default: \"default\")")
 	cmd.Flags().StringVar(&file, "file", "", "target file — raises the confidence bar by its code blast radius")
 	cmd.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph used with --file")
+	return cmd
+}
+
+// cmdOracle runs a verification oracle and reports its calibrated evidence.
+func cmdOracle() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "oracle",
+		Short: "Run deterministic verifiers (tests/compile/lint) as evidence sources",
+	}
+	var source, domain, candidateFile, record string
+	verify := &cobra.Command{
+		Use:   "verify <command...>",
+		Short: "Run a verifier command; report pass/fail + its calibrated LLR",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			candidate := ""
+			if candidateFile != "" {
+				raw, err := os.ReadFile(candidateFile)
+				if err != nil {
+					return err
+				}
+				candidate = string(raw)
+			}
+			src := source
+			if src == "" {
+				src = "verifier:" + args[0]
+			}
+			o := &oracle.CommandOracle{Template: strings.Join(args, " "), Source: src}
+			v, err := o.Verify(context.Background(), candidate, trust.Task{Domain: domain})
+			if err != nil {
+				return err
+			}
+
+			cal, err := trust.New(trust.DefaultPath())
+			if err != nil {
+				return err
+			}
+			if record != "" {
+				if out := trust.ParseOutcome(record); out != trust.OutcomeUnknown {
+					_ = cal.Update(src, domain, v.Passed, out)
+				}
+			}
+			llr := oracle.LLR(cal, src, domain, v)
+
+			status := cortexStyle.Render("PASS")
+			if !v.Passed {
+				status = "FAIL"
+			}
+			fmt.Printf("\n  %s  %s\n", status, dimStyle.Render(src))
+			if v.Detail != "" {
+				fmt.Printf("  %s\n", dimStyle.Render(v.Detail))
+			}
+			fmt.Printf("  calibrated evidence  %+.3f nats\n\n", llr)
+			if !v.Passed {
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+	verify.Flags().StringVar(&source, "source", "", "calibration source id (default: verifier:<cmd>)")
+	verify.Flags().StringVar(&domain, "domain", "", "task domain")
+	verify.Flags().StringVar(&candidateFile, "candidate", "", "file holding the answer to verify (for {file}/{answer})")
+	verify.Flags().StringVar(&record, "record", "", "train calibration with the true outcome: correct|incorrect")
+	cmd.AddCommand(verify)
 	return cmd
 }
 

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -1,0 +1,125 @@
+// Package oracle turns deterministic verifiers — test runners, compilers,
+// linters — into first-class evidence sources for the Trust Control Plane. A
+// passing suite is far stronger evidence of correctness than any single model's
+// opinion, so a calibrated oracle contributes a large log-likelihood ratio to
+// the SPRT ensemble (SPEC §4: "verifiers as sources too").
+package oracle
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+// defaultWriteTemp materializes the candidate to a temp file for {file} oracles.
+func defaultWriteTemp(content string) (path string, cleanup func(), err error) {
+	f, err := os.CreateTemp("", "hydra-oracle-*.txt")
+	if err != nil {
+		return "", nil, err
+	}
+	name := f.Name()
+	if _, err := f.WriteString(content); err != nil {
+		f.Close()
+		os.Remove(name)
+		return "", nil, err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(name)
+		return "", nil, err
+	}
+	return name, func() { os.Remove(name) }, nil
+}
+
+// Verdict is the outcome of a verification.
+type Verdict struct {
+	Passed bool
+	Detail string // first line of output on failure, for diagnostics
+}
+
+// Oracle independently verifies a candidate answer for a task.
+type Oracle interface {
+	// Verify runs the check. It returns a Verdict; a non-nil error means the
+	// oracle itself could not run (not that the candidate failed).
+	Verify(ctx context.Context, candidate string, task trust.Task) (Verdict, error)
+}
+
+// CommandOracle runs an external command as the verifier. Exit code 0 is a pass;
+// any non-zero exit is a fail. The candidate answer is written to a temp file
+// and substituted for {file}; the raw answer is substituted for {answer}.
+type CommandOracle struct {
+	// Template is the command, e.g. "go test ./..." or "tsc --noEmit {file}".
+	Template string
+	// Source is the calibration key for this oracle, e.g. "verifier:go-test".
+	Source string
+	// writeTemp allows tests to stub file materialization; nil uses the real one.
+	writeTemp func(content string) (path string, cleanup func(), err error)
+}
+
+// Verify runs the command oracle.
+func (o *CommandOracle) Verify(ctx context.Context, candidate string, _ trust.Task) (Verdict, error) {
+	parts, cleanup, err := o.buildArgs(candidate)
+	if err != nil {
+		return Verdict{}, err
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if len(parts) == 0 {
+		return Verdict{Passed: true}, nil
+	}
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		if _, ok := runErr.(*exec.ExitError); ok {
+			return Verdict{Passed: false, Detail: firstLine(string(out))}, nil
+		}
+		return Verdict{}, runErr // couldn't launch the verifier at all
+	}
+	return Verdict{Passed: true}, nil
+}
+
+// buildArgs splits the template, substituting {answer} inline and materializing
+// {file} to a temp path. It mirrors editor.runValidatorCmd's safe splitting so
+// paths with spaces are never fragmented.
+func (o *CommandOracle) buildArgs(candidate string) (parts []string, cleanup func(), err error) {
+	tmpl := o.Template
+	if strings.Contains(tmpl, "{file}") {
+		writer := o.writeTemp
+		if writer == nil {
+			writer = defaultWriteTemp
+		}
+		path, cl, werr := writer(candidate)
+		if werr != nil {
+			return nil, nil, werr
+		}
+		cleanup = cl
+		idx := strings.Index(tmpl, "{file}")
+		parts = append(strings.Fields(subAnswer(tmpl[:idx], candidate)), path)
+		parts = append(parts, strings.Fields(subAnswer(tmpl[idx+len("{file}"):], candidate))...)
+		return parts, cleanup, nil
+	}
+	return strings.Fields(subAnswer(tmpl, candidate)), nil, nil
+}
+
+func subAnswer(s, candidate string) string {
+	return strings.ReplaceAll(s, "{answer}", candidate)
+}
+
+// LLR maps a verdict to the calibrated log-likelihood-ratio contribution of this
+// oracle, exactly as any evidence source: a pass is "says correct", a fail is
+// "says incorrect". A verifier calibrated to high sensitivity/specificity yields
+// a large-magnitude contribution — dominating a single model's vote.
+func LLR(cal *trust.Calibrator, source, domain string, v Verdict) float64 {
+	return cal.LLR(source, domain, v.Passed)
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -1,0 +1,103 @@
+package oracle
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+func TestCommandOracle_PassFail(t *testing.T) {
+	ctx := context.Background()
+
+	pass := &CommandOracle{Template: "true"}
+	if v, err := pass.Verify(ctx, "anything", trust.Task{}); err != nil || !v.Passed {
+		t.Errorf("`true` should pass: v=%+v err=%v", v, err)
+	}
+
+	fail := &CommandOracle{Template: "false"}
+	if v, err := fail.Verify(ctx, "anything", trust.Task{}); err != nil || v.Passed {
+		t.Errorf("`false` should fail (not error): v=%+v err=%v", v, err)
+	}
+}
+
+// {file} must be substituted with a real path holding the candidate content,
+// without fragmenting on spaces.
+func TestCommandOracle_FileSubstitution(t *testing.T) {
+	ctx := context.Background()
+
+	// `test -s {file}` passes iff the file is non-empty → candidate content lands there.
+	o := &CommandOracle{Template: "test -s {file}"}
+	if v, err := o.Verify(ctx, "some content", trust.Task{}); err != nil || !v.Passed {
+		t.Errorf("non-empty candidate should make `test -s` pass: v=%+v err=%v", v, err)
+	}
+	if v, err := o.Verify(ctx, "", trust.Task{}); err != nil || v.Passed {
+		t.Errorf("empty candidate should make `test -s` fail: v=%+v err=%v", v, err)
+	}
+}
+
+func TestCommandOracle_FileContentIsCandidate(t *testing.T) {
+	// Capture the temp path the oracle writes, and assert its contents.
+	var seenPath string
+	o := &CommandOracle{
+		Template: "true {file}",
+		writeTemp: func(content string) (string, func(), error) {
+			p := filepath.Join(t.TempDir(), "cand.txt")
+			if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+				return "", nil, err
+			}
+			seenPath = p
+			return p, func() {}, nil
+		},
+	}
+	if _, err := o.Verify(context.Background(), "hello oracle", trust.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(seenPath)
+	if string(raw) != "hello oracle" {
+		t.Errorf("temp file content = %q, want candidate", string(raw))
+	}
+}
+
+func TestCommandOracle_LauncherErrorIsError(t *testing.T) {
+	o := &CommandOracle{Template: "this-command-does-not-exist-hydra"}
+	if _, err := o.Verify(context.Background(), "x", trust.Task{}); err == nil {
+		t.Error("a missing verifier binary should return an error, not a fail verdict")
+	}
+}
+
+// A calibrated verifier contributes a large-magnitude LLR — dominating a model.
+func TestLLR_CalibratedVerifierDominates(t *testing.T) {
+	cal, _ := trust.New("")
+	// Train verifier:tests to near-perfect (se=sp≈0.99).
+	for i := 0; i < 990; i++ {
+		_ = cal.Update("verifier:tests", "go", true, trust.OutcomeCorrect)
+		_ = cal.Update("verifier:tests", "go", false, trust.OutcomeIncorrect)
+	}
+	for i := 0; i < 10; i++ {
+		_ = cal.Update("verifier:tests", "go", false, trust.OutcomeCorrect)
+		_ = cal.Update("verifier:tests", "go", true, trust.OutcomeIncorrect)
+	}
+	// A middling model.
+	for i := 0; i < 70; i++ {
+		_ = cal.Update("model:x", "go", true, trust.OutcomeCorrect)
+		_ = cal.Update("model:x", "go", false, trust.OutcomeIncorrect)
+	}
+	for i := 0; i < 30; i++ {
+		_ = cal.Update("model:x", "go", false, trust.OutcomeCorrect)
+		_ = cal.Update("model:x", "go", true, trust.OutcomeIncorrect)
+	}
+
+	pass := LLR(cal, "verifier:tests", "go", Verdict{Passed: true})
+	fail := LLR(cal, "verifier:tests", "go", Verdict{Passed: false})
+	modelPass := LLR(cal, "model:x", "go", Verdict{Passed: true})
+
+	if pass <= 0 || fail >= 0 {
+		t.Errorf("verifier pass LLR should be +, fail should be −: pass=%.3f fail=%.3f", pass, fail)
+	}
+	if pass <= modelPass {
+		t.Errorf("calibrated verifier (%.3f) should dominate a middling model (%.3f)", pass, modelPass)
+	}
+}


### PR DESCRIPTION
## Summary
A passing test suite or a clean compile is far stronger evidence of correctness than any single model's opinion. This makes deterministic verifiers first-class, high-`D` evidence sources for the Trust Control Plane (SPEC §4: "verifiers as sources too").

## What's in this PR — `internal/oracle`
- **`Oracle` interface** + **`Verdict{Passed, Detail}`**.
- **`CommandOracle`** — runs a verifier command (`go test ./...`, `tsc --noEmit {file}`, …); exit 0 = pass, non-zero = fail. Safe `{file}`/`{answer}` substitution: the candidate is materialized to a temp file and paths are never fragmented by spaces.
- **`oracle.LLR`** — maps a verdict to a *calibrated* log-likelihood contribution via `trust.Calibrator`, so a verifier calibrated to se≈sp≈0.99 contributes ~±4.6 nats — dwarfing a model's ~±1.
- **`hydra oracle verify <command...> [--record correct|incorrect]`** — run a verifier, print pass/fail + its calibrated evidence, optionally train calibration; exits 1 on fail so it composes in scripts.

## Verified
```
$ hydra oracle verify --source verifier:go-test --domain go true    # PASS  +4.605 nats
$ hydra oracle verify --source verifier:go-test --domain go false   # FAIL  −4.605 nats (exit 1)
```

## Tests
- pass/fail (`true`/`false`); `{file}` substitution + content (`test -s`); a missing verifier binary is an *error*, not a fail verdict; a calibrated verifier's LLR dominates a middling model's.
- `go test ./... -race` green.

Docs: README (roadmap → shipped, arc prose, command list), CLAUDE.md (layout + package map).

Closes #109