### PR TITLE
feat(trust): hydra trust benchmark + Trust Control Plane repositioning (Phase 8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
     ╚═╝  ╚═╝   ╚═╝   ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝
 </pre>
 
-### The AI Control Plane for Software Development
+### The Trust Control Plane for AI Development
 
-*One command. Every model. Total control.*
+*Route to a **confidence of correctness**, not just the cheapest model.*
+*One command. Every model. Provable trust.*
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-8b5cf6.svg)](LICENSE)
 [![Go 1.24](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go&logoColor=white)](go.mod)
@@ -131,7 +132,7 @@ Every executor is **native Go** — `agy`, Ollama, per-provider HTTP (OpenAI-com
 | Context signal density | useful tokens = `length × ρ`; a dense 100k window beats a noisy 1M | Law 5; ρ via gzip-ratio proxy (`internal/entropy`) — compact on falling ρ |
 | Output capture | bounded at **33 MB** per subprocess | `internal/util.Accumulator` — no unbounded buffers |
 
-> **Methodology & honesty.** Routing overhead, discovery, calibration, and SPRT figures are **measured** by the test/benchmark suite (`go test ./...`, race-clean in CI). The SPRT numbers come from *synthetic* trials with known ground truth, not production traffic — they validate the algorithm (Wald sequential test), and land above the continuous theoretical `E[N]` (easy 1.33 / blended 2.48) because real evidence arrives in discrete steps. Cost-savings ranges are workload-dependent estimates; `hydra stats` reports your actual spend. As production `trust.jsonl` accumulates, `hydra trust stats` graduates these from *modeled* to *observed*.
+> **Methodology & honesty.** Routing overhead, discovery, calibration, and SPRT figures are **measured** — reproduce the SPRT numbers yourself with `hydra trust benchmark` (deterministic for a fixed seed; race-clean in CI). The SPRT numbers come from *synthetic* trials with known ground truth, not production traffic — they validate the algorithm (Wald sequential test), and land above the continuous theoretical `E[N]` (easy 1.33 / blended 2.48) because real evidence arrives in discrete steps. Cost-savings ranges are workload-dependent estimates; `hydra stats` reports your actual spend. As production `trust.jsonl` accumulates, `hydra trust stats` graduates these from *modeled* to *observed*.
 
 ---
 
@@ -369,6 +370,7 @@ hydra trust record ...                  # feed an outcome to train calibration
 hydra trust defect ...                  # modeled cost of shipping a wrong answer
 hydra trust stats                       # samples saved, achieved vs target confidence
 hydra trust explain <task_hash>         # the LLR ledger for a past SPRT run
+hydra trust benchmark                   # measured SPRT numbers (samples saved, accuracy)
 hydra graph blast <file>                # a file's blast radius + the confidence it demands
 hydra graph parallel <files...>         # optimal number of parallel agents (Law 4)
 hydra context entropy <file|->          # signal density + useful tokens + compact hint

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1497,7 +1497,40 @@ func cmdTrust() *cobra.Command {
 		Short: "Confidence layer: source calibration and defect-cost (Trust Control Plane)",
 	}
 	cmd.AddCommand(cmdTrustCalibration(), cmdTrustRecord(), cmdTrustDefect(),
-		cmdTrustStats(), cmdTrustExplain())
+		cmdTrustStats(), cmdTrustExplain(), cmdTrustBenchmark())
+	return cmd
+}
+
+func cmdTrustBenchmark() *cobra.Command {
+	var trials int
+	var seed int64
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "benchmark",
+		Short: "Measure the SPRT ensemble on a synthetic suite (the [MEASURED] Law 3 numbers)",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			r := trust.Benchmark(trials, seed)
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(r)
+			}
+			fmt.Printf("\n  Hydra Trust Benchmark — %d trials/case (vs fixed-%d swarm)\n", r.Trials, r.FixedN)
+			fmt.Println("  " + strings.Repeat("─", 62))
+			fmt.Printf("  %-18s %10s %10s %12s\n", "workload", "samples", "accuracy", "vs fixed-N")
+			row := func(c trust.BenchCase) {
+				fmt.Printf("  %-18s %10.2f %9.1f%% %11.0f%%\n", c.Label, c.MeanSamples, c.Accuracy*100, c.SavedPct)
+			}
+			for _, c := range r.Cases {
+				row(c)
+			}
+			fmt.Println("  " + strings.Repeat("─", 62))
+			row(r.Blended)
+			fmt.Println()
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&trials, "trials", 20000, "trials per difficulty")
+	cmd.Flags().Int64Var(&seed, "seed", 42, "PRNG seed (fixed → reproducible)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
 	return cmd
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2234,7 +2234,7 @@
       </div>
       <h1 class="animate-on-load delay-1">Cut AI API Costs 80%<br><span class="gradient-text">Without Sacrificing Quality</span></h1>
       <p class="hero-desc animate-on-load delay-2">
-        Hydra routes each task to the cheapest model that can handle it — Claude for hard reasoning, Gemini Flash for standard work, free local Qwen for boilerplate. Your API bill drops ~80%. Your output quality doesn't. Install in 30 seconds.
+        Hydra routes each task to the cheapest model that can handle it — Claude for hard reasoning, Gemini Flash for standard work, free local Qwen for boilerplate. Your API bill drops ~80%. Your output quality doesn't. And with <strong style="color: var(--text-main);">confidence routing</strong>, it can go further — sampling models adaptively until a target <em>confidence of correctness</em> is reached, spending more only where accuracy demands it. The cost router, evolving into a <strong style="color: var(--text-main);">Trust Control Plane</strong>. Install in 30 seconds.
       </p>
       <div class="hero-ctas animate-on-load delay-3">
         <a href="#get-started" class="btn btn-primary" id="cta-get-started">Install via Homebrew →</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
-# Hydra — Multi-Model AI Orchestration CLI
+# Hydra — The Trust Control Plane for AI Development
 
-> Hydra is an open source CLI written in Go that automatically routes developer tasks to the right AI model. It reduces LLM API costs by 70-85% by using cheap or free models for simple tasks (DTOs, CRUD, boilerplate) and reserving frontier models for work that actually needs them (architecture, complex reasoning).
+> Hydra is an open source CLI written in Go that routes developer tasks across every AI model on your machine — not just to the cheapest one, but to a target *confidence of correctness*. It reduces LLM API costs by 70-85% by using cheap or free models for simple tasks and reserving frontier models for work that needs them, and it can route to a calibrated confidence: sampling models adaptively (SPRT) and stopping as soon as the evidence is strong enough, spending more only where accuracy demands it.
 
 ## What It Does
 

--- a/internal/trust/benchmark.go
+++ b/internal/trust/benchmark.go
@@ -1,0 +1,108 @@
+package trust
+
+import (
+	"context"
+	"math/rand"
+)
+
+// FixedSwarmBaseline is the fixed fan-out an SPRT run is compared against.
+const FixedSwarmBaseline = 5
+
+// BenchCase is the measured result for one task difficulty.
+type BenchCase struct {
+	Label       string  `json:"label"`
+	Accuracy    float64 `json:"accuracy"`     // fraction of runs that returned the correct answer
+	MeanSamples float64 `json:"mean_samples"` // average model calls
+	SavedPct    float64 `json:"saved_pct"`    // vs a fixed-N swarm
+}
+
+// BenchmarkResult is the output of Benchmark.
+type BenchmarkResult struct {
+	Trials  int         `json:"trials"`
+	FixedN  int         `json:"fixed_n"`
+	Cases   []BenchCase `json:"cases"`
+	Blended BenchCase   `json:"blended"` // 71% easy / 29% hard task mix
+}
+
+// benchExec answers `truth` with probability p, else a fixed wrong answer.
+type benchExec struct {
+	truth, wrong string
+	p            float64
+	rng          *rand.Rand
+}
+
+func (e *benchExec) Execute(_ context.Context, src Source, _ Task) (Answer, error) {
+	if e.rng.Float64() < e.p {
+		return Answer{Text: e.truth, CostUSD: src.EstCostUSD}, nil
+	}
+	return Answer{Text: e.wrong, CostUSD: src.EstCostUSD}, nil
+}
+
+// Benchmark runs the real SPRT ensemble (Run) over synthetic sources of known
+// reliability and measures samples-vs-fixed-N and accuracy. It is the [MEASURED]
+// counterpart to the Manifesto's [MODEL] Law 3 numbers — deterministic for a
+// given seed. Easy tasks use 90%-reliable sources; hard tasks 74%.
+func Benchmark(trials int, seed int64) BenchmarkResult {
+	if trials <= 0 {
+		trials = 20000
+	}
+	rng := rand.New(rand.NewSource(seed))
+	const pool = 30
+
+	run := func(label, id string, p float64) BenchCase {
+		cal := &Calibrator{store: map[calibKey]*confusion{}}
+		calibrateSynthetic(cal, id, "bench", p, 2000)
+		sources := make([]Source, pool)
+		for i := range sources {
+			sources[i] = Source{ID: id, EstCostUSD: 1}
+		}
+		var totSamples, correct int
+		for i := 0; i < trials; i++ {
+			exec := &benchExec{truth: "A", wrong: "B", p: p, rng: rng}
+			res, _ := Run(context.Background(), Task{Domain: "bench"}, sources, exec, cal, Target{Confidence: 0.95})
+			totSamples += res.Samples
+			if res.Candidate == "A" {
+				correct++
+			}
+		}
+		mean := float64(totSamples) / float64(trials)
+		return BenchCase{
+			Label:       label,
+			Accuracy:    float64(correct) / float64(trials),
+			MeanSamples: mean,
+			SavedPct:    100 * (1 - mean/float64(FixedSwarmBaseline)),
+		}
+	}
+
+	easy := run("easy (p=.90)", "bench-easy", 0.90)
+	hard := run("hard (p=.74)", "bench-hard", 0.74)
+
+	blended := BenchCase{
+		Label:       "blended (71/29)",
+		Accuracy:    0.71*easy.Accuracy + 0.29*hard.Accuracy,
+		MeanSamples: 0.71*easy.MeanSamples + 0.29*hard.MeanSamples,
+	}
+	blended.SavedPct = 100 * (1 - blended.MeanSamples/float64(FixedSwarmBaseline))
+
+	return BenchmarkResult{
+		Trials:  trials,
+		FixedN:  FixedSwarmBaseline,
+		Cases:   []BenchCase{easy, hard},
+		Blended: blended,
+	}
+}
+
+// calibrateSynthetic trains (id,domain) to se=sp≈p with n balanced samples.
+// Production twin of the test helper, used only by Benchmark.
+func calibrateSynthetic(c *Calibrator, id, domain string, p float64, n int) {
+	correct := int(p * float64(n))
+	wrong := n - correct
+	for i := 0; i < correct; i++ {
+		_ = c.Update(id, domain, true, OutcomeCorrect)
+		_ = c.Update(id, domain, false, OutcomeIncorrect)
+	}
+	for i := 0; i < wrong; i++ {
+		_ = c.Update(id, domain, false, OutcomeCorrect)
+		_ = c.Update(id, domain, true, OutcomeIncorrect)
+	}
+}

--- a/internal/trust/benchmark_test.go
+++ b/internal/trust/benchmark_test.go
@@ -1,0 +1,34 @@
+package trust
+
+import "testing"
+
+func TestBenchmark_MeasuredLaw3(t *testing.T) {
+	r := Benchmark(5000, 42)
+
+	if len(r.Cases) != 2 {
+		t.Fatalf("cases = %d, want 2 (easy, hard)", len(r.Cases))
+	}
+	easy, hard := r.Cases[0], r.Cases[1]
+
+	// Easy tasks stop sooner than hard ones.
+	if easy.MeanSamples >= hard.MeanSamples {
+		t.Errorf("easy mean (%.2f) should be < hard mean (%.2f)", easy.MeanSamples, hard.MeanSamples)
+	}
+	// Blended beats a fixed-5 swarm.
+	if r.Blended.SavedPct <= 0 {
+		t.Errorf("blended saved %.1f%%, want > 0 vs fixed-%d", r.Blended.SavedPct, r.FixedN)
+	}
+	// The SPRT holds its confidence target: ≥95% accuracy on every difficulty.
+	if easy.Accuracy < 0.95 || hard.Accuracy < 0.95 || r.Blended.Accuracy < 0.95 {
+		t.Errorf("accuracy below target: easy=%.4f hard=%.4f blended=%.4f",
+			easy.Accuracy, hard.Accuracy, r.Blended.Accuracy)
+	}
+}
+
+func TestBenchmark_Deterministic(t *testing.T) {
+	a := Benchmark(2000, 7)
+	b := Benchmark(2000, 7)
+	if a.Blended.MeanSamples != b.Blended.MeanSamples || a.Blended.Accuracy != b.Blended.Accuracy {
+		t.Error("Benchmark should be deterministic for a fixed seed")
+	}
+}

--- a/internal/trust/sprt_test.go
+++ b/internal/trust/sprt_test.go
@@ -9,17 +9,10 @@ import (
 )
 
 // calibrateSymmetric trains (id,domain) to se=sp≈p using n balanced samples.
+// calibrateSymmetric trains (id,domain) to se=sp≈p; it delegates to the
+// production helper backing `hydra trust benchmark` so the two never diverge.
 func calibrateSymmetric(c *Calibrator, id, domain string, p float64, n int) {
-	correct := int(p * float64(n))
-	wrong := n - correct
-	for i := 0; i < correct; i++ {
-		_ = c.Update(id, domain, true, OutcomeCorrect)   // TP
-		_ = c.Update(id, domain, false, OutcomeIncorrect) // TN
-	}
-	for i := 0; i < wrong; i++ {
-		_ = c.Update(id, domain, false, OutcomeCorrect)  // FN
-		_ = c.Update(id, domain, true, OutcomeIncorrect) // FP
-	}
+	calibrateSynthetic(c, id, domain, p, n)
 }
 
 // scriptExec returns a fixed answer sequence, one per Execute call.


### PR DESCRIPTION
## Summary
The final phase: make the headline numbers **reproducible from the CLI** (graduating them from [MODEL] to [MEASURED]) and reposition the top-line story from cost router to **Trust Control Plane**.

## What's in this PR
- **`trust.Benchmark(trials, seed)`** — runs the *real* `trust.Run` SPRT loop over synthetic easy/hard sources of known reliability and reports mean samples, accuracy, and savings vs a fixed-5 swarm. Deterministic per seed. Consolidated the test's `calibrateSymmetric` onto the production `calibrateSynthetic` so they can't drift.
- **`hydra trust benchmark [--trials N] [--seed S] [--json]`**:
```
  Hydra Trust Benchmark — 20000 trials/case (vs fixed-5 swarm)
  workload              samples   accuracy   vs fixed-N
  easy (p=.90)             2.57      98.7%          49%
  hard (p=.74)             6.82      96.6%         -36%
  blended (71/29)          3.80      98.1%          24%
```
- **Repositioning** — README hero ("The Trust Control Plane for AI Development — route to a confidence of correctness"), `llms.txt` intro, and `index.html` hero. The README numbers methodology now points at `hydra trust benchmark` as the reproducer.

## Tests
- benchmark ordering (easy < hard), ≥95% accuracy on every difficulty, positive blended savings, determinism for a fixed seed. `go test ./... -race` green.

Closes #111

---

### 🏁 This completes the Trust Control Plane build (Phases 0–8)
Calibration → defect cost → SPRT confidence routing → graph blast-radius → causal A2A + optimal parallelism → context entropy → MCP accountability ledger → verification oracles → measured benchmark. Every phase issue-first, CI-green, race-clean.