### PR TITLE
feat(swarm): log SPRT attempts to cost.jsonl

### DIFF
--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -57,7 +57,12 @@ func enrichCosts(attempts []Attempt, pr PricingReader) {
 
 // logAttempts writes one cost.jsonl entry per attempt that actually executed
 // (StatusOK or StatusFailed — not Pending/Canceled).
-func logAttempts(result *SwarmResult, promptPreview string) {
+//
+// It takes the attempts and mode directly rather than a *SwarmResult so the SPRT
+// path can share it: RunSPRT produces attempts without ever building a
+// SwarmResult, and without this its ensemble spend never reached cost.jsonl at
+// all — only the aggregate trust.jsonl row (#175).
+func logAttempts(attempts []Attempt, mode SwarmMode, promptPreview string) {
 	logDir := filepath.Join(config.Dir(), "logs")
 	_ = os.MkdirAll(logDir, 0o700)
 	path := filepath.Join(logDir, "cost.jsonl")
@@ -71,7 +76,7 @@ func logAttempts(result *SwarmResult, promptPreview string) {
 	runID := os.Getenv("HYDRA_RUN_ID")
 	taskID := os.Getenv("HYDRA_TASK_ID")
 
-	for _, a := range result.Attempts {
+	for _, a := range attempts {
 		if a.Status == StatusPending || a.Status == StatusCanceled {
 			continue
 		}
@@ -90,7 +95,7 @@ func logAttempts(result *SwarmResult, promptPreview string) {
 			"tokens_source":   tokensSource,
 			"cost_source":     costSrc,
 			"source":          legacySource,
-			"swarm_mode":      string(result.Mode),
+			"swarm_mode":      string(mode),
 			"swarm_winner":    a.Status == StatusOK && a.Rank == 1,
 			"task_id":         taskID,
 			"run_id":          runID,

--- a/internal/swarm/cost_log_test.go
+++ b/internal/swarm/cost_log_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// readCostRows redirects config.Dir() at a temp HOME, runs fn, and returns every
+// cost.jsonl row written during it.
+func readCostRows(t *testing.T, fn func()) []map[string]any {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // config.Dir() uses os.UserHomeDir()
+
+	fn()
+
+	raw, err := os.ReadFile(filepath.Join(home, ".hydra", "logs", "cost.jsonl"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatal(err)
+	}
+	var rows []map[string]any
+	for _, line := range splitLines(string(raw)) {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("unparseable cost row %q: %v", line, err)
+		}
+		rows = append(rows, m)
+	}
+	return rows
+}
+
+func splitLines(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+func costAttempt(id string, status HeadStatus, rank int) Attempt {
+	return Attempt{
+		Head:         registryHead(id, id, 80),
+		Status:       status,
+		Rank:         rank,
+		InputTokens:  100,
+		OutputTokens: 50,
+		EstCostUSD:   0.02,
+		FinishedAt:   time.Now(),
+	}
+}
+
+// An SPRT run's sampled heads must reach cost.jsonl. Before #175, RunSPRT never
+// called logAttempts, so the whole --confidence path was invisible to
+// `hyctl cost` / `hyctl stats` — only the aggregate trust.jsonl row survived.
+func TestLogAttempts_SPRTModeIsRecorded(t *testing.T) {
+	attempts := []Attempt{
+		costAttempt("a", StatusOK, 1),
+		costAttempt("b", StatusOK, 0),
+	}
+
+	rows := readCostRows(t, func() {
+		logAttempts(attempts, ModeSPRT, "explain this migration")
+	})
+
+	if len(rows) != 2 {
+		t.Fatalf("wrote %d cost rows, want one per sampled head (2)", len(rows))
+	}
+	for _, r := range rows {
+		if r["swarm_mode"] != string(ModeSPRT) {
+			t.Errorf("swarm_mode = %v, want %q so SPRT spend is distinguishable from race/best/all",
+				r["swarm_mode"], ModeSPRT)
+		}
+		// Provenance labels must match the dispatch path — see cost.SourceLabels.
+		if r["cost_source"] != "estimated" {
+			t.Errorf("cost_source = %v, want \"estimated\"", r["cost_source"])
+		}
+		if r["tokens_source"] == nil || r["tokens_source"] == "" {
+			t.Error("tokens_source must be set")
+		}
+	}
+
+	// Exactly the Rank==1 attempt is the winner.
+	var winners int
+	for _, r := range rows {
+		if w, _ := r["swarm_winner"].(bool); w {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Errorf("swarm_winner true on %d rows, want exactly 1", winners)
+	}
+}
+
+// Pending/Canceled heads never executed, so they must not be billed.
+func TestLogAttempts_SkipsUnexecutedAttempts(t *testing.T) {
+	attempts := []Attempt{
+		costAttempt("ok", StatusOK, 1),
+		costAttempt("pending", StatusPending, 0),
+		costAttempt("canceled", StatusCanceled, 0),
+		costAttempt("failed", StatusFailed, 0),
+	}
+
+	rows := readCostRows(t, func() {
+		logAttempts(attempts, ModeRace, "p")
+	})
+
+	// OK + Failed both really ran; Pending/Canceled did not.
+	if len(rows) != 2 {
+		t.Fatalf("wrote %d rows, want 2 (OK + Failed only)", len(rows))
+	}
+	for _, r := range rows {
+		if r["model"] == "pending" || r["model"] == "canceled" {
+			t.Errorf("unexecuted attempt %v was billed", r["model"])
+		}
+	}
+}
+
+// The mode label must be whatever the caller passed — the signature change from
+// *SwarmResult to (attempts, mode) is what lets SPRT share this writer at all.
+func TestLogAttempts_ModeLabelIsCallerSupplied(t *testing.T) {
+	for _, mode := range []SwarmMode{ModeRace, ModeBest, ModeAll, ModeSPRT} {
+		rows := readCostRows(t, func() {
+			logAttempts([]Attempt{costAttempt("h", StatusOK, 1)}, mode, "p")
+		})
+		if len(rows) != 1 {
+			t.Fatalf("mode %s: wrote %d rows, want 1", mode, len(rows))
+		}
+		if rows[0]["swarm_mode"] != string(mode) {
+			t.Errorf("swarm_mode = %v, want %q", rows[0]["swarm_mode"], mode)
+		}
+	}
+}

--- a/internal/swarm/sprt.go
+++ b/internal/swarm/sprt.go
@@ -97,6 +97,11 @@ func (s *Swarm) RunSPRT(ctx context.Context, prompt string, opts Options) (*SPRT
 		}
 	}
 
+	// Log the sampled heads to cost.jsonl, exactly as Run does for race/best/all.
+	// Without this the ensemble's per-head spend is invisible to `hyctl cost` and
+	// `hyctl stats` — only the aggregate trust.jsonl row survives (#175).
+	logAttempts(adapter.attempts, ModeSPRT, truncate(prompt, 80))
+
 	return &SPRTResult{Trust: res, Attempts: adapter.attempts, Domain: domain, Prompt: prompt, Target: opts.Confidence}, nil
 }
 

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -21,6 +21,10 @@ const (
 	ModeRace SwarmMode = "race" // first success wins; all others are canceled
 	ModeBest SwarmMode = "best" // fire all; LLM judge (with CapScore fallback) picks winner
 	ModeAll  SwarmMode = "all"  // fire all; return ranked by CapScore, no judge
+	// ModeSPRT labels cost rows from RunSPRT's adaptive optimal-stopping ensemble.
+	// It is a cost-log label, not a value Options.Mode ever takes — RunSPRT is
+	// entered via Options.Confidence, not via Mode.
+	ModeSPRT SwarmMode = "sprt"
 )
 
 // Options configures a swarm run.
@@ -173,7 +177,7 @@ func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmRes
 	}
 
 	// 7. Log to cost.jsonl.
-	logAttempts(result, truncate(prompt, 80))
+	logAttempts(result.Attempts, result.Mode, truncate(prompt, 80))
 
 	return result, nil
 }


### PR DESCRIPTION
## Summary
`swarm.RunSPRT` never called `logAttempts` — that function had exactly one caller, `Run` (`swarm.go:180`), covering race/best/all only. Every `--confidence` dispatch therefore left **zero rows in cost.jsonl**: the ensemble's per-head spend was invisible to `hyctl cost` and `hyctl stats`, and the only persisted record was the aggregate row in `trust.jsonl`.

## Changes
- `internal/swarm/cost.go` — `logAttempts` now takes `(attempts []Attempt, mode SwarmMode, promptPreview string)` instead of `*SwarmResult`. RunSPRT produces attempts without ever constructing a `SwarmResult`, so the old signature was what blocked sharing this writer.
- `internal/swarm/swarm.go` — adds `ModeSPRT SwarmMode = "sprt"` so ensemble spend stays distinguishable from race/best/all in the cost log. Documented as a cost-log label, not a value `Options.Mode` ever takes (RunSPRT is entered via `Options.Confidence`).
- `internal/swarm/sprt.go` — calls `logAttempts` from `RunSPRT` itself, symmetric with `Run`. Deliberately *not* wired at the CLI layer: doing it inside means every caller of `RunSPRT` gets the logging, not just `cmd/hydra`.
- `internal/swarm/cost_log_test.go` — new.

## Test plan
- [x] `gofmt`, `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` — full suite green
- [x] New tests: SPRT attempts produce one row per sampled head with `swarm_mode: "sprt"` and correct `cost_source`/`tokens_source` provenance labels; exactly one `swarm_winner`; Pending/Canceled attempts are never billed; the mode label is caller-supplied across all four modes

Tests redirect `HOME` to a `t.TempDir()` so they never touch the real `~/.hydra/logs/cost.jsonl`.

First of five Phase 0 items unblocking the terminal-cockpit and desktop-app work — the backend currently has no run identity or event history for either UI to read.

Closes #175