### PR TITLE
feat(budget): rate-aware claude_pct governor — first-passage-time (Phase 9b)

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -209,21 +209,30 @@ func printBudgetStatus() {
 		return
 	}
 	var state struct {
-		ClaudePct int                       `json:"claude_pct"`
-		Budget    map[string]map[string]any `json:"budget"`
+		ClaudePct        int                       `json:"claude_pct"`
+		ClaudePctHistory []int                     `json:"claude_pct_history"`
+		Budget           map[string]map[string]any `json:"budget"`
 	}
 	if err := json.Unmarshal(raw, &state); err != nil {
 		return
 	}
 
-	// claude_pct block (orchestrator context window).
+	// claude_pct block (orchestrator context window). When enough history has
+	// accumulated, show the rate-aware effective mode (first-passage risk) — a
+	// fast burn escalates above the static level band before it crosses a line.
 	if state.ClaudePct > 0 {
-		mode := budget.ModeFor(state.ClaudePct).String()
+		burnRate, risk := budget.RiskFromHistory(state.ClaudePctHistory)
+		eff := budget.EffectiveMode(state.ClaudePct, risk)
 		bar := budgetBar(state.ClaudePct)
-		fmt.Printf("  %s  %s %3d%%  %s\n",
+		line := fmt.Sprintf("  %s  %s %3d%%  %s",
 			dimStyle.Render("Claude  :"),
-			bar, state.ClaudePct, budgetModeStyle(mode).Render(mode),
+			bar, state.ClaudePct, budgetModeStyle(eff.String()).Render(eff.String()),
 		)
+		if eff > budget.ModeFor(state.ClaudePct) {
+			line += "  " + dimStyle.Render(fmt.Sprintf("↑ burning +%.0f%%/step, %.0f%% risk of 80%%",
+				burnRate, risk*100))
+		}
+		fmt.Println(line)
 	}
 
 	if len(state.Budget) == 0 {

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -144,6 +144,101 @@ func TestRegistry_Concurrent(t *testing.T) {
 	}
 }
 
+func TestAppendPctHistory(t *testing.T) {
+	// Appends on change, ignores non-positive, dedups consecutive, bounds length.
+	h := AppendPctHistory(nil, 40, 12)
+	h = AppendPctHistory(h, 40, 12) // no change → no append
+	h = AppendPctHistory(h, 0, 12)  // unknown → ignored
+	h = AppendPctHistory(h, 47, 12)
+	if len(h) != 2 || h[0] != 40 || h[1] != 47 {
+		t.Fatalf("append/dedup failed: %v", h)
+	}
+	// Bounding keeps the newest max entries.
+	h = nil
+	for i := 1; i <= 20; i++ {
+		h = AppendPctHistory(h, i, 5)
+	}
+	if len(h) != 5 || h[0] != 16 || h[4] != 20 {
+		t.Errorf("bounding failed: %v", h)
+	}
+}
+
+func TestFirstPassageProb_EdgeCases(t *testing.T) {
+	if p := FirstPassageProb(0, 0.1, 0.1, 3); p != 1 {
+		t.Errorf("already-at-barrier should be certain, got %v", p)
+	}
+	if p := FirstPassageProb(0.2, 0.1, 0.1, 0); p != 0 {
+		t.Errorf("no horizon should be impossible, got %v", p)
+	}
+	if p := FirstPassageProb(0.2, 0, 0, 3); p != 0 {
+		t.Errorf("no drift, no vol → 0, got %v", p)
+	}
+	if p := FirstPassageProb(0.2, 0.1, 0, 3); p != 1 { // μH = 0.3 ≥ 0.2
+		t.Errorf("drift reaches barrier deterministically → 1, got %v", p)
+	}
+	if p := FirstPassageProb(0.5, 0.01, 0, 3); p != 0 { // μH = 0.03 < 0.5
+		t.Errorf("drift too slow in horizon → 0, got %v", p)
+	}
+}
+
+func TestFirstPassageProb_Monotonic(t *testing.T) {
+	if !(FirstPassageProb(0.3, 0.05, 0.05, 3) > FirstPassageProb(0.3, 0.02, 0.05, 3)) {
+		t.Error("probability should rise with drift")
+	}
+	if !(FirstPassageProb(0.2, 0.03, 0.05, 3) > FirstPassageProb(0.4, 0.03, 0.05, 3)) {
+		t.Error("probability should fall with distance to barrier")
+	}
+}
+
+func TestRiskFromHistory(t *testing.T) {
+	// Fewer than two points → no signal.
+	if br, r := RiskFromHistory([]int{55}); br != 0 || r != 0 {
+		t.Errorf("single point should give no signal, got br=%v r=%v", br, r)
+	}
+	// Fast climb that reaches the 80% barrier within the horizon → high risk.
+	brFast, rFast := RiskFromHistory([]int{60, 68, 74})
+	if brFast <= 0 {
+		t.Errorf("rising series should have positive burn rate, got %v", brFast)
+	}
+	if rFast < 0.5 {
+		t.Errorf("fast climb near barrier should be high risk, got %v", rFast)
+	}
+	// Same distance to barrier but a slower rate → strictly lower risk.
+	_, rSlower := RiskFromHistory([]int{72, 73, 74})
+	if !(rFast > rSlower) {
+		t.Errorf("faster climb should be riskier: fast=%v slower=%v", rFast, rSlower)
+	}
+	// Slow climb far from barrier → low risk.
+	_, rSlow := RiskFromHistory([]int{20, 21, 22})
+	if rSlow > 0.1 {
+		t.Errorf("slow climb far from barrier should be low risk, got %v", rSlow)
+	}
+	// Flat series → zero burn, zero risk.
+	if br, r := RiskFromHistory([]int{60, 60, 60}); br != 0 || r != 0 {
+		t.Errorf("flat series should give no signal, got br=%v r=%v", br, r)
+	}
+}
+
+func TestEffectiveMode(t *testing.T) {
+	// No risk → exactly the level band (backward compatible).
+	for _, pct := range []int{0, 55, 72, 90} {
+		if EffectiveMode(pct, 0) != ModeFor(pct) {
+			t.Errorf("EffectiveMode(%d, 0) should equal ModeFor", pct)
+		}
+	}
+	// High risk floors the mode above a low band.
+	if EffectiveMode(55, 0.9) != ModeCritical { // band=compact, risk≥0.8 → critical
+		t.Errorf("high risk should floor to critical, got %s", EffectiveMode(55, 0.9))
+	}
+	if EffectiveMode(55, 0.6) != ModeWarning { // band=compact, risk≥0.5 → warning
+		t.Errorf("moderate risk should floor to warning, got %s", EffectiveMode(55, 0.6))
+	}
+	// Never downgrades below the level band.
+	if EffectiveMode(90, 0.6) != ModeEmergency { // band already emergency
+		t.Errorf("risk floor must not lower a high band, got %s", EffectiveMode(90, 0.6))
+	}
+}
+
 func TestLoadWindows_Fallback(t *testing.T) {
 	// Non-existent path → empty map, no panic.
 	windows := LoadWindows("/no/such/path")

--- a/internal/budget/risk.go
+++ b/internal/budget/risk.go
@@ -1,0 +1,152 @@
+package budget
+
+import "math"
+
+// The orchestrator's claude_pct is the one genuinely session-cumulative budget
+// quantity: it only climbs as the context window fills. Modelling it as a
+// drift-diffusion process on the utilisation fraction x ∈ [0,1] lets the
+// governor act on the *rate* of burn (and its noise), not just the current
+// level — a session climbing fast at 55% is riskier than one parked at 74%,
+// which the static band table (ModeFor) cannot see. The 80% emergency line is
+// an absorbing barrier; each recorded claude_pct observation is one step.
+const (
+	emergencyFrac = 0.80 // absorbing barrier b (matches ModeEmergency at 80%)
+	riskHorizon   = 3.0  // look-ahead in observations ("within the next ~3 claude_pct updates")
+	MaxPctHistory = 12   // bounded claude_pct series kept in state.json
+
+	// Risk floors: a high probability of hitting the 80% barrier within the
+	// horizon imposes a minimum mode regardless of the current level, so a fast
+	// burn is caught before it crosses a static threshold.
+	riskWarnAt = 0.5 // P ≥ this → at least ModeWarning
+	riskCritAt = 0.8 // P ≥ this → at least ModeCritical
+)
+
+// AppendPctHistory returns hist with pct appended, but only when pct differs
+// from the last entry (the series tracks the claude_pct trajectory, so flat
+// periods add no points), trimmed to the newest max observations. A non-positive
+// pct (unknown) is ignored. Pure, so the state.json writer can stay a thin shell.
+func AppendPctHistory(hist []int, pct, max int) []int {
+	if pct <= 0 {
+		return hist
+	}
+	if n := len(hist); n > 0 && hist[n-1] == pct {
+		return hist // no change → no new observation
+	}
+	hist = append(hist, pct)
+	if max > 0 && len(hist) > max {
+		hist = hist[len(hist)-max:]
+	}
+	return hist
+}
+
+// RiskFromHistory estimates the burn rate and the probability of hitting the
+// 80% emergency line within the horizon, from a claude_pct series. burnRatePct
+// is the mean per-observation increment in percentage points; risk is the
+// first-passage probability. With fewer than two observations there is no rate
+// signal and both are zero, so the governor falls back to the level band.
+func RiskFromHistory(hist []int) (burnRatePct, risk float64) {
+	if len(hist) < 2 {
+		return 0, 0
+	}
+	// Increments in fraction units.
+	n := len(hist) - 1
+	deltas := make([]float64, n)
+	var sum float64
+	for i := 0; i < n; i++ {
+		deltas[i] = float64(hist[i+1]-hist[i]) / 100
+		sum += deltas[i]
+	}
+	mu := sum / float64(n)
+	var ss float64
+	for _, d := range deltas {
+		ss += (d - mu) * (d - mu)
+	}
+	sigma := math.Sqrt(ss / float64(n)) // population stddev of increments
+
+	x := float64(hist[len(hist)-1]) / 100
+	risk = FirstPassageProb(emergencyFrac-x, mu, sigma, riskHorizon)
+	return mu * 100, risk
+}
+
+// FirstPassageProb returns the probability that a Brownian motion with per-step
+// drift mu and per-step volatility sigma, starting dist below an absorbing
+// barrier, reaches that barrier within horizon steps. This is the closed-form
+// first-passage-time CDF for drifted Brownian motion (reflection principle):
+//
+//	P(τ ≤ H) = Φ( (μH − d)/(σ√H) ) + exp(2μd/σ²)·Φ( (−μH − d)/(σ√H) )
+//
+// with d = dist. Degenerate inputs collapse to the deterministic answer: no
+// distance left → already absorbed (1); no horizon → 0; zero volatility → pure
+// drift (1 iff μH ≥ d). The result is clamped to [0,1]; it is a governor
+// heuristic, so numerically extreme regimes clamp rather than error.
+func FirstPassageProb(dist, mu, sigma, horizon float64) float64 {
+	if dist <= 0 {
+		return 1 // already at or past the barrier
+	}
+	if horizon <= 0 {
+		return 0
+	}
+	sqrtH := math.Sqrt(horizon)
+	expo := 2 * mu * dist / (sigma * sigma)
+	if sigma <= 0 || math.IsInf(expo, 0) {
+		// No (or negligible) volatility → deterministic drift.
+		if mu > 0 && mu*horizon >= dist {
+			return 1
+		}
+		return 0
+	}
+	z1 := (mu*horizon - dist) / (sigma * sqrtH)
+	z2 := (-mu*horizon - dist) / (sigma * sqrtH)
+	// The reflection term exp(expo)·Φ(z2) is Inf·0 for strong drift (expo huge,
+	// z2 far in the left tail). Evaluate it in log-space so it underflows to 0
+	// cleanly instead of producing NaN.
+	term2 := math.Exp(expo + logNormCDF(z2))
+	p := normCDF(z1) + term2
+	if math.IsNaN(p) || p < 0 {
+		return 0
+	}
+	if p > 1 {
+		return 1
+	}
+	return p
+}
+
+// normCDF is the standard-normal CDF Φ(z) via the complementary error function.
+func normCDF(z float64) float64 { return 0.5 * math.Erfc(-z/math.Sqrt2) }
+
+// logNormCDF is log Φ(z), stable in the far-left tail where Φ(z) underflows to
+// 0. For z ≥ −1 it takes the direct log; below that it uses the asymptotic
+// log φ(z) − log(−z) (Mills-ratio leading term), which keeps the reflection
+// term finite when combined with a large positive exponent.
+func logNormCDF(z float64) float64 {
+	if z >= -1 {
+		return math.Log(normCDF(z))
+	}
+	const logSqrt2Pi = 0.9189385332046727 // 0.5·ln(2π)
+	return -0.5*z*z - logSqrt2Pi - math.Log(-z)
+}
+
+// riskFloor maps a first-passage risk to the minimum mode it justifies on its
+// own. Below riskWarnAt it imposes nothing (ModeNormal), so a calm session is
+// governed purely by its level band.
+func riskFloor(risk float64) Mode {
+	switch {
+	case risk >= riskCritAt:
+		return ModeCritical
+	case risk >= riskWarnAt:
+		return ModeWarning
+	default:
+		return ModeNormal
+	}
+}
+
+// EffectiveMode combines the level band ModeFor(pct) with the rate-driven risk
+// floor: the governor acts on whichever is more urgent. With risk 0 (flat or
+// unknown history) it is exactly ModeFor(pct) — backward compatible.
+func EffectiveMode(pct int, risk float64) Mode {
+	band := ModeFor(pct)
+	if f := riskFloor(risk); f > band {
+		return f
+	}
+	return band
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -159,10 +159,14 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 }
 
 // claudeMode reads claude_pct from state.json and returns the (possibly downgraded) tier,
-// mode string, and raw percentage.
+// mode string, and raw percentage. The mode is rate-aware: a fast burn (high
+// first-passage risk toward the 80% line) escalates the mode above its static
+// level band, so the tier downgrades earlier. With no history the effective mode
+// equals ModeFor(pct) — identical to the prior behavior.
 func (d *Dispatcher) claudeMode(tierHint string) (tier string, mode string, pct int) {
 	pct = readClaudePct()
-	mode = budget.ModeFor(pct).String()
+	_, risk := budget.RiskFromHistory(readClaudePctHistory())
+	mode = budget.EffectiveMode(pct, risk).String()
 	tier = tierHint
 
 	// Convert tier hint to int so we can downgrade numerically.
@@ -197,6 +201,47 @@ func readClaudePct() int {
 		return 0
 	}
 	return s.ClaudePct
+}
+
+// readClaudePctHistory reads the bounded claude_pct trajectory from state.json.
+// A missing file or field yields nil, so callers get no rate signal.
+func readClaudePctHistory() []int {
+	statePath := filepath.Join(config.Dir(), "logs", "state.json")
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		return nil
+	}
+	var s struct {
+		History []int `json:"claude_pct_history"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil
+	}
+	return s.History
+}
+
+// asInt coerces a value decoded from JSON (numbers arrive as float64) to an int.
+func asInt(v any) int {
+	switch x := v.(type) {
+	case float64:
+		return int(x)
+	case int:
+		return x
+	}
+	return 0
+}
+
+// asIntSlice coerces a JSON-decoded array (elements arrive as float64) to []int.
+func asIntSlice(v any) []int {
+	raw, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]int, 0, len(raw))
+	for _, e := range raw {
+		out = append(out, asInt(e))
+	}
+	return out
 }
 
 // injectA2A reads a handoff JSON file and prepends a structured block to the prompt.
@@ -316,6 +361,15 @@ func (d *Dispatcher) syncStateJSON(r *Result) {
 	existing["last_model"] = r.Head.Name
 	existing["last_status"] = "ok"
 	existing["last_tier"] = rank.UITier(r.Head)
+
+	// Append the current orchestrator claude_pct (written by the orchestrator,
+	// e.g. `jq '.claude_pct = 52'`) to a bounded history, so `hydra status` can
+	// compute a rate-aware first-passage risk from the session trajectory rather
+	// than reacting only to the instantaneous level.
+	if pct := asInt(existing["claude_pct"]); pct > 0 {
+		existing["claude_pct_history"] = budget.AppendPctHistory(
+			asIntSlice(existing["claude_pct_history"]), pct, budget.MaxPctHistory)
+	}
 
 	// Persist per-model budget snapshots so the TUI and status command can read them.
 	if d.budget != nil {


### PR DESCRIPTION
## Summary
`budget.ModeFor(pct)` is a static threshold table (50/65/70/75/80%) that only reacts *after* a line is crossed — no notion of *rate*. This adds a rate-aware governor: model the orchestrator's session-cumulative `claude_pct` as a **drift-diffusion process** and compute the first-passage probability of hitting the 80% emergency line within a short horizon, so a fast burn escalates *before* it crosses a threshold.

## How it works
- **Persist** a bounded (`MaxPctHistory=12`) history of `claude_pct` in `state.json`, appended by `syncStateJSON` when the value changes (no orchestrator protocol change — hydra observes the jq-written value).
- **Estimate** burn rate μ and volatility σ from the series increments; compute the closed-form first-passage CDF `P(τ≤H) = Φ((μH−d)/(σ√H)) + exp(2μd/σ²)·Φ((−μH−d)/(σ√H))`, d = 0.80 − x.
- **Act**: `EffectiveMode = max(level band, risk floor)` drives both the dispatch tier downgrade (`claudeMode`) and the `hydra status` display.

```
A  60% fast burn (46→54→60)  → warning  ↑ burning +7%/step, 73% risk of 80%
B  60% flat (60,60,60)        → compact   (no escalation)
C  72% no history             → warning   (ModeFor unchanged)
```

**Backward compatible**: flat or empty history → risk 0 → `EffectiveMode == ModeFor(pct)`, identical to today. Verified by test.

## Why this layer (not the #119 version)
The first-passage code pulled from #119 was wired to the per-model `budget.Tracker` — recreated each CLI invocation (EWMA never accumulated → risk always 0), and per-model utilisation isn't session-cumulative (stateless API heads reset per call). This puts it on `claude_pct`, the one genuinely monotonic session quantity and the one CLAUDE.md's token-preservation rules target. No dead code: `RiskFromHistory`, `EffectiveMode`, `AppendPctHistory` are all consumed by status + dispatch.

## Verification
```
go build ./... && go vet ./... && go test ./... -race   # all green
```
Tests: `AppendPctHistory` (dedup/bound/ignore-zero), first-passage edge cases + monotonicity, `RiskFromHistory` (fast/slow/flat/single), `EffectiveMode` (backward compat + floors + no-downgrade).

Closes #120