### PR TITLE
fix(seo): Semrush structured-data errors + on-page SEO pass

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Documentation — Hydra</title>
-  <meta name="description" content="Complete Hydra documentation: the CLI, the interactive TUI cockpit, the desktop app, and how Hydra integrates with Claude Code, Codex, Cursor, Gemini, Antigravity, Ollama and more. Every command explained — what it does, how it works, and how to use it.">
+  <title>Hydra Documentation — CLI, TUI, Trust &amp; Integrations</title>
+  <meta name="description" content="Hydra docs: the CLI, the TUI cockpit, integrations (Claude Code, Codex, Gemini, Ollama…), and every command — what it does, how it works, and how to use it.">
   <meta name="keywords" content="Hydra docs, hydra tui, hydra dispatch, Claude Code integration, Codex, Ollama, LM Studio, LLM router documentation, provider-neutral AI orchestration">
 
   <meta property="og:type" content="article">

--- a/docs/first-principles.html
+++ b/docs/first-principles.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>First Principles — The Math Behind Hydra</title>
-  <meta name="description" content="The theorems, measurements, and honest math behind every Hydra routing decision: Wald's SPRT, calibration diagnostic power (KL divergence), Bayes defect-cost, Molloy–Reed percolation, Amdahl optimal parallelism, and context entropy — with interactive derivations.">
+  <meta name="description" content="The math behind Hydra's router — SPRT, calibration, percolation-κ, and optimal parallelism — with interactive, provable derivations you can check.">
   <meta name="keywords" content="SPRT sequential probability ratio test, KL divergence calibration, Molloy-Reed percolation, Amdahl's law parallelism, LLM router math, confidence routing, Bayes decision theory, Hydra">
 
   <meta property="og:type" content="article">
@@ -155,6 +155,8 @@ a{color:inherit;text-decoration:none;}
 .viz .ctl button:hover{border-color:var(--aqua);color:var(--aqua);}
 .viz .readout{margin-left:auto;text-align:right;color:var(--faint);}
 .viz .readout b{color:var(--ink);font-size:15px;}
+figure.viz{margin:24px 0 8px;}
+.vizcap{font-family:var(--mono);font-size:11px;color:var(--faint);padding:9px 16px;border-top:1px solid var(--line);background:rgba(6,7,15,.4);}
 
 .tags{display:flex;flex-wrap:wrap;gap:9px;margin-top:22px;}
 .src{display:flex;flex-wrap:wrap;gap:10px 22px;margin-top:14px;font-family:var(--mono);font-size:12.5px;color:var(--faint);}
@@ -225,7 +227,7 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
       <i>B</i> <span class="op">=</span> <span class="op">ln</span> <span class="frac"><span class="num"><i>β</i></span><span class="den">1 − <i>α</i></span></span>
     </div>
 
-    <div class="viz">
+    <figure class="viz">
       <div class="canvas-wrap"><canvas id="c-sprt" width="1040" height="380" role="img" aria-label="Animated log-odds random walk crossing the accept and reject boundaries"></canvas></div>
       <div class="ctl">
         <label>source reliability <span class="v" id="v-sprt-rel">0.85</span>
@@ -234,7 +236,8 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
         <button id="b-sprt-run" type="button">↻ run again</button>
         <div class="readout">samples used <b class="tnum" id="o-sprt-n">—</b> &nbsp;·&nbsp; fixed-5 would use <b>5</b></div>
       </div>
-    </div>
+      <figcaption class="vizcap">Interactive: the SPRT log-odds walk crossing the accept/reject boundaries.</figcaption>
+    </figure>
 
     <p class="analogy">A doctor ordering one test at a time and stopping the moment the diagnosis is certain — instead of always running the full panel.</p>
     <div class="tags">
@@ -257,7 +260,7 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
       <span class="frac"><span class="num">1 − <i>se</i></span><span class="den"><i>sp</i></span></span>
     </div>
 
-    <div class="viz">
+    <figure class="viz">
       <div class="canvas-wrap"><canvas id="c-cal" width="1040" height="340" role="img" aria-label="Vote probability distributions under correct and incorrect hypotheses, with diagnostic power D"></canvas></div>
       <div class="ctl">
         <label>sensitivity <i>se</i> <span class="v" id="v-cal-se">0.90</span>
@@ -268,7 +271,8 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
         </label>
         <div class="readout">diagnostic power <b class="tnum" id="o-cal-d">1.76</b> nats</div>
       </div>
