### PR TITLE
fix: landing links live + guaranteed release notes + working back-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,18 +18,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # full history required for git-cliff changelog
+          fetch-depth: 0   # full history for accurate build metadata
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
-
-      - name: Install git-cliff
-        uses: taiki-e/install-action@v2
-        with:
-          tool: git-cliff
 
       # Phase 3: enable cosign for binary signing
       # - name: Install cosign

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -1,26 +1,80 @@
 name: Sync develop with main
 
+# GitFlow "reverse merge" (a.k.a. back-merge): after anything lands on main
+# (a release version bump, a hotfix), those commits must flow BACK into develop
+# so develop never falls behind main. The direction is always **main → develop**
+# — main is the source of truth for released code; develop integrates on top.
+#
+# develop is a protected branch (linear history, PR-only, no direct pushes), so
+# we cannot push a merge straight to it. Instead this opens a back-merge PR from
+# a branch that is (develop + main), which is then squash-merged to keep develop
+# linear. The job no-ops when develop already contains everything on main.
+
 on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: back-merge-main
+  cancel-in-progress: true
+
 jobs:
-  sync:
-    name: Merge main → develop
+  back-merge:
+    name: Open back-merge PR (main → develop)
     runs-on: ubuntu-latest
-    if: false
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge main into develop
+      - name: Build back-merge branch (develop + main)
+        id: prep
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout develop
-          git merge origin/main --no-edit --ff-only || git merge origin/main --no-edit -X theirs
-          git push origin develop
+          git fetch origin main develop
+
+          # Start from develop and merge main IN — this keeps develop's own work
+          # and only adds what main has that develop lacks (release/hotfix commits).
+          git checkout -B chore/back-merge-main origin/develop
+          if ! git merge origin/main --no-edit; then
+            git merge --abort
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # If the merge introduced nothing beyond develop, there is nothing to sync.
+          if git diff --quiet origin/develop..HEAD; then
+            echo "nothing=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "nothing=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push branch + open/update PR
+        if: steps.prep.outputs.conflict != 'true' && steps.prep.outputs.nothing != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push -f origin chore/back-merge-main
+          # Create the PR if one isn't already open for this branch; otherwise the
+          # force-push above already updated the existing PR.
+          gh pr create \
+            --base develop \
+            --head chore/back-merge-main \
+            --title "chore: back-merge main → develop" \
+            --body "Automated GitFlow back-merge: released commits on \`main\` flowing back into \`develop\`. **Squash-merge** to keep develop's linear history." \
+            2>/dev/null || echo "A back-merge PR is already open; it was updated by the force-push."
+
+      - name: Nothing to sync
+        if: steps.prep.outputs.nothing == 'true'
+        run: echo "develop already contains everything on main — no back-merge needed."
+
+      - name: Conflict — manual back-merge required
+        if: steps.prep.outputs.conflict == 'true'
+        run: |
+          echo "::warning title=Back-merge conflict::main → develop has conflicts; open the back-merge PR manually and resolve."
+          exit 0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -105,12 +105,21 @@ brews:
 # ── Changelog ─────────────────────────────────────────────────────────────────
 
 changelog:
-  use: git-cliff
-  # git-cliff reads cliff.toml automatically
+  # release-please owns the release notes (see release.mode above), so
+  # GoReleaser does not generate a changelog. NOTE: `use: git-cliff` was
+  # invalid config (valid: git|github|github-native|gitlab) and failed schema
+  # validation — disabling is correct now that notes come from release-please.
+  disable: true
 
 # ── GitHub Release ────────────────────────────────────────────────────────────
 
 release:
+  # release-please already creates the GitHub Release (with sectioned notes:
+  # ✨ Features / 🐛 Fixes / ⚡ Performance) when its Release PR merges.
+  # keep-existing ⇒ GoReleaser ONLY appends binaries / checksums / SBOM and
+  # never overwrites those notes — so every release has notes, guaranteed.
+  # (If the release doesn't exist yet, GoReleaser creates it using header/footer.)
+  mode: keep-existing
   github:
     owner: ankit373
     name: hydra

--- a/docs/index.html
+++ b/docs/index.html
@@ -522,7 +522,7 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
       <button class="install" data-copy="brew install hydra" aria-label="Copy install command">
         <span class="dollar">$</span><span class="cmd">brew install <b>hydra</b></span><span class="cp">copy</span>
       </button>
-      <a class="btn-ghost" href="#start">Read the docs →</a>
+      <a class="btn-ghost" href="/docs.html">Read the docs →</a>
     </div>
   </div>
   <div class="scrollhint" aria-hidden="true">move your cursor · scroll ↓</div>
@@ -852,17 +852,17 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
       </div>
       <div class="col">
         <h4>CLI</h4>
-        <a href="#start">dispatch</a>
-        <a href="#start">probe · status</a>
-        <a href="#start">trust · graph</a>
-        <a href="#start">swarm · cost</a>
+        <a href="/docs.html#dispatch">dispatch</a>
+        <a href="/docs.html#probe">probe · status</a>
+        <a href="/docs.html#trust">trust · graph</a>
+        <a href="/docs.html#swarm">swarm · cost</a>
       </div>
       <div class="col">
         <h4>Resources</h4>
-        <a href="#start">Docs</a>
-        <a href="#start">GitHub ★</a>
-        <a href="#start">llms.txt</a>
-        <a href="#start">pricing.md</a>
+        <a href="/docs.html">Docs</a>
+        <a href="https://github.com/ankit373/hydra">GitHub ★</a>
+        <a href="/llms.txt">llms.txt</a>
+        <a href="/pricing.md">pricing.md</a>
       </div>
     </div>
     <div class="foot-bottom">


### PR DESCRIPTION
Cherry-picks the two post-#70 fixes onto main (clean; avoids the squash-divergence conflict that blocked #133).

- **fix(docs)** #131 — landing-page links point to real pages, not the page bottom → live site fixed on next Pages deploy
- **fix(release)** #132 — GoReleaser `mode: keep-existing` + disabled invalid `changelog: use: git-cliff` (release-please owns notes; binaries appended) + `sync-develop.yml` back-merge (main→develop) now works & enabled

Triggers release-please to refresh the v1.0.0 Release PR (#130) with these fixes.