### PR TITLE
feat(tree): shared run reconstruction — events to tree + timeline

### DIFF
--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: MIT
+
+// Package tree turns a run's event log into the two shapes a UI renders: a
+// supervision tree and a chronological timeline.
+//
+// It is deliberately free of any framework: no lipgloss, no Bubble Tea, no
+// assumptions about a frontend's data shape. The terminal cockpit calls it from
+// a tea.Cmd and wraps the result in a tea.Msg; a desktop app calls it from a
+// bound method or pushes the result over an event channel. Both sit above this
+// package; neither is visible to it.
+//
+// # Two overlaid graphs
+//
+// Ownership (who spawned whom) is a strict tree and governs navigation. A2A
+// handoffs (who handed context to whom) form a DAG overlay on the same nodes.
+// Keeping them apart is the load-bearing decision: a node has exactly one
+// owner, so drill-down stays unambiguous, while collaboration stays as rich as
+// a DAG. Conflating the two collapses navigation.
+//
+// # Reconstruct and Apply
+//
+// Reconstruct rebuilds everything from scratch; Apply folds a single event into
+// an existing tree. They are equivalent by construction — Reconstruct is Apply
+// in a loop — and a property test pins that. Both exist because their callers
+// differ: a terminal redrawing a handful of nodes each tick can afford a full
+// rebuild, while a long-running desktop session accumulating thousands of
+// events needs to fold only what is new.
+package tree
+
+import (
+	"sort"
+	"time"
+
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+// State is where a node is in its lifecycle.
+type State string
+
+const (
+	StatePending State = "pending"
+	StateRunning State = "running"
+	StateOK      State = "ok"
+	StateFailed  State = "failed"
+)
+
+// Handoff is one A2A context transfer — an edge in the collaboration overlay,
+// never an ownership edge.
+type Handoff struct {
+	To     string
+	Seq    uint64
+	TS     time.Time
+	Detail string
+}
+
+// Node is one agent/head in the run.
+type Node struct {
+	ID     string
+	Parent string // ownership edge; "" at a root
+	TaskID string
+
+	Head  string
+	Model string
+	Tier  int
+	State State
+
+	CostUSD    float64
+	Confidence float64
+	DurationMS int64
+
+	StartedAt  time.Time
+	FinishedAt time.Time
+
+	// Children are ownership edges, in the order they first appeared.
+	Children []string
+	// Handoffs are the A2A overlay — kept separate from Children on purpose.
+	Handoffs []Handoff
+
+	// Detail is a short human string (an error, a note). Never bulk content.
+	Detail string
+}
+
+// Tree is a run's supervision tree.
+type Tree struct {
+	RunID string
+	Roots []string
+	Nodes map[string]*Node
+
+	// Order is node-creation order, so a renderer can lay nodes out stably
+	// rather than at the mercy of map iteration.
+	Order []string
+
+	// Skipped counts events that could not be attributed to a node. Surfaced
+	// rather than hidden: silently dropping events renders a partial run as a
+	// complete one.
+	Skipped int
+}
+
+// Entry is one timeline row.
+type Entry struct {
+	Seq        uint64
+	TS         time.Time
+	Kind       runlog.Kind
+	NodeID     string
+	TaskID     string
+	Head       string
+	Model      string
+	Tier       int
+	Status     string
+	CostUSD    float64
+	DurationMS int64
+	Confidence float64
+	Detail     string
+}
+
+// Timeline is the run's events in order, for a chronological view.
+type Timeline struct {
+	RunID   string
+	Entries []Entry
+}
+
+// NewTree returns an empty tree ready for Apply.
+func NewTree(runID string) *Tree {
+	return &Tree{RunID: runID, Nodes: map[string]*Node{}}
+}
+
+// Reconstruct builds a tree and timeline from a run's events. Events are taken
+// in the order given — runlog.Load returns them in append order, which is the
+// authoritative ordering (wall-clock timestamps can tie or invert between
+// concurrent goroutines).
+func Reconstruct(events []runlog.Event) (*Tree, *Timeline) {
+	var runID string
+	if len(events) > 0 {
+		runID = events[0].RunID
+	}
+	t := NewTree(runID)
+	tl := &Timeline{RunID: runID, Entries: make([]Entry, 0, len(events))}
+
+	for _, e := range events {
+		Apply(t, e)
+		tl.Entries = append(tl.Entries, entryOf(e))
+	}
+	return t, tl
+}
+
+// Apply folds one event into t and returns it, so calls can be chained. A nil
+// tree is created on demand. Unknown or malformed events are counted in
+// Skipped rather than dropped silently or panicking — a live UI must survive a
+// log written by a newer Hydra than itself.
+func Apply(t *Tree, e runlog.Event) *Tree {
+	if t == nil {
+		t = NewTree(e.RunID)
+	}
+	if t.RunID == "" {
+		t.RunID = e.RunID
+	}
+
+	id := nodeID(e)
+	if id == "" {
+		// Run-level events (run_started/run_finished) belong to no node; they
+		// are timeline-only, not a failure.
+		if e.Kind != runlog.KindRunStarted && e.Kind != runlog.KindRunFinished {
+			t.Skipped++
+		}
+		return t
+	}
+
+	n := t.node(id)
+	if e.TaskID != "" {
+		n.TaskID = e.TaskID
+	}
+	if e.Head != "" {
+		n.Head = e.Head
+	}
+	if e.Model != "" {
+		n.Model = e.Model
+	}
+	if e.Tier != 0 {
+		n.Tier = e.Tier
+	}
+	if e.CostUSD != 0 {
+		n.CostUSD = e.CostUSD
+	}
+	if e.Confidence != 0 {
+		n.Confidence = e.Confidence
+	}
+	if e.DurationMS != 0 {
+		n.DurationMS = e.DurationMS
+	}
+	if e.Parent != "" && e.Parent != id {
+		t.link(e.Parent, id)
+	}
+
+	ts := parseTS(e.TS)
+
+	switch e.Kind {
+	case runlog.KindHeadSelected, runlog.KindDispatchStarted, runlog.KindTaskStarted:
+		n.State = StateRunning
+		if n.StartedAt.IsZero() {
+			n.StartedAt = ts
+		}
+	case runlog.KindDispatchFinished, runlog.KindTaskFinished, runlog.KindAttempt, runlog.KindSample:
+		n.FinishedAt = ts
+		n.State = stateFor(e.Status, StateOK)
+		if n.StartedAt.IsZero() {
+			n.StartedAt = ts
+		}
+	case runlog.KindError:
+		n.FinishedAt = ts
+		n.State = StateFailed
+		if e.Detail != "" {
+			n.Detail = e.Detail
+		}
+	case runlog.KindHandoff:
+		// Collaboration edge, not ownership — this is why Handoffs is a
+		// separate field from Children.
+		if e.Ref != "" || e.Detail != "" {
+			n.Handoffs = append(n.Handoffs, Handoff{
+				To: e.Ref, Seq: e.Seq, TS: ts, Detail: e.Detail,
+			})
+		}
+	case runlog.KindEdit:
+		if n.State == "" {
+			n.State = StateRunning
+		}
+		if e.Detail != "" {
+			n.Detail = e.Detail
+		}
+	default:
+		// A kind this build does not know about. The node still exists and
+		// carries whatever fields came with it; only the lifecycle is unknown.
+		if n.State == "" {
+			n.State = StatePending
+		}
+	}
+	return t
+}
+
+// node returns the node for id, creating it (and recording creation order) if new.
+func (t *Tree) node(id string) *Node {
+	if n, ok := t.Nodes[id]; ok {
+		return n
+	}
+	n := &Node{ID: id, State: StatePending}
+	t.Nodes[id] = n
+	t.Order = append(t.Order, id)
+	t.Roots = append(t.Roots, id) // provisional; link() promotes it to a child
+	return n
+}
+
+// link records an ownership edge, creating either endpoint if needed. A node
+// keeps its first owner: ownership is single by definition, so a later claim is
+// a collaboration relationship, not a re-parenting.
+func (t *Tree) link(parent, child string) {
+	p := t.node(parent)
+	c := t.node(child)
+	if c.Parent != "" {
+		return
+	}
+	c.Parent = parent
+	for _, existing := range p.Children {
+		if existing == child {
+			return
+		}
+	}
+	p.Children = append(p.Children, child)
+	// No longer a root.
+	for i, r := range t.Roots {
+		if r == child {
+			t.Roots = append(t.Roots[:i], t.Roots[i+1:]...)
+			break
+		}
+	}
+}
+
+// nodeID picks the identity an event belongs to: the explicit agent if given,
+// else the head, else the task. Dispatch emits head-scoped events today; a
+// future spawning runtime will emit agent-scoped ones.
+func nodeID(e runlog.Event) string {
+	switch {
+	case e.Agent != "":
+		return e.Agent
+	case e.Head != "":
+		return e.Head
+	default:
+		return e.TaskID
+	}
+}
+
+func stateFor(status string, dflt State) State {
+	switch status {
+	case "ok", "success":
+		return StateOK
+	case "failed", "error", "timeout", "canceled":
+		return StateFailed
+	case "":
+		return dflt
+	default:
+		return State(status)
+	}
+}
+
+func parseTS(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if ts, err := time.Parse(layout, s); err == nil {
+			return ts
+		}
+	}
+	return time.Time{}
+}
+
+func entryOf(e runlog.Event) Entry {
+	return Entry{
+		Seq: e.Seq, TS: parseTS(e.TS), Kind: e.Kind,
+		NodeID: nodeID(e), TaskID: e.TaskID,
+		Head: e.Head, Model: e.Model, Tier: e.Tier, Status: e.Status,
+		CostUSD: e.CostUSD, DurationMS: e.DurationMS, Confidence: e.Confidence,
+		Detail: e.Detail,
+	}
+}
+
+// ── read helpers a renderer needs ────────────────────────────────────────────
+
+// Row is one line of a flattened tree, with the depth a renderer needs to
+// indent. Producing this here keeps every consumer from re-deriving it.
+type Row struct {
+	Node  *Node
+	Depth int
+	Last  bool // last child of its parent — for box-drawing glyphs
+}
+
+// Rows flattens the ownership tree depth-first in creation order. Cycles cannot
+// occur (link refuses to re-parent), but a visited set guards anyway: a
+// malformed log must not hang a UI.
+func (t *Tree) Rows() []Row {
+	var rows []Row
+	visited := map[string]bool{}
+
+	var walk func(id string, depth int, last bool)
+	walk = func(id string, depth int, last bool) {
+		n, ok := t.Nodes[id]
+		if !ok || visited[id] {
+			return
+		}
+		visited[id] = true
+		rows = append(rows, Row{Node: n, Depth: depth, Last: last})
+		for i, child := range n.Children {
+			walk(child, depth+1, i == len(n.Children)-1)
+		}
+	}
+	for i, r := range t.Roots {
+		walk(r, 0, i == len(t.Roots)-1)
+	}
+	// Any node unreachable from a root (a log that lost its parent event) is
+	// still shown, rather than vanishing.
+	for _, id := range t.Order {
+		if !visited[id] {
+			walk(id, 0, true)
+		}
+	}
+	return rows
+}
+
+// TotalCost sums every node's cost.
+func (t *Tree) TotalCost() float64 {
+	var sum float64
+	for _, n := range t.Nodes {
+		sum += n.CostUSD
+	}
+	return sum
+}
+
+// Span returns the run's wall-clock extent.
+func (t *Tree) Span() (start, end time.Time) {
+	for _, n := range t.Nodes {
+		if !n.StartedAt.IsZero() && (start.IsZero() || n.StartedAt.Before(start)) {
+			start = n.StartedAt
+		}
+		if !n.FinishedAt.IsZero() && n.FinishedAt.After(end) {
+			end = n.FinishedAt
+		}
+	}
+	return start, end
+}
+
+// CountByState tallies nodes per lifecycle state, for a status summary.
+func (t *Tree) CountByState() map[State]int {
+	counts := map[State]int{}
+	for _, n := range t.Nodes {
+		counts[n.State]++
+	}
+	return counts
+}
+
+// SortedEntries returns timeline entries by sequence number. Load already
+// yields append order; this makes the guarantee explicit for callers that
+// merge entries from more than one source.
+func (tl *Timeline) SortedEntries() []Entry {
+	out := make([]Entry, len(tl.Entries))
+	copy(out, tl.Entries)
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Seq < out[j].Seq })
+	return out
+}

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MIT
+
+package tree
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+func ev(seq uint64, kind runlog.Kind, mods ...func(*runlog.Event)) runlog.Event {
+	e := runlog.Event{
+		V: runlog.SchemaVersion, Seq: seq, RunID: "run-1",
+		TS: time.Now().UTC().Format(time.RFC3339Nano), Kind: kind,
+	}
+	for _, m := range mods {
+		m(&e)
+	}
+	return e
+}
+
+func agent(id string) func(*runlog.Event)  { return func(e *runlog.Event) { e.Agent = id } }
+func parent(id string) func(*runlog.Event) { return func(e *runlog.Event) { e.Parent = id } }
+func head(h string) func(*runlog.Event)    { return func(e *runlog.Event) { e.Head = h } }
+func status(s string) func(*runlog.Event)  { return func(e *runlog.Event) { e.Status = s } }
+func cost(c float64) func(*runlog.Event)   { return func(e *runlog.Event) { e.CostUSD = c } }
+func ref(r string) func(*runlog.Event)     { return func(e *runlog.Event) { e.Ref = r } }
+
+func TestReconstruct_BuildsOwnershipTree(t *testing.T) {
+	events := []runlog.Event{
+		ev(1, runlog.KindTaskStarted, agent("root")),
+		ev(2, runlog.KindTaskStarted, agent("child-a"), parent("root")),
+		ev(3, runlog.KindTaskStarted, agent("child-b"), parent("root")),
+		ev(4, runlog.KindTaskStarted, agent("grandchild"), parent("child-a")),
+		ev(5, runlog.KindDispatchFinished, agent("grandchild"), status("ok"), cost(0.01)),
+	}
+
+	tr, tl := Reconstruct(events)
+
+	if tr.RunID != "run-1" {
+		t.Errorf("RunID = %q, want run-1", tr.RunID)
+	}
+	if len(tr.Nodes) != 4 {
+		t.Fatalf("got %d nodes, want 4", len(tr.Nodes))
+	}
+	if len(tr.Roots) != 1 || tr.Roots[0] != "root" {
+		t.Fatalf("Roots = %v, want [root]", tr.Roots)
+	}
+	if got := tr.Nodes["child-a"].Parent; got != "root" {
+		t.Errorf("child-a parent = %q, want root", got)
+	}
+	if got := tr.Nodes["grandchild"].State; got != StateOK {
+		t.Errorf("grandchild state = %q, want ok", got)
+	}
+	if len(tl.Entries) != len(events) {
+		t.Errorf("timeline has %d entries, want %d", len(tl.Entries), len(events))
+	}
+}
+
+// The load-bearing decision from AGENT_TREE_MODEL.md: a handoff is a
+// collaboration edge, never an ownership edge. If a handoff ever became a
+// child, drill-down navigation would stop being a tree.
+func TestApply_HandoffIsOverlayNotOwnership(t *testing.T) {
+	events := []runlog.Event{
+		ev(1, runlog.KindTaskStarted, agent("a")),
+		ev(2, runlog.KindTaskStarted, agent("b")),
+		ev(3, runlog.KindHandoff, agent("a"), ref("b"), func(e *runlog.Event) { e.Detail = "context" }),
+	}
+	tr, _ := Reconstruct(events)
+
+	a := tr.Nodes["a"]
+	if len(a.Children) != 0 {
+		t.Errorf("handoff created ownership children %v — it must be overlay only", a.Children)
+	}
+	if len(a.Handoffs) != 1 || a.Handoffs[0].To != "b" {
+		t.Fatalf("handoff overlay = %+v, want one edge to b", a.Handoffs)
+	}
+	if tr.Nodes["b"].Parent != "" {
+		t.Errorf("handoff re-parented b to %q — ownership must be untouched", tr.Nodes["b"].Parent)
+	}
+	// Both remain roots: neither owns the other.
+	if len(tr.Roots) != 2 {
+		t.Errorf("Roots = %v, want both a and b", tr.Roots)
+	}
+}
+
+// Ownership is single by definition. A second claim is a collaboration
+// relationship, not a re-parenting — otherwise the "tree" silently becomes a
+// graph and drill-down breaks.
+func TestApply_NodeKeepsFirstOwner(t *testing.T) {
+	events := []runlog.Event{
+		ev(1, runlog.KindTaskStarted, agent("p1")),
+		ev(2, runlog.KindTaskStarted, agent("p2")),
+		ev(3, runlog.KindTaskStarted, agent("c"), parent("p1")),
+		ev(4, runlog.KindTaskStarted, agent("c"), parent("p2")), // second claim
+	}
+	tr, _ := Reconstruct(events)
+
+	if got := tr.Nodes["c"].Parent; got != "p1" {
+		t.Errorf("c parent = %q, want p1 (first owner wins)", got)
+	}
+	if len(tr.Nodes["p2"].Children) != 0 {
+		t.Errorf("p2 gained children %v from a second ownership claim", tr.Nodes["p2"].Children)
+	}
+}
+
+// The property that makes shipping both functions safe: folding events one at a
+// time must equal reconstructing them in bulk. If these diverge, the desktop
+// app's incremental path and the terminal's full-rebuild path show different
+// trees for the same run.
+func TestApply_EqualsReconstruct(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	kinds := []runlog.Kind{
+		runlog.KindTaskStarted, runlog.KindHeadSelected, runlog.KindDispatchFinished,
+		runlog.KindError, runlog.KindAttempt, runlog.KindSample, runlog.KindEdit,
+	}
+	agents := []string{"a", "b", "c", "d"}
+
+	for trial := 0; trial < 50; trial++ {
+		var events []runlog.Event
+		for i := 0; i < 40; i++ {
+			mods := []func(*runlog.Event){agent(agents[rng.Intn(len(agents))])}
+			if rng.Intn(3) == 0 {
+				mods = append(mods, parent(agents[rng.Intn(len(agents))]))
+			}
+			if rng.Intn(4) == 0 {
+				mods = append(mods, status("ok"), cost(rng.Float64()))
+			}
+			events = append(events, ev(uint64(i+1), kinds[rng.Intn(len(kinds))], mods...))
+		}
+
+		bulk, _ := Reconstruct(events)
+
+		folded := NewTree(events[0].RunID)
+		for _, e := range events {
+			folded = Apply(folded, e)
+		}
+
+		if len(bulk.Nodes) != len(folded.Nodes) {
+			t.Fatalf("trial %d: bulk has %d nodes, folded has %d", trial, len(bulk.Nodes), len(folded.Nodes))
+		}
+		if fmt.Sprint(bulk.Roots) != fmt.Sprint(folded.Roots) {
+			t.Fatalf("trial %d: roots differ: bulk=%v folded=%v", trial, bulk.Roots, folded.Roots)
+		}
+		if fmt.Sprint(bulk.Order) != fmt.Sprint(folded.Order) {
+			t.Fatalf("trial %d: creation order differs", trial)
+		}
+		for id, bn := range bulk.Nodes {
+			fn, ok := folded.Nodes[id]
+			if !ok {
+				t.Fatalf("trial %d: folded missing node %q", trial, id)
+			}
+			if bn.Parent != fn.Parent || bn.State != fn.State ||
+				fmt.Sprint(bn.Children) != fmt.Sprint(fn.Children) ||
+				bn.CostUSD != fn.CostUSD {
+				t.Fatalf("trial %d: node %q differs:\n bulk=%+v\n fold=%+v", trial, id, bn, fn)
+			}
+		}
+	}
+}
+
+// A live UI must survive a log written by a newer Hydra than itself.
+func TestApply_UnknownKindDoesNotPanic(t *testing.T) {
+	tr := NewTree("run-x")
+	tr = Apply(tr, ev(1, runlog.Kind("kind_from_the_future"), agent("a")))
+	if len(tr.Nodes) != 1 {
+		t.Fatalf("unknown kind produced %d nodes, want 1", len(tr.Nodes))
+	}
+	if tr.Nodes["a"].State != StatePending {
+		t.Errorf("unknown kind set state %q, want pending", tr.Nodes["a"].State)
+	}
+}
+
+// Events that belong to no node are counted, not silently dropped — a partial
+// run must not render as a complete one.
+func TestApply_UnattributableEventsAreCounted(t *testing.T) {
+	tr := NewTree("run-x")
+	tr = Apply(tr, ev(1, runlog.KindAttempt)) // no agent/head/task
+	if tr.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", tr.Skipped)
+	}
+	// Run-level events legitimately have no node and must not count as skipped.
+	tr = Apply(tr, ev(2, runlog.KindRunStarted))
+	tr = Apply(tr, ev(3, runlog.KindRunFinished))
+	if tr.Skipped != 1 {
+		t.Errorf("Skipped = %d after run-level events, want still 1", tr.Skipped)
+	}
+}
+
+func TestApply_NilTreeIsCreated(t *testing.T) {
+	tr := Apply(nil, ev(1, runlog.KindTaskStarted, agent("a")))
+	if tr == nil || len(tr.Nodes) != 1 {
+		t.Fatalf("Apply(nil) = %+v, want a tree with one node", tr)
+	}
+	if tr.RunID != "run-1" {
+		t.Errorf("RunID = %q, want run-1", tr.RunID)
+	}
+}
+
+func TestReconstruct_EmptyIsUsable(t *testing.T) {
+	tr, tl := Reconstruct(nil)
+	if tr == nil || tl == nil {
+		t.Fatal("Reconstruct(nil) returned nil")
+	}
+	if len(tr.Rows()) != 0 || len(tl.Entries) != 0 {
+		t.Error("empty run produced rows or entries")
+	}
+}
+
+func TestRows_DepthAndLastFlags(t *testing.T) {
+	events := []runlog.Event{
+		ev(1, runlog.KindTaskStarted, agent("root")),
+		ev(2, runlog.KindTaskStarted, agent("a"), parent("root")),
+		ev(3, runlog.KindTaskStarted, agent("b"), parent("root")),
+		ev(4, runlog.KindTaskStarted, agent("a1"), parent("a")),
+	}
+	tr, _ := Reconstruct(events)
+	rows := tr.Rows()
+
+	if len(rows) != 4 {
+		t.Fatalf("got %d rows, want 4", len(rows))
+	}
+	want := []struct {
+		id    string
+		depth int
+		last  bool
+	}{
+		{"root", 0, true},
+		{"a", 1, false},
+		{"a1", 2, true},
+		{"b", 1, true},
+	}
+	for i, w := range want {
+		if rows[i].Node.ID != w.id || rows[i].Depth != w.depth || rows[i].Last != w.last {
+			t.Errorf("row %d = {%s d=%d last=%v}, want {%s d=%d last=%v}",
+				i, rows[i].Node.ID, rows[i].Depth, rows[i].Last, w.id, w.depth, w.last)
+		}
+	}
+}
+
+// A log that lost a parent event must still show its orphans, not silently
+// hide work that happened.
+func TestRows_OrphansAreStillShown(t *testing.T) {
+	tr := NewTree("run-x")
+	// Child references a parent that never got its own event... which link()
+	// creates. Simulate a true orphan by adding a node with a parent that is
+	// removed from Roots but unreachable: easiest is a self-consistent tree
+	// plus a node created directly.
+	tr = Apply(tr, ev(1, runlog.KindTaskStarted, agent("visible")))
+	tr = Apply(tr, ev(2, runlog.KindTaskStarted, agent("orphan")))
+	// Manually break reachability the way a corrupt log could.
+	tr.Roots = []string{"visible"}
+
+	rows := tr.Rows()
+	var sawOrphan bool
+	for _, r := range rows {
+		if r.Node.ID == "orphan" {
+			sawOrphan = true
+		}
+	}
+	if !sawOrphan {
+		t.Error("an unreachable node vanished from Rows — work would be hidden")
+	}
+}
+
+func TestTree_Aggregates(t *testing.T) {
+	events := []runlog.Event{
+		ev(1, runlog.KindDispatchFinished, agent("a"), status("ok"), cost(0.02)),
+		ev(2, runlog.KindDispatchFinished, agent("b"), status("ok"), cost(0.03)),
+		ev(3, runlog.KindError, agent("c"), status("failed")),
+	}
+	tr, _ := Reconstruct(events)
+
+	if got := tr.TotalCost(); got < 0.049 || got > 0.051 {
+		t.Errorf("TotalCost = %v, want ~0.05", got)
+	}
+	counts := tr.CountByState()
+	if counts[StateOK] != 2 {
+		t.Errorf("ok count = %d, want 2", counts[StateOK])
+	}
+	if counts[StateFailed] != 1 {
+		t.Errorf("failed count = %d, want 1", counts[StateFailed])
+	}
+	start, end := tr.Span()
+	if start.IsZero() || end.IsZero() {
+		t.Errorf("Span() = (%v, %v), want a real interval", start, end)
+	}
+}
+
+func TestTimeline_SortedBySeq(t *testing.T) {
+	// Deliberately out of sequence order, as a merge of two sources could be.
+	events := []runlog.Event{
+		ev(3, runlog.KindAttempt, agent("a")),
+		ev(1, runlog.KindTaskStarted, agent("a")),
+		ev(2, runlog.KindHeadSelected, agent("a")),
+	}
+	_, tl := Reconstruct(events)
+	sorted := tl.SortedEntries()
+	for i, want := range []uint64{1, 2, 3} {
+		if sorted[i].Seq != want {
+			t.Errorf("sorted[%d].Seq = %d, want %d", i, sorted[i].Seq, want)
+		}
+	}
+	// The original slice must not be reordered under the caller.
+	if tl.Entries[0].Seq != 3 {
+		t.Error("SortedEntries mutated the underlying slice")
+	}
+}
+
+// The head-scoped events dispatch emits today must reconstruct sensibly, since
+// that is the only producer wired up so far.
+func TestReconstruct_FromRealDispatchShape(t *testing.T) {
+	events := []runlog.Event{
+		ev(1, runlog.KindHeadSelected, head("h1"), func(e *runlog.Event) { e.TaskID = "t1"; e.Tier = 3 }),
+		ev(2, runlog.KindError, head("h1"), status("failed"), func(e *runlog.Event) { e.Detail = "timeout" }),
+		ev(3, runlog.KindHeadSelected, head("h2"), func(e *runlog.Event) { e.TaskID = "t1"; e.Tier = 5 }),
+		ev(4, runlog.KindDispatchFinished, head("h2"), status("ok"), cost(0.01)),
+	}
+	tr, _ := Reconstruct(events)
+
+	if len(tr.Nodes) != 2 {
+		t.Fatalf("got %d nodes, want 2 (one per head tried)", len(tr.Nodes))
+	}
+	if tr.Nodes["h1"].State != StateFailed {
+		t.Errorf("h1 state = %q, want failed", tr.Nodes["h1"].State)
+	}
+	if tr.Nodes["h1"].Detail != "timeout" {
+		t.Errorf("h1 detail = %q, want the failure reason", tr.Nodes["h1"].Detail)
+	}
+	if tr.Nodes["h2"].State != StateOK {
+		t.Errorf("h2 state = %q, want ok", tr.Nodes["h2"].State)
+	}
+	if tr.Nodes["h2"].TaskID != "t1" && tr.Nodes["h1"].TaskID != "t1" {
+		t.Error("task id was not carried onto the nodes")
+	}
+}