-    </div>
+      <figcaption class="vizcap">Interactive: vote distributions under both hypotheses — the gap between them is the diagnostic power D.</figcaption>
+    </figure>
 
     <p class="analogy">A witness's credibility measured in nats. A coin-flip witness tells you nothing however many times they testify.</p>
     <div class="tags">
@@ -289,7 +293,7 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
       <span class="frac"><span class="num"><i>τ</i></span><span class="den"><i>C</i><sub>defect</sub></span></span>
     </div>
 
-    <div class="viz">
+    <figure class="viz">
       <div class="canvas-wrap"><canvas id="c-defect" width="1040" height="300" role="img" aria-label="Required confidence rising as the defect cost grows"></canvas></div>
       <div class="ctl">
         <label>defect cost <i>C</i><sub>defect</sub> <span class="v" id="v-def-c">$126</span>
@@ -297,7 +301,8 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
         </label>
         <div class="readout">required confidence <b class="tnum" id="o-def-cstar">96.0%</b> &nbsp;·&nbsp; ≈ <b class="tnum" id="o-def-n">2</b> samples</div>
       </div>
-    </div>
+      <figcaption class="vizcap">Interactive: the required confidence rising as the defect cost grows.</figcaption>
+    </figure>
 
     <p class="analogy">You demand far more certainty before heart surgery than before a haircut — the bar scales with what a mistake costs.</p>
     <div class="tags">
@@ -319,7 +324,7 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
       <span class="op">≥</span> <span class="cyv">2</span>
     </div>
 
-    <div class="viz">
+    <figure class="viz">
       <div class="canvas-wrap"><canvas id="c-perc" width="1040" height="400" role="img" aria-label="Random dependency graph; the giant component appears as mean degree crosses the percolation threshold"></canvas></div>
       <div class="ctl">
         <label>mean degree ⟨<i>k</i>⟩ <span class="v" id="v-perc-k">1.8</span>
@@ -328,7 +333,8 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
         <button id="b-perc-re" type="button">↻ resample graph</button>
         <div class="readout"><b class="tnum" id="o-perc-kappa">2.7</b> = κ &nbsp;·&nbsp; <b id="o-perc-state">cascade core</b> &nbsp;·&nbsp; giant <b class="tnum" id="o-perc-frac">72%</b></div>
       </div>
-    </div>
+      <figcaption class="vizcap">Interactive: a random dependency graph where the giant component appears as κ crosses 2.</figcaption>
+    </figure>
 
     <p class="analogy">The epidemic threshold R₀ — below it a change stays local; above it, one edit can infect the whole graph.</p>
     <div class="tags">
@@ -353,7 +359,7 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
       <span class="op" style="font-size:1.3em;">√</span><span class="rt"><span class="frac"><span class="num">1 − <i>s</i></span><span class="den"><i>k</i></span></span></span>
     </div>
 
-    <div class="viz">
+    <figure class="viz">
       <div class="canvas-wrap"><canvas id="c-amdahl" width="1040" height="360" role="img" aria-label="Speedup curve versus number of agents, with the optimal n-star marker"></canvas></div>
       <div class="ctl">
         <label>serial fraction <i>s</i> <span class="v" id="v-amd-s">0.05</span>
@@ -364,7 +370,8 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
         </label>
         <div class="readout">optimum <b class="tnum" id="o-amd-n">6.9</b> agents &nbsp;·&nbsp; peak speedup <b class="tnum" id="o-amd-s">×3.1</b></div>
       </div>
-    </div>
+      <figcaption class="vizcap">Interactive: the speedup curve versus agent count, with the optimal n★ marked.</figcaption>
+    </figure>
 
     <p class="analogy">Adding cooks to a kitchen: past n★ they spend more time coordinating than cooking.</p>
     <div class="tags">
@@ -387,7 +394,7 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
       useful <span class="op">=</span> <i>L</i> <span class="op">·</span> <i>ρ</i>
     </div>
 
-    <div class="viz">
+    <figure class="viz">
       <div class="canvas-wrap"><canvas id="c-entropy" width="1040" height="260" role="img" aria-label="Useful tokens shrinking as context redundancy rises"></canvas></div>
       <div class="ctl">
         <label>context redundancy <span class="v" id="v-ent-r">40%</span>
@@ -395,7 +402,8 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
         </label>
         <div class="readout">ρ = <b class="tnum" id="o-ent-rho">0.60</b> &nbsp;·&nbsp; useful <b class="tnum" id="o-ent-u">120k</b> of 200k</div>
       </div>
