### PR TITLE
feat(tui): render the agent tree from real run events

### DIFF
--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -27,6 +27,8 @@ import (
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/tree"
 )
 
 // ── palette (ck-prefixed to avoid clashing with splash.go/init.go) ──────────────
@@ -158,8 +160,11 @@ type Cockpit struct {
 	codeShown int
 	codeGen   int // generation guard so a new run cancels stale tick loops
 
-	// agent-tree view selection cursor.
-	treeSel int
+	// agent-tree view: the reconstructed run and its flattened rows.
+	treeSel  int
+	runID    string
+	runLive  bool
+	treeRows []tree.Row
 }
 
 // NewCockpit builds the cockpit from the machine's real state: heads from a
@@ -185,6 +190,7 @@ func NewCockpit() Cockpit {
 		heads:     heads,
 		spend:     ckSpendToday(),
 	}
+	m.runID, m.runLive, m.treeRows = ckLoadTree()
 
 	switch len(heads) {
 	case 0:
@@ -263,7 +269,7 @@ func (m Cockpit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.treeSel--
 			}
 		case tea.KeyDown:
-			if m.view == 2 && m.treeSel < len(ckTree)-1 {
+			if m.view == 2 && m.treeSel < len(m.treeRows)-1 {
 				m.treeSel++
 			}
 		case tea.KeyEnter:
@@ -670,4 +676,26 @@ func (m Cockpit) headSummary() string {
 	}
 	s := "heads: " + strings.Join(names, "·")
 	return truncate(s, 46)
+}
+
+// ckLoadTree reconstructs the run to display: the live one if a heartbeat is
+// fresh, else the most recent. Returns no rows when nothing has been recorded,
+// which the view renders as an honest empty state rather than an example (#191).
+func ckLoadTree() (runID string, live bool, rows []tree.Row) {
+	if ids, err := runlog.LiveRuns(); err == nil && len(ids) > 0 {
+		runID, live = ids[0], true
+	} else {
+		ids, err := runlog.Runs()
+		if err != nil || len(ids) == 0 {
+			return "", false, nil
+		}
+		runID = ids[0]
+	}
+
+	events, err := runlog.Load(runID)
+	if err != nil || len(events) == 0 {
+		return runID, live, nil
+	}
+	t, _ := tree.Reconstruct(events)
+	return runID, live, t.Rows()
 }

--- a/internal/tui/cockpit_tree_test.go
+++ b/internal/tui/cockpit_tree_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/tree"
+)
+
+// The old view stored a box-drawing prefix per node, which is why it could only
+// ever render one fixed shape. Deriving it from depth/last is what makes
+// arbitrary depth and branching work.
+func TestTreePrefix_DerivedFromDepthAndLast(t *testing.T) {
+	tests := []struct {
+		name  string
+		depth int
+		last  bool
+		want  string
+	}{
+		{"root", 0, false, ""},
+		{"root last", 0, true, ""},
+		{"child", 1, false, "├─ "},
+		{"last child", 1, true, "└─ "},
+		{"grandchild", 2, false, "│  ├─ "},
+		{"last grandchild", 2, true, "│  └─ "},
+		{"depth 4", 4, false, "│  │  │  ├─ "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := treePrefix(tree.Row{Depth: tt.depth, Last: tt.last})
+			if got != tt.want {
+				t.Errorf("treePrefix(depth=%d,last=%v) = %q, want %q", tt.depth, tt.last, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeLabel_PrefersHeadOverID(t *testing.T) {
+	if got := nodeLabel(&tree.Node{ID: "abc123", Head: "claude"}); got != "claude" {
+		t.Errorf("nodeLabel = %q, want the head name", got)
+	}
+	if got := nodeLabel(&tree.Node{ID: "abc123"}); got != "abc123" {
+		t.Errorf("nodeLabel with no head = %q, want the id", got)
+	}
+}
+
+// With nothing recorded the view must say so and point at how to produce a run
+// — never fall back to a fictional example, which is what it used to show.
+func TestTreeView_EmptyStateIsHonest(t *testing.T) {
+	m := Cockpit{w: 100, h: 30, ready: true}
+	out := m.tree(100, 30)
+
+	if !strings.Contains(out, "no runs recorded") {
+		t.Errorf("empty tree view does not say it is empty:\n%s", out)
+	}
+	if !strings.Contains(out, "hyctl dispatch") {
+		t.Error("empty state does not tell the user how to produce a run")
+	}
+	// The fictional run must be gone for good.
+	for _, ghost := range []string{"token-rotation", "worker-1", "orchestrator"} {
+		if strings.Contains(out, ghost) {
+			t.Errorf("empty view still shows the old fictional node %q", ghost)
+		}
+	}
+}
+
+// A real run must render with correct structure at arbitrary depth.
+func TestTreeView_RendersRealRun(t *testing.T) {
+	events := []runlog.Event{
+		{V: 1, Seq: 1, RunID: "r", Kind: runlog.KindTaskStarted, Agent: "root"},
+		{V: 1, Seq: 2, RunID: "r", Kind: runlog.KindTaskStarted, Agent: "a", Parent: "root"},
+		{V: 1, Seq: 3, RunID: "r", Kind: runlog.KindTaskStarted, Agent: "deep", Parent: "a"},
+		{V: 1, Seq: 4, RunID: "r", Kind: runlog.KindDispatchFinished, Agent: "deep",
+			Head: "claude", Model: "M", Tier: 3, Status: "ok", CostUSD: 0.02, DurationMS: 1200},
+		{V: 1, Seq: 5, RunID: "r", Kind: runlog.KindTaskStarted, Agent: "b", Parent: "root"},
+	}
+	tr, _ := tree.Reconstruct(events)
+
+	m := Cockpit{w: 110, h: 30, ready: true, runID: "r", treeRows: tr.Rows()}
+	out := m.tree(110, 30)
+
+	// Depth-2 node must carry the nested prefix, which the old fixed-shape
+	// renderer could not produce for an arbitrary tree.
+	if !strings.Contains(out, "│  ") {
+		t.Errorf("no nested prefix rendered — depth is not being derived:\n%s", out)
+	}
+	for _, want := range []string{"root", "claude", "ok"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered tree missing %q:\n%s", want, out)
+		}
+	}
+	// Real cost from the event, not an invented figure.
+	if !strings.Contains(out, "0.0200") {
+		t.Errorf("real cost not rendered:\n%s", out)
+	}
+	if strings.Contains(out, "run r") == false {
+		t.Errorf("run id not shown in the header:\n%s", out)
+	}
+}
+
+// Confidence is shown only when recorded — the previous view printed one for
+// every node regardless.
+func TestTreeView_OmitsUnrecordedConfidence(t *testing.T) {
+	events := []runlog.Event{
+		{V: 1, Seq: 1, RunID: "r", Kind: runlog.KindDispatchFinished, Agent: "n1", Status: "ok"},
+	}
+	tr, _ := tree.Reconstruct(events)
+	m := Cockpit{w: 100, h: 30, ready: true, runID: "r", treeRows: tr.Rows()}
+
+	if strings.Contains(m.tree(100, 30), "confidence") {
+		t.Error("a confidence line was rendered for a node that never recorded one")
+	}
+}
+
+// A selection cursor beyond the row count must not panic — rows come from a
+// log whose length the view does not control.
+func TestTreeView_SelectionOutOfRangeIsSafe(t *testing.T) {
+	events := []runlog.Event{
+		{V: 1, Seq: 1, RunID: "r", Kind: runlog.KindTaskStarted, Agent: "only"},
+	}
+	tr, _ := tree.Reconstruct(events)
+
+	for _, sel := range []int{-5, 1, 99} {
+		m := Cockpit{w: 100, h: 30, ready: true, runID: "r", treeRows: tr.Rows(), treeSel: sel}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("treeSel=%d panicked: %v", sel, r)
+				}
+			}()
+			if out := m.tree(100, 30); out == "" {
+				t.Errorf("treeSel=%d rendered nothing", sel)
+			}
+		}()
+	}
+}
+
+// A2A handoffs must render as an overlay, distinct from ownership children.
+func TestTreeView_ShowsHandoffOverlay(t *testing.T) {
+	events := []runlog.Event{
+		{V: 1, Seq: 1, RunID: "r", Kind: runlog.KindTaskStarted, Agent: "a"},
+		{V: 1, Seq: 2, RunID: "r", Kind: runlog.KindTaskStarted, Agent: "b"},
+		{V: 1, Seq: 3, RunID: "r", Kind: runlog.KindHandoff, Agent: "a", Ref: "b", Detail: "ctx"},
+	}
+	tr, _ := tree.Reconstruct(events)
+	m := Cockpit{w: 100, h: 30, ready: true, runID: "r", treeRows: tr.Rows()}
+	out := m.tree(100, 30)
+
+	if !strings.Contains(out, "┄") {
+		t.Errorf("handoff overlay glyph not rendered:\n%s", out)
+	}
+}

--- a/internal/tui/cockpit_views.go
+++ b/internal/tui/cockpit_views.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/ankit373/hydra/internal/budget"
+	"github.com/ankit373/hydra/internal/tree"
 	"github.com/ankit373/hydra/internal/trust"
 )
 
