### PR TITLE
feat(runlog): per-run heartbeat with TTL-based staleness

### DIFF
--- a/internal/runlog/heartbeat.go
+++ b/internal/runlog/heartbeat.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+
+package runlog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Heartbeat defaults. StaleAfter is a multiple of Interval so a reader tolerates
+// a missed tick or two — a briefly busy process must not flicker to "dead".
+const (
+	HeartbeatInterval = 2 * time.Second
+	StaleAfter        = 10 * time.Second
+)
+
+// HeartbeatPath is the liveness marker for a run.
+func HeartbeatPath(runID string) string {
+	return filepath.Join(Dir(), runID+".alive")
+}
+
+// Heartbeat keeps a run's liveness marker fresh.
+//
+// Liveness is inferred from the marker's *freshness*, never from its existence.
+// The obvious design — create on start, delete on exit — is wrong: a crashed or
+// killed process never runs its cleanup, leaving a permanent "still running"
+// ghost a reader can never clear. Touching a marker periodically makes the
+// failure self-healing: a dead process simply stops touching it and the marker
+// ages out.
+//
+// Stop is best-effort tidiness for the graceful case. Correctness does not
+// depend on it ever running.
+type Heartbeat struct {
+	path     string
+	interval time.Duration
+	stop     chan struct{}
+	done     chan struct{}
+	once     sync.Once
+}
+
+// StartHeartbeat begins touching runID's marker until Stop is called or ctx is
+// cancelled. interval <= 0 uses HeartbeatInterval.
+func StartHeartbeat(ctx context.Context, runID string, interval time.Duration) *Heartbeat {
+	if interval <= 0 {
+		interval = HeartbeatInterval
+	}
+	h := &Heartbeat{
+		path:     HeartbeatPath(runID),
+		interval: interval,
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	h.touch() // mark alive immediately; don't wait a full interval
+
+	go func() {
+		defer close(h.done)
+		t := time.NewTicker(h.interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				h.touch()
+			case <-h.stop:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return h
+}
+
+// Stop ends the heartbeat and removes the marker. It is idempotent and waits
+// for the goroutine to exit, so a caller that returns immediately afterwards
+// leaves nothing running.
+func (h *Heartbeat) Stop() {
+	h.once.Do(func() { close(h.stop) })
+	<-h.done
+	_ = os.Remove(h.path)
+}
+
+// touch creates or updates the marker's mtime. Errors are ignored: a missing
+// heartbeat degrades a run to "not shown as live", which must never be allowed
+// to fail the run itself.
+func (h *Heartbeat) touch() {
+	if err := os.MkdirAll(filepath.Dir(h.path), 0o700); err != nil {
+		return
+	}
+	now := time.Now()
+	if err := os.Chtimes(h.path, now, now); err == nil {
+		return
+	}
+	// Not there yet — create it.
+	f, err := os.OpenFile(h.path, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	_ = f.Close()
+}
+
+// IsAlive reports whether a run looks live: its marker exists and was touched
+// within StaleAfter. A marker left behind by a crash ages out on its own.
+func IsAlive(runID string) bool { return aliveAt(HeartbeatPath(runID), time.Now(), StaleAfter) }
+
+// aliveAt is IsAlive with the clock and window injected, so staleness is
+// testable without sleeping.
+func aliveAt(path string, now time.Time, staleAfter time.Duration) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false // no marker: never started, or cleanly stopped
+	}
+	return now.Sub(fi.ModTime()) <= staleAfter
+}
+
+// LiveRuns returns the runs currently considered alive, newest first.
+func LiveRuns() ([]string, error) {
+	ids, err := Runs()
+	if err != nil {
+		return nil, err
+	}
+	var live []string
+	for _, id := range ids {
+		if IsAlive(id) {
+			live = append(live, id)
+		}
+	}
+	return live, nil
+}

--- a/internal/runlog/heartbeat_test.go
+++ b/internal/runlog/heartbeat_test.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+
+package runlog
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestHeartbeat_LiveRunIsAlive(t *testing.T) {
+	tempHome(t)
+	h := StartHeartbeat(context.Background(), "run-live", 10*time.Millisecond)
+	defer h.Stop()
+
+	if !IsAlive("run-live") {
+		t.Fatal("a just-started heartbeat is not alive — the marker should be touched immediately")
+	}
+}
+
+func TestIsAlive_MissingMarkerIsDead(t *testing.T) {
+	tempHome(t)
+	if IsAlive("never-ran") {
+		t.Error("a run with no marker reported alive")
+	}
+}
+
+// The design's whole point: a crashed process never runs cleanup, so its marker
+// lingers. Liveness must come from freshness, not existence, or the UI shows a
+// permanent ghost it can never clear.
+func TestIsAlive_StaleMarkerFromCrashAgesOut(t *testing.T) {
+	tempHome(t)
+	// Interval long enough that it never ticks again — the marker is written
+	// once at start and then, as in a crash, never touched.
+	StartHeartbeat(context.Background(), "run-crashed", time.Hour)
+	path := HeartbeatPath("run-crashed")
+
+	if !IsAlive("run-crashed") {
+		t.Fatal("fresh marker should be alive")
+	}
+
+	// Simulate a crash: the marker is left behind and stops being touched.
+	// Backdate it well past the staleness window.
+	old := time.Now().Add(-StaleAfter - time.Minute)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if IsAlive("run-crashed") {
+		t.Error("a marker left behind by a crash still reports alive — it must age out")
+	}
+	// The file is still there; deletion is not what makes it dead.
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("marker unexpectedly gone: %v", err)
+	}
+}
+
+// Boundary: exactly at the window is alive, one tick past is not.
+func TestAliveAt_Boundary(t *testing.T) {
+	tempHome(t)
+	path := HeartbeatPath("run-boundary")
+	if err := os.MkdirAll(Dir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now()
+	if err := os.Chtimes(path, base, base); err != nil {
+		t.Fatal(err)
+	}
+
+	if !aliveAt(path, base.Add(StaleAfter), StaleAfter) {
+		t.Error("exactly at the staleness window should still be alive")
+	}
+	if aliveAt(path, base.Add(StaleAfter+time.Millisecond), StaleAfter) {
+		t.Error("past the staleness window should be dead")
+	}
+}
+
+// A busy process that misses a tick must not flicker to dead — hence
+// StaleAfter being a multiple of the interval.
+func TestStaleAfter_ToleratesMissedTicks(t *testing.T) {
+	if StaleAfter <= HeartbeatInterval {
+		t.Fatalf("StaleAfter (%v) must exceed HeartbeatInterval (%v) or a single missed tick reads as dead",
+			StaleAfter, HeartbeatInterval)
+	}
+	if StaleAfter < 3*HeartbeatInterval {
+		t.Errorf("StaleAfter (%v) tolerates fewer than 3 missed ticks at interval %v — too twitchy",
+			StaleAfter, HeartbeatInterval)
+	}
+}
+
+func TestHeartbeat_KeepsMarkerFresh(t *testing.T) {
+	tempHome(t)
+	h := StartHeartbeat(context.Background(), "run-fresh", 10*time.Millisecond)
+	defer h.Stop()
+
+	first, err := os.Stat(HeartbeatPath("run-fresh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(60 * time.Millisecond)
+	second, err := os.Stat(HeartbeatPath("run-fresh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.ModTime().After(first.ModTime()) {
+		t.Error("marker mtime did not advance — the heartbeat is not ticking")
+	}
+}
+
+func TestHeartbeat_StopIsIdempotentAndRemovesMarker(t *testing.T) {
+	tempHome(t)
+	h := StartHeartbeat(context.Background(), "run-stop", 10*time.Millisecond)
+	h.Stop()
+	h.Stop() // must not panic or block
+
+	if _, err := os.Stat(HeartbeatPath("run-stop")); !os.IsNotExist(err) {
+		t.Error("Stop did not remove the marker in the graceful case")
+	}
+	if IsAlive("run-stop") {
+		t.Error("run still reports alive after Stop")
+	}
+}
+
+func TestHeartbeat_ContextCancellationStops(t *testing.T) {
+	tempHome(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	h := StartHeartbeat(ctx, "run-ctx", 10*time.Millisecond)
+
+	cancel()
+	// Stop must still return promptly even though the goroutine exited via ctx.
+	done := make(chan struct{})
+	go func() { h.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop blocked after context cancellation")
+	}
+}
+
+// Stop waits for the goroutine, so nothing is left running afterwards.
+func TestHeartbeat_NoGoroutineLeak(t *testing.T) {
+	tempHome(t)
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 20; i++ {
+		h := StartHeartbeat(context.Background(), "run-leak", 5*time.Millisecond)
+		h.Stop()
+	}
+
+	// Give any stragglers a chance to be scheduled out.
+	time.Sleep(50 * time.Millisecond)
+	after := runtime.NumGoroutine()
+	if after > before+2 { // small slack for the test runtime itself
+		t.Errorf("goroutines grew from %d to %d — heartbeat goroutines leaked", before, after)
+	}
+}
+
+func TestLiveRuns_ListsOnlyFresh(t *testing.T) {
+	tempHome(t)
+
+	// Two runs with events; only one is beating.
+	for _, id := range []string{"20260801T100000Z-old", "20260801T110000Z-new"} {
+		if err := New(id).Append(Event{Kind: KindRunStarted}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	h := StartHeartbeat(context.Background(), "20260801T110000Z-new", time.Hour)
+	defer h.Stop()
+
+	// The other run crashed: marker exists but is stale.
+	stalePath := HeartbeatPath("20260801T100000Z-old")
+	if err := os.WriteFile(stalePath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-StaleAfter - time.Minute)
+	if err := os.Chtimes(stalePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	live, err := LiveRuns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(live) != 1 || live[0] != "20260801T110000Z-new" {
+		t.Errorf("LiveRuns() = %v, want only the beating run", live)
+	}
+}
+
+func TestLiveRuns_NoRunsIsEmpty(t *testing.T) {
+	tempHome(t)
+	live, err := LiveRuns()
+	if err != nil {
+		t.Fatalf("no runs should not error: %v", err)
+	}
+	if len(live) != 0 {
+		t.Errorf("got %v, want none", live)
+	}
+}


### PR DESCRIPTION
## Problem
A Fleet view has to distinguish "this run is happening right now" from "this run finished or died". Hydra has no liveness signal — `runlog.Runs()` lists every run ever recorded, with no way to tell which are live.

## Why TTL, and not cleanup-on-exit
The obvious design — write a marker on start, delete it on exit — is **wrong**: a crashed or killed process never runs its deferred cleanup. That leaves a permanent false-positive "still running" ghost the UI can never clear, and it fails *silently*.

So liveness is inferred from **freshness**, never existence. The runner touches the marker on an interval; a reader treats it as dead once the mtime is older than `StaleAfter`. A crash then self-heals — nothing touches the marker, and it ages out on its own. `Stop()` removing the file is tidiness for the graceful case; correctness never depends on it running.

`StaleAfter` is deliberately several multiples of `HeartbeatInterval` so a briefly-busy process can miss a tick without flickering to "dead" — and a test pins that relationship so it survives future tuning of either constant.

## API
- `StartHeartbeat(ctx, runID, interval) *Heartbeat` — touches immediately, then on the interval; stops on `Stop()` or ctx cancellation
- `IsAlive(runID) bool`
- `LiveRuns() ([]string, error)`

## Test plan
- [x] `gofmt`, `go build ./...`, `go vet ./...`, `go test -race ./...` — green
- [x] `internal/runlog` **87.4%** coverage
- [x] **Crash case explicitly tested**: a marker left behind and backdated past the window reports dead *while the file still exists* — proving deletion isn't what makes it dead
- [x] Staleness boundary (exactly at the window is alive, 1ms past is dead), missing marker is dead not an error, `Stop()` idempotent, context cancellation, `LiveRuns` filters stale, and a **goroutine-leak check** (20 start/stop cycles under `-race`)

**Stacked on #184** — base is `feature/183-runlog-event-log`; GitHub retargets to `develop` as the stack merges. Last of five Phase 0 items.

Closes #185