### PR TITLE
fix(docs): landing-page links point to real pages (not #start)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -522,7 +522,7 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
       <button class="install" data-copy="brew install hydra" aria-label="Copy install command">
         <span class="dollar">$</span><span class="cmd">brew install <b>hydra</b></span><span class="cp">copy</span>
       </button>
-      <a class="btn-ghost" href="#start">Read the docs →</a>
+      <a class="btn-ghost" href="/docs.html">Read the docs →</a>
     </div>
   </div>
   <div class="scrollhint" aria-hidden="true">move your cursor · scroll ↓</div>
@@ -852,17 +852,17 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
       </div>
       <div class="col">
         <h4>CLI</h4>
-        <a href="#start">dispatch</a>
-        <a href="#start">probe · status</a>
-        <a href="#start">trust · graph</a>
-        <a href="#start">swarm · cost</a>
+        <a href="/docs.html#dispatch">dispatch</a>
+        <a href="/docs.html#probe">probe · status</a>
+        <a href="/docs.html#trust">trust · graph</a>
+        <a href="/docs.html#swarm">swarm · cost</a>
       </div>
       <div class="col">
         <h4>Resources</h4>
-        <a href="#start">Docs</a>
-        <a href="#start">GitHub ★</a>
-        <a href="#start">llms.txt</a>
-        <a href="#start">pricing.md</a>
+        <a href="/docs.html">Docs</a>
+        <a href="https://github.com/ankit373/hydra">GitHub ★</a>
+        <a href="/llms.txt">llms.txt</a>
+        <a href="/pricing.md">pricing.md</a>
       </div>
     </div>
     <div class="foot-bottom">


### PR DESCRIPTION
Read the docs → `/docs.html`; footer CLI → `/docs.html#<cmd>`; Resources → docs / GitHub / llms.txt / pricing.md. Fixes links that dumped readers at the page bottom. Get-started + install CTAs unchanged.