### PR TITLE
fix(swarm): bound each head with a default per-head timeout

### DIFF
--- a/internal/swarm/runner.go
+++ b/internal/swarm/runner.go
@@ -11,6 +11,29 @@ import (
 	"github.com/ankit373/hydra/internal/provider"
 )
 
+// defaultPerHeadTimeout bounds any head whose executor does not self-limit.
+// Without a deadline a single hung head (e.g. a reachable-but-TTY-blocked CLI,
+// or a subprocess that never returns) blocks runAll's wg.Wait forever. Aligned
+// with the agy executor's own 300s print-timeout so this acts as a backstop
+// rather than preempting executor-level handling. Override per call via
+// Options.PerHeadTimeout.
+const defaultPerHeadTimeout = 300 * time.Second
+
+// executorFor resolves the executor for a head. Indirected through a package
+// variable so tests can inject a stub without a live provider.
+var executorFor = executor.For
+
+// effectiveTimeout returns the per-head deadline to apply: the caller's explicit
+// Options.PerHeadTimeout when positive, otherwise defaultPerHeadTimeout. Swarm
+// never runs a head unbounded — a zero value means "use the default", not "no
+// limit".
+func effectiveTimeout(opts Options) time.Duration {
+	if opts.PerHeadTimeout > 0 {
+		return opts.PerHeadTimeout
+	}
+	return defaultPerHeadTimeout
+}
+
 // executeHead runs one head and returns a completed Attempt.
 // Never returns an error — all failures are captured in Attempt.Status/Err.
 func executeHead(ctx context.Context, h provider.Head, prompt string, opts Options) Attempt {
@@ -20,14 +43,10 @@ func executeHead(ctx context.Context, h provider.Head, prompt string, opts Optio
 		StartedAt: time.Now(),
 	}
 
-	execCtx := ctx
-	var cancel context.CancelFunc
-	if opts.PerHeadTimeout > 0 {
-		execCtx, cancel = context.WithTimeout(ctx, opts.PerHeadTimeout)
-		defer cancel()
-	}
+	execCtx, cancel := context.WithTimeout(ctx, effectiveTimeout(opts))
+	defer cancel()
 
-	exec := executor.For(h)
+	exec := executorFor(h)
 	resp, err := exec.Execute(execCtx, executor.Request{
 		Prompt:    prompt,
 		Head:      h,

--- a/internal/swarm/runner_test.go
+++ b/internal/swarm/runner_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+func TestEffectiveTimeout(t *testing.T) {
+	if got := effectiveTimeout(Options{}); got != defaultPerHeadTimeout {
+		t.Errorf("zero PerHeadTimeout = %v, want default %v", got, defaultPerHeadTimeout)
+	}
+	if got := effectiveTimeout(Options{PerHeadTimeout: 5 * time.Second}); got != 5*time.Second {
+		t.Errorf("explicit PerHeadTimeout = %v, want 5s", got)
+	}
+	// Regression guard: swarm must never run a head unbounded.
+	if effectiveTimeout(Options{}) <= 0 {
+		t.Fatal("default per-head timeout must be positive — heads must never run unbounded")
+	}
+}
+
+// hangingExecutor blocks until its context is canceled, simulating a head that
+// never returns on its own (e.g. a reachable-but-TTY-blocked CLI).
+type hangingExecutor struct{}
+
+func (hangingExecutor) Execute(ctx context.Context, _ executor.Request) (*executor.Response, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// withStubExecutor swaps executorFor for the duration of a test.
+func withStubExecutor(t *testing.T, e executor.Executor) {
+	t.Helper()
+	orig := executorFor
+	executorFor = func(provider.Head) executor.Executor { return e }
+	t.Cleanup(func() { executorFor = orig })
+}
+
+// A hung head must degrade to a clean StatusTimeout — not block wg.Wait forever.
+func TestRunAll_BoundsHangingHead(t *testing.T) {
+	withStubExecutor(t, hangingExecutor{})
+	heads := []provider.Head{registryHead("a", "A", 90), registryHead("b", "B", 80)}
+
+	done := make(chan []Attempt, 1)
+	go func() {
+		done <- runAll(context.Background(), heads, "p", Options{PerHeadTimeout: 50 * time.Millisecond})
+	}()
+
+	select {
+	case attempts := <-done:
+		if len(attempts) != 2 {
+			t.Fatalf("got %d attempts, want 2", len(attempts))
+		}
+		for i, a := range attempts {
+			if a.Status != StatusTimeout {
+				t.Errorf("head %d status = %q, want %q", i, a.Status, StatusTimeout)
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runAll did not return within 5s — hung head was not bounded by the per-head timeout")
+	}
+}
+
+// runRace must also drain rather than hang when every head hangs and none wins.
+func TestRunRace_BoundsHangingHeads(t *testing.T) {
+	withStubExecutor(t, hangingExecutor{})
+	heads := []provider.Head{registryHead("a", "A", 90), registryHead("b", "B", 80)}
+
+	done := make(chan []Attempt, 1)
+	go func() {
+		done <- runRace(context.Background(), heads, "p", Options{PerHeadTimeout: 50 * time.Millisecond})
+	}()
+
+	select {
+	case <-done:
+		// Returned instead of hanging — that is the property under test.
+	case <-time.After(5 * time.Second):
+		t.Fatal("runRace did not return within 5s — hung heads were not bounded")
+	}
+}

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -35,7 +35,7 @@ type Options struct {
 
 	// Execution constraints.
 	MaxHeads       int           // hard cap on fan-out (0 → defaultMaxHeads = 5)
-	PerHeadTimeout time.Duration // per-head deadline (0 = inherit parent ctx)
+	PerHeadTimeout time.Duration // per-head deadline (0 → defaultPerHeadTimeout, 300s; never unbounded)
 	MaxEstCostUSD  float64       // pre-flight guard; 0 = no limit
 	LocalOnly      bool
 


### PR DESCRIPTION
## Summary
`internal/swarm`'s `executeHead` applied a per-head deadline only when `Options.PerHeadTimeout > 0`. The default (`0`) inherited the parent context, and **no caller sets `PerHeadTimeout`** — so every swarm/SPRT dispatch ran each head unbounded. A single hung head (e.g. a reachable-but-TTY-blocked CLI) would block `runAll`'s `wg.Wait` (and `runRace` when nothing wins) indefinitely.

## Changes
- `internal/swarm/runner.go` — add `defaultPerHeadTimeout` (300s, aligned with the agy executor's own print-timeout); `executeHead` always applies a deadline via `effectiveTimeout(opts)`. Executor resolution indirected through `executorFor` for testability.
- `internal/swarm/swarm.go` — `Options.PerHeadTimeout` doc: `0 → default 300s, never unbounded`.
- `internal/swarm/runner_test.go` — `TestEffectiveTimeout`, plus `runAll`/`runRace` bound-a-hanging-head tests using a stub executor.

A hung head now degrades to a clean `StatusTimeout` (already mapped by `classifyError`) instead of hanging the batch.

## Context
Surfaced while root-causing an n≥4 straggler in the Trust Control Plane benchmark. The observed stragglers were a harness artifact (a blocked Bash tool call in the Agent-tool layer, **not** `internal/swarm`) — but the investigation exposed this real latent gap in the shipped runner.

## Verification
- `go build ./...`, `go vet ./...`, `go test -race ./...` all green.

Closes #145