### PR TITLE
fix(ci): allowlist Ahrefs public data-key in gitleaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,4 @@ jobs:
         uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: ${{ github.workspace }}/.gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+# Gitleaks configuration for Hydra.
+# Extends the full default ruleset, then allowlists values that are PUBLIC by
+# design and therefore NOT secrets.
+
+title = "Hydra"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Public, intentional identifiers embedded in the shipped site — not secrets"
+regexes = [
+  # Ahrefs Web Analytics data-key: a public site identifier embedded in the page
+  # <head> and served to every visitor (equivalent to a GA measurement ID).
+  '''yRz83E87rXgYWlhmro5mIg''',
+]


### PR DESCRIPTION
Cherry-pick of #139 → main. Adds `.gitleaks.toml` (extends default ruleset + allowlists the public Ahrefs Web Analytics data-key) so the Secret-scan stops flagging it. Verified locally: docs/ scan goes from 'leaks found: 4' to 'no leaks found'.