### PR TITLE
ci(release): auto-publish brew/npm/pip on every release + bump to 1.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,129 @@
+name: Publish (all channels)
+
+# Single source of truth for shipping a release everywhere: binaries + checksums
+# (GitHub release), Homebrew tap, npm, and pip. curl (install.sh) needs nothing —
+# it always resolves the latest release at runtime.
+#
+# Called automatically by release-please.yml when a release is created, and
+# manually via workflow_dispatch (e.g. to (re)publish an existing tag).
+#
+# Each channel is gated on its secret being present, so the release never fails
+# just because a token has not been configured yet:
+#   HOMEBREW_TAP_GITHUB_TOKEN  → PAT with push access to ankit373/homebrew-hydra
+#   NPM_TOKEN                  → npm automation token (publish)
+#   PYPI_API_TOKEN             → PyPI API token (publish)
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.0.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  binaries:
+    name: Binaries + checksums (GoReleaser)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: anchore/sbom-action/download-syft@v0
+      - name: GoReleaser (append to existing release)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag }}
+
+  homebrew:
+    name: Homebrew tap
+    needs: binaries
+    runs-on: ubuntu-latest
+    env:
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+      - name: Update tap formula
+        if: ${{ env.TAP_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: ./scripts/update-tap-formula.sh "${{ inputs.tag }}"
+      - name: Skipped (no token)
+        if: ${{ env.TAP_TOKEN == '' }}
+        run: echo "::warning::HOMEBREW_TAP_GITHUB_TOKEN not set — skipping Homebrew tap update."
+
+  npm:
+    name: npm
+    needs: binaries
+    runs-on: ubuntu-latest
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Publish
+        if: ${{ env.NPM_TOKEN != '' }}
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION="${{ inputs.tag }}"; VERSION="${VERSION#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          npm publish --access public
+      - name: Skipped (no token)
+        if: ${{ env.NPM_TOKEN == '' }}
+        run: echo "::warning::NPM_TOKEN not set — skipping npm publish."
+
+  pip:
+    name: pip / PyPI
+    needs: binaries
+    runs-on: ubuntu-latest
+    env:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build + publish
+        if: ${{ env.PYPI_API_TOKEN != '' }}
+        working-directory: pip
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          VERSION="${{ inputs.tag }}"; VERSION="${VERSION#v}"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
+          sed -i "s/^__version__ = .*/__version__ = \"$VERSION\"/" hyctl/__init__.py
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine upload dist/*
+      - name: Skipped (no token)
+        if: ${{ env.PYPI_API_TOKEN == '' }}
+        run: echo "::warning::PYPI_API_TOKEN not set — skipping PyPI publish."

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,11 @@ name: Release Please
 
 # release-please watches for conventional commits on main and:
 #   1. Opens a "Release PR" with bumped version + updated CHANGELOG.md
-#   2. When the Release PR is merged, creates the tag → triggers release.yml
+#   2. When the Release PR is merged, creates the tag + GitHub release
+#   3. This workflow then fans the release out to every channel (binaries,
+#      Homebrew, npm, pip) via publish.yml — so a feature release auto-updates
+#      everywhere with no manual steps. curl (install.sh) always resolves the
+#      latest release at runtime, so it needs nothing.
 
 on:
   push:
@@ -17,6 +21,9 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -29,3 +36,12 @@ jobs:
           #   feat!: or BREAKING CHANGE → major bump (1.1.0 → 2.0.0)
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish:
+    name: Publish everywhere
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+# Fallback path for a manually pushed vX.Y.Z tag (release-please tags are handled
+# by release-please.yml instead). Both paths funnel through publish.yml so every
+# channel — binaries, Homebrew, npm, pip — is updated the same way.
+
 on:
   push:
     tags:
@@ -7,34 +11,10 @@ on:
 
 permissions:
   contents: write
-  id-token: write   # for cosign keyless signing (Phase 3)
-  packages: write
 
 jobs:
-  goreleaser:
-    name: GoReleaser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0   # full history for accurate build metadata
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      # Phase 3: enable cosign for binary signing
-      # - name: Install cosign
-      #   uses: sigstore/cosign-installer@v3
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+  publish:
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyctl",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hydra (hyctl) — local-first, multi-vendor AI control plane. Discovers every model on your machine and routes each task to the cheapest head that clears your target confidence.",
   "keywords": [
     "ai",

--- a/pip/hyctl/__init__.py
+++ b/pip/hyctl/__init__.py
@@ -17,7 +17,7 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 REPO = "ankit373/hydra"
 PROJECT = "hydra"  # goreleaser archive filename prefix

--- a/pip/pyproject.toml
+++ b/pip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hyctl"
-version = "1.0.0"
+version = "1.0.1"
 description = "Hydra (hyctl) — local-first, multi-vendor AI control plane. Routes each task to the cheapest model on your machine that clears your target confidence."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
Makes every future feature release **auto-update everywhere** — brew, npm, npx, pip, curl — with zero manual steps.

- **`publish.yml`** (new, reusable): publishes a tag to all channels — GoReleaser binaries+checksums, Homebrew tap, npm, pip. Each channel is gated on its secret (release never fails if a token is absent); npm/pip versions derived from the tag.
- **`release-please.yml`**: on `release_created`, calls `publish.yml` with the new tag → the automated path.
- **`release.yml`**: manual tag pushes funnel through the same `publish.yml`.
- npm/pip package versions bumped to **1.0.1**.

curl (`install.sh`) needs nothing — always resolves latest at runtime.

## Required secrets for full automation (each optional; channel skips if unset)
- `HOMEBREW_TAP_GITHUB_TOKEN` — PAT with push to `homebrew-hydra`
- `NPM_TOKEN` — npm automation token
- `PYPI_API_TOKEN` — PyPI API token

## Validation
All five methods installed + ran end-to-end against the live **v1.0.1** release: brew, curl, npm, npx, pip.

Refs #148