### PR TITLE
feat(config): deployment-identity breadcrumb stamped into ledger/trust/cost logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -684,7 +684,7 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/cost` | Reads `cost.jsonl`, produces spend summaries |
 | `internal/policy` | Allow/deny rules (PII local-only, etc.) |
 | `internal/rank` | CapScore ranking helpers |
-| `internal/config` | Hydra config load/save (`~/.config/hydra/`) |
+| `internal/config` | Hydra config load/save (`~/.config/hydra/`); `Breadcrumb()` — SHA256 deployment-identity fingerprint over `registry/{routing,models,domains}.yaml`, auto-stamped into ledger/trust/cost log entries so they can be tied back to the exact routing rules in effect. |
 | `internal/capabilities` | Model capability scores: embedded `data.json` ⊕ runtime user overlay (`~/.hydra/models.json`) merged at discovery, so new models are added without a rebuild. Drives `hyctl models list\|add\|remove\|sync`. |
 | `internal/budget` | Token-budget governor: static pressure bands (`ModeFor`) + a rate-aware first-passage-time model on the orchestrator's `claude_pct` session history (`RiskFromHistory`/`EffectiveMode`) that escalates before a threshold is crossed. Feeds `claudeMode` downgrades and `hyctl status`. |
 | `internal/trust` | Trust Control Plane confidence layer: per-source calibration (Beta-Bernoulli → LLR/D), defect-cost model + `RequiredConfidence`, and the SPRT optimal-stopping ensemble (`trust.Run`). Drives `hyctl dispatch --confidence` and `hyctl trust calibration\|record\|defect\|stats\|explain`. |

--- a/internal/config/breadcrumb.go
+++ b/internal/config/breadcrumb.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+)
+
+// breadcrumbFiles are the registry files that define this deployment's
+// routing behavior; their combined bytes are the deployment's identity.
+var breadcrumbFiles = []string{"routing.yaml", "models.yaml", "domains.yaml"}
+
+// Breadcrumb is a SHA256 hex fingerprint of the registry files that define
+// this Hydra deployment's routing behavior. It lets ledger/trust/cost log
+// entries be tied back to the exact routing rules in effect when they were
+// written, and lets logs from different machines — or from before/after a
+// registry edit — be told apart.
+func Breadcrumb() (string, error) {
+	dir := filepath.Join(ScriptHome(), "registry")
+	h := sha256.New()
+	for _, name := range breadcrumbFiles {
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return "", err
+		}
+		h.Write(raw)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/config/breadcrumb.go
+++ b/internal/config/breadcrumb.go
@@ -9,19 +9,25 @@ import (
 	"path/filepath"
 )
 
-// breadcrumbFiles are the registry files that define this deployment's
+// BreadcrumbFiles are the registry files that define this deployment's
 // routing behavior; their combined bytes are the deployment's identity.
-var breadcrumbFiles = []string{"routing.yaml", "models.yaml", "domains.yaml"}
+var BreadcrumbFiles = []string{"routing.yaml", "models.yaml", "domains.yaml"}
 
 // Breadcrumb is a SHA256 hex fingerprint of the registry files that define
 // this Hydra deployment's routing behavior. It lets ledger/trust/cost log
 // entries be tied back to the exact routing rules in effect when they were
 // written, and lets logs from different machines — or from before/after a
 // registry edit — be told apart.
+//
+// Deliberately not memoized: it is read once per logged event (never inside a
+// loop — the swarm writer hoists it), the registry is ~36 KB, and a
+// process-lifetime cache would serve a stale fingerprint to the long-running
+// TUI after `hyctl init` or a registry edit. Freshness is worth more than the
+// microseconds. Revisit only with a profile that says otherwise.
 func Breadcrumb() (string, error) {
 	dir := filepath.Join(ScriptHome(), "registry")
 	h := sha256.New()
-	for _, name := range breadcrumbFiles {
+	for _, name := range BreadcrumbFiles {
 		raw, err := os.ReadFile(filepath.Join(dir, name))
 		if err != nil {
 			return "", err

--- a/internal/config/breadcrumb.go
+++ b/internal/config/breadcrumb.go
@@ -5,13 +5,15 @@ package config
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
 // BreadcrumbFiles are the registry files that define this deployment's
 // routing behavior; their combined bytes are the deployment's identity.
-var BreadcrumbFiles = []string{"routing.yaml", "models.yaml", "domains.yaml"}
+// pricing.yaml is included because it drives cost-based routing decisions.
+var BreadcrumbFiles = []string{"routing.yaml", "models.yaml", "domains.yaml", "pricing.yaml"}
 
 // Breadcrumb is a SHA256 hex fingerprint of the registry files that define
 // this Hydra deployment's routing behavior. It lets ledger/trust/cost log
@@ -32,6 +34,11 @@ func Breadcrumb() (string, error) {
 		if err != nil {
 			return "", err
 		}
+		// Length-prefix each file with its name. Plain concatenation is
+		// ambiguous: moving a line from the end of routing.yaml to the start of
+		// models.yaml would leave the byte stream — and so the fingerprint —
+		// unchanged, while being a materially different deployment.
+		fmt.Fprintf(h, "%s\x00%d\x00", name, len(raw))
 		h.Write(raw)
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil

--- a/internal/config/breadcrumb_test.go
+++ b/internal/config/breadcrumb_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestBreadcrumb_DeterministicForSameRegistry(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteRegistry(t, dir, "routing: a", "models: b", "domains: c")
+	testutil.WriteRegistry(t, dir, "routing: a", "models: b", "domains: c", "pricing: d")
 	t.Setenv("HYDRA_HOME", dir)
 
 	h1, err := config.Breadcrumb()
@@ -36,7 +36,7 @@ func TestBreadcrumb_DeterministicForSameRegistry(t *testing.T) {
 // long-running TUI must not keep serving a stale hash after a registry edit.
 func TestBreadcrumb_ChangesWhenAnyRegistryFileChanges(t *testing.T) {
 	dir := t.TempDir()
-	testutil.WriteRegistry(t, dir, "routing: a", "models: b", "domains: c")
+	testutil.WriteRegistry(t, dir, "routing: a", "models: b", "domains: c", "pricing: d")
 	t.Setenv("HYDRA_HOME", dir)
 
 	before, err := config.Breadcrumb()
@@ -44,13 +44,57 @@ func TestBreadcrumb_ChangesWhenAnyRegistryFileChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testutil.WriteRegistry(t, dir, "routing: a-edited", "models: b", "domains: c")
+	testutil.WriteRegistry(t, dir, "routing: a-edited", "models: b", "domains: c", "pricing: d")
 	after, err := config.Breadcrumb()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if before == after {
 		t.Error("Breadcrumb should change when routing.yaml changes")
+	}
+}
+
+// Plain concatenation would be ambiguous: moving content across a file boundary
+// leaves the byte stream unchanged, so two materially different deployments
+// would share a fingerprint — exactly what the breadcrumb exists to prevent.
+func TestBreadcrumb_DistinguishesContentMovedAcrossFileBoundary(t *testing.T) {
+	dirA := t.TempDir()
+	testutil.WriteRegistry(t, dirA, "tier: 1\n", "model: x\n", "d: y\n", "p: z\n")
+	t.Setenv("HYDRA_HOME", dirA)
+	a, err := config.Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dirB := t.TempDir()
+	testutil.WriteRegistry(t, dirB, "tier: 1\nmodel: x\n", "", "d: y\n", "p: z\n")
+	t.Setenv("HYDRA_HOME", dirB)
+	b, err := config.Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Errorf("fingerprint collided across a file boundary: both %s", a[:16])
+	}
+}
+
+// pricing.yaml drives cost-based routing, so an edit must change the identity.
+func TestBreadcrumb_CoversPricing(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteRegistry(t, dir, "routing: a", "models: b", "domains: c", "tier1: 0.001")
+	t.Setenv("HYDRA_HOME", dir)
+	before, err := config.Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testutil.WriteRegistry(t, dir, "routing: a", "models: b", "domains: c", "tier1: 999.0")
+	after, err := config.Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Error("a pricing.yaml edit must change the deployment fingerprint")
 	}
 }
 

--- a/internal/config/breadcrumb_test.go
+++ b/internal/config/breadcrumb_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeRegistry(t *testing.T, dir string, routing, models, domains string) {
+	t.Helper()
+	regDir := filepath.Join(dir, "registry")
+	if err := os.MkdirAll(regDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{"routing.yaml": routing, "models.yaml": models, "domains.yaml": domains}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(regDir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestBreadcrumb_DeterministicForSameRegistry(t *testing.T) {
+	dir := t.TempDir()
+	writeRegistry(t, dir, "routing: a", "models: b", "domains: c")
+	t.Setenv("HYDRA_HOME", dir)
+
+	h1, err := Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 != h2 {
+		t.Errorf("Breadcrumb should be deterministic for an unchanged registry: %s != %s", h1, h2)
+	}
+	if len(h1) != 64 { // SHA256 hex
+		t.Errorf("Breadcrumb length = %d, want 64 (sha256 hex)", len(h1))
+	}
+}
+
+func TestBreadcrumb_ChangesWhenAnyRegistryFileChanges(t *testing.T) {
+	dir := t.TempDir()
+	writeRegistry(t, dir, "routing: a", "models: b", "domains: c")
+	t.Setenv("HYDRA_HOME", dir)
+
+	before, err := Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeRegistry(t, dir, "routing: a-edited", "models: b", "domains: c")
+	after, err := Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == after {
+		t.Error("Breadcrumb should change when routing.yaml changes")
+	}
+}
+
+func TestBreadcrumb_MissingRegistryErrors(t *testing.T) {
+	t.Setenv("HYDRA_HOME", t.TempDir()) // no registry/ dir at all
+	if _, err := Breadcrumb(); err == nil {
+		t.Error("Breadcrumb should error when registry files are unreadable")
+	}
+}

--- a/internal/config/breadcrumb_test.go
+++ b/internal/config/breadcrumb_test.go
@@ -1,37 +1,26 @@
 // SPDX-License-Identifier: MIT
 
-package config
+// External test package: internal/testutil imports config, so config's own
+// in-package tests could not use the shared registry fixture without a cycle.
+package config_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
-)
 
-func writeRegistry(t *testing.T, dir string, routing, models, domains string) {
-	t.Helper()
-	regDir := filepath.Join(dir, "registry")
-	if err := os.MkdirAll(regDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	files := map[string]string{"routing.yaml": routing, "models.yaml": models, "domains.yaml": domains}
-	for name, content := range files {
-		if err := os.WriteFile(filepath.Join(regDir, name), []byte(content), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-}
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/testutil"
+)
 
 func TestBreadcrumb_DeterministicForSameRegistry(t *testing.T) {
 	dir := t.TempDir()
-	writeRegistry(t, dir, "routing: a", "models: b", "domains: c")
+	testutil.WriteRegistry(t, dir, "routing: a", "models: b", "domains: c")
 	t.Setenv("HYDRA_HOME", dir)
 
-	h1, err := Breadcrumb()
+	h1, err := config.Breadcrumb()
 	if err != nil {
 		t.Fatal(err)
 	}
-	h2, err := Breadcrumb()
+	h2, err := config.Breadcrumb()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,18 +32,20 @@ func TestBreadcrumb_DeterministicForSameRegistry(t *testing.T) {
 	}
 }
 
+// Guards against caching the fingerprint for the process lifetime: the
+// long-running TUI must not keep serving a stale hash after a registry edit.
 func TestBreadcrumb_ChangesWhenAnyRegistryFileChanges(t *testing.T) {
 	dir := t.TempDir()
-	writeRegistry(t, dir, "routing: a", "models: b", "domains: c")
+	testutil.WriteRegistry(t, dir, "routing: a", "models: b", "domains: c")
 	t.Setenv("HYDRA_HOME", dir)
 
-	before, err := Breadcrumb()
+	before, err := config.Breadcrumb()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	writeRegistry(t, dir, "routing: a-edited", "models: b", "domains: c")
-	after, err := Breadcrumb()
+	testutil.WriteRegistry(t, dir, "routing: a-edited", "models: b", "domains: c")
+	after, err := config.Breadcrumb()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +56,7 @@ func TestBreadcrumb_ChangesWhenAnyRegistryFileChanges(t *testing.T) {
 
 func TestBreadcrumb_MissingRegistryErrors(t *testing.T) {
 	t.Setenv("HYDRA_HOME", t.TempDir()) // no registry/ dir at all
-	if _, err := Breadcrumb(); err == nil {
+	if _, err := config.Breadcrumb(); err == nil {
 		t.Error("Breadcrumb should error when registry files are unreadable")
 	}
 }

--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -37,6 +37,7 @@ type Row struct {
 	RunID          string  `json:"run_id"`
 	SwarmMode      string  `json:"swarm_mode"`
 	SwarmWinner    bool    `json:"swarm_winner"`
+	Config         string  `json:"config,omitempty"` // deployment-identity breadcrumb (config.Breadcrumb)
 }
 
 // Totals is an aggregate summary.

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -496,7 +496,9 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options) error {
 			"source":          legacySource,
 			"task_id":         taskID,
 			"run_id":          runID,
-			"config":          breadcrumb,
+		}
+		if breadcrumb != "" { // match the omitempty on cost.Row.Config
+			costEntry["config"] = breadcrumb
 		}
 		_ = appendJSONL(filepath.Join(logDir, "cost.jsonl"), costEntry)
 	}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -479,6 +479,7 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options) error {
 		// always "estimated" (est_cost_usd is pricing × tokens, never billed);
 		// the legacy `source` field mirrors tokens_source for older readers.
 		tokensSource, costSource, legacySource := cost.SourceLabels(r.Response.TokensEstimated)
+		breadcrumb, _ := config.Breadcrumb()
 		costEntry := map[string]any{
 			"ts":              time.Now().UTC().Format(time.RFC3339),
 			"tier":            tier,
@@ -495,6 +496,7 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options) error {
 			"source":          legacySource,
 			"task_id":         taskID,
 			"run_id":          runID,
+			"config":          breadcrumb,
 		}
 		_ = appendJSONL(filepath.Join(logDir, "cost.jsonl"), costEntry)
 	}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/policy"
 )
 
@@ -92,6 +93,11 @@ type Event struct {
 	// Classification is the data-sensitivity tag this access was evaluated
 	// under (e.g. "pii"). Empty means unclassified.
 	Classification string `json:"classification,omitempty"`
+
+	// Config is the deployment-identity breadcrumb (config.Breadcrumb) in
+	// effect when this event was recorded, ties the event to the exact
+	// routing rules that were live.
+	Config string `json:"config,omitempty"`
 }
 
 // HashParams returns a SHA256 hex hash of params, for tamper-evident binding
@@ -170,10 +176,15 @@ func DefaultPath() string {
 	return filepath.Join(home, ".hydra", "mcp_ledger.jsonl")
 }
 
-// Record appends one event, stamping TS if blank.
+// Record appends one event, stamping TS and Config (best-effort) if blank.
 func Record(path string, e Event) error {
 	if e.TS == "" {
 		e.TS = time.Now().UTC().Format(time.RFC3339)
+	}
+	if e.Config == "" {
+		if bc, err := config.Breadcrumb(); err == nil {
+			e.Config = bc
+		}
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -10,6 +10,50 @@ import (
 	"testing"
 )
 
+func writeTestRegistry(t *testing.T, dir string) {
+	t.Helper()
+	regDir := filepath.Join(dir, "registry")
+	if err := os.MkdirAll(regDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"routing.yaml", "models.yaml", "domains.yaml"} {
+		if err := os.WriteFile(filepath.Join(regDir, name), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestRecord_StampsConfigBreadcrumbWhenBlank(t *testing.T) {
+	home := t.TempDir()
+	writeTestRegistry(t, home)
+	t.Setenv("HYDRA_HOME", home)
+
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := Load(path)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("Load = %d events, err %v", len(events), err)
+	}
+	if events[0].Config == "" {
+		t.Error("Record should stamp Config from config.Breadcrumb when blank and a registry is available")
+	}
+}
+
+func TestRecord_ConfigOmittedGracefullyWithoutRegistry(t *testing.T) {
+	t.Setenv("HYDRA_HOME", t.TempDir()) // no registry/ present
+
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+		t.Fatalf("Record should not fail when the breadcrumb is unavailable: %v", err)
+	}
+	events, _ := Load(path)
+	if len(events) != 1 || events[0].Config != "" {
+		t.Errorf("Config should stay empty when registry files are unreadable, got %+v", events)
+	}
+}
+
 func TestPolicy_Decide_FirstMatchWins(t *testing.T) {
 	p := Policy{
 		Rules: []Rule{

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -8,24 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-)
 
-func writeTestRegistry(t *testing.T, dir string) {
-	t.Helper()
-	regDir := filepath.Join(dir, "registry")
-	if err := os.MkdirAll(regDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	for _, name := range []string{"routing.yaml", "models.yaml", "domains.yaml"} {
-		if err := os.WriteFile(filepath.Join(regDir, name), []byte("x"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-}
+	"github.com/ankit373/hydra/internal/testutil"
+)
 
 func TestRecord_StampsConfigBreadcrumbWhenBlank(t *testing.T) {
 	home := t.TempDir()
-	writeTestRegistry(t, home)
+	testutil.WriteRegistry(t, home)
 	t.Setenv("HYDRA_HOME", home)
 
 	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -107,7 +107,9 @@ func logAttempts(attempts []Attempt, mode SwarmMode, opts Options, promptPreview
 			"task_id":         taskID,
 			"run_id":          runID,
 			"prompt_preview":  promptPreview,
-			"config":          breadcrumb,
+		}
+		if breadcrumb != "" { // match the omitempty on cost.Row.Config
+			entry["config"] = breadcrumb
 		}
 		raw, _ := json.Marshal(entry)
 		_, _ = fmt.Fprintln(f, string(raw))

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -81,6 +81,7 @@ func logAttempts(attempts []Attempt, mode SwarmMode, opts Options, promptPreview
 
 	runID := runid.ResolveRun(opts.RunID)
 	taskID := runid.ResolveTask(opts.TaskID)
+	breadcrumb, _ := config.Breadcrumb()
 
 	for _, a := range attempts {
 		if a.Status == StatusPending || a.Status == StatusCanceled {
@@ -106,6 +107,7 @@ func logAttempts(attempts []Attempt, mode SwarmMode, opts Options, promptPreview
 			"task_id":         taskID,
 			"run_id":          runID,
 			"prompt_preview":  promptPreview,
+			"config":          breadcrumb,
 		}
 		raw, _ := json.Marshal(entry)
 		_, _ = fmt.Fprintln(f, string(raw))

--- a/internal/testutil/registry.go
+++ b/internal/testutil/registry.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+// Package testutil holds test fixtures shared across packages. Go test helpers
+// cannot be imported from another package's _test.go files, so anything more
+// than one package needs lives here.
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/config"
+)
+
+// WriteRegistry writes a minimal registry/ tree under dir with the given file
+// contents, so config.Breadcrumb() has something to fingerprint. Point
+// HYDRA_HOME at dir (via t.Setenv) to make it the resolved ScriptHome.
+func WriteRegistry(t *testing.T, dir string, contents ...string) {
+	t.Helper()
+	if len(contents) != 0 && len(contents) != len(config.BreadcrumbFiles) {
+		t.Fatalf("WriteRegistry: got %d contents, want 0 or %d", len(contents), len(config.BreadcrumbFiles))
+	}
+	regDir := filepath.Join(dir, "registry")
+	if err := os.MkdirAll(regDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for i, name := range config.BreadcrumbFiles {
+		body := "x"
+		if len(contents) != 0 {
+			body = contents[i]
+		}
+		if err := os.WriteFile(filepath.Join(regDir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/trust/log.go
+++ b/internal/trust/log.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/ankit373/hydra/internal/config"
 )
 
 // RunLog is one persisted SPRT run — the data the "By The Numbers" page
@@ -27,6 +29,7 @@ type RunLog struct {
 	CostSource string     `json:"cost_source"` // from cost.SourceLabels
 	Decision   string     `json:"decision"`    // accept | stopped_on_budget
 	Ledger     []Evidence `json:"ledger,omitempty"`
+	Config     string     `json:"config,omitempty"` // deployment-identity breadcrumb (config.Breadcrumb)
 }
 
 // DefaultLogPath is where SPRT runs are persisted (~/.hydra/trust.jsonl).
@@ -43,10 +46,16 @@ func TaskHash(prompt string) string {
 	return fmt.Sprintf("%08x", h.Sum32())
 }
 
-// LogRun appends one run to the trust log, stamping TS if the caller left it blank.
+// LogRun appends one run to the trust log, stamping TS and Config (best-effort)
+// if the caller left them blank.
 func LogRun(path string, r RunLog) error {
 	if r.TS == "" {
 		r.TS = time.Now().UTC().Format(time.RFC3339)
+	}
+	if r.Config == "" {
+		if bc, err := config.Breadcrumb(); err == nil {
+			r.Config = bc
+		}
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err

--- a/internal/trust/log_test.go
+++ b/internal/trust/log_test.go
@@ -4,27 +4,15 @@ package trust
 
 import (
 	"math"
-	"os"
 	"path/filepath"
 	"testing"
-)
 
-func writeTestRegistry(t *testing.T, dir string) {
-	t.Helper()
-	regDir := filepath.Join(dir, "registry")
-	if err := os.MkdirAll(regDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	for _, name := range []string{"routing.yaml", "models.yaml", "domains.yaml"} {
-		if err := os.WriteFile(filepath.Join(regDir, name), []byte("x"), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-}
+	"github.com/ankit373/hydra/internal/testutil"
+)
 
 func TestLogRun_StampsConfigBreadcrumbWhenBlank(t *testing.T) {
 	home := t.TempDir()
-	writeTestRegistry(t, home)
+	testutil.WriteRegistry(t, home)
 	t.Setenv("HYDRA_HOME", home)
 
 	path := filepath.Join(t.TempDir(), "trust.jsonl")

--- a/internal/trust/log_test.go
+++ b/internal/trust/log_test.go
@@ -4,9 +4,54 @@ package trust
 
 import (
 	"math"
+	"os"
 	"path/filepath"
 	"testing"
 )
+
+func writeTestRegistry(t *testing.T, dir string) {
+	t.Helper()
+	regDir := filepath.Join(dir, "registry")
+	if err := os.MkdirAll(regDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"routing.yaml", "models.yaml", "domains.yaml"} {
+		if err := os.WriteFile(filepath.Join(regDir, name), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestLogRun_StampsConfigBreadcrumbWhenBlank(t *testing.T) {
+	home := t.TempDir()
+	writeTestRegistry(t, home)
+	t.Setenv("HYDRA_HOME", home)
+
+	path := filepath.Join(t.TempDir(), "trust.jsonl")
+	if err := LogRun(path, RunLog{TaskHash: "abc"}); err != nil {
+		t.Fatal(err)
+	}
+	runs, err := LoadRuns(path)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("LoadRuns = %d runs, err %v", len(runs), err)
+	}
+	if runs[0].Config == "" {
+		t.Error("LogRun should stamp Config from config.Breadcrumb when blank and a registry is available")
+	}
+}
+
+func TestLogRun_ConfigOmittedGracefullyWithoutRegistry(t *testing.T) {
+	t.Setenv("HYDRA_HOME", t.TempDir()) // no registry/ present
+
+	path := filepath.Join(t.TempDir(), "trust.jsonl")
+	if err := LogRun(path, RunLog{TaskHash: "abc"}); err != nil {
+		t.Fatalf("LogRun should not fail when the breadcrumb is unavailable: %v", err)
+	}
+	runs, _ := LoadRuns(path)
+	if len(runs) != 1 || runs[0].Config != "" {
+		t.Errorf("Config should stay empty when registry files are unreadable, got %+v", runs)
+	}
+}
 
 func TestTaskHash_StableAndDistinct(t *testing.T) {
 	if TaskHash("hello") != TaskHash("hello") {


### PR DESCRIPTION
## Summary
- `config.Breadcrumb()` — SHA256 hex fingerprint over the concatenated bytes of `registry/{routing,models,domains}.yaml`. Lets ledger/trust/cost log entries be tied back to the exact routing rules that were live when they were written, and lets logs from different machines (or from before/after a registry edit) be told apart — nothing in Hydra currently ties a log line to "which config produced this."
- Stamped best-effort (non-fatal if the registry is missing/unreadable — the field is just omitted) into: `ledger.Event` (in `Record`), `trust.RunLog` (in `LogRun`), and both cost.jsonl writers (`internal/dispatch/dispatch.go:logDispatch`, `internal/swarm/cost.go:logAttempts`) + `cost.Row` for the read side.

Borrowed from CoSAI/rabbidave's "System Breadcrumb" pattern (a SHA256 fingerprint of a deployment's declared config used as a log-anchor) — adopted narrowly as a config-identity hash; their shared-secret/auth use case doesn't apply to Hydra's local-first single-operator model.

**Stacked on #163** (this branch is based on `fix/161-ledger-param-hash-classification`'s tip, not `develop`, to avoid both PRs independently inserting fields into the same `ledger.Event` struct region and conflicting). PR base is set to `fix/161-ledger-param-hash-classification` — please merge #163 first, then this one (GitHub will retarget the base to `develop` automatically once #163 merges).

## Changes
- `internal/config/breadcrumb.go` (new) + test
- `internal/ledger/ledger.go` — `Event.Config`, stamped in `Record`
- `internal/trust/log.go` — `RunLog.Config`, stamped in `LogRun`
- `internal/cost/cost.go` — `Row.Config` (read side)
- `internal/dispatch/dispatch.go`, `internal/swarm/cost.go` — stamp `"config"` in the cost.jsonl writers
- `CLAUDE.md` — package-map line synced

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` — all green, including new tests: breadcrumb determinism, changes-on-edit, graceful error on missing registry; ledger/trust auto-stamp-when-blank and graceful-omission-without-registry

Closes #162