### PR TITLE
feat(capabilities): wire runtime model overlay into discovery + hydra models CLI

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ankit373/hydra/internal/budget"
 	"github.com/ankit373/hydra/internal/build"
+	"github.com/ankit373/hydra/internal/capabilities"
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/cost"
 	"github.com/ankit373/hydra/internal/dispatch"
@@ -75,7 +76,7 @@ func rootCmd() *cobra.Command {
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdDispatch(),
 		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(),
-		cmdPricing(), cmdTrust(), cmdGraph(), cmdContext(), cmdMCP(), cmdOracle(),
+		cmdPricing(), cmdTrust(), cmdGraph(), cmdContext(), cmdMCP(), cmdOracle(), cmdModels(),
 		cmdVersion(),
 	)
 	return root
@@ -657,6 +658,138 @@ func cmdMCP() *cobra.Command {
 	report.Flags().BoolVar(&repJSON, "json", false, "machine-readable JSON output")
 
 	cmd.AddCommand(check, record, logCmd, report)
+	return cmd
+}
+
+// cmdModels manages the runtime-extensible model capability registry.
+func cmdModels() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "models",
+		Short: "Manage the model registry — add new models (e.g. Kimi K2) without recompiling",
+	}
+	overlay := capabilities.DefaultOverlayPath()
+
+	var jsonOut bool
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List all models (built-in + your additions), by capability score",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			db, err := capabilities.Load(overlay)
+			if err != nil {
+				return err
+			}
+			entries := db.Entries()
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(entries)
+			}
+			fmt.Printf("\n  %-26s %-14s %6s  %s\n", "ID", "PROVIDER", "SCORE", "SOURCE")
+			fmt.Println("  " + strings.Repeat("─", 58))
+			for _, e := range entries {
+				src := dimStyle.Render(e.Source)
+				if e.Source == "user" {
+					src = cortexStyle.Render("user")
+				}
+				fmt.Printf("  %-26.26s %-14.14s %6d  %s\n", e.ID, e.Provider, e.CapScore, src)
+			}
+			fmt.Println()
+			return nil
+		},
+	}
+	list.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
+
+	var addName, addProvider string
+	var addScore int
+	add := &cobra.Command{
+		Use:   "add <id>",
+		Short: "Add or update a model in your registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			if addScore < 0 || addScore > 100 {
+				return fmt.Errorf("--cap-score must be 0–100, got %d", addScore)
+			}
+			e := capabilities.Entry{ID: args[0], Name: addName, Provider: addProvider, CapScore: addScore}
+			if e.Name == "" {
+				e.Name = args[0]
+			}
+			replaced, err := capabilities.AddModel(overlay, e)
+			if err != nil {
+				return err
+			}
+			verb := "added"
+			if replaced {
+				verb = "updated"
+			}
+			fmt.Printf("  %s %s (%s, score %d) → %s\n", verb, e.ID, e.Provider, e.CapScore, overlay)
+			return nil
+		},
+	}
+	add.Flags().StringVar(&addName, "name", "", "display name (default: the id)")
+	add.Flags().StringVar(&addProvider, "provider", "", "provider, e.g. moonshot / openai / local")
+	add.Flags().IntVar(&addScore, "cap-score", 70, "capability score 0–100")
+
+	remove := &cobra.Command{
+		Use:   "remove <id>",
+		Short: "Remove a model from your registry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			removed, err := capabilities.RemoveModel(overlay, args[0])
+			if err != nil {
+				return err
+			}
+			if !removed {
+				return fmt.Errorf("%q is not in your registry (built-ins can't be removed, only overridden)", args[0])
+			}
+			fmt.Printf("  removed %s\n", args[0])
+			return nil
+		},
+	}
+
+	var syncFilter string
+	var syncDry bool
+	sync := &cobra.Command{
+		Use:   "sync",
+		Short: "Import models from the live OpenRouter catalog (provisional capScores)",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			db := pricing.Load()
+			models := db.Models()
+			added, skipped := 0, 0
+			builtin, _ := capabilities.Load("")
+			for _, id := range models {
+				if syncFilter != "" && !strings.Contains(strings.ToLower(id), strings.ToLower(syncFilter)) {
+					continue
+				}
+				// Don't clobber a model already known (built-in or user).
+				if builtin.Name(id) != id {
+					skipped++
+					continue
+				}
+				provider := id
+				if i := strings.IndexByte(id, '/'); i > 0 {
+					provider = id[:i]
+				}
+				e := capabilities.Entry{ID: id, Name: id, Provider: provider, CapScore: capabilities.HeuristicCapScore(id)}
+				if syncDry {
+					fmt.Printf("  + %-40.40s %-12.12s score %d\n", e.ID, e.Provider, e.CapScore)
+					added++
+					continue
+				}
+				if _, err := capabilities.AddModel(overlay, e); err != nil {
+					return err
+				}
+				added++
+			}
+			word := "imported"
+			if syncDry {
+				word = "would import"
+			}
+			fmt.Printf("\n  %s %d models (%d already known, skipped). capScores are provisional — refine with `hydra models add`.\n\n", word, added, skipped)
+			return nil
+		},
+	}
+	sync.Flags().StringVar(&syncFilter, "filter", "", "only import models whose id contains this substring")
+	sync.Flags().BoolVar(&syncDry, "dry-run", false, "show what would be imported without writing")
+
+	cmd.AddCommand(list, add, remove, sync)
 	return cmd
 }
 

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -1,22 +1,27 @@
-// Package capabilities provides model scoring data, embedded at compile time.
-// To add or update scores: edit data.json — no code changes needed.
+// Package capabilities provides model scoring data, embedded at compile time
+// and extensible at runtime via a user overlay (~/.hydra/models.json), so users
+// can add new models (e.g. Kimi K2) without editing source or recompiling.
 package capabilities
 
 import (
 	_ "embed"
 	"encoding/json"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 )
 
 //go:embed data.json
 var defaultData []byte
 
