### PR TITLE
fix(trust,optimal): behavior-based SPRT agreement + guard optimal model's S≤n ceiling

### DIFF
--- a/internal/optimal/optimal.go
+++ b/internal/optimal/optimal.go
@@ -44,6 +44,17 @@ func Agents(s, k float64) (nStar int, speedup float64) {
 }
 
 // Speedup evaluates S(n) for the given parameters.
+//
+// Domain of validity: this Amdahl-with-linear-coordination form models
+// coordination-BOUND work and has a hard ceiling S(n) ≤ n for every s ≥ 0, k ≥ 0
+// (equality only at s = k = 0). It therefore cannot represent *superlinear*
+// speedup. The real optimal-parallelism benchmark measured superlinear speedup —
+// S = 2.33 at n=2 and 9.3 at n=4 — driven by per-agent context dilution (each of
+// n agents holds ~1/n of the context and generates faster), a regime this model
+// falsifiably does not cover: no (s, k) can fit S > n, which is why the grid-fit
+// pinned to the boundary with high residual. A context/entropy-aware successor is
+// data-gated future work. See TRUST_CONTROL_PLANE_BENCHMARK_FINDINGS.md §2 and
+// TestSpeedup_CeilingIsN_NeverSuperlinear.
 func Speedup(s, k, n float64) float64 {
 	if n <= 0 {
 		return 1

--- a/internal/optimal/optimal_test.go
+++ b/internal/optimal/optimal_test.go
@@ -82,3 +82,30 @@ func TestAgents_ZeroK(t *testing.T) {
 		t.Errorf("k=0 speedup should be Amdahl ceiling 1/s = 5, got %v", speedup)
 	}
 }
+
+// Falsification invariant (see findings §2): the Amdahl+coordination model has a
+// hard ceiling S(n) ≤ n for every valid (s ≥ 0, k ≥ 0) — it structurally cannot
+// produce superlinear speedup. The real benchmark measured S = 2.33 at n=2 and
+// 9.3 at n=4 (superlinear, from per-agent context dilution), so no (s, k) can fit
+// that data — a clean refutation of this model for embarrassingly-parallel,
+// context-bound agent work, not a tuning miss. Guarding the ceiling here keeps the
+// falsification honest and reproducible.
+func TestSpeedup_CeilingIsN_NeverSuperlinear(t *testing.T) {
+	for s := 0.0; s <= 1.0+1e-9; s += 0.1 {
+		for k := 0.0; k <= 1.0+1e-9; k += 0.05 {
+			for _, n := range []float64{1, 2, 3, 4, 6, 8, 16, 32} {
+				if got := Speedup(s, k, n); got > n+1e-9 {
+					t.Fatalf("Speedup(s=%.2f, k=%.2f, n=%.0f) = %.4f exceeds n — "+
+						"model must be incapable of superlinear speedup", s, k, n, got)
+				}
+			}
+		}
+	}
+	// Sanity: the observed benchmark speedups are superlinear, hence unreachable.
+	if s := Speedup(0, 0, 2); s > 2.33 {
+		t.Fatalf("best-case S(2) = %.4f should be < observed 2.33 (superlinear)", s)
+	}
+	if s := Speedup(0, 0, 4); s > 9.3 {
+		t.Fatalf("best-case S(4) = %.4f should be < observed 9.3 (superlinear)", s)
+	}
+}

--- a/internal/swarm/sprt.go
+++ b/internal/swarm/sprt.go
@@ -5,9 +5,11 @@ package swarm
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
 	"github.com/ankit373/hydra/internal/trust"
@@ -69,10 +71,20 @@ func (s *Swarm) RunSPRT(ctx context.Context, prompt string, opts Options) (*SPRT
 	}
 
 	adapter := &sprtExecutor{swarm: s, prompt: prompt, opts: opts, byID: byID}
+
+	// Behavior-based agreement: two independently-correct answers that differ only
+	// in wording must count as agreement, not disagreement — the effect that capped
+	// real SPRT confidence at 32.9% (see the findings doc §3). nil when no
+	// dispatcher is available, in which case trust.Run keeps its textual default.
+	var equiv trust.AnswerEquivalence
+	if s.d != nil {
+		equiv = s.judgeEquivalence(ctx, prompt, opts)
+	}
+
 	res, err := trust.Run(ctx, trust.Task{Domain: domain}, sources, adapter, cal, trust.Target{
 		Confidence: opts.Confidence,
 		MaxCostUSD: opts.MaxEstCostUSD,
-	})
+	}, trust.WithEquivalence(equiv))
 	if err != nil {
 		return nil, err
 	}
