### PR TITLE
fix(tui): wire the cockpit dashboard to real data

### DIFF
--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -7,13 +7,26 @@ package tui
 // decisions, with a dashboard view (Tab). Neon identity, aqua interaction.
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ankit373/hydra/internal/budget"
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/cost"
+	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/pricing"
+	"github.com/ankit373/hydra/internal/probe"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/rank"
 )
 
 // ── palette (ck-prefixed to avoid clashing with splash.go/init.go) ──────────────
@@ -89,6 +102,43 @@ func ValidSnapshotView(view int) (ok bool, names []string) {
 	return ckValidView(view), append([]string(nil), ckViewNames...)
 }
 
+// ckHeadsFrom converts a real probe result into display rows, ranked the way
+// dispatch ranks them so the cockpit shows the order routing would actually
+// use. price comes from the live pricing DB; a head with no known price shows
+// 0, which renders as "—" rather than a fabricated figure.
+func ckHeadsFrom(heads []provider.Head, pr *pricing.DB) []ckHead {
+	out := make([]ckHead, 0, len(heads))
+	for _, h := range heads {
+		tier := rank.UITier(h)
+		var price float64
+		if pr != nil {
+			// Per-1K-token yardstick, only for the relative cost colour ramp.
+			price = pr.EstimateCost(tier, 1000, 0)
+		}
+		out = append(out, ckHead{
+			name:  h.Name,
+			tier:  tier,
+			price: price,
+			up:    executor.Supports(h),
+			color: ckTierColor(tier),
+		})
+	}
+	return out
+}
+
+// ckTierColor maps a capability tier onto the cost ramp: cheap local heads
+// green, mid amber, expensive frontier heads violet/red.
+func ckTierColor(tier int) lipgloss.Color {
+	switch {
+	case tier <= 2:
+		return ckViolet
+	case tier <= 6:
+		return ckCyan
+	default:
+		return ckCheap
+	}
+}
+
 // Cockpit is the interactive `hydra tui` model.
 type Cockpit struct {
 	w, h      int
@@ -99,9 +149,8 @@ type Cockpit struct {
 	heads     []ckHead
 	mode      string
 	runs      int
-	saved     float64
-	local     int
 	claudePct int
+	spend     float64 // today's real estimated spend, from cost.jsonl
 
 	// live code panel (chat+code view): a snippet streamed line-by-line.
 	codeLang  string
@@ -109,31 +158,84 @@ type Cockpit struct {
 	codeShown int
 	codeGen   int // generation guard so a new run cancels stale tick loops
 
-	// last dispatch confidence (dashboard figure).
-	lastConf   float64
-	lastTarget float64
-
 	// agent-tree view selection cursor.
 	treeSel int
 }
 
-// NewCockpit builds the cockpit model with discovered-head placeholders.
+// NewCockpit builds the cockpit from the machine's real state: heads from a
+// probe, the governor from state.json, spend from cost.jsonl.
+//
+// It previously shipped a hardcoded roster of five heads that may not exist on
+// this machine, a governor that counted up from 52 as you typed, and a price
+// table used to compute "savings" — all presented as live telemetry, and all
+// reachable by `--snapshot`, which generates imagery for the docs site (#189).
+// Anything not yet measurable is now omitted rather than simulated.
 func NewCockpit() Cockpit {
-	return Cockpit{
+	ctx, cancel := context.WithTimeout(context.Background(), ckProbeTimeout)
+	defer cancel()
+	probed := probe.Run(ctx)
+
+	pr := pricing.Load()
+	heads := ckHeadsFrom(probed.Heads, pr)
+
+	pct := ckClaudePct()
+	m := Cockpit{
 		mode:      "dispatch",
-		claudePct: 52,
-		heads: []ckHead{
-			{"agy · claude", 1, 0.015, true, ckViolet},
-			{"gemini pro", 5, 0.0012, true, ckCyan},
-			{"gemini flash", 8, 0.00012, true, ckCyan},
-			{"openrouter", 6, 0.0009, true, ckCyan},
-			{"qwen · local", 10, 0, true, ckCheap},
-		},
-		log: []string{
-			ckDimS.Render("🐉 Hydra initialised · 5 heads discovered · routing engine ready."),
-			ckDimS.Render("Type a task and press enter. Tab = chat/dash/tree · /trust /swarm /local · :q quits."),
-		},
+		claudePct: pct,
+		heads:     heads,
+		spend:     ckSpendToday(),
 	}
+
+	switch len(heads) {
+	case 0:
+		m.log = []string{
+			ckDimS.Render("🐉 Hydra initialised · no heads discovered."),
+			ckDimS.Render("Run `hyctl probe` to see what was found, or `hyctl init` to configure."),
+		}
+	default:
+		m.log = []string{
+			ckDimS.Render(fmt.Sprintf("🐉 Hydra initialised · %d head%s discovered · routing engine ready.",
+				len(heads), plural(len(heads)))),
+			ckDimS.Render("Type a task and press enter. Tab = chat/dash/tree · /trust /swarm /local · :q quits."),
+		}
+	}
+	return m
+}
+
+// ckProbeTimeout bounds startup: a wedged provider must not hang the cockpit
+// before it can draw anything.
+const ckProbeTimeout = 5 * time.Second
+
+// ckClaudePct reads the orchestrator's real context usage from state.json.
+// Absent state means unknown, which renders as unknown — not as a number.
+func ckClaudePct() int {
+	raw, err := os.ReadFile(filepath.Join(config.Dir(), "logs", "state.json"))
+	if err != nil {
+		return 0
+	}
+	var s struct {
+		ClaudePct int `json:"claude_pct"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return 0
+	}
+	return s.ClaudePct
+}
+
+// ckSpendToday returns today's real estimated spend from cost.jsonl.
+func ckSpendToday() float64 {
+	summary, err := cost.Summary()
+	if err != nil || summary == nil {
+		return 0
+	}
+	return summary.Today.EstCostUSD
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func (m Cockpit) Init() tea.Cmd { return nil }
@@ -244,13 +346,21 @@ func ckBaseName(n string) string {
 	return n
 }
 
-// run simulates a dispatch and appends the live routing decision to the log.
+// run previews the routing decision for a task and appends it to the log.
+// It does not execute anything — see the note it prints.
 func (m Cockpit) run(task string) Cockpit {
 	m.runs++
 	m.log = append(m.log, ckYouS.Render("❯ "+task))
 
 	enum, wantTier := classifyTask(task, m.mode)
 	idx := m.pickHead(wantTier)
+	// Since #189 the roster is a real probe, so it can legitimately be empty on
+	// a machine with nothing installed. There is no route to preview then, and
+	// inventing one is exactly what this PR removes.
+	if idx < 0 {
+		m.log = append(m.log, ckDimS.Render("  no heads discovered — run `hyctl probe` to see why"))
+		return m
+	}
 	h := m.heads[idx]
 	fell := m.mode != "local" && h.tier > wantTier
 
@@ -261,57 +371,41 @@ func (m Cockpit) run(task string) Cockpit {
 
 	cost := h.price
 	base, baseName := m.baseline()
-	saved := base - cost
-	if saved < 0 {
-		saved = 0
-	}
-	m.saved += saved
-	if h.tier >= 9 {
-		m.local++
-	}
-
-	target := 0.80
-	if m.mode == "trust" || hasFilePath(task) {
-		target = 0.95
-	}
-	reached := target
-	if h.tier <= 3 {
-		reached += 0.03
-	}
-	if h.tier >= 9 {
-		reached -= 0.06
-	}
-	if reached > 0.999 {
-		reached = 0.999
-	}
-	m.lastConf, m.lastTarget = reached, target
 
 	flow := ckDimS.Render("  prompt ") + ckAquaS.Render("→ ") + ckInkS.Render(enum) +
 		ckAquaS.Render(" → ") + ckDimS.Render(fmt.Sprintf("T%d", wantTier))
 	if fell {
-		flow += ckAquaS.Render(" → ") + ckMidS.Render("✗ rate-limited") +
-			ckAquaS.Render(" → ") + ckCyanS.Render(fmt.Sprintf("T%d fallback", h.tier))
+		flow += ckAquaS.Render(" → ") + ckMidS.Render("no head at that tier") +
+			ckAquaS.Render(" → ") + ckCyanS.Render(fmt.Sprintf("T%d", h.tier))
 	}
 	flow += ckAquaS.Render(" → ") + lipgloss.NewStyle().Foreground(h.color).Render(h.name)
 	m.log = append(m.log, flow)
 
 	costStr := "free (local)"
 	if cost > 0 {
-		costStr = fmt.Sprintf("$%.4f", cost)
+		costStr = fmt.Sprintf("~$%.4f", cost)
+	} else if base == 0 {
+		// No pricing data loaded — say so rather than implying "free".
+		costStr = "cost unknown"
 	}
-	m.log = append(m.log, ckDimS.Render("  route  ")+
-		lipgloss.NewStyle().Foreground(h.color).Render(h.name)+
-		ckDimS.Render(fmt.Sprintf("  %s  vs all-%s $%.4f", costStr, baseName, base)))
-	if hasFilePath(task) {
-		m.log = append(m.log, ckDimS.Render("  blast  ")+ckExpS.Render("κ=3.1 ⚠")+
-			ckDimS.Render("  12 dependents → confidence bar raised to 0.95"))
+	line := ckDimS.Render("  route  ") +
+		lipgloss.NewStyle().Foreground(h.color).Render(h.name) +
+		ckDimS.Render("  "+costStr)
+	if base > 0 {
+		line += ckDimS.Render(fmt.Sprintf("  vs all-%s ~$%.4f", baseName, base))
 	}
-	m.log = append(m.log, ckDimS.Render("  conf   ")+ckCyanS.Render(fmt.Sprintf("%.2f", reached))+
-		ckDimS.Render(fmt.Sprintf(" / target %.2f · SPRT ", target))+ckCheapS.Render("accept"))
-	m.log = append(m.log, ckCheapS.Render("  ✔ done")+ckDimS.Render("  · saved ")+
-		ckCheapS.Render(fmt.Sprintf("$%.4f", saved)))
+	m.log = append(m.log, line)
 
-	m.claudePct = min(96, 52+m.runs*3)
+	// Confidence and blast radius are deliberately absent. The cockpit used to
+	// print an invented "conf 0.98 / target 0.95 · SPRT accept" and a literal
+	// "κ=3.1 ⚠ 12 dependents" for any prompt containing a file path, with no
+	// trust or graph code involved. Both are real Hydra capabilities
+	// (`--confidence`, `--file`) but reach them via the CLI until the cockpit
+	// executes dispatches for real — a fabricated number is worse than none,
+	// especially since --snapshot publishes these frames (#189).
+	m.log = append(m.log, ckDimS.Render("  plan   ")+
+		ckDimS.Render("routing preview only — the cockpit does not execute dispatches yet"))
+
 	return m
 }
 
@@ -332,7 +426,7 @@ func (m Cockpit) pickHead(wantTier int) int {
 				return i
 			}
 		}
-		return len(m.heads) - 1
+		return len(m.heads) - 1 // -1 when the roster is empty; callers must check
 	}
 	return best
 }
@@ -380,19 +474,22 @@ func (m Cockpit) chatCode(bodyH int) string {
 func (m Cockpit) header() string {
 	viewName := ckViewName(m.view)
 	left := ckWordmark("HYDRA") + ckDimS.Render(" ▸ ") + ckCyanS.Render(viewName) +
-		ckDimS.Render(" · heads: agy·gemini·openrouter·qwen")
-	mode, mc := "normal", ckCheapS
-	switch {
-	case m.claudePct >= 75:
-		mode, mc = "critical", ckExpS
-	case m.claudePct >= 65:
-		mode, mc = "warning", ckMidS
-	case m.claudePct >= 50:
-		mode, mc = "compact", ckMidS
+		ckDimS.Render(" · "+m.headSummary())
+
+	// budget.ModeFor is the single source of truth for the band. This used to
+	// re-implement the thresholds inline — a fourth copy, alongside the two in
+	// cockpit_views.go and the real one in internal/budget (#189).
+	mode := budget.ModeFor(m.claudePct)
+	mc := ckCheapS
+	switch mode.String() {
+	case "critical", "emergency":
+		mc = ckExpS
+	case "warning", "caution", "compact":
+		mc = ckMidS
 	}
-	right := ckDimS.Render("MODE ") + mc.Render(mode) +
+	right := ckDimS.Render("MODE ") + mc.Render(mode.String()) +
 		ckDimS.Render(fmt.Sprintf(" %d%%   ", m.claudePct)) +
-		ckDimS.Render("saved ") + ckCheapS.Render(fmt.Sprintf("$%.2f", m.saved))
+		ckDimS.Render("today ") + ckCheapS.Render(fmt.Sprintf("$%.4f", m.spend))
 	gap := m.w - lipgloss.Width(left) - lipgloss.Width(right) - 2
 	if gap < 1 {
 		gap = 1
@@ -558,4 +655,19 @@ func truncate(s string, n int) string {
 		return s[:n]
 	}
 	return s[:n-1] + "…"
+}
+
+// headSummary names the discovered heads for the header, truncated to keep the
+// bar from wrapping. It replaced a hardcoded "agy·gemini·openrouter·qwen"
+// string that named heads the machine may not have (#189).
+func (m Cockpit) headSummary() string {
+	if len(m.heads) == 0 {
+		return "no heads"
+	}
+	names := make([]string, 0, len(m.heads))
+	for _, h := range m.heads {
+		names = append(names, ckBaseName(h.name))
+	}
+	s := "heads: " + strings.Join(names, "·")
+	return truncate(s, 46)
 }

--- a/internal/tui/cockpit_views.go
+++ b/internal/tui/cockpit_views.go
@@ -4,17 +4,19 @@ package tui
 
 // cockpit_views.go — the three cockpit view modes cycled by Tab:
 //   view 0  chat + live code panel   (chatCode → codePanel)
-//   view 1  dashboard / fleet pulse  (dash)
-//   view 2  agent supervision tree   (tree)
-// plus their pure helpers (syntax highlighter, sparklines, tier/state colour
-// ramps, the fixed example agent tree). Neon identity via the ck-prefixed
-// palette declared in cockpit.go.
+//   view 1  dashboard                (dash) — reads real probe/cost/trust data
+//   view 2  agent supervision tree   (tree) — still a fixed example; see #189
+// plus their pure helpers (syntax highlighter, tier/state colour ramps). Neon
+// identity via the ck-prefixed palette declared in cockpit.go.
 
 import (
 	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ankit373/hydra/internal/budget"
+	"github.com/ankit373/hydra/internal/trust"
 )
 
 // ── view 0 · live code panel ─────────────────────────────────────────────────
@@ -62,62 +64,85 @@ func (m Cockpit) codePanel(w, h int) string {
 
 // ── view 1 · dashboard ───────────────────────────────────────────────────────
 
-// dash is the fleet pulse: per-head sparklines, cost saved, confidence, and the
-// band-coloured governor gauge.
+// dash is the fleet pulse: discovered heads, real spend, real calibration
+// stats, and the governor gauge.
+//
+// Everything here reads a real source. It previously rendered LCG-hashed
+// "sparklines", a per-head confidence bucketed by tier, and a savings figure
+// derived from an invented price table — all with no backing data (#189).
+// Where a real figure is not available yet it is labelled unavailable rather
+// than invented, because --snapshot publishes these frames.
 func (m Cockpit) dash(w, h int) string {
 	var fleet strings.Builder
-	fleet.WriteString(ckLabelS.Render("FLEET PULSE · heads") + "\n\n")
+	fleet.WriteString(ckLabelS.Render("FLEET · discovered heads") + "\n\n")
+	if len(m.heads) == 0 {
+		fleet.WriteString(ckDimS.Render(" no heads discovered — run `hyctl probe`") + "\n")
+	}
 	for _, hd := range m.heads {
 		st := ckCheapS.Render("● up  ")
 		if !hd.up {
 			st = ckExpS.Render("● down")
 		}
-		name := lipgloss.NewStyle().Foreground(hd.color).Width(14).Render(truncate(hd.name, 14))
-		spark := lipgloss.NewStyle().Foreground(hd.color).
-			Render(ckSparkStr(ckSparkVals(ckHashSeed(hd.name)+m.runs, 14)))
-		conf := 0.80
-		switch {
-		case hd.tier <= 3:
-			conf = 0.94
-		case hd.tier >= 9:
-			conf = 0.74
+		name := lipgloss.NewStyle().Foreground(hd.color).Width(18).Render(truncate(hd.name, 18))
+		price := ckDimS.Render("       —")
+		if hd.price > 0 {
+			price = ckDimS.Render(fmt.Sprintf(" ~$%.4f", hd.price))
 		}
 		fleet.WriteString(" " + name + " " + st +
-			ckDimS.Render(fmt.Sprintf(" T%-2d ", hd.tier)) + spark +
-			ckDimS.Render(fmt.Sprintf("  %.2f", conf)) + "\n")
+			ckDimS.Render(fmt.Sprintf(" T%-2d", hd.tier)) + price + "\n")
 	}
-	fleet.WriteString("\n" + ckDimS.Render(fmt.Sprintf("%d dispatches · %d local · mode ", m.runs, m.local)) +
-		ckCyanS.Render(m.mode))
+	fleet.WriteString("\n" + ckDimS.Render(fmt.Sprintf("%d head%s · mode ",
+		len(m.heads), plural(len(m.heads)))) + ckCyanS.Render(m.mode))
 
-	savedPct := int(m.saved * 40)
-	_, baseName := m.baseline()
-	saveBox := ckLabelS.Render("SAVED vs all-"+baseName) + "\n\n " +
-		lipgloss.NewStyle().Foreground(ckCheap).Bold(true).Render(fmt.Sprintf("$%.4f", m.saved)) + "\n " +
-		ckBar(min(100, savedPct), 20) + "\n " + ckDimS.Render(fmt.Sprintf("%d runs routed cheap", m.runs))
+	// Real spend, from cost.jsonl.
+	spendBox := ckLabelS.Render("SPEND · today") + "\n\n " +
+		lipgloss.NewStyle().Foreground(ckCheap).Bold(true).Render(fmt.Sprintf("$%.4f", m.spend)) + "\n " +
+		ckFaintS.Render("estimated, not billed") + "\n " +
+		ckDimS.Render("`hyctl cost` for the breakdown")
 
-	confBox := ckLabelS.Render("CONFIDENCE · last dispatch") + "\n\n " +
-		lipgloss.NewStyle().Foreground(ckCyan).Bold(true).Render(fmt.Sprintf("%.2f", m.lastConf)) +
-		ckDimS.Render(fmt.Sprintf("  / target %.2f", m.lastTarget)) + "\n " +
-		ckBar(int(m.lastConf*100), 20) + "\n " + ckDimS.Render("SPRT ") + ckCheapS.Render("accept")
+	// Real calibration stats, from trust.jsonl.
+	confBox := ckLabelS.Render("TRUST · calibration") + "\n\n " + m.trustSummary()
 
-	band, bc := "normal", ckCheapS
-	switch {
-	case m.claudePct >= 75:
-		band, bc = "critical", ckExpS
-	case m.claudePct >= 65:
-		band, bc = "warning", ckMidS
-	case m.claudePct >= 50:
-		band, bc = "compact", ckMidS
+	// One source of truth for the band — internal/budget. This block used to
+	// re-implement the thresholds, making a third copy that already disagreed
+	// with the governor (CLAUDE.md forbids exactly this).
+	mode := budget.ModeFor(m.claudePct)
+	bc := ckCheapS
+	switch mode.String() {
+	case "critical", "emergency":
+		bc = ckExpS
+	case "warning", "caution":
+		bc = ckMidS
+	case "compact":
+		bc = ckMidS
+	}
+	govLine := ckDimS.Render("band ") + bc.Render(mode.String())
+	if m.claudePct == 0 {
+		govLine = ckFaintS.Render("no claude_pct in state.json yet")
 	}
 	govBox := ckLabelS.Render("GOVERNOR · claude_pct") + "\n\n " + ckBar(m.claudePct, 20) +
-		ckDimS.Render(fmt.Sprintf("  %d%%", m.claudePct)) + "\n " +
-		ckDimS.Render("band ") + bc.Render(band) + "\n " +
-		ckFaintS.Render("first-passage → 80%: ") + ckCheapS.Render("low")
+		ckDimS.Render(fmt.Sprintf("  %d%%", m.claudePct)) + "\n " + govLine
 
 	right := lipgloss.JoinVertical(lipgloss.Left,
-		ckBoxS.Render(saveBox), ckBoxS.Render(confBox), ckBoxS.Render(govBox))
+		ckBoxS.Render(spendBox), ckBoxS.Render(confBox), ckBoxS.Render(govBox))
 	row := lipgloss.JoinHorizontal(lipgloss.Top, ckBoxS.Render(fleet.String()), " ", right)
 	return lipgloss.NewStyle().Width(w).Height(h).Render(row)
+}
+
+// trustSummary renders real SPRT statistics, or says plainly that there are
+// none yet. It never invents a confidence figure.
+func (m Cockpit) trustSummary() string {
+	runs, err := trust.LoadRuns(trust.DefaultLogPath())
+	if err != nil || len(runs) == 0 {
+		return ckFaintS.Render("no SPRT runs recorded") + "\n " +
+			ckDimS.Render("`hyctl dispatch --confidence 0.95 …`")
+	}
+	st := trust.Aggregate(runs, 5)
+	return lipgloss.NewStyle().Foreground(ckCyan).Bold(true).
+		Render(fmt.Sprintf("%.2f", st.MeanFinalConf)) +
+		ckDimS.Render(fmt.Sprintf("  mean over %d run%s", st.Runs, plural(st.Runs))) + "\n " +
+		ckBar(int(st.MeanFinalConf*100), 20) + "\n " +
+		ckDimS.Render(fmt.Sprintf("%.1f samples · %.0f%% auto-cleared", st.MeanSamples, st.AutoClearedPct))
 }
 
 // ── view 2 · agent tree ──────────────────────────────────────────────────────
@@ -315,46 +340,6 @@ func ckSnippet(enum string) (string, []string) {
 }
 
 // ── sparklines + colour ramps ────────────────────────────────────────────────
-
-var ckBlocks = []rune("▁▂▃▄▅▆▇█")
-
-// ckSparkVals produces n deterministic values in [0,1] from a seed (LCG) — a
-// stable but lively pulse trace per head.
-func ckSparkVals(seed, n int) []float64 {
-	s := uint32(seed)*2654435761 | 1
-	out := make([]float64, n)
-	for i := range out {
-		s = s*1664525 + 1013904223
-		out[i] = float64(s>>24) / 255.0
-	}
-	return out
-}
-
-// ckSparkStr maps [0,1] values to block glyphs ▁▂▃▄▅▆▇█.
-func ckSparkStr(vals []float64) string {
-	var b strings.Builder
-	for _, x := range vals {
-		idx := int(x * float64(len(ckBlocks)))
-		if idx >= len(ckBlocks) {
-			idx = len(ckBlocks) - 1
-		}
-		if idx < 0 {
-			idx = 0
-		}
-		b.WriteRune(ckBlocks[idx])
-	}
-	return b.String()
-}
-
-// ckHashSeed is a small FNV-1a hash used only to seed sparklines.
-func ckHashSeed(s string) int {
-	h := uint32(2166136261)
-	for _, r := range s {
-		h ^= uint32(r)
-		h *= 16777619
-	}
-	return int(h & 0x7fffffff)
-}
 
 // ckCostColor ramps the cost/tier scale: T1 (expensive) red → mid amber →
 // T10 (cheap, local) green.


### PR DESCRIPTION
## Problem
`hyctl tui` bills itself as "chat, route work, and watch spend live" while **inventing every number**. `cockpit.go` imported nothing from `provider`, `dispatch`, `trust`, or `probe`.

This is not only cosmetic: **`--snapshot` generates imagery for the docs site**, so fabricated figures could be published as measured.

## Before / after, on this machine

**Before** — five hardcoded heads that may not exist here, LCG-hashed "sparklines", per-head confidence bucketed by tier, and a fabricated **0.98** confidence:
```
│  agy · claude   ● up   T1  ▇▁▁▁▄▃▆▄▆▃▅▅▄▆  0.94 │ │ SAVED vs all-claude   │
│  gemini pro     ● up   T5  ▂▅▂▂▂▇▁█▅▆▆█▄▁  0.80 │ │  $0.0149              │
│ 2 dispatches · 0 local                          │ │ CONFIDENCE · last dispatch │
                                                    │  0.98  / target 0.95       │
```

**After** — 11 real discovered heads with Ollama correctly shown down, real tiers, real pricing, and the **real 0.50 mean confidence over 16 recorded SPRT runs**:
```
│  Claude Code        ● up   T1  ~$0.0150 │ │ SPEND · today                   │
│  Gemini 3.5 Flash … ● up   T9  ~$0.0001 │ │  $0.0000  estimated, not billed │
│  Ollama             ● down T9  ~$0.0001 │ │ TRUST · calibration             │
│ 11 heads · mode dispatch                │ │  0.50  mean over 16 runs        │
                                            │  2.5 samples · 0% auto-cleared  │
```
That 0.50 / 0% is the genuine calibration ceiling — the pathology diagnosed earlier in this repo's own benchmark work, now visible instead of masked by an invented 0.98.

## What was removed rather than reimplemented
Per-head confidence and blast radius are **gone, not faked**. Both are real capabilities (`--confidence`, `--file`), but the cockpit cannot execute dispatches yet, and an absent figure is honest where an invented one is not. `run()` now states it is a routing preview instead of printing `✔ done` for work that never happened.

## Bonus: four copies of the governor band table → one
`cockpit.go:header()` and two blocks in `cockpit_views.go` each re-implemented the claude_pct thresholds, **already disagreeing with `budget.ModeFor`** (no `caution`, no `emergency`). All now call `budget.ModeFor`. This is the exact duplication CLAUDE.md calls out.

Dead code removed: `ckSparkVals`/`ckSparkStr`/`ckHashSeed` (grep-confirmed zero remaining callers), plus the `saved`/`local`/`lastConf`/`lastTarget` fields.

## Scope
Dashboard only. **The agent-tree view is deliberately untouched** — `ckTree` is a flat literal with hand-typed indentation and no renderer for arbitrary depth, so it is new code, not a data-source swap. That is Phase 1.2, built on `internal/tree` (#187).

Deliberately does **not** touch the view-name lookup line, which #179 owns, to avoid a pointless conflict.

## Test plan
- [x] `gofmt`, `go build ./...`, `go vet ./...`, `go test -race ./...` — green
- [x] Rendered `--snapshot --view 1` against this machine's real state (output above)

**Stacked on #188** — retargets to `develop` as the chain merges.

Closes #189