### PR TITLE
feat(dispatch,swarm,parallel): thread run/task identity so logs correlate

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/review"
+	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/swarm"
 	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/tui"
@@ -390,6 +391,11 @@ func cmdDispatch() *cobra.Command {
 			prompt := strings.Join(args, " ")
 			ctx := context.Background()
 
+			// One invocation is one run with one logical task, whichever path
+			// below handles it — so a swarm's attempts and the dispatch that
+			// drove them share an identity in the logs (#181).
+			runID, taskID := runid.New(), runid.New()
+
 			d, err := dispatch.New(ctx)
 			if err != nil {
 				return err
@@ -423,6 +429,8 @@ func cmdDispatch() *cobra.Command {
 					System:        system,
 					Confidence:    effectiveConf,
 					Domain:        domain,
+					RunID:         runID,
+					TaskID:        taskID,
 				})
 				if err != nil {
 					return err
@@ -456,6 +464,8 @@ func cmdDispatch() *cobra.Command {
 					LocalOnly:     localOnly,
 					System:        system,
 					JudgeTierHint: swarmJudge,
+					RunID:         runID,
+					TaskID:        taskID,
 				})
 				if err != nil {
 					return err
@@ -472,6 +482,8 @@ func cmdDispatch() *cobra.Command {
 				System:    system,
 				A2AFile:   a2aFile,
 				Enum:      enumKey,
+				RunID:     runID,
+				TaskID:    taskID,
 			}
 
 			result, err := d.Dispatch(ctx, prompt, opts)
@@ -1296,7 +1308,7 @@ func cmdParallel() *cobra.Command {
 			}
 
 			ctx := context.Background()
-			results, err := parallel.Run(ctx, tasks)
+			results, err := parallel.Run(ctx, tasks, parallel.Options{RunID: runid.New()})
 			if err != nil {
 				return err
 			}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
+	"github.com/ankit373/hydra/internal/runid"
 )
 
 // Options controls dispatch behaviour.
@@ -36,6 +37,14 @@ type Options struct {
 	DryRun    bool   // print selected head without executing
 	A2AFile   string // path to A2A handoff JSON; prepends structured context to prompt
 	Enum      string // enum key (e.g. "SIMPLE") for cost logging
+
+	// RunID groups every log row produced by one user-facing invocation;
+	// TaskID groups the rows for one logical task inside it. Empty means
+	// "derive one" (see runid.ResolveRun/ResolveTask) — pass them explicitly
+	// when several dispatches belong to the same run, as a parallel batch or a
+	// swarm does, otherwise each call is its own run.
+	RunID  string
+	TaskID string
 }
 
 // Result is the outcome of a successful dispatch.
@@ -412,6 +421,11 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options) error {
 	logDir := filepath.Join(config.Dir(), "logs")
 	_ = os.MkdirAll(logDir, 0o700)
 
+	// Resolve once so both rows carry the same identity. Before #181 these read
+	// env vars nothing ever set, so every row logged run_id:"" / task_id:"".
+	runID := runid.ResolveRun(opts.RunID)
+	taskID := runid.ResolveTask(opts.TaskID)
+
 	dispatchEntry := map[string]any{
 		"ts":             time.Now().UTC().Format(time.RFC3339),
 		"head":           r.Head.ID,
@@ -423,8 +437,8 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options) error {
 		"duration_ms":    wallMs,
 		"local":          r.Head.LocalOnly,
 		"prompt_preview": truncate(prompt, 80),
-		"task_id":        os.Getenv("HYDRA_TASK_ID"),
-		"run_id":         os.Getenv("HYDRA_RUN_ID"),
+		"task_id":        taskID,
+		"run_id":         runID,
 	}
 	if err := appendJSONL(filepath.Join(logDir, "dispatch.jsonl"), dispatchEntry); err != nil {
 		return err
@@ -452,8 +466,8 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options) error {
 			"tokens_source":   tokensSource,
 			"cost_source":     costSource,
 			"source":          legacySource,
-			"task_id":         os.Getenv("HYDRA_TASK_ID"),
-			"run_id":          os.Getenv("HYDRA_RUN_ID"),
+			"task_id":         taskID,
+			"run_id":          runID,
 		}
 		_ = appendJSONL(filepath.Join(logDir, "cost.jsonl"), costEntry)
 	}