@@ -116,4 +128,63 @@ func (e *sprtExecutor) Execute(ctx context.Context, src trust.Source, _ trust.Ta
 		return trust.Answer{}, fmt.Errorf("sprt: head %s failed: %s", h.ID, a.Status)
 	}
 	return trust.Answer{Text: a.Output, CostUSD: a.EstCostUSD}, nil
+}
+
+// judgeEquivalence returns a behavior-based trust.AnswerEquivalence backed by the
+// LLM judge: it asks whether two answers are equivalent solutions to the prompt,
+// so two independently-correct answers that differ only in wording count as
+// agreement rather than disagreement. Identical text (mod formatting) short-
+// circuits without a call; any dispatch/parse failure degrades to the textual
+// default, so the ensemble never blocks on the judge. Like the ModeBest judge,
+// these calls are ensemble overhead and are not added to the SPRT sample spend.
+func (s *Swarm) judgeEquivalence(ctx context.Context, prompt string, opts Options) trust.AnswerEquivalence {
+	timeout := opts.JudgeTimeout
+	if timeout <= 0 {
+		timeout = defaultJudgeTimeout
+	}
+	return func(candidate, answer string) bool {
+		if trust.TextEquivalence(candidate, answer) {
+			return true // identical mod formatting — no need to spend a judge call
+		}
+		jctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		out, err := s.d.Dispatch(jctx, buildEquivalencePrompt(prompt, candidate, answer), dispatch.Options{
+			TierHint: opts.JudgeTierHint,
+			System:   "You compare two answers for equivalence. Reply with exactly one word: YES or NO.",
+		})
+		if err != nil {
+			return trust.TextEquivalence(candidate, answer) // degrade, never block
+		}
+		return parseYesNo(out.Output)
+	}
+}
+
+// buildEquivalencePrompt asks whether two answers are equivalent solutions.
+func buildEquivalencePrompt(prompt, a, b string) string {
+	var sb strings.Builder
+	sb.WriteString("Two answers were given to the same task. Decide whether they are EQUIVALENT — ")
+	sb.WriteString("both correct/valid solutions that satisfy the task, even if they differ in ")
+	sb.WriteString("wording, identifiers, formatting, or style.\n\nTask:\n---\n")
+	sb.WriteString(prompt)
+	sb.WriteString("\n---\n\nAnswer A:\n---\n")
+	sb.WriteString(a)
+	sb.WriteString("\n---\n\nAnswer B:\n---\n")
+	sb.WriteString(b)
+	sb.WriteString("\n---\n\nAre A and B equivalent? Reply with exactly one word: YES or NO.")
+	return sb.String()
+}
+
+// parseYesNo extracts a yes/no decision from a judge reply. Ambiguous or empty
+// replies are treated as NO — the conservative direction for a trust check, so a
+// confused judge never inflates agreement.
+func parseYesNo(s string) bool {
+	for _, f := range strings.Fields(strings.ToLower(s)) {
+		switch {
+		case strings.HasPrefix(f, "yes"):
+			return true
+		case strings.HasPrefix(f, "no"):
+			return false
+		}
+	}
+	return false
 }

