### PR TITLE
feat(runlog): append-only per-run event log

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
 	"github.com/ankit373/hydra/internal/runid"
+	"github.com/ankit373/hydra/internal/runlog"
 )
 
 // Options controls dispatch behaviour.
@@ -145,8 +146,20 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		return &Result{Head: candidates[0], Fallbacks: candidates[1:]}, nil
 	}
 
+	// The run log records the shape of the run — which head was picked, when,
+	// and how it ended — none of which the cost/dispatch outcome rows capture.
+	// Observability must never fail the work, so every append error is ignored.
+	rl := runlog.New(runid.ResolveRun(opts.RunID))
+	taskID := runid.ResolveTask(opts.TaskID)
+
 	var lastErr error
 	for i, h := range candidates {
+		_ = rl.Append(runlog.Event{
+			Kind: runlog.KindHeadSelected, TaskID: taskID,
+			Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
+			Detail: fmt.Sprintf("candidate %d of %d", i+1, len(candidates)),
+		})
+		started := time.Now()
 		exec := executor.For(h)
 		resp, err := exec.Execute(ctx, executor.Request{
 			Prompt:    prompt,
@@ -156,9 +169,23 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		})
 		if err != nil {
 			lastErr = err
+			// A failed candidate is part of the run's shape: it is why the
+			// fallback chain advanced, and nothing else records it.
+			_ = rl.Append(runlog.Event{
+				Kind: runlog.KindError, TaskID: taskID,
+				Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
+				Status: "failed", DurationMS: time.Since(started).Milliseconds(),
+				Detail: truncate(err.Error(), 200),
+			})
 			continue
 		}
 		r := &Result{Output: resp.Output, Head: h, Retries: i, Response: resp}
+		_ = rl.Append(runlog.Event{
+			Kind: runlog.KindDispatchFinished, TaskID: taskID,
+			Head: h.ID, Model: resp.Model, Tier: rank.UITier(h), Status: "ok",
+			CostUSD:    d.estimateCost(rank.UITier(h), resp.InputTokens, resp.OutputTokens),
+			DurationMS: resp.Duration.Milliseconds(),
+		})
 		_ = d.logDispatch(r, prompt, opts)
 		_ = d.writeHandoff(r, prompt)
 		d.recordBudget(r)

--- a/internal/dispatch/runlog_test.go
+++ b/internal/dispatch/runlog_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+
+package dispatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/policy"
+	"github.com/ankit373/hydra/internal/pricing"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+// registryHead is executor.Supports()-eligible without any API key, so these
+// tests exercise real selection rather than being filtered out.
+func rlHead(id string, capScore int) provider.Head {
+	return provider.Head{
+		ID: id, Name: id, Provider: "agy", Source: "registry",
+		CapScore: capScore, AuthReady: true,
+	}
+}
+
+func rlDispatcher(heads ...provider.Head) *Dispatcher {
+	return &Dispatcher{
+		cfg:     &config.Config{},
+		heads:   heads,
+		policy:  policy.New(policy.DefaultRules(false)),
+		pricing: pricing.Load(),
+	}
+}
+
+// A dispatch must leave a reconstructable trail: which head was selected, and
+// how the call ended. Nothing in cost.jsonl/dispatch.jsonl records the
+// selection moment or a failed candidate.
+func TestDispatch_WritesRunLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	d := rlDispatcher(rlHead("h1", 90))
+	// The head is selectable but cannot actually execute in a test environment,
+	// so this exercises the select-then-fail path — which is the one nothing
+	// else in Hydra records.
+	_, err := d.Dispatch(context.Background(), "hello", Options{
+		RunID: "run-rl", TaskID: "task-rl",
+	})
+	if err == nil {
+		t.Log("dispatch unexpectedly succeeded; the assertions below still hold")
+	}
+
+	events, loadErr := runlog.Load("run-rl")
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(events) == 0 {
+		t.Fatal("dispatch wrote no run-log events")
+	}
+
+	var sawSelected bool
+	for _, e := range events {
+		if e.RunID != "run-rl" {
+			t.Errorf("event run_id = %q, want run-rl", e.RunID)
+		}
+		if e.TaskID != "task-rl" {
+			t.Errorf("event task_id = %q, want task-rl", e.TaskID)
+		}
+		if e.Kind == runlog.KindHeadSelected {
+			sawSelected = true
+			if e.Head != "h1" {
+				t.Errorf("head_selected recorded head %q, want h1", e.Head)
+			}
+		}
+	}
+	if !sawSelected {
+		t.Error("no head_selected event — the routing decision was not recorded")
+	}
+}
+
+// Every candidate that fails must be recorded, because that is the only trace
+// of why the fallback chain advanced.
+func TestDispatch_RecordsFailedCandidates(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	// Three candidates, none of which can execute here.
+	d := rlDispatcher(rlHead("h1", 95), rlHead("h2", 85), rlHead("h3", 75))
+	_, _ = d.Dispatch(context.Background(), "hello", Options{RunID: "run-fb"})
+
+	events, err := runlog.Load("run-fb")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	selected, failed := 0, 0
+	for _, e := range events {
+		switch e.Kind {
+		case runlog.KindHeadSelected:
+			selected++
+		case runlog.KindError:
+			failed++
+		}
+	}
+	if selected == 0 {
+		t.Fatal("no candidates recorded as selected")
+	}
+	// Each attempted candidate should produce a selection and, since none can
+	// run here, a matching failure.
+	if failed != selected {
+		t.Errorf("%d selections but %d failures — every attempted candidate should record its outcome",
+			selected, failed)
+	}
+	// Events must be in append order with monotonic sequence.
+	for i := 1; i < len(events); i++ {
+		if events[i].Seq <= events[i-1].Seq {
+			t.Errorf("event %d seq %d not greater than previous %d", i, events[i].Seq, events[i-1].Seq)
+		}
+	}
+}
+
+// Two runs must never contaminate each other — the per-run-file design exists
+// precisely so a reader of one run never sees another's events.
+func TestDispatch_RunsAreIsolated(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	d := rlDispatcher(rlHead("h1", 90))
+	_, _ = d.Dispatch(context.Background(), "a", Options{RunID: "run-a"})
+	_, _ = d.Dispatch(context.Background(), "b", Options{RunID: "run-b"})
+
+	for _, id := range []string{"run-a", "run-b"} {
+		events, err := runlog.Load(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(events) == 0 {
+			t.Errorf("run %s has no events", id)
+		}
+		for _, e := range events {
+			if e.RunID != id {
+				t.Errorf("run %s contains an event from %s", id, e.RunID)
+			}
+		}
+	}
+}

--- a/internal/runlog/runlog.go
+++ b/internal/runlog/runlog.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+
+// Package runlog is Hydra's append-only record of what happened during a run.
+//
+// The other logs answer "what did this cost" and "what was the verdict".
+// This one answers "what happened, in what order, and under whom" — the
+// lifecycle events a timeline or supervision-tree view is reconstructed from.
+// Nothing else in Hydra carries that: a2a's handoff file keeps only the latest
+// hop, the MCP ledger is never called from the dispatch pipeline, and
+// dispatch/cost rows are per-call outcomes with no start/finish or parentage.
+//
+// # One file per run
+//
+// Events live in ~/.hydra/logs/runs/<run_id>.jsonl rather than one global file.
+// That gives retention for free (delete whole files; never compact one that is
+// being appended to), bounds reconstruction cost to a single run however long
+// Hydra has been in use, and means a reader tailing one run never has to skip
+// another's events.
+//
+// # Ordering
+//
+// File order is the authority, not timestamps. Concurrent goroutines can
+// produce equal or inverted wall-clock values at typical resolution, so Load
+// returns events in the order they were appended. Seq is a per-writer counter
+// carried for gap detection and display; it is not the sort key, and two
+// processes appending to one run (an external orchestrator sharing a run ID)
+// will legitimately produce interleaved sequences.
+//
+// # Concurrency
+//
+// Append does one os.OpenFile(O_APPEND) + one Fprintln, the same pattern every
+// other jsonl writer in this codebase uses without a mutex. POSIX makes an
+// O_APPEND write atomic, within and across processes, so concurrent writers
+// cannot tear each other's lines. Keep entries small — the guarantee is about
+// a single write() call, so bulk payloads (diffs, full model output) must be
+// referenced via Ref, never inlined.
+package runlog
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+)
+
+// SchemaVersion is stamped on every event. It exists so the terminal cockpit
+// and the desktop app — two independent readers of this format — can branch on
+// a version rather than guess, and so a format change is a one-line reader
+// change instead of a coordinated migration.
+const SchemaVersion = 1
+
+// Kind is what happened. The set is deliberately small: these are the events a
+// timeline and a supervision tree are built from, not a general trace facility.
+type Kind string
+
+const (
+	KindRunStarted   Kind = "run_started"
+	KindRunFinished  Kind = "run_finished"
+	KindTaskStarted  Kind = "task_started"
+	KindTaskFinished Kind = "task_finished"
+
+	// KindHeadSelected records the routing decision itself — which head won and
+	// why — which no existing log captures.
+	KindHeadSelected Kind = "head_selected"
+
+	KindDispatchStarted  Kind = "dispatch_started"
+	KindDispatchFinished Kind = "dispatch_finished"
+
+	// KindAttempt is one head's execution inside a swarm or SPRT ensemble.
+	KindAttempt Kind = "attempt"
+
+	// KindSample is one source's contribution to an SPRT run, carrying the
+	// per-source timestamp trust.Evidence lacks.
+	KindSample Kind = "sample"
+
+	// KindHandoff is an A2A context handoff. a2a keeps only the newest in
+	// last_handoff.json; appending it here is what makes a chain reconstructable.
+	KindHandoff Kind = "handoff"
+
+	// KindEdit is a file edit. Ref points at the content; the body is never inlined.
+	KindEdit Kind = "edit"
+
+	KindError Kind = "error"
+)
+
+// Event is one record. Fields are omitempty so a line stays small — the atomic
+// append guarantee is per write() call, not per arbitrary size.
+type Event struct {
+	V   int    `json:"v"`
+	Seq uint64 `json:"seq"`
+	TS  string `json:"ts"` // display only; ordering comes from file position
+
+	RunID  string `json:"run_id"`
+	TaskID string `json:"task_id,omitempty"`
+	Kind   Kind   `json:"kind"`
+
+	// Agent is this node's id in the supervision tree; Parent is its ownership
+	// edge. Together they reconstruct the tree — separate from any A2A
+	// collaboration edge, which is a KindHandoff event.
+	Agent  string `json:"agent,omitempty"`
+	Parent string `json:"parent,omitempty"`
+
+	Head   string `json:"head,omitempty"`
+	Model  string `json:"model,omitempty"`
+	Tier   int    `json:"tier,omitempty"`
+	Status string `json:"status,omitempty"`
+
+	CostUSD    float64 `json:"cost_usd,omitempty"`
+	DurationMS int64   `json:"duration_ms,omitempty"`
+	Confidence float64 `json:"confidence,omitempty"`
+
+	// Ref points at bulk content held elsewhere (a path, a hash). Detail is a
+	// short human string. Neither may carry a diff or a full model response.
+	Ref    string `json:"ref,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// Dir is where per-run files live.
+func Dir() string { return filepath.Join(config.Dir(), "logs", "runs") }
+
+// Path is the log file for a run.
+func Path(runID string) string { return filepath.Join(Dir(), runID+".jsonl") }
+
+// Logger appends events for one run. The zero value is unusable; use New.
+// A Logger is safe for concurrent use.
+type Logger struct {
+	runID string
+	path  string
+	seq   atomic.Uint64
+}
+
+// New returns a Logger for runID. It does not create the file — that happens on
+// the first Append, so a run that never logs leaves nothing behind.
+func New(runID string) *Logger {
+	return &Logger{runID: runID, path: Path(runID)}
+}
+
+// RunID reports which run this Logger writes.
+func (l *Logger) RunID() string { return l.runID }
+
+// Append writes one event. It stamps V, Seq, TS, and RunID, so callers supply
+// only what happened.
+//
+// Errors are returned but callers may reasonably ignore them: losing an
+// observability event must never fail the work being observed.
+func (l *Logger) Append(e Event) error {
+	e.V = SchemaVersion
+	e.Seq = l.seq.Add(1)
+	if e.TS == "" {
+		e.TS = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	e.RunID = l.runID
+
+	if err := os.MkdirAll(filepath.Dir(l.path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(l.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	raw, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	// One Fprintln = one write() = atomic under O_APPEND. Do not split this.
+	_, err = fmt.Fprintln(f, string(raw))
+	return err
+}
+
+// Load reads a run's events in append order. A missing run yields no events and
+// no error — a run that logged nothing is not a failure.
+func Load(runID string) ([]Event, error) {
+	events, _, err := LoadCounted(Path(runID))
+	return events, err
+}
+
+// LoadCounted is Load for an explicit path, plus the number of unparseable
+// lines skipped. An append-only record that silently drops entries is worse
+// than useless for reconstruction — a crash mid-write leaves a truncated tail,
+// and a reader that hides it will render an incomplete run as a complete one.
+func LoadCounted(path string) ([]Event, int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	var (
+		events  []Event
+		skipped int
+	)
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e Event
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			skipped++
+			continue
+		}
+		events = append(events, e)
+	}
+	return events, skipped, sc.Err()
+}
+
+// Runs lists known run IDs, newest first. Filenames are timestamp-prefixed
+// (see internal/runid), so lexical descending order is chronological.
+func Runs() ([]string, error) {
+	entries, err := os.ReadDir(Dir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var ids []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		ids = append(ids, strings.TrimSuffix(e.Name(), ".jsonl"))
+	}
+	// ReadDir returns sorted ascending; reverse for newest-first.
+	for i, j := 0, len(ids)-1; i < j; i, j = i+1, j-1 {
+		ids[i], ids[j] = ids[j], ids[i]
+	}
+	return ids, nil
+}

--- a/internal/runlog/runlog_test.go
+++ b/internal/runlog/runlog_test.go
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: MIT
+
+package runlog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// tempHome points config.Dir() at a scratch directory.
+func tempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+func TestAppendLoad_RoundTrip(t *testing.T) {
+	tempHome(t)
+	l := New("run-1")
+
+	in := []Event{
+		{Kind: KindRunStarted, Detail: "hyctl dispatch"},
+		{Kind: KindHeadSelected, TaskID: "t1", Head: "h1", Model: "M", Tier: 3},
+		{Kind: KindDispatchFinished, TaskID: "t1", Status: "ok", CostUSD: 0.012, DurationMS: 1500},
+	}
+	for _, e := range in {
+		if err := l.Append(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := Load("run-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(in) {
+		t.Fatalf("loaded %d events, want %d", len(got), len(in))
+	}
+	for i := range got {
+		if got[i].Kind != in[i].Kind {
+			t.Errorf("event %d kind = %q, want %q (append order must be preserved)", i, got[i].Kind, in[i].Kind)
+		}
+		if got[i].V != SchemaVersion {
+			t.Errorf("event %d schema version = %d, want %d", i, got[i].V, SchemaVersion)
+		}
+		if got[i].RunID != "run-1" {
+			t.Errorf("event %d run_id = %q, want run-1", i, got[i].RunID)
+		}
+		if got[i].TS == "" {
+			t.Errorf("event %d has no timestamp", i)
+		}
+	}
+	// Field fidelity on the richest event.
+	if got[2].CostUSD != 0.012 || got[2].DurationMS != 1500 || got[2].Status != "ok" {
+		t.Errorf("event 2 round-trip lost data: %+v", got[2])
+	}
+}
+
+func TestAppend_SeqIsMonotonic(t *testing.T) {
+	tempHome(t)
+	l := New("run-seq")
+	for i := 0; i < 20; i++ {
+		if err := l.Append(Event{Kind: KindAttempt}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := Load("run-seq")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, e := range got {
+		if e.Seq != uint64(i+1) {
+			t.Errorf("event %d seq = %d, want %d", i, e.Seq, i+1)
+		}
+	}
+}
+
+// The design's load-bearing assumption: concurrent appends are atomic under
+// O_APPEND, so N goroutines produce N intact, parseable lines with no mutex.
+// If this fails, the whole no-lock premise is wrong.
+func TestAppend_ConcurrentWritersDoNotTear(t *testing.T) {
+	tempHome(t)
+	l := New("run-concurrent")
+
+	const goroutines, perGoroutine = 16, 25
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				if err := l.Append(Event{
+					Kind:   KindAttempt,
+					Agent:  fmt.Sprintf("g%d", g),
+					Detail: strings.Repeat("x", 200), // non-trivial line length
+				}); err != nil {
+					t.Errorf("append: %v", err)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	want := goroutines * perGoroutine
+	events, skipped, err := LoadCounted(Path("run-concurrent"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skipped != 0 {
+		t.Errorf("%d lines were unparseable — concurrent appends tore", skipped)
+	}
+	if len(events) != want {
+		t.Fatalf("loaded %d events, want %d — lines were lost or merged", len(events), want)
+	}
+	// Every sequence number must appear exactly once.
+	seen := map[uint64]bool{}
+	for _, e := range events {
+		if seen[e.Seq] {
+			t.Errorf("duplicate seq %d", e.Seq)
+		}
+		seen[e.Seq] = true
+	}
+	if len(seen) != want {
+		t.Errorf("%d distinct seqs, want %d", len(seen), want)
+	}
+}
+
+// A crash mid-write leaves a truncated tail. Silently dropping it would render
+// an incomplete run as a complete one.
+func TestLoadCounted_ReportsTruncatedTail(t *testing.T) {
+	tempHome(t)
+	l := New("run-trunc")
+	for i := 0; i < 3; i++ {
+		if err := l.Append(Event{Kind: KindAttempt}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Simulate a crash mid-append.
+	f, err := os.OpenFile(Path("run-trunc"), os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"v":1,"seq":4,"kind":"att`); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	events, skipped, err := LoadCounted(Path("run-trunc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 3 {
+		t.Errorf("parsed %d events, want the 3 intact ones", len(events))
+	}
+	if skipped != 1 {
+		t.Errorf("skipped = %d, want 1 — a discarded record must be reported", skipped)
+	}
+}
+
+// Runs that never logged must not error, and must not create files.
+func TestLoad_MissingRunIsEmpty(t *testing.T) {
+	tempHome(t)
+	events, err := Load("never-existed")
+	if err != nil {
+		t.Fatalf("missing run should not error: %v", err)
+	}
+	if events != nil {
+		t.Errorf("missing run yielded %d events, want none", len(events))
+	}
+	if _, err := os.Stat(Path("never-existed")); !os.IsNotExist(err) {
+		t.Error("Load created a file for a run that never logged")
+	}
+}
+
+func TestNew_DoesNotCreateFileUntilAppend(t *testing.T) {
+	tempHome(t)
+	l := New("lazy")
+	if _, err := os.Stat(Path("lazy")); !os.IsNotExist(err) {
+		t.Fatal("New created the file eagerly")
+	}
+	if err := l.Append(Event{Kind: KindRunStarted}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(Path("lazy")); err != nil {
+		t.Errorf("file missing after Append: %v", err)
+	}
+}
+
+// Per-run files are the retention story: one run's events never mix with another's.
+func TestRuns_ListsNewestFirstAndIsolatesRuns(t *testing.T) {
+	tempHome(t)
+	for _, id := range []string{"20260801T100000Z-aaa", "20260801T110000Z-bbb", "20260801T120000Z-ccc"} {
+		if err := New(id).Append(Event{Kind: KindRunStarted, Detail: id}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ids, err := Runs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("Runs() = %d ids, want 3", len(ids))
+	}
+	if ids[0] != "20260801T120000Z-ccc" {
+		t.Errorf("Runs()[0] = %q, want the newest run first", ids[0])
+	}
+	// Each run's file holds only its own events.
+	for _, id := range ids {
+		events, err := Load(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(events) != 1 || events[0].Detail != id {
+			t.Errorf("run %s leaked events from another run: %+v", id, events)
+		}
+	}
+}
+
+func TestRuns_NoDirectoryIsEmpty(t *testing.T) {
+	tempHome(t)
+	ids, err := Runs()
+	if err != nil {
+		t.Fatalf("missing runs dir should not error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("got %d ids, want none", len(ids))
+	}
+}
+
+// Schema version must be on the wire, not just the struct — the desktop app
+// will read these bytes without importing this package.
+func TestAppend_SchemaVersionIsSerialized(t *testing.T) {
+	tempHome(t)
+	if err := New("run-schema").Append(Event{Kind: KindRunStarted}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(Path("run-schema"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(raw))), &m); err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := m["v"]; !ok || int(v.(float64)) != SchemaVersion {
+		t.Errorf("wire format missing schema version: %v", m)
+	}
+	if _, ok := m["seq"]; !ok {
+		t.Error("wire format missing seq")
+	}
+}


### PR DESCRIPTION
## Problem
Nothing in Hydra records the *shape* of a run — only its aggregate outcomes. A timeline or supervision-tree view (both UIs need one) cannot be reconstructed from what exists:

| source | why it can't be used |
|---|---|
| `a2a` `last_handoff.json` | single fixed path, **overwritten every dispatch** — only the latest hop survives |
| `internal/ledger` | never called from the dispatch/swarm/parallel pipeline; opt-in `hyctl mcp` CLI only, so zero events in a normal session |
| `trust.Evidence` | preserves consultation order but has **no per-item timestamp** |
| dispatch.jsonl / cost.jsonl | per-call *outcome* rows — no start/finish, no parentage, and **no record of a failed candidate** |

## Design
One append-only file per run: `~/.hydra/logs/runs/<run_id>.jsonl`.

- **Per-run files, not one global log** — retention becomes "delete old files" instead of compacting a file that is being appended to; reconstruction cost is bounded to one run however long Hydra has been in use; and one run's events can never interleave with another's.
- **File order is the ordering authority, not timestamps.** Concurrent goroutines can produce equal or inverted wall-clock values at typical resolution. `Seq` is a per-writer counter carried for gap detection and display, explicitly *not* the sort key.
- **No mutex.** `Append` does one `os.OpenFile(O_APPEND)` + one `Fprintln`, the pattern every jsonl writer here already uses. A test pins the assumption: **16 goroutines × 25 events → 400 intact lines, zero tears, zero duplicate seqs.**
- **Schema-versioned** (`"v": 1`) on the wire from day one — cheap before two independent readers exist, expensive after.
- **Bulk payloads are referenced, never inlined** (`Ref`), following `parallel.go`'s existing side-file pattern, so entries stay within the single-`write()` atomicity guarantee.

## Wired into dispatch
Not shipped as a package with no callers. `Dispatch` now records the routing decision (`head_selected`), the outcome (`dispatch_finished`), and **each failed candidate** — the only trace anywhere of why the fallback chain advanced. Append errors are deliberately ignored: losing an observability event must never fail the work being observed.

## Test plan
- [x] `gofmt`, `go build ./...`, `go vet ./...`, `go test -race ./...` — green
- [x] `internal/runlog` at **85.2%** coverage: round-trip fidelity, monotonic seq, concurrent-append integrity, truncated-tail reporting, missing-run is not an error, lazy file creation, per-run isolation, schema version on the wire
- [x] `internal/dispatch` **0% → 34.8%**: a dispatch writes a reconstructable trail; every attempted candidate records its outcome; two runs never contaminate each other

**Stacked on #182** (needs `internal/runid` and `Options.RunID`) — base is `feature/181-run-task-identity`; GitHub retargets to `develop` once that merges. Fourth of five Phase 0 items.

Closes #183