--- a/internal/dispatch/identity_test.go
+++ b/internal/dispatch/identity_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+
+package dispatch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/pricing"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// readLog returns the parsed rows of one jsonl file under the temp HOME.
+func readLog(t *testing.T, home, name string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(home, ".hydra", "logs", name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatal(err)
+	}
+	var rows []map[string]any
+	for _, line := range strings.Split(strings.TrimRight(string(raw), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("unparseable %s row %q: %v", name, line, err)
+		}
+		rows = append(rows, m)
+	}
+	return rows
+}
+
+// logResult is a minimal successful dispatch Result with token data, so both
+// dispatch.jsonl and cost.jsonl get written.
+func logResult() *Result {
+	return &Result{
+		Output: "ok",
+		Head:   provider.Head{ID: "h1", Name: "H1", Provider: "agy", Source: "registry", CapScore: 90},
+		Response: &executor.Response{
+			Output:       "ok",
+			Model:        "m",
+			InputTokens:  100,
+			OutputTokens: 50,
+			Duration:     time.Second,
+		},
+	}
+}
+
+func newTestDispatcher() *Dispatcher {
+	return &Dispatcher{pricing: pricing.Load()}
+}
+
+// The bug: every row in the real cost.jsonl carried run_id:"" because these
+// read env vars nothing ever set. They must now always be populated.
+func TestLogDispatch_IdentityIsNeverEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_RUN_ID", "")
+	t.Setenv("HYDRA_TASK_ID", "")
+
+	d := newTestDispatcher()
+	if err := d.logDispatch(logResult(), "a prompt", Options{}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"dispatch.jsonl", "cost.jsonl"} {
+		rows := readLog(t, home, name)
+		if len(rows) != 1 {
+			t.Fatalf("%s: got %d rows, want 1", name, len(rows))
+		}
+		if id, _ := rows[0]["run_id"].(string); id == "" {
+			t.Errorf("%s: run_id is empty — this is exactly the #181 bug", name)
+		}
+		if id, _ := rows[0]["task_id"].(string); id == "" {
+			t.Errorf("%s: task_id is empty", name)
+		}
+	}
+}
+
+// dispatch.jsonl and cost.jsonl describe the same call, so they must agree —
+// otherwise a reader joining the two logs sees two different runs.
+func TestLogDispatch_BothLogsShareOneIdentity(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	d := newTestDispatcher()
+	if err := d.logDispatch(logResult(), "p", Options{RunID: "run-9", TaskID: "task-9"}); err != nil {
+		t.Fatal(err)
+	}
+
+	disp := readLog(t, home, "dispatch.jsonl")
+	cost := readLog(t, home, "cost.jsonl")
+	if len(disp) != 1 || len(cost) != 1 {
+		t.Fatalf("dispatch=%d cost=%d rows, want 1 each", len(disp), len(cost))
+	}
+	if disp[0]["run_id"] != "run-9" || cost[0]["run_id"] != "run-9" {
+		t.Errorf("run_id mismatch: dispatch=%v cost=%v, want run-9 in both",
+			disp[0]["run_id"], cost[0]["run_id"])
+	}
+	if disp[0]["task_id"] != "task-9" || cost[0]["task_id"] != "task-9" {
+		t.Errorf("task_id mismatch: dispatch=%v cost=%v, want task-9 in both",
+			disp[0]["task_id"], cost[0]["task_id"])
+	}
+}
+
+func TestLogDispatch_ExplicitBeatsEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_RUN_ID", "env-run")
+
+	d := newTestDispatcher()
+	if err := d.logDispatch(logResult(), "p", Options{RunID: "explicit-run"}); err != nil {
+		t.Fatal(err)
+	}
+	rows := readLog(t, home, "cost.jsonl")
+	if len(rows) != 1 || rows[0]["run_id"] != "explicit-run" {
+		t.Errorf("run_id = %v, want the explicit Options value to win over env", rows[0]["run_id"])
+	}
+}
+
+// An external orchestrator that exports HYDRA_RUN_ID to group several hyctl
+// invocations must still be honoured when no explicit value is passed.
+func TestLogDispatch_EnvUsedWhenNoExplicit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_RUN_ID", "orchestrator-run")
+
+	d := newTestDispatcher()
+	if err := d.logDispatch(logResult(), "p", Options{}); err != nil {
+		t.Fatal(err)
+	}
+	rows := readLog(t, home, "cost.jsonl")
+	if len(rows) != 1 || rows[0]["run_id"] != "orchestrator-run" {
+		t.Errorf("run_id = %v, want the env value", rows[0]["run_id"])
+	}
+}

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/policy"
+	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/workspace"
 )
 