-    </div>
+      <figcaption class="vizcap">Interactive: useful tokens shrinking as context redundancy rises.</figcaption>
+    </figure>
 
     <p class="analogy">Signal-to-noise: a short, sharp briefing beats a rambling transcript ten times its length.</p>
     <div class="tags">

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Hydra — Multi-Model AI Orchestration CLI</title>
-  <meta name="description" content="Cut AI API costs 80% without changing your workflow. Hydra routes dev tasks to the cheapest model that can handle them — Claude for hard reasoning, Gemini Flash for standard work, free local Qwen for boilerplate. Open source CLI, MIT license.">
+  <meta name="description" content="Cut AI API costs 70–85% without changing your workflow. Hydra routes each dev task to the cheapest capable model — Claude, Gemini, or free local Qwen.">
   <meta name="keywords" content="multi-model AI orchestration, LLM router, Claude Code, Ollama, local LLM, AI model routing, LLM cost optimization, AI coding assistant, llm orchestration CLI, model routing open source">
 
   <!-- Open Graph / Social sharing -->
@@ -57,8 +57,8 @@
       "priceCurrency": "USD"
     },
     "keywords": "multi-model AI orchestration, LLM router, Claude Code, Ollama, local LLM, AI model routing, LLM cost optimization, AI coding assistant, go cli, swarm dispatch",
-    "codeRepository": "https://github.com/ankit373/hydra",
-    "programmingLanguage": ["Go"],
+    "image": "https://hydra.uvansa.com/logo.png",
+    "sameAs": "https://github.com/ankit373/hydra",
     "featureList": [
       "10-tier model routing by task complexity",
       "Automatic fallback chains terminating at always-on local Qwen",
@@ -515,7 +515,7 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
   <div class="hero-vign" aria-hidden="true"></div>
   <div class="hero-inner">
     <div class="eyebrow">local-first <span>·</span> provider-neutral <span>·</span> trust control plane</div>
-    <h1 class="wordmark">HYDRA</h1>
+    <h1 class="wordmark">HYDRA<span style="position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%);white-space:nowrap;"> — the local-first Trust Control Plane: multi-model AI orchestration CLI</span></h1>
     <div class="tagline">One Cortex · Many Heads</div>
     <p class="subline">The local-first <b>Trust Control Plane</b> for AI. Hydra discovers every model on your machine — CLI agents, API keys, local servers — and routes each task to the cheapest head that clears your <b>target confidence</b>.</p>
     <div class="ctas">

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Pricing — Hydra is $0</title>
-  <meta name="description" content="Hydra is free and open source. No seats, no tiers, no telemetry. You bring your own API keys and pay the model providers directly — Hydra just makes you pay them 70–85% less. Want Hydra customised or built out for your stack? Get in touch.">
+  <meta name="description" content="Hydra is free and open source — no seats, no tiers, no telemetry. Bring your own keys; Hydra just cuts the model bill 70–85%. Custom builds on request.">
   <meta name="keywords" content="Hydra pricing, free LLM router, open source AI orchestration, bring your own keys">
 
   <meta property="og:type" content="website">
@@ -29,6 +29,7 @@
     "@type": "Product",
     "name": "Hydra",
     "description": "Open source multi-model AI orchestration CLI. Free to use.",
+    "image": "https://hydra.uvansa.com/logo.png",
     "url": "https://hydra.uvansa.com/pricing.html",
     "brand": { "@type": "Brand", "name": "Hydra" },
     "offers": {


### PR DESCRIPTION
Resolves the Semrush/Google structured-data errors and does an on-page SEO cleanup.

**Structured data (errors)**
- pricing **Product** → add required `image`
- index **SoftwareApplication** → remove invalid `codeRepository`/`programmingLanguage` (kept on the valid `SoftwareSourceCode` block), add `image` + `sameAs`

**On-page**
- meta descriptions trimmed to ~150–160 (were 243–267 → truncated in SERPs)
- index **H1** now carries the primary keyword (sr-only descriptor; wordmark visual unchanged)
- docs `<title>` enriched
- first-principles: 6 interactive viz wrapped in `<figure>`/`<figcaption>` (raises semantic-HTML + text/HTML ratio)

_Note: the SoftwareApplication `aggregateRating`/`review` warning is intentionally **not** satisfied — we won't fabricate ratings (it's a rich-result recommendation, not a validity error)._