### PR TITLE
fix(ci): allowlist Ahrefs public data-key in gitleaks (false positive)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,4 @@ jobs:
         uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: ${{ github.workspace }}/.gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+# Gitleaks configuration for Hydra.
+# Extends the full default ruleset, then allowlists values that are PUBLIC by
+# design and therefore NOT secrets.
+
+title = "Hydra"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Public, intentional identifiers embedded in the shipped site — not secrets"
+regexes = [
+  # Ahrefs Web Analytics data-key: a public site identifier embedded in the page
+  # <head> and served to every visitor (equivalent to a GA measurement ID).
+  '''yRz83E87rXgYWlhmro5mIg''',
+]


### PR DESCRIPTION
The Secret-scan CI failed because Gitleaks flagged the **Ahrefs Web Analytics data-key** as a generic API key. That key is **public by design** (embedded in the page `<head>`, served to every visitor — like a GA measurement ID), so it's a false positive.

- Add `.gitleaks.toml` — extends the default ruleset, allowlists the specific key.
- Point CI at it via `GITLEAKS_CONFIG`.
- **Verified locally with gitleaks 8.30.1:** `docs/` scan goes from *leaks found: 4* → *no leaks found*.