-type modelEntry struct {
+// Entry is one model's capability record. Source is "builtin" or "user".
+type Entry struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`
 	Provider string `json:"provider"`
 	CapScore int    `json:"capScore"`
+	Source   string `json:"source,omitempty"`
 }
 
 type ollamaFamily struct {
@@ -25,39 +30,59 @@ type ollamaFamily struct {
 }
 
 type data struct {
-	Known          []modelEntry   `json:"known"`
+	Known          []Entry        `json:"known"`
 	OllamaFamilies []ollamaFamily `json:"ollamaFamilies"`
 	DefaultScore   int            `json:"defaultScore"`
 }
 
-// DB is a queryable capability database.
+// DB is a queryable capability database (built-in ⊕ user overlay).
 type DB struct {
 	d     data
-	index map[string]modelEntry
+	index map[string]Entry
 }
 
-// Load builds a DB from the embedded default, optionally overridden by a
-// user file at path (pass "" to use embedded data only).
-func Load(overridePath string) (*DB, error) {
-	raw := defaultData
-	if overridePath != "" {
-		if b, err := os.ReadFile(overridePath); err == nil {
-			raw = b
-		}
-	}
+// Load builds a DB from the embedded defaults, then MERGES a user overlay if
+// overlayPath is non-empty and present: overlay entries add new models and
+// override built-ins by ID. Pass "" for built-ins only.
+func Load(overlayPath string) (*DB, error) {
 	var d data
-	if err := json.Unmarshal(raw, &d); err != nil {
+	if err := json.Unmarshal(defaultData, &d); err != nil {
 		return nil, err
 	}
-	idx := make(map[string]modelEntry, len(d.Known))
+	for i := range d.Known {
+		d.Known[i].Source = "builtin"
+	}
+
+	idx := make(map[string]Entry, len(d.Known))
 	for _, m := range d.Known {
 		idx[m.ID] = m
 	}
+
+	if overlayPath != "" {
+		overlay, err := LoadOverlay(overlayPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range overlay {
+			e.Source = "user"
+			if _, existed := idx[e.ID]; !existed {
+				d.Known = append(d.Known, e)
+			} else {
+				// Replace the built-in entry in the slice too, so Entries() is consistent.
+				for i := range d.Known {
+					if d.Known[i].ID == e.ID {
+						d.Known[i] = e
+					}
+				}
+			}
+			idx[e.ID] = e
+		}
+	}
+
 	return &DB{d: d, index: idx}, nil
 }
 
-// Score returns the capability score for a known model ID.
-// Returns DefaultScore if the ID is not in the database.
+// Score returns the capability score for a known model ID, or DefaultScore.
 func (db *DB) Score(id string) int {
 	if m, ok := db.index[id]; ok {
 		return m.CapScore
@@ -76,10 +101,121 @@ func (db *DB) ScoreOllama(modelName string) int {
 	return db.d.DefaultScore
 }
 
-// Name returns the display name for a known model ID.
+// Name returns the display name for a known model ID, or the ID itself.
 func (db *DB) Name(id string) string {
 	if m, ok := db.index[id]; ok {
 		return m.Name
 	}
 	return id
+}
+
+// Entries returns all models (built-in ⊕ user), sorted by capScore descending.
+func (db *DB) Entries() []Entry {
+	out := append([]Entry(nil), db.d.Known...)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].CapScore > out[j].CapScore })
+	return out
+}
+
+// ── User overlay (~/.hydra/models.json): a flat JSON array of Entry ──────────
+
+// DefaultOverlayPath is where user-added models live.
+func DefaultOverlayPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".hydra", "models.json")
+}
+
+// LoadOverlay reads the user overlay. A missing file yields no entries.
+func LoadOverlay(path string) ([]Entry, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var entries []Entry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// SaveOverlay writes the overlay atomically-ish (dir created, 0600).
+func SaveOverlay(path string, entries []Entry) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, raw, 0o600)
+}
+
+// AddModel upserts an entry in the overlay by ID and returns whether it replaced
+// an existing overlay entry.
+func AddModel(path string, e Entry) (replaced bool, err error) {
+	entries, err := LoadOverlay(path)
+	if err != nil {
+		return false, err
+	}
+	e.Source = "user"
+	for i := range entries {
+		if entries[i].ID == e.ID {
+			entries[i] = e
+			return true, SaveOverlay(path, entries)
+		}
+	}
+	entries = append(entries, e)
+	return false, SaveOverlay(path, entries)
+}
+
+// RemoveModel deletes an entry from the overlay by ID; returns whether it existed.
+func RemoveModel(path, id string) (removed bool, err error) {
+	entries, err := LoadOverlay(path)
+	if err != nil {
+		return false, err
+	}
+	out := entries[:0]
+	for _, e := range entries {
+		if e.ID == id {
+			removed = true
+			continue
+		}
+		out = append(out, e)
+	}
+	if !removed {
+		return false, nil
+	}
+	return true, SaveOverlay(path, out)
+}
+
+// HeuristicCapScore estimates a provisional capScore from a model id/name, used
+// by `hydra models sync` when importing from OpenRouter. Deliberately rough —
+// users can override with `hydra models add`.
+func HeuristicCapScore(id string) int {
+	s := strings.ToLower(id)
+	switch {
+	case containsAny(s, "opus", "gpt-5", "o1", "o3", "gpt-4.1", "claude-3.7", "claude-4"):
+		return 92
+	case containsAny(s, "sonnet", "gpt-4o", "gpt-4", "gemini-2.5-pro", "gemini-1.5-pro", "deepseek-r1", "grok-4"):
+		return 86
+	case containsAny(s, "gemini-2", "flash", "haiku", "mistral-large", "qwen2.5-coder", "kimi", "llama-3.3", "llama-3.1-70b", "70b"):
+		return 78
+	case containsAny(s, "8b", "7b", "mini", "small", "gemma", "phi"):
+		return 66
+	case containsAny(s, "3b", "1b", "tiny", "nano"):
+		return 55
+	default:
+		return 70
+	}
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/capabilities/capabilities_test.go
+++ b/internal/capabilities/capabilities_test.go
@@ -1,0 +1,115 @@
+package capabilities
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_BuiltinOnly(t *testing.T) {
+	db, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if db.Score("claude") < 90 {
+		t.Errorf("claude score = %d, want ≥90", db.Score("claude"))
+	}
+	if db.Name("claude") != "Claude Code" {
+		t.Errorf("claude name = %q", db.Name("claude"))
+	}
+	// Unknown model → default score.
+	if db.Score("kimi-k2") == 0 {
+		t.Error("unknown model should get DefaultScore, not 0")
+	}
+}
+
+func TestOverlay_AddMergesOverBuiltin(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "models.json")
+
+	// Add a brand-new model (Kimi K2) and override a built-in (claude).
+	if _, err := AddModel(path, Entry{ID: "kimi-k2", Name: "Kimi K2", Provider: "moonshot", CapScore: 82}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AddModel(path, Entry{ID: "claude", Name: "Claude Code (tuned)", CapScore: 99}); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if db.Score("kimi-k2") != 82 {
+		t.Errorf("kimi-k2 score = %d, want 82 (added via overlay)", db.Score("kimi-k2"))
+	}
+	if db.Score("claude") != 99 {
+		t.Errorf("claude score = %d, want 99 (overlay overrides built-in)", db.Score("claude"))
+	}
+	if db.Name("claude") != "Claude Code (tuned)" {
+		t.Errorf("claude name = %q, want overridden", db.Name("claude"))
+	}
+}
+
+func TestOverlay_AddIsUpsert(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "models.json")
+	if replaced, _ := AddModel(path, Entry{ID: "kimi-k2", CapScore: 80}); replaced {
+		t.Error("first add should not report replaced")
+	}
+	if replaced, _ := AddModel(path, Entry{ID: "kimi-k2", CapScore: 85}); !replaced {
+		t.Error("second add of same ID should report replaced")
+	}
+	entries, _ := LoadOverlay(path)
+	if len(entries) != 1 || entries[0].CapScore != 85 {
+		t.Errorf("upsert failed: %+v", entries)
+	}
+}
+
+func TestOverlay_Remove(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "models.json")
+	_, _ = AddModel(path, Entry{ID: "kimi-k2", CapScore: 82})
+
+	if removed, _ := RemoveModel(path, "kimi-k2"); !removed {
+		t.Error("remove of existing model should report removed")
+	}
+	if removed, _ := RemoveModel(path, "nonexistent"); removed {
+		t.Error("remove of missing model should report not-removed")
+	}
+	entries, _ := LoadOverlay(path)
+	if len(entries) != 0 {
+		t.Errorf("overlay should be empty after removal, got %+v", entries)
+	}
+}
+
+func TestEntries_MarksSourceAndSorts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "models.json")
+	_, _ = AddModel(path, Entry{ID: "kimi-k2", Name: "Kimi K2", CapScore: 100}) // top score
+
+	db, _ := Load(path)
+	entries := db.Entries()
+	if len(entries) < 2 {
+		t.Fatal("expected merged entries")
+	}
+	if entries[0].ID != "kimi-k2" || entries[0].Source != "user" {
+		t.Errorf("highest-score entry should be the user-added kimi-k2, got %+v", entries[0])
+	}
+	// A built-in should be marked "builtin".
+	for _, e := range entries {
+		if e.ID == "claude" && e.Source != "builtin" {
+			t.Errorf("claude should be source=builtin, got %q", e.Source)
+		}
+	}
+}
+
+func TestHeuristicCapScore(t *testing.T) {
+	cases := map[string]int{
+		"anthropic/claude-opus-4": 92,
+		"openai/gpt-4o":           86,
+		"moonshot/kimi-k2":        78,
+		"meta-llama/llama-3.1-8b": 66,
+		"qwen/qwen-3b":            55,
+		"some-unknown-model":      70,
+	}
+	for id, want := range cases {
+		if got := HeuristicCapScore(id); got != want {
+			t.Errorf("HeuristicCapScore(%q) = %d, want %d", id, got, want)
+		}
+	}
+}

--- a/internal/provider/cli/provider.go
+++ b/internal/provider/cli/provider.go
@@ -17,7 +17,7 @@ type Provider struct{}
 func (p *Provider) ID() string { return "cli" }
 
 func (p *Provider) Discover(_ context.Context) ([]provider.Head, error) {
-	caps, err := capabilities.Load("")
+	caps, err := capabilities.Load(capabilities.DefaultOverlayPath())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/env/provider.go
+++ b/internal/provider/env/provider.go
@@ -17,7 +17,7 @@ type Provider struct{}
 func (p *Provider) ID() string { return "env" }
 
 func (p *Provider) Discover(_ context.Context) ([]provider.Head, error) {
-	caps, err := capabilities.Load("")
+	caps, err := capabilities.Load(capabilities.DefaultOverlayPath())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/port/provider.go
+++ b/internal/provider/port/provider.go
@@ -31,7 +31,7 @@ type Provider struct{}
 func (p *Provider) ID() string { return "port" }
 
 func (p *Provider) Discover(ctx context.Context) ([]provider.Head, error) {
-	caps, err := capabilities.Load("")
+	caps, err := capabilities.Load(capabilities.DefaultOverlayPath())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
The runtime model overlay (`~/.hydra/models.json`) already existed in `internal/capabilities` — `Load(overlayPath)` merge logic plus `AddModel`/`RemoveModel`/`LoadOverlay`/`SaveOverlay`, all unit-tested — but it was **dead code**: every provider discovery path called `capabilities.Load("")` and no CLI exposed it. Adding a model (e.g. Kimi K3) still required editing `data.json` and recompiling.

This wires it up end to end.

## Changes
- `internal/provider/{cli,env,port}` — load the overlay via `DefaultOverlayPath()` instead of `""`
- `cmd/hydra/main.go` — new `hydra models` command:
  - `list [--json]` — built-in ⊕ user models by capScore, with `builtin`/`user` source labels
  - `add <id> --name --provider --cap-score` — upsert into the overlay (0–100 validation)
  - `remove <id>` — delete a user entry (built-ins can be overridden but not removed)
  - `sync [--filter --dry-run]` — import the OpenRouter catalog with provisional heuristic capScores
- `internal/capabilities/capabilities_test.go` — overlay merge/upsert/remove coverage

## Verification
```
go build ./... && go vet ./... && go test ./... -race   # green
# e2e against a temp HOME:
hydra models add kimi-k3 --name "Kimi K3" --provider moonshot --cap-score 85
hydra models list | grep kimi     # kimi-k3  moonshot  85  user
hydra models remove kimi-k3       # gone
hydra models remove claude        # rejected: built-ins can't be removed
hydra models add foo --cap-score 999   # rejected: must be 0–100
```

Closes #113