### PR DESCRIPTION
## Problem
Both planned UIs need to turn a run's event log into a supervision tree and a timeline. Building that twice guarantees drift, and the two consumers have different enough cost profiles that a naive shared implementation would just get bypassed.

## Design

**Framework-free by construction.** Three imports — `runlog`, `sort`, `time`. Verified: `go list -f '{{.Deps}}'` shows no lipgloss/Bubble Tea/charm anywhere. The terminal calls it from a `tea.Cmd` and wraps the result in a `tea.Msg`; a desktop app calls a bound method or pushes over a channel. Both sit above; neither is visible to the package.

**Two overlaid graphs, kept apart** — `AGENT_TREE_MODEL.md`'s load-bearing decision. Ownership (`Parent`/`Children`) is a strict tree and governs navigation; A2A handoffs (`Handoffs`) are a DAG overlay on the same nodes. A handoff never becomes a child, and a node **keeps its first owner** — a second ownership claim is collaboration, not re-parenting. Conflating them turns drill-down from a tree into a graph, which the design doc names as the primary failure mode. Both behaviours are pinned by tests.

**`Apply` ships now, not later.** Full rebuild per tick is fine for the terminal's small node counts; a long-running desktop session folding thousands of accumulated events is a different cost profile, and retrofitting incremental fold after both consumers exist is the exact false economy this package avoids. A **property test over 50 randomised trials × 40 events** pins `fold-one-at-a-time == reconstruct-in-bulk`, so the two callers can never render different trees for the same run.