@@ -73,13 +74,26 @@ type Result struct {
 func (r Result) MarshalJSON() ([]byte, error) { return r.raw, nil }
 func (r Result) Raw() json.RawMessage         { return r.raw }
 
+// Options configures a batch run.
+type Options struct {
+	// RunID groups every log row the batch produces. All tasks in one batch
+	// share it; each task still gets its own TaskID, so a reader can tell "one
+	// batch of three tasks" from "three unrelated runs" (#181). Empty derives
+	// one for the batch.
+	RunID string
+}
+
 // Run fans all tasks out as goroutines and collects results.
 // Returns non-nil error only for pre-flight failures; individual task errors
 // are captured in each result's Status/Error fields.
-func Run(ctx context.Context, tasks []Task) ([]Result, error) {
+func Run(ctx context.Context, tasks []Task, opts Options) ([]Result, error) {
 	if len(tasks) == 0 {
 		return nil, fmt.Errorf("no tasks provided")
 	}
+
+	// Resolve the batch's run identity once, here rather than per goroutine, so
+	// every task in the batch genuinely shares it.
+	runID := runid.ResolveRun(opts.RunID)
 
 	// Pre-flight: detect duplicate file targets.
 	seen := map[string]string{}
@@ -100,12 +114,14 @@ func Run(ctx context.Context, tasks []Task) ([]Result, error) {
 
 	for i, task := range tasks {
 		i, task := i, task
+		// Each task is its own logical unit of work inside the shared run.
+		taskID := runid.New()
 		g.Go(func() error {
 			var raw json.RawMessage
 			if task.File != "" {
-				raw = runEditTask(gctx, task)
+				raw = runEditTask(gctx, task, runID, taskID)
 			} else {
-				raw = runTextTask(gctx, task)
+				raw = runTextTask(gctx, task, runID, taskID)
 			}
 			mu.Lock()
 			results[i] = Result{raw: raw}
@@ -121,7 +137,7 @@ func Run(ctx context.Context, tasks []Task) ([]Result, error) {
 }
 
 // runTextTask dispatches a prompt and returns the raw JSON result.
-func runTextTask(ctx context.Context, task Task) json.RawMessage {
+func runTextTask(ctx context.Context, task Task, runID, taskID string) json.RawMessage {
 	d, err := dispatch.New(ctx)
 	if err != nil {
 		return failText(task, "dispatcher init: "+err.Error())
@@ -136,6 +152,8 @@ func runTextTask(ctx context.Context, task Task) json.RawMessage {
 
 	result, err := d.Dispatch(ctx, prompt, dispatch.Options{
 		TierHint: enumToTier(task.Enum),
+		RunID:    runID,
+		TaskID:   taskID,
 	})
 	if err != nil {
 		return failText(task, err.Error())
@@ -153,7 +171,7 @@ func runTextTask(ctx context.Context, task Task) json.RawMessage {
 // runEditTask performs an atomic file edit and returns the raw JSON result.
 // Self-contained port of the edit.sh flow so this package compiles on develop
 // before internal/editor merges. Once editor merges, this can delegate to editor.Edit.
-func runEditTask(ctx context.Context, task Task) json.RawMessage {
+func runEditTask(ctx context.Context, task Task, runID, taskID string) json.RawMessage {
 	file := task.File
 	if !filepath.IsAbs(file) {
 		return failEdit(task, "file path must be absolute")
@@ -235,6 +253,8 @@ snippet) between these exact markers and nothing else:
 	}
 	dispResult, err := d.Dispatch(ctx, editPrompt, dispatch.Options{
 		TierHint: enumToTier(task.Enum),
+		RunID:    runID,
+		TaskID:   taskID,
 	})
 	if err != nil {
 		cleanupBackup()

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRun_EmptyBatch(t *testing.T) {
-	_, err := Run(context.Background(), nil)
+	_, err := Run(context.Background(), nil, Options{})
 	if err == nil {
 		t.Fatal("Run(nil) = nil error, want error")
 	}
@@ -23,7 +23,7 @@ func TestRun_DuplicateFileConflict(t *testing.T) {
 		{Label: "a", Enum: "SIMPLE", File: "/abs/path/foo.go", Prompt: "x"},
 		{Label: "b", Enum: "SIMPLE", File: "/abs/path/foo.go", Prompt: "y"},
 	}
-	_, err := Run(context.Background(), tasks)
+	_, err := Run(context.Background(), tasks, Options{})
 	if err == nil {
 		t.Fatal("Run(duplicate file) = nil error, want conflict error")
 	}

--- a/internal/runid/runid.go
+++ b/internal/runid/runid.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+// Package runid mints the identifiers that correlate a single logical unit of
+// work across Hydra's logs.
+//
+// Two levels exist. A *run* is one user-facing invocation — `hyctl dispatch`,
+// one `hyctl parallel` batch, one swarm. A *task* is one logical piece of work
+// inside it; a run has one task in the simple case and several in a parallel
+// batch. Every attempt a swarm or SPRT ensemble makes on the same task shares
+// that task's ID, which is what lets a reader group the rows that belong
+// together.
+//
+// IDs are timestamp-prefixed so they sort chronologically and are greppable in
+// a jsonl file by eye, with random bytes so two processes starting in the same
+// second cannot collide.
+package runid
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Env vars an external orchestrator can set to group Hydra invocations it
+// spawns into one run. Read as a fallback only — an explicit value always wins,
+// because env is process-global and cannot distinguish concurrent runs inside a
+// single long-lived host process.
+const (
+	EnvRunID  = "HYDRA_RUN_ID"
+	EnvTaskID = "HYDRA_TASK_ID"
+)
+
+// New returns a fresh identifier, e.g. "20260801T104530Z-3f9c1a".
+func New() string {
+	var b [3]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failing is not a reason to lose correlation entirely;
+		// the timestamp alone still groups a run in practice.
+		return time.Now().UTC().Format("20060102T150405Z")
+	}
+	return fmt.Sprintf("%s-%s", time.Now().UTC().Format("20060102T150405Z"), hex.EncodeToString(b[:]))
+}
+
+// ResolveRun returns the run ID to log: an explicit value, else HYDRA_RUN_ID,
+// else a fresh one. It never returns empty — before this existed every log row
+// carried run_id:"" and nothing could be correlated (#181).
+func ResolveRun(explicit string) string { return resolve(explicit, EnvRunID) }
+
+// ResolveTask is ResolveRun for the task level.
+func ResolveTask(explicit string) string { return resolve(explicit, EnvTaskID) }
+
+func resolve(explicit, envKey string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	return New()
+}

--- a/internal/runid/runid_test.go
+++ b/internal/runid/runid_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+
+package runid
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestNew_NonEmptyAndUnique(t *testing.T) {
+	seen := map[string]bool{}
+	for i := 0; i < 500; i++ {
+		id := New()
+		if id == "" {
+			t.Fatal("New() returned empty")
+		}
+		if seen[id] {
+			t.Fatalf("New() collided on %q after %d calls", id, i)
+		}
+		seen[id] = true
+	}
+}
+
+// IDs are timestamp-prefixed so a jsonl log sorts chronologically by run.
+func TestNew_IsTimestampPrefixed(t *testing.T) {
+	id := New()
+	if len(id) < 16 {
+		t.Fatalf("id %q is shorter than a timestamp prefix", id)
+	}
+	if !strings.Contains(id, "T") || !strings.Contains(id, "Z") {
+		t.Errorf("id %q does not look like a UTC timestamp prefix", id)
+	}
+}
+
+func TestNew_ConcurrentCallsDoNotCollide(t *testing.T) {
+	const n = 200
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			id := New()
+			mu.Lock()
+			defer mu.Unlock()
+			if seen[id] {
+				t.Errorf("concurrent collision on %q", id)
+			}
+			seen[id] = true
+		}()
+	}
+	wg.Wait()
+	if len(seen) != n {
+		t.Errorf("got %d distinct ids from %d goroutines", len(seen), n)
+	}
+}
+
+// Resolution order: explicit wins over env, env wins over generated. Explicit
+// must win because env is process-global and cannot distinguish concurrent runs
+// inside one long-lived host process.
+func TestResolve_ExplicitBeatsEnv(t *testing.T) {
+	t.Setenv(EnvRunID, "from-env")
+	if got := ResolveRun("explicit"); got != "explicit" {
+		t.Errorf("ResolveRun(explicit) = %q, want the explicit value", got)
+	}
+	t.Setenv(EnvTaskID, "task-env")
+	if got := ResolveTask("explicit-task"); got != "explicit-task" {
+		t.Errorf("ResolveTask(explicit) = %q, want the explicit value", got)
+	}
+}
+
+func TestResolve_EnvUsedWhenNoExplicit(t *testing.T) {
+	t.Setenv(EnvRunID, "orchestrator-run")
+	if got := ResolveRun(""); got != "orchestrator-run" {
+		t.Errorf("ResolveRun(\"\") = %q, want the env value", got)
+	}
+	t.Setenv(EnvTaskID, "orchestrator-task")
+	if got := ResolveTask(""); got != "orchestrator-task" {
+		t.Errorf("ResolveTask(\"\") = %q, want the env value", got)
+	}
+}
+
+// The bug this package exists to fix: identity must never be empty. Every log
+// row used to carry run_id:"" because nothing set the env var.
+func TestResolve_NeverEmpty(t *testing.T) {
+	t.Setenv(EnvRunID, "")
+	t.Setenv(EnvTaskID, "")
+	if got := ResolveRun(""); got == "" {
+		t.Error("ResolveRun with no explicit value and no env returned empty")
+	}
+	if got := ResolveTask(""); got == "" {
+		t.Error("ResolveTask with no explicit value and no env returned empty")
+	}
+}

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ankit373/hydra/internal/cost"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
+	"github.com/ankit373/hydra/internal/runid"
 )
 
 // PricingReader abstracts the per-tier cost lookup so swarm doesn't need to
@@ -62,7 +63,12 @@ func enrichCosts(attempts []Attempt, pr PricingReader) {
 // path can share it: RunSPRT produces attempts without ever building a
 // SwarmResult, and without this its ensemble spend never reached cost.jsonl at
 // all — only the aggregate trust.jsonl row (#175).
-func logAttempts(attempts []Attempt, mode SwarmMode, promptPreview string) {
+//
+// Every attempt shares the run's identity: heads racing or voting on one prompt
+// are all working the same logical task, so they carry the same TaskID. That is
+// what lets a reader group "5 heads on one task" rather than seeing 5 unrelated
+// rows (#181).
+func logAttempts(attempts []Attempt, mode SwarmMode, opts Options, promptPreview string) {
 	logDir := filepath.Join(config.Dir(), "logs")
 	_ = os.MkdirAll(logDir, 0o700)
 	path := filepath.Join(logDir, "cost.jsonl")
@@ -73,8 +79,8 @@ func logAttempts(attempts []Attempt, mode SwarmMode, promptPreview string) {
 	}
 	defer f.Close()
 
-	runID := os.Getenv("HYDRA_RUN_ID")
-	taskID := os.Getenv("HYDRA_TASK_ID")
+	runID := runid.ResolveRun(opts.RunID)
+	taskID := runid.ResolveTask(opts.TaskID)
 
 	for _, a := range attempts {
 		if a.Status == StatusPending || a.Status == StatusCanceled {

--- a/internal/swarm/cost_log_test.go
+++ b/internal/swarm/cost_log_test.go
@@ -78,7 +78,7 @@ func TestLogAttempts_SPRTModeIsRecorded(t *testing.T) {
 	}
 
 	rows := readCostRows(t, func() {
-		logAttempts(attempts, ModeSPRT, "explain this migration")
+		logAttempts(attempts, ModeSPRT, Options{}, "explain this migration")
 	})
 
 	if len(rows) != 2 {
@@ -120,7 +120,7 @@ func TestLogAttempts_SkipsUnexecutedAttempts(t *testing.T) {
 	}
 
 	rows := readCostRows(t, func() {
-		logAttempts(attempts, ModeRace, "p")
+		logAttempts(attempts, ModeRace, Options{}, "p")
 	})
 
 	// OK + Failed both really ran; Pending/Canceled did not.
@@ -139,7 +139,7 @@ func TestLogAttempts_SkipsUnexecutedAttempts(t *testing.T) {
 func TestLogAttempts_ModeLabelIsCallerSupplied(t *testing.T) {
 	for _, mode := range []SwarmMode{ModeRace, ModeBest, ModeAll, ModeSPRT} {
 		rows := readCostRows(t, func() {
-			logAttempts([]Attempt{costAttempt("h", StatusOK, 1)}, mode, "p")
+			logAttempts([]Attempt{costAttempt("h", StatusOK, 1)}, mode, Options{}, "p")
 		})
 		if len(rows) != 1 {
 			t.Fatalf("mode %s: wrote %d rows, want 1", mode, len(rows))

--- a/internal/swarm/identity_test.go
+++ b/internal/swarm/identity_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// costRows redirects config.Dir() at a temp HOME, runs fn, and returns the
+// cost.jsonl rows written during it.
+func costRows(t *testing.T, fn func()) []map[string]any {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	// Identity must come from Options, not ambient env.
+	t.Setenv("HYDRA_RUN_ID", "")
+	t.Setenv("HYDRA_TASK_ID", "")
+
+	fn()
+
+	raw, err := os.ReadFile(filepath.Join(home, ".hydra", "logs", "cost.jsonl"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatal(err)
+	}
+	var rows []map[string]any
+	for _, line := range strings.Split(strings.TrimRight(string(raw), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("unparseable cost row %q: %v", line, err)
+		}
+		rows = append(rows, m)
+	}
+	return rows
+}
+
+func idAttempt(id string) Attempt {
+	return Attempt{
+		Head:         registryHead(id, id, 80),
+		Status:       StatusOK,
+		InputTokens:  10,
+		OutputTokens: 5,
+		FinishedAt:   time.Now(),
+	}
+}
+
+// Every head racing or voting on one prompt is working the same logical task,
+// so all its rows must carry the same run_id AND task_id. Before #181 both were
+// always "" and nothing could be grouped.
+func TestLogAttempts_AllHeadsShareRunAndTaskID(t *testing.T) {
+	result := &SwarmResult{
+		Mode:     ModeBest,
+		Attempts: []Attempt{idAttempt("a"), idAttempt("b"), idAttempt("c")},
+	}
+	opts := Options{RunID: "run-1", TaskID: "task-1"}
+
+	rows := costRows(t, func() { logAttempts(result.Attempts, result.Mode, opts, "p") })
+
+	if len(rows) != 3 {
+		t.Fatalf("wrote %d rows, want 3", len(rows))
+	}
+	for i, r := range rows {
+		if r["run_id"] != "run-1" {
+			t.Errorf("row %d run_id = %v, want run-1", i, r["run_id"])
+		}
+		if r["task_id"] != "task-1" {
+			t.Errorf("row %d task_id = %v, want task-1 (one task, many heads)", i, r["task_id"])
+		}
+	}
+}
+
+// With no explicit identity the rows must still be correlatable — the whole
+// point is that run_id/task_id are never empty again.
+func TestLogAttempts_DerivesIdentityWhenAbsent(t *testing.T) {
+	result := &SwarmResult{
+		Mode:     ModeRace,
+		Attempts: []Attempt{idAttempt("a"), idAttempt("b")},
+	}
+
+	rows := costRows(t, func() { logAttempts(result.Attempts, result.Mode, Options{}, "p") })
+
+	if len(rows) != 2 {
+		t.Fatalf("wrote %d rows, want 2", len(rows))
+	}
+	runID, _ := rows[0]["run_id"].(string)
+	taskID, _ := rows[0]["task_id"].(string)
+	if runID == "" || taskID == "" {
+		t.Fatalf("derived identity is empty: run_id=%q task_id=%q", runID, taskID)
+	}
+	// Derived once for the whole call, not per row.
+	for i, r := range rows {
+		if r["run_id"] != runID {
+			t.Errorf("row %d run_id = %v, want all rows to share %q", i, r["run_id"], runID)
+		}
+		if r["task_id"] != taskID {
+			t.Errorf("row %d task_id = %v, want all rows to share %q", i, r["task_id"], taskID)
+		}
+	}
+}
+
+// An external orchestrator can group Hydra invocations via env, but an explicit
+// Options value must win — env is process-global and can't distinguish
+// concurrent runs inside one host process.
+func TestLogAttempts_ExplicitOptionsBeatEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_RUN_ID", "env-run")
+
+	result := &SwarmResult{Mode: ModeAll, Attempts: []Attempt{idAttempt("a")}}
+	logAttempts(result.Attempts, result.Mode, Options{RunID: "explicit-run"}, "p")
+
+	raw, err := os.ReadFile(filepath.Join(home, ".hydra", "logs", "cost.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(raw))), &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["run_id"] != "explicit-run" {
+		t.Errorf("run_id = %v, want the explicit Options value to beat env", m["run_id"])
+	}
+}

--- a/internal/swarm/sprt.go
+++ b/internal/swarm/sprt.go
@@ -100,7 +100,7 @@ func (s *Swarm) RunSPRT(ctx context.Context, prompt string, opts Options) (*SPRT
 	// Log the sampled heads to cost.jsonl, exactly as Run does for race/best/all.
 	// Without this the ensemble's per-head spend is invisible to `hyctl cost` and
 	// `hyctl stats` — only the aggregate trust.jsonl row survives (#175).
-	logAttempts(adapter.attempts, ModeSPRT, truncate(prompt, 80))
+	logAttempts(adapter.attempts, ModeSPRT, opts, truncate(prompt, 80))
 
 	return &SPRTResult{Trust: res, Attempts: adapter.attempts, Domain: domain, Prompt: prompt, Target: opts.Confidence}, nil
 }

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -54,6 +54,13 @@ type Options struct {
 	// SPRT mode (RunSPRT).
 	Confidence float64 // target P(correct); >0 selects the SPRT ensemble
 	Domain     string  // calibration domain ("" → "default")
+
+	// RunID/TaskID group this swarm's attempt rows with the invocation and the
+	// logical task they belong to. Every head racing or voting on one prompt is
+	// working the same task, so they share a TaskID — that is what lets a reader
+	// tell "5 heads on one task" from "5 separate tasks" (#181).
+	RunID  string
+	TaskID string
 }
 
 // SwarmResult is the complete outcome of a swarm dispatch.
@@ -177,7 +184,7 @@ func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmRes
 	}
 
 	// 7. Log to cost.jsonl.
-	logAttempts(result.Attempts, result.Mode, truncate(prompt, 80))
+	logAttempts(result.Attempts, result.Mode, opts, truncate(prompt, 80))
 
 	return result, nil
 }


### PR DESCRIPTION
## Problem
`HYDRA_RUN_ID` / `HYDRA_TASK_ID` were read in `dispatch.go` (dispatch.jsonl + cost.jsonl) and `swarm/cost.go`, but **never set anywhere** — the only writer was `dispatch/route.sh`, deleted with the shell layer (#86/#88).

Measured on a real machine before this change:
```
55 rows in ~/.hydra/logs/cost.jsonl
rows with EMPTY run_id: 55/55
  run_id=''  task_id=''  model=Claude Code
```
So nothing could be grouped: a `hyctl parallel` batch's N sub-dispatches, a swarm's N racing heads, and an SPRT ensemble's N samples all landed as unrelated rows. No UI can ask "what happened during this run" against that.

## Approach
Identity is threaded **explicitly through the Options structs**, not via env. Env is process-global, invisible across goroutines, and wrong for a long-running host process that runs many logical runs at once (a desktop app). Env is retained as a *fallback* so an external orchestrator can still group invocations it spawns — but an explicit value always wins.

**Semantics:** a *run* is one user-facing invocation; a *task* is one logical unit inside it.
- `hyctl dispatch` → 1 run, 1 task
- `hyctl parallel --tasks a,b,c` → 1 run, 3 tasks
- swarm / SPRT → 1 run, 1 task, N attempts (N heads on **one** prompt is one task, not N)

## Changes
- **`internal/runid`** (new) — `New()` mints a timestamp-prefixed, chronologically sortable ID with a `crypto/rand` suffix; `ResolveRun`/`ResolveTask` implement explicit → env → generated, and never return empty.
- `dispatch.Options` / `swarm.Options` — gain `RunID`/`TaskID`; `logDispatch` resolves once so dispatch.jsonl and cost.jsonl always agree.
- **`internal/parallel` had no `Options` struct at all** (this was the open question in the plan) — `Run` now takes one. The batch resolves a single `RunID` up front, outside the goroutines, so all tasks genuinely share it; each task mints its own `TaskID`.
- `cmd/hydra` — one run identity per `dispatch` invocation, passed to whichever of the three paths handles it; `parallel` gets its own batch RunID.

## Test plan
- [x] `gofmt`, `go build ./...`, `go vet ./...`
- [x] `go test -race ./...` — full suite green
- [x] New: `internal/runid` (uniqueness incl. 200 concurrent goroutines, timestamp prefix, full resolution order, never-empty)
- [x] New: `internal/swarm` — all heads share one run_id **and** task_id; identity derived once per call when absent; explicit beats env
- [x] New: **`internal/dispatch` had zero tests** — now covers identity never empty, dispatch.jsonl/cost.jsonl agreeing, explicit-beats-env, env-when-no-explicit

Third of five Phase 0 items. Builds on #176 (`logAttempts` signature) — merge that first if both are open; no conflict with #179.

Closes #181