### PR TITLE
fix(dispatch): make tier and enum routing actually route

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -477,8 +477,14 @@ func cmdDispatch() *cobra.Command {
 			}
 
 			// ── normal single dispatch ─────────────────────────────────────
+			// An enum is a routing instruction, not just a cost label: resolve
+			// it to a tier when no explicit --tier was given (#165).
+			tierHint := tier
+			if tierHint == "" && enumKey != "" {
+				tierHint = dispatch.EnumToTier(enumKey)
+			}
 			opts := dispatch.Options{
-				TierHint:  tier,
+				TierHint:  tierHint,
 				LocalOnly: localOnly,
 				DryRun:    dryRun,
 				System:    system,
@@ -527,7 +533,7 @@ func cmdDispatch() *cobra.Command {
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show selected head without executing")
 	cmd.Flags().StringVarP(&system, "system", "s", "", "system prompt")
 	cmd.Flags().StringVar(&a2aFile, "a2a", "", "path to A2A handoff JSON (prepends structured context to prompt)")
-	cmd.Flags().StringVar(&enumKey, "enum", "", "routing enum key for cost logging (e.g. SIMPLE)")
+	cmd.Flags().StringVar(&enumKey, "enum", "", "routing enum key, e.g. SIMPLE — selects the tier when --tier is unset")
 	// swarm flags
 	cmd.Flags().BoolVar(&doSwarm, "swarm", false, "fan prompt out to multiple heads simultaneously")
 	cmd.Flags().StringVar(&swarmMode, "swarm-mode", "best", "response strategy: best|race|all")

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -105,8 +106,14 @@ func New(ctx context.Context) (*Dispatcher, error) {
 
 // Dispatch routes prompt through policy + tier selection + execution with fallback.
 func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) (*Result, error) {
+	// Resolve the hint to a capability number BEFORE the governor runs. A named
+	// config tier ("expert") is otherwise opaque to claudeMode's Atoi, which
+	// left the whole token-preservation table inert for every non-numeric hint
+	// (#165).
+	hint := d.resolveTierHint(opts.TierHint)
+
 	// Apply claude% preservation — may downgrade tier or abort.
-	tier, mode, pct := d.claudeMode(opts.TierHint)
+	tier, mode, pct := d.claudeMode(hint)
 	switch mode {
 	case "emergency":
 		log.Printf("🚨 EMERGENCY: Claude at %d%% — routing to local tier only. Start a new session.", pct)
@@ -137,9 +144,14 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		return nil, fmt.Errorf("dispatch denied by policy: %s", action.Reason)
 	}
 
-	candidates := d.selectHeads(tier, action.LocalOnly || opts.LocalOnly)
+	localOnly := action.LocalOnly || opts.LocalOnly
+	candidates := d.selectHeads(tier, localOnly)
 	if len(candidates) == 0 {
-		return nil, fmt.Errorf("no available heads for tier %q (localOnly=%v)", tier, opts.LocalOnly)
+		// Report the effective localOnly (policy may have forced it), not just
+		// the caller's flag, or a PII-forced local-only run points the user at
+		// the wrong cause.
+		return nil, fmt.Errorf("no available heads for tier %q (localOnly=%v); "+
+			"check `hyctl probe` and the tier names in your config", tier, localOnly)
 	}
 
 	if opts.DryRun {
@@ -316,12 +328,61 @@ func (d *Dispatcher) writeHandoff(r *Result, prompt string) error {
 	return h.Save(handoffPath)
 }
 
+// resolveTierHint normalizes a tier hint to a capability number ("1".."10").
+//
+// An empty hint stays empty. A numeric hint passes through. A named config
+// tier resolves to the strongest capability tier among its live heads, so the
+// budget governor can reason about — and downgrade — named tiers too. An
+// unrecognized name is returned unchanged so selectHeads yields nothing and
+// the caller can report the bad hint instead of silently widening.
+func (d *Dispatcher) resolveTierHint(hint string) string {
+	if hint == "" {
+		return ""
+	}
+	if _, err := strconv.Atoi(hint); err == nil {
+		return hint
+	}
+	for _, t := range d.cfg.Tiers {
+		if t.Name != hint {
+			continue
+		}
+		ids := make(map[string]bool, len(t.Heads))
+		for _, id := range t.Heads {
+			ids[id] = true
+		}
+		strongest := 0
+		for _, h := range d.heads {
+			if !ids[h.ID] {
+				continue
+			}
+			if n := rank.UITier(h); strongest == 0 || n < strongest {
+				strongest = n
+			}
+		}
+		if strongest > 0 {
+			return strconv.Itoa(strongest)
+		}
+		return hint // named tier has no live heads; let the caller report it
+	}
+	return hint
+}
+
 // selectHeads returns heads to try, in order of preference.
 //
-// No tier hint → all probed heads ranked by score (config tiers ignored).
-// Tier hint    → only heads assigned to that tier in config;
+// No tier hint  → all probed heads ranked by score (config tiers ignored).
+// Named tier    → heads assigned to that tier in config (e.g. "expert").
+// Numeric tier  → heads whose capability tier is at or below the requested
 //
-//	falls back to all probed heads if the tier has no live heads.
+//	strength, via rank.UITier. Lower number = stronger, so "10" yields the
+//	cheapest local heads and "1" yields everything with the strongest first.
+//
+// Numeric hints must NOT be resolved through config tier names: config tiers
+// are named (expert/complex/…) while enums resolve to "1".."10", so an exact
+// name match can never succeed and the old fall-through silently returned the
+// single most expensive head — the exact inverse of cost routing (#165).
+//
+// A hint that matches nothing returns no candidates; the caller reports that
+// rather than silently widening to every head.
 func (d *Dispatcher) selectHeads(tierHint string, localOnly bool) []provider.Head {
 	filter := func(h provider.Head) bool {
 		if !executor.Supports(h) {
@@ -344,7 +405,38 @@ func (d *Dispatcher) selectHeads(tierHint string, localOnly bool) []provider.Hea
 		return all
 	}
 
-	// Collect head IDs assigned to the requested tier in config.
+	// Numeric hint → select by capability tier, independent of config naming.
+	if want, err := strconv.Atoi(tierHint); err == nil {
+		var candidates []provider.Head
+		for _, h := range d.heads {
+			// d.heads is pre-sorted by CapScore (probe.Run → rank.ByCapScore),
+			// so "at or below the requested strength" yields the strongest
+			// eligible head first and weaker ones as the fallback chain.
+			if filter(h) && rank.UITier(h) >= want {
+				candidates = append(candidates, h)
+			}
+		}
+		if len(candidates) > 0 {
+			return candidates
+		}
+		// Nothing is that cheap. Degrade to the cheapest heads available —
+		// ascending capability, so the fallback is the least expensive option
+		// rather than the most. Silently escalating to the strongest head is
+		// what made tier routing worthless in the first place (#165).
+		for _, h := range d.heads {
+			if filter(h) {
+				candidates = append(candidates, h)
+			}
+		}
+		if len(candidates) > 0 {
+			slices.Reverse(candidates) // pre-sorted strongest-first → cheapest-first
+			log.Printf("⚠️  no head at tier %d or cheaper — falling back to the cheapest available (%s)",
+				want, candidates[0].ID)
+		}
+		return candidates
+	}
+
+	// Named tier → heads assigned to it in config.
 	tierIDs := map[string]bool{}
 	for _, t := range d.cfg.Tiers {
 		if t.Name == tierHint {
@@ -354,17 +446,11 @@ func (d *Dispatcher) selectHeads(tierHint string, localOnly bool) []provider.Hea
 		}
 	}
 
-	// Filter live probed heads to those in the tier.
 	var candidates []provider.Head
 	for _, h := range d.heads {
 		if filter(h) && tierIDs[h.ID] {
 			candidates = append(candidates, h)
 		}
-	}
-
-	// Tier had no live heads — fall back to all available.
-	if len(candidates) == 0 {
-		return d.selectHeads("", localOnly)
 	}
 	return candidates
 }

--- a/internal/dispatch/routing_test.go
+++ b/internal/dispatch/routing_test.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/ankit373/hydra/internal/budget"
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/policy"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/rank"
+)
+
+// registryHead is executor.Supports()-eligible without any API key, so these
+// tests exercise real selection rather than being filtered out wholesale.
+func registryHead(id string, capScore int, local bool) provider.Head {
+	return provider.Head{
+		ID: id, Name: id, Provider: "agy", Source: "registry",
+		CapScore: capScore, LocalOnly: local, AuthReady: true,
+	}
+}
+
+// routingDispatcher mirrors a real install: heads pre-sorted by CapScore
+// (as probe.Run does via rank.ByCapScore) and tiers named the way
+// internal/tui/init.go actually writes them — NOT numerically.
+func routingDispatcher() *Dispatcher {
+	heads := []provider.Head{
+		registryHead("strongest", 100, false), // UITier 1  (orchestrator class)
+		registryHead("expert", 92, false),     // UITier 2  (enum EXPERT)
+		registryHead("mid", 70, false),        // UITier 7  (enum STANDARD)
+		registryHead("weak", 40, true),        // UITier 10 (enum GRUNT, local)
+	}
+	cfg := &config.Config{Tiers: []config.Tier{
+		{Name: "expert", Heads: []string{"strongest"}},
+		{Name: "local", Heads: []string{"weak"}},
+	}}
+	return &Dispatcher{
+		cfg: cfg, heads: heads,
+		policy: policy.New(policy.DefaultRules(false)),
+		budget: budget.NewRegistry(nil),
+	}
+}
+
+// The regression that matters: a cost router must never answer "cheapest"
+// with "most expensive". Before #165 every numeric tier fell through to the
+// full head list and returned the strongest head.
+func TestSelectHeads_NumericTierDoesNotReturnStrongest(t *testing.T) {
+	d := routingDispatcher()
+
+	got := d.selectHeads("10", false)
+	if len(got) == 0 {
+		t.Fatal("tier 10 selected no heads")
+	}
+	if got[0].ID == "strongest" {
+		t.Fatalf("tier 10 (cheapest) selected the STRONGEST head %q — cost routing inverted", got[0].ID)
+	}
+	if got[0].ID != "weak" {
+		t.Errorf("tier 10 primary = %q, want \"weak\"", got[0].ID)
+	}
+	for _, h := range got {
+		if rank.UITier(h) < 10 {
+			t.Errorf("tier 10 selected %q at capability tier %d — stronger than requested", h.ID, rank.UITier(h))
+		}
+	}
+}
+
+func TestSelectHeads_NumericTierOrdering(t *testing.T) {
+	d := routingDispatcher()
+
+	// Strongest tier: everything is eligible, best first.
+	if got := d.selectHeads("1", false); len(got) == 0 || got[0].ID != "strongest" {
+		t.Errorf("tier 1 primary = %v, want \"strongest\"", ids(got))
+	}
+	// Mid tier: excludes the strongest, keeps mid + weaker as fallback.
+	got := d.selectHeads("7", false)
+	if len(got) == 0 || got[0].ID != "mid" {
+		t.Fatalf("tier 7 primary = %v, want \"mid\"", ids(got))
+	}
+	for _, h := range got {
+		if h.ID == "strongest" {
+			t.Error("tier 7 must not include the tier-1 head")
+		}
+	}
+}
+
+// An unmatched hint previously widened to every head (and so to the most
+// expensive one). It must now select nothing so the caller can report it.
+func TestSelectHeads_UnknownTierSelectsNothing(t *testing.T) {
+	d := routingDispatcher()
+	for _, hint := range []string{"expret", "nonsense", "Expert"} {
+		if got := d.selectHeads(hint, false); len(got) != 0 {
+			t.Errorf("unknown tier %q selected %v — must not silently widen", hint, ids(got))
+		}
+	}
+}
+
+func TestSelectHeads_NamedTierStillWorks(t *testing.T) {
+	d := routingDispatcher()
+	if got := d.selectHeads("expert", false); len(got) != 1 || got[0].ID != "strongest" {
+		t.Errorf("named tier \"expert\" = %v, want [strongest]", ids(got))
+	}
+	if got := d.selectHeads("local", false); len(got) != 1 || got[0].ID != "weak" {
+		t.Errorf("named tier \"local\" = %v, want [weak]", ids(got))
+	}
+}
+
+func TestSelectHeads_LocalOnlyFilters(t *testing.T) {
+	d := routingDispatcher()
+	for _, h := range d.selectHeads("1", true) {
+		if !h.LocalOnly {
+			t.Errorf("localOnly selection included remote head %q", h.ID)
+		}
+	}
+}
+
+// Named tiers must resolve to a capability number so claudeMode can downgrade
+// them; previously Atoi failed and the whole pressure table was inert.
+func TestResolveTierHint(t *testing.T) {
+	d := routingDispatcher()
+	tests := []struct{ in, want string }{
+		{"", ""},
+		{"8", "8"},         // numeric passes through
+		{"expert", "1"},    // named → strongest member's capability tier
+		{"local", "10"},    //
+		{"bogus", "bogus"}, // unknown returned as-is so the caller can report it
+	}
+	for _, tt := range tests {
+		if got := d.resolveTierHint(tt.in); got != tt.want {
+			t.Errorf("resolveTierHint(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// The end-to-end contract CLAUDE.md documents: an enum is a routing
+// instruction. GRUNT must not land on the most expensive head.
+func TestEnumToTier_RoutesAwayFromStrongest(t *testing.T) {
+	d := routingDispatcher()
+
+	cheap := d.selectHeads(EnumToTier("GRUNT"), false)
+	if len(cheap) == 0 {
+		t.Fatal("GRUNT selected no heads")
+	}
+	if cheap[0].ID == "strongest" {
+		t.Errorf("enum GRUNT routed to the strongest head — the router is inverted")
+	}
+	if cheap[0].ID != "weak" {
+		t.Errorf("enum GRUNT primary = %q, want \"weak\"", cheap[0].ID)
+	}
+
+	// EXPERT resolves to tier 2, so the tier-1 orchestrator-class head is
+	// deliberately excluded: an enum must not escalate past what it asked for.
+	expensive := d.selectHeads(EnumToTier("EXPERT"), false)
+	if len(expensive) == 0 || expensive[0].ID != "expert" {
+		t.Errorf("enum EXPERT primary = %v, want \"expert\"", ids(expensive))
+	}
+	for _, h := range expensive {
+		if h.ID == "strongest" {
+			t.Error("enum EXPERT must not escalate to the tier-1 head")
+		}
+	}
+}
+
+func ids(heads []provider.Head) []string {
+	out := make([]string, 0, len(heads))
+	for _, h := range heads {
+		out = append(out, h.ID)
+	}
+	return out
+}
+
+// When nothing is cheap enough, degrade to the CHEAPEST available head — never
+// silently escalate to the most expensive one, which is the #165 failure mode.
+func TestSelectHeads_NoCheapHeadFallsBackToCheapest(t *testing.T) {
+	d := routingDispatcher()
+	d.heads = []provider.Head{
+		registryHead("strongest", 100, false), // UITier 1
+		registryHead("expert", 92, false),     // UITier 2
+	}
+
+	got := d.selectHeads("10", false) // nothing at tier 10
+	if len(got) == 0 {
+		t.Fatal("fallback selected nothing")
+	}
+	if got[0].ID == "strongest" {
+		t.Errorf("fell back to the STRONGEST head %q — must degrade to the cheapest", got[0].ID)
+	}
+	if got[0].ID != "expert" {
+		t.Errorf("fallback primary = %q, want cheapest (\"expert\")", got[0].ID)
+	}
+}


### PR DESCRIPTION
## Summary
Hydra is a cost router; **every tier and every enum selected the most expensive available head.** Verified on the real binary (`HYDRA_HOME` = repo, valid registry).

**Before:**
```
--tier 1  -> Claude Code (95)     --enum EXPERT   -> Claude Code (95)
--tier 5  -> Claude Code (95)     --enum STANDARD -> Claude Code (95)
--tier 8  -> Claude Code (95)     --enum SIMPLE   -> Claude Code (95)
--tier 10 -> Claude Code (95)     --enum GRUNT    -> Claude Code (95)
```

**After:**
```
--tier 1  -> Claude Code (95)             --enum EXPERT   -> Claude Opus 4.6 (92)
--tier 5  -> Gemini 3.1 Pro High (80)     --enum STANDARD -> Gemini 3.5 Flash High (72)
--tier 8  -> Gemini 3.5 Flash Med (70)    --enum SIMPLE   -> Gemini 3.5 Flash Med (70)
--tier 10 -> Gemini 3.5 Flash Low (68)    --enum GRUNT    -> Gemini 3.5 Flash Low (68)
```

## Root causes (three, composing)
1. **`--enum` never routed.** `EnumToTier` had exactly two callers — `parallel.go:509`, `editor.go:446` — and `cmd/hydra` was not one. `enumKey` reached dispatch only as a cost-log label. Its own flag help said *"for cost logging"*, while CLAUDE.md documents `--enum` as the **preferred** dispatch form.
2. **Numeric hints could never match.** `selectHeads` compared `t.Name == tierHint`; config tier names are `expert|complex|standard|simple|local` (per `tui/init.go:283`) while enums resolve to `"1"`..`"10"`. No intersection → fell through to all heads, `rank.ByCapScore`-sorted → strongest.
3. **The governor was inert.** `claudeMode`'s `strconv.Atoi` failed on every named/empty hint and returned it unchanged, so the entire `claude_pct` pressure table never downgraded.

## Approach
`rank.UITier(h)` already assigns every head a capability tier (1–10) independent of config naming, so routing now resolves through it:
- `resolveTierHint` normalizes any hint to a number **once**, before both the governor and selection — so named tiers can be downgraded under pressure too.
- Numeric selection takes heads at `UITier >= want` (at or below the requested strength), already capability-sorted, so stronger heads are never silently escalated to and weaker ones form the fallback chain.
- Named tiers keep working exactly as before.
- **No head cheap enough → degrade to the *cheapest* available with a warning**, not the most expensive. This preserves the terminal-fallback promise without reintroducing the bug.
- An unknown tier is now reported (`--tier expret` errors) instead of quietly widening to all heads.
- Also fixes the `localOnly` misreport in that error (a PII-policy-forced local-only run pointed the user at the wrong cause).

## Why it survived
`internal/dispatch` was at **0.0% coverage** — its only test file contained 4 benchmarks and zero test functions, and constructed tiers with numeric names `buildTiers` never emits.

## Tests
8 new regression tests in `internal/dispatch/routing_test.go`: numeric selection never returns the strongest; per-tier ordering; enum contract (GRUNT != strongest, EXPERT doesn't escalate to tier 1); unknown hint selects nothing; named tiers unchanged; localOnly filtering; `resolveTierHint` table; cheapest-fallback.

- [x] `gofmt`, `go vet`, `go build`
- [x] `go test -race ./...` green
- [x] E2E re-verified on the real binary (table above)

## Follow-ups found while verifying (not in this PR)
- No head on this machine reaches `UITier 10` — the local Ollama head isn't `executor.Supports()`-eligible, so CLAUDE.md's *"Qwen (tier 10) is always the terminal fallback"* is currently false. Related to the unreachable `internal/executor/ollama.go`.
- `EnumToTier("EXPERT")` = tier 2, so a tier-1 head is deliberately excluded from EXPERT. Worth confirming that matches your intent for the enum table.

Closes #165