### PR TITLE
fix(release): guaranteed release notes + working main→develop back-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # full history required for git-cliff changelog
+          fetch-depth: 0   # full history for accurate build metadata
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
-
-      - name: Install git-cliff
-        uses: taiki-e/install-action@v2
-        with:
-          tool: git-cliff
 
       # Phase 3: enable cosign for binary signing
       # - name: Install cosign

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,26 +1,80 @@
 name: Sync develop with main
 
+# GitFlow "reverse merge" (a.k.a. back-merge): after anything lands on main
+# (a release version bump, a hotfix), those commits must flow BACK into develop
+# so develop never falls behind main. The direction is always **main → develop**
+# — main is the source of truth for released code; develop integrates on top.
+#
+# develop is a protected branch (linear history, PR-only, no direct pushes), so
+# we cannot push a merge straight to it. Instead this opens a back-merge PR from
+# a branch that is (develop + main), which is then squash-merged to keep develop
+# linear. The job no-ops when develop already contains everything on main.
+
 on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: back-merge-main
+  cancel-in-progress: true
+
 jobs:
-  sync:
-    name: Merge main → develop
+  back-merge:
+    name: Open back-merge PR (main → develop)
     runs-on: ubuntu-latest
-    if: false
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge main into develop
+      - name: Build back-merge branch (develop + main)
+        id: prep
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout develop
-          git merge origin/main --no-edit --ff-only || git merge origin/main --no-edit -X theirs
-          git push origin develop
+          git fetch origin main develop
+
+          # Start from develop and merge main IN — this keeps develop's own work
+          # and only adds what main has that develop lacks (release/hotfix commits).
+          git checkout -B chore/back-merge-main origin/develop
+          if ! git merge origin/main --no-edit; then
+            git merge --abort
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # If the merge introduced nothing beyond develop, there is nothing to sync.
+          if git diff --quiet origin/develop..HEAD; then
+            echo "nothing=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "nothing=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push branch + open/update PR
+        if: steps.prep.outputs.conflict != 'true' && steps.prep.outputs.nothing != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push -f origin chore/back-merge-main
+          # Create the PR if one isn't already open for this branch; otherwise the
+          # force-push above already updated the existing PR.
+          gh pr create \
+            --base develop \
+            --head chore/back-merge-main \
+            --title "chore: back-merge main → develop" \
+            --body "Automated GitFlow back-merge: released commits on \`main\` flowing back into \`develop\`. **Squash-merge** to keep develop's linear history." \
+            2>/dev/null || echo "A back-merge PR is already open; it was updated by the force-push."
+
+      - name: Nothing to sync
+        if: steps.prep.outputs.nothing == 'true'
+        run: echo "develop already contains everything on main — no back-merge needed."
+
+      - name: Conflict — manual back-merge required
+        if: steps.prep.outputs.conflict == 'true'
+        run: |
+          echo "::warning title=Back-merge conflict::main → develop has conflicts; open the back-merge PR manually and resolve."
+          exit 0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -105,12 +105,21 @@ brews:
 # ── Changelog ─────────────────────────────────────────────────────────────────
 
 changelog:
-  use: git-cliff
-  # git-cliff reads cliff.toml automatically
+  # release-please owns the release notes (see release.mode above), so
+  # GoReleaser does not generate a changelog. NOTE: `use: git-cliff` was
+  # invalid config (valid: git|github|github-native|gitlab) and failed schema
+  # validation — disabling is correct now that notes come from release-please.
+  disable: true
 
 # ── GitHub Release ────────────────────────────────────────────────────────────
 
 release:
+  # release-please already creates the GitHub Release (with sectioned notes:
+  # ✨ Features / 🐛 Fixes / ⚡ Performance) when its Release PR merges.
+  # keep-existing ⇒ GoReleaser ONLY appends binaries / checksums / SBOM and
+  # never overwrites those notes — so every release has notes, guaranteed.
+  # (If the release doesn't exist yet, GoReleaser creates it using header/footer.)
+  mode: keep-existing
   github:
     owner: ankit373
     name: hydra


### PR DESCRIPTION
## Release notes — always present
- **GoReleaser `release.mode: keep-existing`** — release-please creates the GitHub Release with sectioned notes (✨/🐛/⚡) when its Release PR merges; GoReleaser now only *appends* binaries/checksums/SBOM and never overwrites the body.
- **Disabled GoReleaser changelog** — it was `use: git-cliff`, which is **invalid** (valid: git|github|github-native|gitlab) and failed schema validation. release-please owns the notes now.
- Dropped the unused git-cliff install step from `release.yml`.

## Back-merge (reverse merge) — right direction, actually works
- `sync-develop.yml` rewritten: **main → develop** GitFlow back-merge via a **PR** (develop was protected: linear-history + PR-only, so the old direct merge-push was impossible → it had been disabled with `if: false`).
- Enabled, no-ops when develop already has everything on main, warns on conflict.

_Leftover `cliff.toml` is now unused (harmless); can be removed in a follow-up._