**Degrade visibly, never silently.** Unknown event kinds (a log written by a newer Hydra) don't panic; unattributable events increment `Skipped` rather than vanishing; nodes unreachable from a root are still rendered. Hidden work is worse than ugly work — a partial run must never look complete.

## Also included
`Rows()` flattens the tree with depth and last-child flags so every renderer doesn't re-derive box-drawing state; plus `TotalCost`, `Span`, `CountByState` for summary lines.

## Test plan
- [x] `gofmt`, `go build ./...`, `go vet ./...`, `go test -race ./...` — green
- [x] **90.0%** coverage, 13 tests
- [x] Ownership tree construction; handoff-is-overlay-not-ownership; first-owner-wins; `Apply ≡ Reconstruct` property; unknown kinds; unattributable events counted; nil tree; empty run; `Rows` depth/last flags; orphans still shown; aggregates; timeline sort stability (and that it doesn't mutate the caller's slice)
- [x] Reconstructs correctly from **the head-scoped event shape dispatch actually emits today** — including the select→fail→select→succeed fallback sequence

**Stacked on #186** — base is `feature/185-runlog-heartbeat`; retargets to `develop` as the chain merges. This is Phase 2 of the plan, pulled ahead of Phase 1.2 because the terminal tree view consumes it.

Closes #187