### PR TITLE
fix(tui): --snapshot --view N panics for N outside [0,2]

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -109,8 +109,18 @@ func cmdTui() *cobra.Command {
 		Use:   "tui",
 		Short: "Interactive cockpit — chat, route work, and watch spend live",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			viewSet := cmd.Flags().Changed("view")
+			if viewSet {
+				if ok, names := tui.ValidSnapshotView(snapView); !ok {
+					return fmt.Errorf("--view %d is out of range: valid values are 0..%d (%s)",
+						snapView, len(names)-1, strings.Join(names, ", "))
+				}
+				if !snapshot {
+					return fmt.Errorf("--view applies only with --snapshot")
+				}
+			}
 			if snapshot {
-				if cmd.Flags().Changed("view") {
+				if viewSet {
 					fmt.Print(tui.CockpitSnapshotView(snapView))
 				} else {
 					fmt.Print(tui.CockpitSnapshot())

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -57,11 +57,43 @@ type ckHead struct {
 	color lipgloss.Color
 }
 
+// Cockpit views. The name table is the single source of truth — deriving the
+// count and the bounds check from it keeps the Tab cycle, the header label, and
+// the --view validation from drifting apart when a view is added.
+const (
+	ckViewChatCode = iota
+	ckViewDashboard
+	ckViewAgentTree
+)
+
+var ckViewNames = []string{"chat+code", "dashboard", "agent-tree"}
+
+// ckViewCount is how many views exist.
+func ckViewCount() int { return len(ckViewNames) }
+
+// ckViewName is total: an out-of-range view yields the default label rather
+// than panicking. `--snapshot --view N` reaches the header with unvalidated N.
+func ckViewName(v int) string {
+	if !ckValidView(v) {
+		return ckViewNames[ckViewChatCode]
+	}
+	return ckViewNames[v]
+}
+
+// ckValidView reports whether v names a real view.
+func ckValidView(v int) bool { return v >= 0 && v < len(ckViewNames) }
+
+// ValidSnapshotView reports whether view is a usable --view value, and returns
+// the valid view names so a caller can build a useful error message.
+func ValidSnapshotView(view int) (ok bool, names []string) {
+	return ckValidView(view), append([]string(nil), ckViewNames...)
+}
+
 // Cockpit is the interactive `hydra tui` model.
 type Cockpit struct {
 	w, h      int
 	ready     bool
-	view      int // 0 = chat+code, 1 = dashboard, 2 = agent tree
+	view      int // one of the ckView* constants
 	input     string
 	log       []string
 	heads     []ckHead
@@ -123,7 +155,7 @@ func (m Cockpit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyCtrlC:
 			return m, tea.Quit
 		case tea.KeyTab:
-			m.view = (m.view + 1) % 3
+			m.view = (m.view + 1) % ckViewCount()
 		case tea.KeyUp:
 			if m.view == 2 && m.treeSel > 0 {
 				m.treeSel--
@@ -346,7 +378,7 @@ func (m Cockpit) chatCode(bodyH int) string {
 }
 
 func (m Cockpit) header() string {
-	viewName := []string{"chat+code", "dashboard", "agent-tree"}[m.view]
+	viewName := ckViewName(m.view)
 	left := ckWordmark("HYDRA") + ckDimS.Render(" ▸ ") + ckCyanS.Render(viewName) +
 		ckDimS.Render(" · heads: agy·gemini·openrouter·qwen")
 	mode, mc := "normal", ckCheapS
@@ -415,13 +447,18 @@ func (m Cockpit) hint() string {
 
 // CockpitSnapshotView renders one static frame of the given view (0 chat+code,
 // 1 dashboard, 2 agent-tree) after two demo dispatches, with the code stream and
-// tree selection settled so the frame is fully populated.
+// tree selection settled so the frame is fully populated. An out-of-range view
+// falls back to the default instead of panicking; callers that can report an
+// error to the user should reject it up front with ValidSnapshotView.
 func CockpitSnapshotView(view int) string {
 	m := NewCockpit()
 	m = m.run("write a User DTO for profile settings")            // SIMPLE → TS interface
 	m = m.run("rotate the signing key in internal/auth/token.go") // CORE   → Go key-rotation
 	m.codeShown = len(m.codeLines)                                // reveal the whole snippet
 	m.treeSel = 2                                                 // highlight the token-rotation node
+	if !ckValidView(view) {
+		view = ckViewChatCode
+	}
 	m.view = view
 	m.w, m.h, m.ready = 100, 30, true
 	return m.View()

--- a/internal/tui/cockpit_test.go
+++ b/internal/tui/cockpit_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// `hydra tui --snapshot --view 3` used to panic with an index-out-of-range:
+// header() indexed a 3-element slice literal with an unvalidated m.view.
+func TestCockpitSnapshotView_OutOfRangeDoesNotPanic(t *testing.T) {
+	for _, view := range []int{-1, -100, 3, 99} {
+		t.Run(strings.TrimSpace(viewLabel(view)), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("--view %d panicked: %v", view, r)
+				}
+			}()
+			out := CockpitSnapshotView(view)
+			if out == "" {
+				t.Errorf("--view %d rendered nothing", view)
+			}
+		})
+	}
+}
+
+func viewLabel(v int) string {
+	if v < 0 {
+		return "negative"
+	}
+	return "too-large"
+}
+
+func TestCockpitSnapshotView_ValidViewsRender(t *testing.T) {
+	for view, name := range ckViewNames {
+		out := CockpitSnapshotView(view)
+		if out == "" {
+			t.Fatalf("view %d (%s) rendered nothing", view, name)
+		}
+		// The header labels the active view — the frame really is the one asked for.
+		if !strings.Contains(out, name) {
+			t.Errorf("view %d frame does not mention %q", view, name)
+		}
+	}
+}
+
+func TestCkViewName_IsTotal(t *testing.T) {
+	if got := ckViewName(-1); got != ckViewNames[ckViewChatCode] {
+		t.Errorf("ckViewName(-1) = %q, want the default label", got)
+	}
+	if got := ckViewName(len(ckViewNames)); got != ckViewNames[ckViewChatCode] {
+		t.Errorf("ckViewName(out of range) = %q, want the default label", got)
+	}
+	for i, want := range ckViewNames {
+		if got := ckViewName(i); got != want {
+			t.Errorf("ckViewName(%d) = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// ValidSnapshotView is what the CLI uses to reject a bad --view before
+// rendering, so it must agree with the internal bounds check.
+func TestValidSnapshotView(t *testing.T) {
+	for i := range ckViewNames {
+		if ok, _ := ValidSnapshotView(i); !ok {
+			t.Errorf("ValidSnapshotView(%d) = false, want true", i)
+		}
+	}
+	for _, bad := range []int{-1, len(ckViewNames), 99} {
+		if ok, _ := ValidSnapshotView(bad); ok {
+			t.Errorf("ValidSnapshotView(%d) = true, want false", bad)
+		}
+	}
+	if _, names := ValidSnapshotView(0); len(names) != len(ckViewNames) {
+		t.Errorf("ValidSnapshotView returned %d names, want %d", len(names), len(ckViewNames))
+	}
+}
+
+// The returned name slice must be a copy — a caller mutating it must not
+// corrupt the package's view table.
+func TestValidSnapshotView_ReturnsCopy(t *testing.T) {
+	_, names := ValidSnapshotView(0)
+	if len(names) == 0 {
+		t.Fatal("no names returned")
+	}
+	names[0] = "mutated"
+	if ckViewNames[0] == "mutated" {
+		t.Error("ValidSnapshotView leaked the package view table to the caller")
+	}
+}
+
+// Tab cycles through every view and always lands in range.
+func TestTabCycleStaysInRange(t *testing.T) {
+	view := 0
+	for i := 0; i < ckViewCount()*3; i++ {
+		view = (view + 1) % ckViewCount()
+		if !ckValidView(view) {
+			t.Fatalf("after %d tabs view = %d, out of range", i+1, view)
+		}
+	}
+	if view != 0 {
+		t.Errorf("cycling %d times should return to view 0, got %d", ckViewCount()*3, view)
+	}
+}


### PR DESCRIPTION
## Summary
`hyctl tui --snapshot --view 3` (or any N < 0 or > 2) died with an index-out-of-range panic and a stack trace. `header()` indexed a 3-element slice literal with an unvalidated `m.view`; the `switch m.view` in `View()` was already safe via its `default` branch, so the panic came solely from that separate unchecked lookup.

Before / after on the real binary:
```
$ hyctl tui --snapshot --view 3     # before
panic: runtime error: index out of range [3] with length 3
goroutine 1 [running]: ...

$ hyctl tui --snapshot --view 3     # after
Error: --view 3 is out of range: valid values are 0..2 (chat+code, dashboard, agent-tree)
```

## Changes
- `internal/tui/cockpit.go` — replaces the scattered bare view integers with a `ckViewNames` table as the single source of truth; the Tab cycle (`% ckViewCount()`), the header label (`ckViewName`), and flag validation (`ckValidView`) all derive from it, so adding a view can't leave one behind. `ckViewName` is **total** and `CockpitSnapshotView` falls back to the default rather than panicking — defence in depth, so no future caller can reintroduce this.
- `cmd/hydra/main.go` — rejects an out-of-range `--view` with a message naming the valid values, instead of clamping silently. Also rejects `--view` without `--snapshot`, which was previously accepted and silently ignored.
- `internal/tui/cockpit_test.go` — new; `internal/tui` previously had **zero tests**.

## Test plan
- [x] `gofmt`, `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` — full suite green
- [x] Manual: `--view 3`, `--view -1` → clean error; `--view 1` without `--snapshot` → clean error; `--view 0/1/2` render chat+code / dashboard / agent-tree as before
- [x] New tests: out-of-range (-1, -100, 3, 99) doesn't panic; all valid views render and are labelled correctly; `ckViewName` totality; `ValidSnapshotView` agrees with the internal check and returns a **copy** (a caller mutating the returned names can't corrupt the package table); Tab cycling stays in range

Second of five Phase 0 items. Independent of #176 — no shared files.

Closes #177