--- a/internal/swarm/sprt_test.go
+++ b/internal/swarm/sprt_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseYesNo(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"YES", true},
+		{"yes", true},
+		{"Yes, they are equivalent.", true},
+		{"NO", false},
+		{"no — different behavior", false},
+		{"  yes\n", true},
+		{"They are equivalent, yes", true}, // first decisive token wins
+		{"maybe, but leaning yes", true},   // skips non-decisive words
+		{"", false},                        // empty → conservative NO
+		{"I cannot determine", false},      // ambiguous → conservative NO
+		{"nope", false},                    // "no" prefix
+	}
+	for _, c := range cases {
+		if got := parseYesNo(c.in); got != c.want {
+			t.Errorf("parseYesNo(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBuildEquivalencePrompt(t *testing.T) {
+	p := buildEquivalencePrompt("write add", "return a+b", "return b+a")
+	for _, want := range []string{"write add", "return a+b", "return b+a", "YES or NO", "EQUIVALENT"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("equivalence prompt missing %q", want)
+		}
+	}
+}

--- a/internal/trust/sprt.go
+++ b/internal/trust/sprt.go
@@ -90,9 +90,13 @@ type Result struct {
 // runs out of budget. A source that disagrees with the candidate pushes Λ down;
 // if Λ crosses the reject threshold B the run pivots to that source's answer
 // (destructive interference collapses to the better branch).
-func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *Calibrator, t Target) (*Result, error) {
+func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *Calibrator, t Target, opts ...RunOption) (*Result, error) {
 	if len(sources) == 0 {
 		return nil, fmt.Errorf("sprt: no sources provided")
+	}
+	cfg := runConfig{equiv: TextEquivalence}
+	for _, o := range opts {
+		o(&cfg)
 	}
 	alpha := 1 - t.Confidence
 	if alpha <= 0 || alpha >= 1 {
@@ -131,7 +135,7 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 		if candidate == "" {
 			candidate = ans.Text // first answer seeds the candidate
 		}
-		agreed := normalizeAnswer(ans.Text) == normalizeAnswer(candidate)
+		agreed := cfg.equiv(candidate, ans.Text)
 
 		llr := cal.LLR(src.ID, task.Domain, agreed)
 		if src.Family != "" && familySeen[src.Family] {
@@ -176,9 +180,49 @@ func evidencePerCost(cal *Calibrator, src Source, domain string) float64 {
 	return d / src.EstCostUSD
 }
 
-// normalizeAnswer defines answer equality for agreement detection. v1 is a
-// conservative trim; semantic/structural equivalence is future work.
-func normalizeAnswer(s string) string { return strings.TrimSpace(s) }
+// AnswerEquivalence decides whether a source's answer counts as agreeing with the
+// current candidate for the purpose of accumulating correctness evidence.
+//
+// The v1 default (TextEquivalence) compares normalized text — which miscounts two
+// independently-correct answers that differ only in wording (variable names,
+// println vs. fmt.Println) as *disagreement*, pushing Λ the wrong way. In the real
+// benchmark this capped achieved confidence at 32.9% even though both sources were
+// oracle-verified correct (see TRUST_CONTROL_PLANE_BENCHMARK_FINDINGS.md §3).
+// Callers that can compare *behavior* — an oracle verdict in a benchmark, an LLM
+// judge in production — inject a semantic comparator via WithEquivalence.
+type AnswerEquivalence func(candidate, answer string) bool
+
+// RunOption configures an SPRT run without changing Run's core signature.
+type RunOption func(*runConfig)
+
+type runConfig struct {
+	equiv AnswerEquivalence
+}
+
+// WithEquivalence overrides how answer agreement is decided (default:
+// TextEquivalence). A nil comparator is ignored, keeping the default.
+func WithEquivalence(fn AnswerEquivalence) RunOption {
+	return func(c *runConfig) {
+		if fn != nil {
+			c.equiv = fn
+		}
+	}
+}
+
+// TextEquivalence is the v1 default agreement check: case-insensitive with
+// collapsed whitespace. It removes trivial-formatting false disagreements but is
+// NOT semantic — two behaviorally-equivalent answers with different identifiers
+// still register as disagreement. Supply WithEquivalence for behavior-based
+// comparison.
+func TextEquivalence(candidate, answer string) bool {
+	return normalizeAnswer(candidate) == normalizeAnswer(answer)
+}
+
+// normalizeAnswer canonicalizes text for TextEquivalence: lowercase, with runs of
+// whitespace collapsed to single spaces and leading/trailing space removed.
+func normalizeAnswer(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(s)), " ")
+}
 
 // sigmoid maps the log-odds Λ back to a probability for display.
 func sigmoid(x float64) float64 { return 1 / (1 + math.Exp(-x)) }

--- a/internal/trust/sprt_test.go
+++ b/internal/trust/sprt_test.go
@@ -146,6 +146,68 @@ func TestSPRT_MiscalibratedSourceContributesNothing(t *testing.T) {
 	}
 }
 
+// A behavior-based comparator lifts the "two correct answers disagree" cap: three
+// differently-worded but equivalent answers must accumulate agreement (Λ → accept),
+// where the default text check counts them as disagreement and never accepts. This
+// is the mechanism that resolves the 32.9% real-confidence cap (findings §3).
+func TestSPRT_BehavioralEquivalenceLiftsAgreement(t *testing.T) {
+	c, _ := New("")
+	calibrateSymmetric(c, "sim", "d", 0.9, 1000)
+
+	// Correct answers, worded differently — a textual check calls these "disagree".
+	seq := func() []string {
+		return []string{"return a + b", "func sum(a,b int) int { return b+a }", "the sum: a plus b"}
+	}
+
+	// Default (text) equivalence: differing texts never converge → not accepted.
+	def, err := Run(context.Background(), Task{Domain: "d"}, nSources("sim", 3, 1),
+		&scriptExec{seq: seq()}, c, Target{Confidence: 0.95})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.Decision == DecisionAccept {
+		t.Fatalf("precondition: default text check should NOT accept three differing texts")
+	}
+
+	// Behavioral equivalence (all three are equivalent solutions): agreement accrues.
+	allEquiv := func(_, _ string) bool { return true }
+	beh, err := Run(context.Background(), Task{Domain: "d"}, nSources("sim", 3, 1),
+		&scriptExec{seq: seq()}, c, Target{Confidence: 0.95}, WithEquivalence(allEquiv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if beh.Decision != DecisionAccept {
+		t.Errorf("behavioral equivalence: decision = %v, want accept", beh.Decision)
+	}
+	if beh.Confidence <= def.Confidence {
+		t.Errorf("behavioral equivalence should raise confidence: beh=%.4f def=%.4f", beh.Confidence, def.Confidence)
+	}
+}
+
+// A nil comparator (WithEquivalence(nil)) is ignored — the default is kept.
+func TestSPRT_WithEquivalenceNilKeepsDefault(t *testing.T) {
+	c, _ := New("")
+	calibrateSymmetric(c, "sim", "d", 0.9, 1000)
+	res, err := Run(context.Background(), Task{Domain: "d"}, nSources("sim", 5, 1),
+		&scriptExec{seq: []string{"A", "A", "A", "A", "A"}}, c, Target{Confidence: 0.95}, WithEquivalence(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Decision != DecisionAccept {
+		t.Errorf("nil equivalence should fall back to default text check; decision = %v", res.Decision)
+	}
+}
+
+// TextEquivalence is case- and whitespace-insensitive but not semantic.
+func TestTextEquivalence(t *testing.T) {
+	if !TextEquivalence("Return  A+B", "return a+b") {
+		t.Error("case/whitespace differences should be equivalent under the text default")
+	}
+	if TextEquivalence("return a+b", "return b+a") {
+		t.Error("materially different text should NOT be equivalent under the text default")
+	}
+}
+
 // probExec answers `truth` with probability p, else `wrong` — a stochastic model.
 type probExec struct {
 	truth, wrong string


### PR DESCRIPTION
Resolves two Trust Control Plane benchmark caveats (findings §2 + §3), analysis + code only — no re-runs.

## #1 — SPRT agreement (trust)
`trust.Run` decided agreement by **text equality**, so two independently-correct answers that differ only in wording registered as disagreement (−1.253 LLR), capping real achieved confidence at **32.9%** despite both being oracle-verified correct.

- `internal/trust/sprt.go` — `AnswerEquivalence` type + `WithEquivalence(...)` option on `Run` (non-breaking variadic). Default `TextEquivalence` (case/whitespace-insensitive; improved over the old bare `TrimSpace`, still not semantic).
- `internal/swarm/sprt.go` — `RunSPRT` wires an **LLM-judge-backed semantic comparator** (`judgeEquivalence`): differently-worded-but-correct answers are judged equivalent and accrue agreement. Short-circuits identical text, times out, degrades to `TextEquivalence` on any judge error (never blocks). Judge calls are ensemble overhead (not added to sample spend), matching the ModeBest judge.

## #2 — optimal model (falsification, not a fit)
The benchmark measured **superlinear** speedup (S=2.33 at n=2, 9.3 at n=4). `Speedup(s,k,n)` has a hard ceiling **S(n) ≤ n** for all s≥0, k≥0 — so no (s,k) can fit, which is why the ad-hoc grid-fit hit the boundary with high residual. That's a clean falsification for context-bound agent work (superlinearity = context dilution), not an inconclusive fit.

- `internal/optimal/optimal.go` — document the model's validity domain.
- `internal/optimal/optimal_test.go` — `TestSpeedup_CeilingIsN_NeverSuperlinear` guards the ceiling, making the falsification reproducible. A context/entropy-aware successor is **data-gated** (N=2 too thin to fit responsibly).

## Tests
`TestSPRT_BehavioralEquivalenceLiftsAgreement`, `TestSPRT_WithEquivalenceNilKeepsDefault`, `TestTextEquivalence`, `TestParseYesNo`, `TestBuildEquivalencePrompt`, `TestSpeedup_CeilingIsN_NeverSuperlinear`. `go build`, `go vet`, `go test -race ./...`, `gofmt` all green.

Closes #151
Closes #152