@@ -147,84 +148,129 @@ func (m Cockpit) trustSummary() string {
 
 // ── view 2 · agent tree ──────────────────────────────────────────────────────
 
-// ckTreeNode is one node in the fixed example supervision tree. prefix carries
-// the box-drawing indent so the flat slice renders as a tree.
-type ckTreeNode struct {
-	prefix string
-	name   string
-	model  string
-	tier   int
-	state  string // returned | running | await | pending | failed
-	conf   float64
-	instr  string
-}
-
-// ckTree is a small, representative run: the orchestrator delegates key
-// rotation, tests, and docs; token-rotation itself fans out to two workers.
-var ckTree = []ckTreeNode{
-	{"", "orchestrator", "cortex · you", 1, "await", 0.71, "Coordinate: rotate signing key, add tests, update docs — target 0.95"},
-	{"├─ ", "design", "agy · claude", 3, "returned", 0.93, "Design a safe key-rotation; check blast radius κ=3.1 (12 dependents)"},
-	{"├─ ", "token-rotation", "agy · claude", 3, "running", 0.88, "Rotate signing key in internal/auth/token.go without breaking live tokens"},
-	{"│  ├─ ", "worker-1", "gemini pro", 6, "returned", 0.91, "Implement RotateSigningKey(): stage the new key, retire the old one"},
-	{"│  └─ ", "worker-2", "gemini flash", 8, "running", 0.62, "Update callers to reference the new active key ID"},
-	{"├─ ", "tests", "gemini pro", 6, "pending", 0.0, "Write rotation tests; verify pre-rotation tokens still verify"},
-	{"└─ ", "docs", "qwen · local", 10, "returned", 0.87, "Document the key-rotation runbook + rollback steps"},
-}
-
-// tree renders the supervision tree with a selection cursor and a detail line
-// for the highlighted node. Ownership edges are solid (─); the A2A handoff is
-// drawn dashed (┄) as an overlay note.
+// tree renders the supervision tree for a real run, reconstructed from the
+// per-run event log via internal/tree.
+//
+// It replaced a hand-authored 7-node literal in which each row carried its own
+// box-drawing indent as a string field — a picture of a tree rather than a
+// tree, fixed at one shape and describing a run that never happened (#191).
+// Prefixes are now derived from depth and last-child position, so arbitrary
+// depth and branching render correctly.
+//
+// Ownership edges are solid (─); A2A handoffs are a dashed overlay (┄), kept
+// visually distinct because they are a different relation, not a parent.
 func (m Cockpit) tree(w, h int) string {
-	sel := m.treeSel
-	if sel < 0 || sel >= len(ckTree) {
-		sel = 0
-	}
 	var b strings.Builder
 	b.WriteString(ckLabelS.Render("AGENT TREE · supervision") +
 		ckDimS.Render("   ownership ") + ckFaintS.Render("─") +
-		ckDimS.Render("   A2A ") + lipgloss.NewStyle().Foreground(ckMagenta).Render("┄") + "\n\n")
+		ckDimS.Render("   A2A ") + lipgloss.NewStyle().Foreground(ckMagenta).Render("┄"))
 
-	for i, n := range ckTree {
+	if m.runID != "" {
+		live := ""
+		if m.runLive {
+			live = ckCheapS.Render("  ● live")
+		}
+		b.WriteString(ckFaintS.Render("   run "+truncate(m.runID, 24)) + live)
+	}
+	b.WriteString("\n\n")
+
+	rows := m.treeRows
+	if len(rows) == 0 {
+		// No fictional fallback: say there is nothing and how to make some.
+		b.WriteString(ckFaintS.Render(" no runs recorded yet") + "\n\n" +
+			ckDimS.Render(" Run a dispatch to populate this view:") + "\n" +
+			ckDimS.Render("   hyctl dispatch \"add a retry to the token refresher\"") + "\n\n" +
+			ckFaintS.Render(" Events are written to ~/.hydra/logs/runs/<run_id>.jsonl"))
+		return lipgloss.NewStyle().Width(w).Height(h).Padding(0, 1).Render(b.String())
+	}
+
+	sel := m.treeSel
+	if sel < 0 || sel >= len(rows) {
+		sel = 0
+	}
+
+	for i, r := range rows {
 		marker := "  "
 		if i == sel {
 			marker = ckAquaS.Render("▸ ")
 		}
-		label := lipgloss.NewStyle().Foreground(ckCostColor(n.tier)).Bold(i == sel).Render(n.name)
-		conf := ckDimS.Render("conf ") + ckCyanS.Render(fmt.Sprintf("%.2f", n.conf))
-		if n.conf == 0 {
-			conf = ckDimS.Render("conf —")
+		n := r.Node
+		label := lipgloss.NewStyle().Foreground(ckCostColor(n.Tier)).Bold(i == sel).
+			Render(truncate(nodeLabel(n), 28))
+
+		line := marker + ckFaintS.Render(treePrefix(r)) + label +
+			ckDimS.Render(fmt.Sprintf("  T%-2d", n.Tier))
+		if n.Model != "" {
+			line += ckDimS.Render("  " + truncate(n.Model, 20))
 		}
-		b.WriteString(marker + ckFaintS.Render(n.prefix) + label + "  " +
-			ckDimS.Render(fmt.Sprintf("T%-2d", n.tier)) + "  " +
-			ckDimS.Render(n.model) + ckFaintS.Render(" · ") +
-			ckStateStyle(n.state).Render(n.state) + ckFaintS.Render(" · ") + conf + "\n")
+		line += ckFaintS.Render(" · ") + ckStateStyle(string(n.State)).Render(string(n.State))
+		if n.CostUSD > 0 {
+			line += ckFaintS.Render(" · ") + ckDimS.Render(fmt.Sprintf("$%.4f", n.CostUSD))
+		}
+		if len(n.Handoffs) > 0 {
+			line += lipgloss.NewStyle().Foreground(ckMagenta).
+				Render(fmt.Sprintf("  ┄%d", len(n.Handoffs)))
+		}
+		b.WriteString(line + "\n")
 	}
 
-	b.WriteString("\n     " + lipgloss.NewStyle().Foreground(ckMagenta).Render("┄┄▶ A2A") +
-		ckDimS.Render("  token-rotation → tests   ") +
-		ckFaintS.Render("(handoff: files resolved +1 · context compacted)") + "\n")
-
-	// selected-node detail
-	s := ckTree[sel]
+	// Selected-node detail.
+	s := rows[sel].Node
 	detail := ckLabelS.Render("SELECTED") + "  " +
-		lipgloss.NewStyle().Foreground(ckCostColor(s.tier)).Bold(true).Render(s.name) +
-		ckDimS.Render(fmt.Sprintf(" · T%d · %s · ", s.tier, s.model)) +
-		ckStateStyle(s.state).Render(s.state)
-	instrW := w - 18
-	if instrW < 10 {
-		instrW = 10
+		lipgloss.NewStyle().Foreground(ckCostColor(s.Tier)).Bold(true).Render(nodeLabel(s)) +
+		ckDimS.Render(fmt.Sprintf(" · T%d", s.Tier))
+	if s.Model != "" {
+		detail += ckDimS.Render(" · " + s.Model)
 	}
-	instr := ckDimS.Render("instruction  ") + ckInkS.Render(truncate(s.instr, instrW))
-	var confLine string
-	if s.conf > 0 {
-		confLine = ckDimS.Render("confidence   ") + ckBar(int(s.conf*100), 20) +
-			ckCyanS.Render(fmt.Sprintf("  %.2f", s.conf)) + ckDimS.Render(" / target 0.95")
-	} else {
-		confLine = ckDimS.Render("confidence   ") + ckFaintS.Render("pending — not yet dispatched")
+	detail += ckDimS.Render(" · ") + ckStateStyle(string(s.State)).Render(string(s.State))
+
+	lines := []string{b.String(), detail}
+
+	if s.DurationMS > 0 {
+		lines = append(lines, ckDimS.Render("duration     ")+
+			ckInkS.Render(fmt.Sprintf("%dms", s.DurationMS)))
+	}
+	if s.Detail != "" {
+		dw := w - 18
+		if dw < 10 {
+			dw = 10
+		}
+		lines = append(lines, ckDimS.Render("detail       ")+ckInkS.Render(truncate(s.Detail, dw)))
+	}
+	// Confidence is shown only when one was actually recorded — never invented.
+	if s.Confidence > 0 {
+		lines = append(lines, ckDimS.Render("confidence   ")+ckBar(int(s.Confidence*100), 20)+
+			ckCyanS.Render(fmt.Sprintf("  %.2f", s.Confidence)))
+	}
+	for _, hf := range s.Handoffs {
+		lines = append(lines, lipgloss.NewStyle().Foreground(ckMagenta).Render("┄┄▶ A2A      ")+
+			ckDimS.Render(hf.To+"  ")+ckFaintS.Render(truncate(hf.Detail, 40)))
 	}
 
-	body := b.String() + "\n" + detail + "\n" + instr + "\n" + confLine
-	return lipgloss.NewStyle().Width(w).Height(h).Padding(0, 1).Render(body)
+	return lipgloss.NewStyle().Width(w).Height(h).Padding(0, 1).
+		Render(strings.Join(lines, "\n"))
+}
+
+// nodeLabel prefers a human name over an opaque id.
+func nodeLabel(n *tree.Node) string {
+	if n.Head != "" {
+		return n.Head
+	}
+	return n.ID
+}
+
+// treePrefix builds the box-drawing indent from a row's depth and last-child
+// flag. The old implementation stored this string per node, which is why it
+// only ever rendered one fixed shape.
+func treePrefix(r tree.Row) string {
+	if r.Depth == 0 {
+		return ""
+	}
+	branch := "├─ "
+	if r.Last {
+		branch = "└─ "
+	}
+	return strings.Repeat("│  ", r.Depth-1) + branch
 }
 
 // ── syntax highlighter ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
The cockpit's agent-tree view was a **hand-authored 7-node literal**. Each row carried its own box-drawing indent as a string field (`"├─ "`, `"│  ├─ "`) — a *picture* of a tree, not a tree. It could only ever render that one fixed shape, and it described a run that never happened, with invented confidences, regardless of what Hydra had actually done.

## After — reconstructed from a real event log
```
 AGENT TREE · supervision   ownership ─   A2A ┄   run 20260801T120000Z-demo

   orchestrator  T0  · running
   ├─ design  T3   Claude Sonnet · ok · $0.0182
 ▸ ├─ token-rotation  T3   Claude Sonnet · running  ┄1
   │  ├─ worker-1  T6   Gemini Pro · ok · $0.0031
   │  └─ worker-2  T9   Gemini Flash · failed
   └─ tests  T10  Qwen local · running

 SELECTED  token-rotation · T3 · Claude Sonnet · running
 ┄┄▶ A2A      tests  files resolved +1
```
Every value there comes from `runlog` events via `tree.Reconstruct`: correct nesting at depth 2, the timed-out worker shown as failed, real costs, and the A2A handoff as a `┄1` overlay badge kept visually distinct from ownership.

## Changes
- **Prefixes derived from depth + last-child**, not stored per node — this is what makes arbitrary depth and branching work at all.
- Prefers a **live run** (fresh heartbeat, #185) over the most recent.
- **Confidence shown only when recorded.** The old view printed one for every node.
- **Honest empty state**: with nothing recorded it says so and shows the command to produce a run — no fictional fallback, since `--snapshot` publishes these frames.
- `ckTree`/`ckTreeNode` deleted (grep-confirmed).

## Test plan
- [x] `gofmt`, `go build ./...`, `go vet ./...`, `go test -race ./...` — green
- [x] End-to-end against a hand-written log in the real format (output above)
- [x] New tests: prefix derivation across four depths incl. last-child; `nodeLabel` fallback; empty state (and that the old fictional nodes are *gone*); real-run rendering with nested prefixes and real cost; confidence omitted when unrecorded; out-of-range selection is safe; handoff overlay renders

`internal/tui` had **zero tests** before this stack.

**Stacked on #190** — retargets to `develop` as the chain merges. This completes Phase 1.

Closes #191