### PR TITLE
feat(graph): percolation-κ blast radius (Molloy–Reed) (Phase 9)

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -866,15 +866,28 @@ func cmdGraph() *cobra.Command {
 			for _, id := range g.NodesInFile(file) {
 				deps += g.DependentCount(id)
 			}
+			pFactor := g.PercolationFactor(file)
 			if jsonOut {
 				return json.NewEncoder(os.Stdout).Encode(map[string]any{
 					"file": file, "blast_radius": radius, "transitive_dependents": deps,
 					"defect_cost_usd": dm.CostUSD(task), "required_confidence": dm.RequiredConfidence(task),
+					"kappa": g.Kappa(), "percolates": g.Percolates(), "percolation_factor": pFactor,
 				})
 			}
 			fmt.Printf("\n  %s\n", cortexStyle.Render(file))
 			fmt.Printf("    transitive dependents  %d\n", deps)
 			fmt.Printf("    blast radius           %.2f×\n", radius)
+			if g.Percolates() {
+				core := "periphery"
+				if pFactor > 1.0 {
+					core = fmt.Sprintf("core (+%.0f%%)", (pFactor-1)*100)
+				}
+				fmt.Printf("    graph κ                %.2f  %s\n",
+					g.Kappa(), dimStyle.Render("supercritical — cascades possible; this file is "+core))
+			} else {
+				fmt.Printf("    graph κ                %.2f  %s\n",
+					g.Kappa(), dimStyle.Render("subcritical — edits stay local"))
+			}
 			fmt.Printf("    defect cost            $%.2f\n", dm.CostUSD(task))
 			fmt.Printf("    demands confidence     %.1f%%\n\n", dm.RequiredConfidence(task)*100)
 			return nil

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -38,6 +38,13 @@ type Graph struct {
 	dependents map[string][]string
 	// filesToNodes maps a file path to the node IDs declared in it.
 	filesToNodes map[string][]string
+	// degree[x] = total incident edges (in + out) on node x, over the undirected
+	// projection of the dependency graph — the input to the percolation criterion.
+	degree map[string]int
+	// meanDeg is ⟨k⟩ and kappa is the Molloy–Reed ratio ⟨k²⟩/⟨k⟩, both computed
+	// once at load. kappa ≥ 2 ⟹ a giant (cascade-capable) component exists.
+	meanDeg float64
+	kappa   float64
 }
 
 // Load reads graph.json from path. A missing file yields an empty graph and no
@@ -66,8 +73,16 @@ func fromDoc(doc Doc) *Graph {
 	g := &Graph{
 		dependents:   make(map[string][]string),
 		filesToNodes: make(map[string][]string),
+		degree:       make(map[string]int),
 	}
+	// Every declared node exists in the degree map, even isolated ones — an
+	// isolated node has degree 0 and correctly drags ⟨k⟩ down.
+	nodes := make(map[string]bool)
 	for _, n := range doc.Nodes {
+		nodes[n.ID] = true
+		if _, ok := g.degree[n.ID]; !ok {
+			g.degree[n.ID] = 0
+		}
 		if n.File != "" {
 			g.filesToNodes[n.File] = append(g.filesToNodes[n.File], n.ID)
 		}
@@ -75,8 +90,35 @@ func fromDoc(doc Doc) *Graph {
 	for _, e := range doc.Edges {
 		// e.From depends on e.To → e.To has dependent e.From.
 		g.dependents[e.To] = append(g.dependents[e.To], e.From)
+		// Undirected projection for percolation: the edge adds one incident
+		// endpoint to each of From and To. Endpoints not declared as nodes are
+		// still counted so degree reflects the real edge set.
+		g.degree[e.From]++
+		g.degree[e.To]++
+		nodes[e.From] = true
+		nodes[e.To] = true
 	}
+	g.computeKappa(nodes)
 	return g
+}
+
+// computeKappa fills meanDeg = ⟨k⟩ and kappa = ⟨k²⟩/⟨k⟩ over the given node set.
+// With no nodes or no edges (⟨k⟩ = 0) both stay 0, i.e. no percolation.
+func (g *Graph) computeKappa(nodes map[string]bool) {
+	n := len(nodes)
+	if n == 0 {
+		return
+	}
+	var sum, sumSq float64
+	for id := range nodes {
+		k := float64(g.degree[id])
+		sum += k
+		sumSq += k * k
+	}
+	g.meanDeg = sum / float64(n)
+	if g.meanDeg > 0 {
+		g.kappa = (sumSq / float64(n)) / g.meanDeg
+	}
 }
 
 // transitiveDependents returns every node that transitively depends on any node
@@ -132,16 +174,76 @@ func (g *Graph) seedsForFile(file string) []string {
 }
 
 // BlastRadiusForFile returns a defect-cost multiplier for editing a file:
-// 1 + log2(1 + transitive dependents) over all nodes declared in that file. A
-// leaf (or an unknown file, or no graph) yields 1.0; a widely-depended-on file
-// grows sub-linearly so one hub node doesn't produce an absurd multiplier.
+// (1 + log2(1 + transitive dependents)) × percolation factor, over all nodes
+// declared in that file. A leaf (or an unknown file, or no graph) yields 1.0; a
+// widely-depended-on file grows sub-linearly so one hub node doesn't produce an
+// absurd multiplier. The percolation factor (≥1) additionally lifts files that
+// sit in the graph's cascade-capable core — see PercolationFactor.
 func (g *Graph) BlastRadiusForFile(file string) float64 {
 	seeds := g.seedsForFile(file)
 	if len(seeds) == 0 {
 		return 1.0
 	}
 	count := len(g.transitiveDependents(seeds))
-	return 1.0 + math.Log2(1.0+float64(count))
+	base := 1.0 + math.Log2(1.0+float64(count))
+	return base * g.PercolationFactor(file)
+}
+
+// Kappa is the Molloy–Reed ratio κ = ⟨k²⟩/⟨k⟩ of the (undirected projection of
+// the) dependency graph. A random graph has a giant connected component — the
+// substrate for a breaking-change cascade — iff κ ≥ 2 (Molloy & Reed 1995). It
+// is a single global property of the codebase: κ near 2 means edits stay local;
+// κ ≫ 2 means the graph has a dense core where a change can ripple widely.
+func (g *Graph) Kappa() float64 {
+	if g == nil {
+		return 0
+	}
+	return g.kappa
+}
+
+// Percolates reports whether the graph is supercritical (κ ≥ 2) — i.e. a change
+// is topologically capable of cascading through a giant component.
+func (g *Graph) Percolates() bool { return g.Kappa() >= 2.0 }
+
+// percolationCap bounds the percolation factor's contribution so topology can
+// meaningfully weight blast radius without ever dominating the dependent-count
+// term: the factor stays in [1, 1+percolationCap].
+const percolationCap = 2.0
+
+// PercolationFactor returns a multiplier ≥ 1 that raises the blast radius of a
+// file sitting in the graph's cascade-capable core. It is > 1 only when BOTH:
+//   - the graph is supercritical (κ ≥ 2), so cascades are possible at all, and
+//   - the file's hub-iest node is above the mean degree ⟨k⟩, so it is plausibly
+//     part of the giant component rather than the sparse periphery.
+//
+// Two files with an identical transitive-dependent count are thereby priced
+// differently when one is a densely-connected hub and the other is peripheral.
+// Subcritical graph, unknown file, or no graph → exactly 1.0 (backward compatible).
+func (g *Graph) PercolationFactor(file string) float64 {
+	if g == nil || g.meanDeg <= 0 || g.kappa < 2.0 {
+		return 1.0
+	}
+	seeds := g.seedsForFile(file)
+	if len(seeds) == 0 {
+		return 1.0
+	}
+	maxDeg := 0
+	for _, id := range seeds {
+		if d := g.degree[id]; d > maxDeg {
+			maxDeg = d
+		}
+	}
+	excess := float64(maxDeg)/g.meanDeg - 1.0 // how far above average this file's hub is
+	if excess <= 0 {
+		return 1.0 // at or below average connectivity — periphery, no lift
+	}
+	// superMargin ∈ (0,1]: 0 at the κ=2 threshold, saturating to 1 by κ=4.
+	superMargin := math.Min((g.kappa-2.0)/2.0, 1.0)
+	lift := superMargin * excess
+	if lift > percolationCap {
+		lift = percolationCap
+	}
+	return 1.0 + lift
 }
 
 // Coordination-cost bounds for Coupling, mapping graph overlap → the k used by

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -129,6 +129,102 @@ func TestCoupling(t *testing.T) {
 	}
 }
 
+// starGraph: m leaves each depending on one center → highly supercritical.
+func starGraph(m int) *Graph {
+	nodes := []Node{{ID: "center", File: "center.go"}}
+	var edges []Edge
+	for i := 0; i < m; i++ {
+		id := "leaf" + string(rune('A'+i))
+		nodes = append(nodes, Node{ID: id, File: id + ".go"})
+		edges = append(edges, Edge{From: id, To: "center"})
+	}
+	return fromDoc(Doc{Nodes: nodes, Edges: edges})
+}
+
+// pathGraph: a directed chain 0→1→…→(n-1). κ approaches 2 from below.
+func pathGraph(n int) *Graph {
+	var nodes []Node
+	var edges []Edge
+	for i := 0; i < n; i++ {
+		id := "n" + string(rune('0'+i))
+		nodes = append(nodes, Node{ID: id, File: id + ".go"})
+		if i > 0 {
+			edges = append(edges, Edge{From: "n" + string(rune('0'+i-1)), To: id})
+		}
+	}
+	return fromDoc(Doc{Nodes: nodes, Edges: edges})
+}
+
+func TestKappa_TopologyOrdering(t *testing.T) {
+	star := starGraph(9) // κ = (m+1)/2 = 5
+	path := pathGraph(9)  // κ → 2⁻
+	disc := fromDoc(Doc{Nodes: []Node{{ID: "x", File: "x.go"}, {ID: "y", File: "y.go"}}})
+
+	if !star.Percolates() {
+		t.Errorf("star κ = %.3f, expected supercritical (≥2)", star.Kappa())
+	}
+	if star.Kappa() <= path.Kappa() {
+		t.Errorf("star κ (%.3f) should exceed path κ (%.3f)", star.Kappa(), path.Kappa())
+	}
+	if path.Kappa() >= 2.0 || path.Kappa() < 1.5 {
+		t.Errorf("path κ = %.3f, want in [1.5, 2.0)", path.Kappa())
+	}
+	if disc.Kappa() != 0 || disc.Percolates() {
+		t.Errorf("edgeless graph κ = %.3f, want 0 and non-percolating", disc.Kappa())
+	}
+}
+
+// A hub-core file and a peripheral file with the SAME transitive-dependent count
+// must be priced differently once the graph is supercritical.
+func TestPercolation_EqualCountDifferentDegree(t *testing.T) {
+	nodes := []Node{{ID: "X", File: "x.go"}, {ID: "Y", File: "y.go"}}
+	var edges []Edge
+	// X: a fan-in hub with 6 direct dependents (degree 6, count 6).
+	for _, d := range []string{"a", "b", "c", "g", "h", "i"} {
+		nodes = append(nodes, Node{ID: d, File: d + ".go"})
+		edges = append(edges, Edge{From: d, To: "X"})
+	}
+	// Y: a 6-long chain of dependents (degree 1 at Y, count 6).
+	chain := []string{"d", "e", "f", "p", "q", "r"}
+	prev := "Y"
+	for _, c := range chain {
+		nodes = append(nodes, Node{ID: c, File: c + ".go"})
+		edges = append(edges, Edge{From: c, To: prev})
+		prev = c
+	}
+	g := fromDoc(Doc{Nodes: nodes, Edges: edges})
+
+	if !g.Percolates() {
+		t.Fatalf("test graph κ = %.3f, expected supercritical", g.Kappa())
+	}
+	if cx, cy := g.DependentCount("X"), g.DependentCount("Y"); cx != cy {
+		t.Fatalf("precondition: equal counts required, got X=%d Y=%d", cx, cy)
+	}
+	bx, by := g.BlastRadiusForFile("x.go"), g.BlastRadiusForFile("y.go")
+	if bx <= by {
+		t.Errorf("hub file blast (%.3f) should exceed peripheral file blast (%.3f) at equal count", bx, by)
+	}
+	// The peripheral file (below-mean degree) gets no lift.
+	if f := g.PercolationFactor("y.go"); f != 1.0 {
+		t.Errorf("peripheral PercolationFactor = %.3f, want 1.0", f)
+	}
+	if f := g.PercolationFactor("x.go"); f <= 1.0 {
+		t.Errorf("hub PercolationFactor = %.3f, want > 1.0", f)
+	}
+}
+
+func TestPercolation_SubcriticalIsNeutral(t *testing.T) {
+	// The canonical sample graph is subcritical (κ≈1.67) → factor 1.0 everywhere,
+	// so blast radius is unchanged from the pre-percolation formula.
+	g := sampleGraph()
+	if g.Percolates() {
+		t.Fatalf("sample graph unexpectedly supercritical (κ=%.3f)", g.Kappa())
+	}
+	if f := g.PercolationFactor("a.go"); f != 1.0 {
+		t.Errorf("subcritical PercolationFactor = %.3f, want exactly 1.0", f)
+	}
+}
+
 func TestLoad_RoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "graph.json")
 	data := `{"nodes":[{"id":"a","file":"a.go"},{"id":"b","file":"b.go"}],"edges":[{"from":"b","to":"a"}]}`


### PR DESCRIPTION
## Summary
Adds the **Molloy–Reed percolation criterion** to blast-radius routing. Blast radius was pure cardinality (`1 + log2(1+dependents)`) — blind to *where* a file sits in the dependency graph.

`κ = ⟨k²⟩/⟨k⟩` is computed once at load over the undirected projection. A giant, cascade-capable component exists iff `κ ≥ 2` (Molloy & Reed 1995). `PercolationFactor(file)` lifts the blast multiplier for files in the supercritical **core** — so two files with the **same** transitive-dependent count are priced differently when one is a densely-connected hub and the other peripheral.

```
hub.go   κ 3.29  core (+156%)   blast 10.24×
a.go     κ 3.29  core (+9%)     blast  2.18×   # 1 dependent, barely above ⟨k⟩
```

**Backward compatible**: a subcritical graph yields factor 1.0 and reproduces the pre-existing blast numbers exactly (verified by test). Surfaced in `hydra graph blast` (κ, supercritical/subcritical, core/periphery + %).

## Scope note (reworked after review)
This PR originally also carried a first-passage-time budget governor. It was **pulled before merge** because it was wired to the wrong layer: the per-model `budget.Tracker` is recreated each CLI invocation (EWMA never accumulates → risk always 0), and per-model utilisation isn't session-cumulative (stateless API heads reset per call). The correct design — first-passage on the orchestrator's `claude_pct` session history — is refiled as **#120**. Also removed a dead exported `MeanDegree()`.

## Verification
```
go build ./... && go vet ./... && go test ./... -race   # all green
```
Tests: Molloy–Reed κ on star/path/disconnected graphs, equal-count-different-degree pricing, subcritical neutrality.

Closes #116