### PR TITLE
feat(tui): restore the dashboard panels with real data

### DIFF
--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -65,6 +65,7 @@ var ckFileRe = regexp.MustCompile(`[\w/]+\.(go|ts|js|py|rs|java)`)
 // ── model ───────────────────────────────────────────────────────────────────────
 
 type ckHead struct {
+	id    string
 	name  string
 	tier  int
 	price float64
@@ -118,6 +119,7 @@ func ckHeadsFrom(heads []provider.Head, pr *pricing.DB) []ckHead {
 			price = pr.EstimateCost(tier, 1000, 0)
 		}
 		out = append(out, ckHead{
+			id:    h.ID,
 			name:  h.Name,
 			tier:  tier,
 			price: price,
@@ -152,7 +154,8 @@ type Cockpit struct {
 	mode      string
 	runs      int
 	claudePct int
-	spend     float64 // today's real estimated spend, from cost.jsonl
+	spend     float64   // today's real estimated spend, from cost.jsonl
+	metrics   ckMetrics // real latency/savings/blast/calibration, loaded once
 
 	// live code panel (chat+code view): a snippet streamed line-by-line.
 	codeLang  string
@@ -189,6 +192,7 @@ func NewCockpit() Cockpit {
 		claudePct: pct,
 		heads:     heads,
 		spend:     ckSpendToday(),
+		metrics:   ckLoadMetrics(pr),
 	}
 	m.runID, m.runLive, m.treeRows = ckLoadTree()
 
@@ -402,13 +406,26 @@ func (m Cockpit) run(task string) Cockpit {
 	}
 	m.log = append(m.log, line)
 
-	// Confidence and blast radius are deliberately absent. The cockpit used to
-	// print an invented "conf 0.98 / target 0.95 · SPRT accept" and a literal
-	// "κ=3.1 ⚠ 12 dependents" for any prompt containing a file path, with no
-	// trust or graph code involved. Both are real Hydra capabilities
-	// (`--confidence`, `--file`) but reach them via the CLI until the cockpit
-	// executes dispatches for real — a fabricated number is worse than none,
-	// especially since --snapshot publishes these frames (#189).
+	// Real blast radius, walked from graph.json, when the prompt names a file
+	// that is actually in the graph. This replaced a literal "κ=3.1 ⚠ 12
+	// dependents" printed for any prompt containing a file path (#193).
+	if f := ckFileRe.FindString(task); f != "" {
+		if radius, deps, kappa, ok := m.metrics.ckBlastFor(f); ok {
+			risk := ckCheapS
+			if kappa >= 2 {
+				risk = ckExpS
+			}
+			m.log = append(m.log, ckDimS.Render("  blast  ")+
+				risk.Render(fmt.Sprintf("κ=%.1f", kappa))+
+				ckDimS.Render(fmt.Sprintf("  %d dependent%s · radius %.2f×  → %s",
+					deps, plural(deps), radius, truncate(f, 40))))
+		}
+	}
+
+	// Confidence is still absent: it requires actually running the SPRT
+	// ensemble, which the cockpit cannot do until it executes dispatches. Blast
+	// radius above is different — it is a static graph property, computable
+	// without running anything.
 	m.log = append(m.log, ckDimS.Render("  plan   ")+
 		ckDimS.Render("routing preview only — the cockpit does not execute dispatches yet"))
 
@@ -650,8 +667,6 @@ func containsAny(s string, subs ...string) bool {
 	}
 	return false
 }
-
-func hasFilePath(s string) bool { return ckFileRe.MatchString(s) }
 
 func truncate(s string, n int) string {
 	if len(s) <= n {

--- a/internal/tui/cockpit_metrics.go
+++ b/internal/tui/cockpit_metrics.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// cockpit_metrics.go — the real numbers behind the dashboard.
+//
+// These panels previously showed invented values (an LCG-hashed "sparkline", a
+// confidence bucketed by tier, savings from a made-up price table, a literal
+// "κ=3.1 ⚠ 12 dependents"). #189 deleted them for being fake; that was half a
+// fix, because every one of them is computable from data Hydra already stores.
+// This file computes them for real. The rule is unchanged — never invent a
+// figure — but a figure that exists must be shown, not dropped.
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/cost"
+	"github.com/ankit373/hydra/internal/graph"
+	"github.com/ankit373/hydra/internal/pricing"
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+// ckMetrics is everything the dashboard needs, computed once at startup so the
+// render path stays pure and does no I/O.
+type ckMetrics struct {
+	latency  map[string][]float64 // model → recent wall_ms, oldest first
+	lastMS   map[string]int64     // model → most recent wall_ms
+	savedUSD float64              // real spend vs a top-tier baseline
+	baseUSD  float64              // what that baseline would have cost
+	spendUSD float64              // today's real spend
+	graph    *graph.Graph         // nil when graph.json is absent
+
+	// calibrator is nil when no calibration ledger exists yet.
+	calibrator *trust.Calibrator
+}
+
+// ckSparkWidth is how many samples a sparkline shows.
+const ckSparkWidth = 14
+
+// ckPricer is the per-tier cost lookup the savings panel needs. Taking an
+// interface rather than *pricing.DB keeps the arithmetic testable without a
+// resolvable registry/pricing.yaml on disk — the same reason internal/swarm
+// defines PricingReader.
+type ckPricer interface {
+	EstimateCost(tier, inputTokens, outputTokens int) float64
+}
+
+// ckLoadMetrics reads the real logs once. Every field degrades to empty rather
+// than to a placeholder value, so the renderer can tell "no data" from "zero".
+func ckLoadMetrics(pr *pricing.DB) ckMetrics {
+	m := ckMetrics{
+		latency: map[string][]float64{},
+		lastMS:  map[string]int64{},
+	}
+
+	rows, err := cost.LoadAll()
+	if err == nil && len(rows) > 0 {
+		m.latency, m.lastMS = ckLatencySeries(rows)
+		m.savedUSD, m.baseUSD = ckSavings(rows, pr)
+	}
+	if s, err := cost.Summary(); err == nil && s != nil {
+		m.spendUSD = s.Today.EstCostUSD
+	}
+	if cal, err := trust.New(trust.DefaultPath()); err == nil {
+		m.calibrator = cal
+	}
+	// graph.json is optional; a missing one simply means no blast radius.
+	if g, err := graph.Load(ckGraphPath()); err == nil {
+		m.graph = g
+	}
+	return m
+}
+
+// ckGraphPath locates graph.json the same way the CLI does.
+func ckGraphPath() string { return filepath.Join(config.ScriptHome(), "graph.json") }
+
+// ckLatencySeries turns cost rows into a per-model wall_ms history, oldest
+// first, capped at ckSparkWidth. cost.jsonl carries wall_ms on every row, so
+// this is a genuine latency trace — the thing the old LCG "sparkline" was
+// pretending to be.
+func ckLatencySeries(rows []cost.Row) (map[string][]float64, map[string]int64) {
+	byModel := map[string][]float64{}
+	last := map[string]int64{}
+	for _, r := range rows {
+		if r.WallMS <= 0 || r.Model == "" {
+			continue
+		}
+		byModel[r.Model] = append(byModel[r.Model], float64(r.WallMS))
+		last[r.Model] = r.WallMS
+	}
+	for k, v := range byModel {
+		if len(v) > ckSparkWidth {
+			byModel[k] = v[len(v)-ckSparkWidth:]
+		}
+	}
+	return byModel, last
+}
+
+// ckSavings compares what was actually spent against what the same work would
+// have cost routed entirely to tier 1 — the "one expensive model for
+// everything" baseline Hydra exists to beat. Both sides come from real rows;
+// the baseline is priced with the same pricing DB used for the real cost, so
+// the two are comparable.
+func ckSavings(rows []cost.Row, pr ckPricer) (saved, baseline float64) {
+	if pr == nil {
+		return 0, 0
+	}
+	var actual float64
+	for _, r := range rows {
+		actual += r.EstCostUSD
+		baseline += pr.EstimateCost(1, r.PromptTokens, r.ResponseTokens)
+	}
+	saved = baseline - actual
+	if saved < 0 {
+		saved = 0 // never claim a saving that did not happen
+	}
+	return saved, baseline
+}
+
+// ckSpark renders values as block glyphs, scaled to the series' own range so a
+// flat-but-slow head still reads as flat. Fewer than two samples is not a
+// trace, so it renders as "—" rather than a misleading single bar.
+func ckSpark(vals []float64) string {
+	if len(vals) < 2 {
+		return "—"
+	}
+	lo, hi := vals[0], vals[0]
+	for _, v := range vals {
+		if v < lo {
+			lo = v
+		}
+		if v > hi {
+			hi = v
+		}
+	}
+	blocks := []rune("▁▂▃▄▅▆▇█")
+	var b strings.Builder
+	for _, v := range vals {
+		idx := 0
+		if hi > lo {
+			idx = int((v - lo) / (hi - lo) * float64(len(blocks)-1))
+		}
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(blocks) {
+			idx = len(blocks) - 1
+		}
+		b.WriteRune(blocks[idx])
+	}
+	return b.String()
+}
+
+// ckBlastFor computes the real blast radius of a file: the dependent count and
+// percolation factor from the code graph. Returns ok=false when there is no
+// graph or the file is not in it — the caller then says nothing, rather than
+// printing the fixed "κ=3.1 ⚠ 12 dependents" this replaced.
+func (m ckMetrics) ckBlastFor(file string) (radius float64, dependents int, kappa float64, ok bool) {
+	if m.graph == nil || file == "" {
+		return 0, 0, 0, false
+	}
+	radius = m.graph.BlastRadiusForFile(file)
+	kappa = m.graph.PercolationFactor(file)
+	for _, id := range m.graph.NodesInFile(file) {
+		dependents += m.graph.DependentCount(id)
+	}
+	// A file absent from the graph yields the neutral radius; saying nothing is
+	// more honest than reporting a floor value as a measurement.
+	if radius <= 1.0 && dependents == 0 {
+		return 0, 0, 0, false
+	}
+	return radius, dependents, kappa, true
+}
+
+// ckDiagnosticity is a head's calibrated information content in nats, from the
+// trust ledger. Zero means uncalibrated, which the renderer shows as "—" —
+// this replaced a confidence hardcoded by tier band.
+func (m ckMetrics) ckDiagnosticity(headName, domain string) float64 {
+	if m.calibrator == nil {
+		return 0
+	}
+	if domain == "" {
+		domain = "default"
+	}
+	return m.calibrator.D(headName, domain)
+}
+
+// ckSeriesFor finds a head's latency history. cost.jsonl records the model as
+// the executor reported it ("Qwen2.5-Coder:7b (Ollama)") while probe names the
+// head after its provider ("Ollama"), so an exact match silently misses — the
+// bug that showed a busy local head as having never run. Matching is therefore
+// tolerant: exact, then either string containing the other, case-insensitively.
+func (m ckMetrics) ckSeriesFor(name, id string) ([]float64, int64) {
+	if v, ok := m.latency[name]; ok {
+		return v, m.lastMS[name]
+	}
+	if v, ok := m.latency[id]; ok {
+		return v, m.lastMS[id]
+	}
+	for _, key := range []string{name, id} {
+		if key == "" {
+			continue
+		}
+		lk := strings.ToLower(key)
+		for model, v := range m.latency {
+			lm := strings.ToLower(model)
+			if strings.Contains(lm, lk) || strings.Contains(lk, lm) {
+				return v, m.lastMS[model]
+			}
+		}
+	}
+	return nil, 0
+}
+
+// ckSortedModels lists models with latency history, most-sampled first, so the
+// dashboard's own ordering is stable rather than map-random.
+func (m ckMetrics) ckSortedModels() []string {
+	out := make([]string, 0, len(m.latency))
+	for k := range m.latency {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if len(m.latency[out[i]]) != len(m.latency[out[j]]) {
+			return len(m.latency[out[i]]) > len(m.latency[out[j]])
+		}
+		return out[i] < out[j]
+	})
+	return out
+}
+
+// ckFmtMS renders a latency for the dashboard.
+func ckFmtMS(ms int64) string {
+	if ms <= 0 {
+		return "—"
+	}
+	if ms >= 10000 {
+		return fmt.Sprintf("%.1fs", float64(ms)/1000)
+	}
+	return fmt.Sprintf("%dms", ms)
+}

--- a/internal/tui/cockpit_metrics_test.go
+++ b/internal/tui/cockpit_metrics_test.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/cost"
+	"github.com/ankit373/hydra/internal/graph"
+)
+
+// cost.jsonl carries wall_ms on every row, so a per-head latency trace is real
+// data — the thing the old LCG-hashed "sparkline" was imitating.
+func TestLatencySeries_FromRealRows(t *testing.T) {
+	rows := []cost.Row{
+		{Model: "A", WallMS: 100},
+		{Model: "B", WallMS: 900},
+		{Model: "A", WallMS: 200},
+		{Model: "A", WallMS: 300},
+		{Model: "C"}, // no timing — must not create a series
+	}
+	series, last := ckLatencySeries(rows)
+
+	if got := series["A"]; len(got) != 3 || got[0] != 100 || got[2] != 300 {
+		t.Errorf("A series = %v, want [100 200 300] oldest-first", got)
+	}
+	if last["A"] != 300 {
+		t.Errorf("A last = %d, want the most recent (300)", last["A"])
+	}
+	if _, ok := series["C"]; ok {
+		t.Error("a row with no wall_ms produced a series")
+	}
+}
+
+func TestLatencySeries_CapsToSparkWidth(t *testing.T) {
+	var rows []cost.Row
+	for i := 0; i < ckSparkWidth*3; i++ {
+		rows = append(rows, cost.Row{Model: "A", WallMS: int64(i + 1)})
+	}
+	series, _ := ckLatencySeries(rows)
+	got := series["A"]
+	if len(got) != ckSparkWidth {
+		t.Fatalf("series length = %d, want %d", len(got), ckSparkWidth)
+	}
+	// Must keep the newest samples, not the oldest.
+	if got[len(got)-1] != float64(ckSparkWidth*3) {
+		t.Errorf("last sample = %v, want the most recent", got[len(got)-1])
+	}
+}
+
+// One sample is not a trace. Rendering a single bar would imply a trend that
+// was never measured.
+func TestSpark_TooFewSamplesRendersDash(t *testing.T) {
+	if got := ckSpark(nil); got != "—" {
+		t.Errorf("ckSpark(nil) = %q, want —", got)
+	}
+	if got := ckSpark([]float64{5}); got != "—" {
+		t.Errorf("ckSpark(one sample) = %q, want —", got)
+	}
+}
+
+func TestSpark_ScalesToSeriesRange(t *testing.T) {
+	got := ckSpark([]float64{10, 20, 30})
+	if len([]rune(got)) != 3 {
+		t.Fatalf("ckSpark produced %d glyphs, want 3", len([]rune(got)))
+	}
+	r := []rune(got)
+	if r[0] != '▁' {
+		t.Errorf("minimum sample rendered %q, want the lowest block", string(r[0]))
+	}
+	if r[2] != '█' {
+		t.Errorf("maximum sample rendered %q, want the highest block", string(r[2]))
+	}
+	// A flat series must not render as noise.
+	flat := ckSpark([]float64{7, 7, 7, 7})
+	for _, g := range flat {
+		if g != '▁' {
+			t.Errorf("flat series rendered %q — a constant latency must look constant", flat)
+			break
+		}
+	}
+}
+
+// Savings compares real spend against the same work priced at tier 1. Both
+// sides come from real rows, so the comparison is like-for-like.
+func TestSavings_RealComparison(t *testing.T) {
+	rows := []cost.Row{
+		{Tier: 10, PromptTokens: 1000, ResponseTokens: 500, EstCostUSD: 0.0001},
+		{Tier: 8, PromptTokens: 2000, ResponseTokens: 1000, EstCostUSD: 0.0004},
+	}
+	saved, baseline := ckSavings(rows, testPricing(t))
+
+	if baseline <= 0 {
+		t.Fatal("baseline is zero — tier-1 pricing did not resolve")
+	}
+	if saved <= 0 {
+		t.Errorf("saved = %v, want positive (cheap tiers vs a tier-1 baseline)", saved)
+	}
+	if saved > baseline {
+		t.Errorf("saved (%v) exceeds the baseline (%v)", saved, baseline)
+	}
+}
+
+// Routing everything to tier 1 saves nothing. The panel must never claim a
+// saving that did not happen.
+func TestSavings_NeverNegative(t *testing.T) {
+	rows := []cost.Row{
+		{Tier: 1, PromptTokens: 1000, ResponseTokens: 500, EstCostUSD: 999.0},
+	}
+	saved, _ := ckSavings(rows, testPricing(t))
+	if saved != 0 {
+		t.Errorf("saved = %v, want 0 — spending more than baseline is not a saving", saved)
+	}
+}
+
+func TestSavings_NilPricingIsZero(t *testing.T) {
+	saved, base := ckSavings([]cost.Row{{Tier: 1, EstCostUSD: 1}}, nil)
+	if saved != 0 || base != 0 {
+		t.Errorf("with no pricing DB got saved=%v base=%v, want 0/0", saved, base)
+	}
+}
+
+// With no graph loaded there is no blast radius to report — and reporting one
+// anyway is exactly the bug this replaced.
+func TestBlastFor_NoGraphSaysNothing(t *testing.T) {
+	var m ckMetrics
+	if _, _, _, ok := m.ckBlastFor("internal/auth/token.go"); ok {
+		t.Error("reported a blast radius with no graph loaded")
+	}
+	if _, _, _, ok := m.ckBlastFor(""); ok {
+		t.Error("reported a blast radius for an empty path")
+	}
+}
+
+// An uncalibrated head has no diagnosticity to show.
+func TestDiagnosticity_UncalibratedIsZero(t *testing.T) {
+	var m ckMetrics
+	if d := m.ckDiagnosticity("some-head", ""); d != 0 {
+		t.Errorf("uncalibrated head reported D=%v, want 0 so the view renders —", d)
+	}
+}
+
+func TestFmtMS(t *testing.T) {
+	for _, tt := range []struct {
+		in   int64
+		want string
+	}{
+		{0, "—"}, {-1, "—"}, {250, "250ms"}, {9999, "9999ms"}, {10000, "10.0s"}, {37654, "37.7s"},
+	} {
+		if got := ckFmtMS(tt.in); got != tt.want {
+			t.Errorf("ckFmtMS(%d) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSortedModels_MostSampledFirstAndStable(t *testing.T) {
+	m := ckMetrics{latency: map[string][]float64{
+		"few":  {1, 2},
+		"many": {1, 2, 3, 4},
+		"mid":  {1, 2, 3},
+	}}
+	got := m.ckSortedModels()
+	want := []string{"many", "mid", "few"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+	// Stable across calls — not map-random.
+	for i := 0; i < 20; i++ {
+		if strings.Join(m.ckSortedModels(), ",") != strings.Join(got, ",") {
+			t.Fatal("ordering is not stable between calls")
+		}
+	}
+}
+
+// A head with no recorded runs must render "—", never a zero-filled chart that
+// implies it ran and was instant.
+func TestDashboard_HeadWithNoHistoryRendersDash(t *testing.T) {
+	m := Cockpit{
+		w: 120, h: 30, ready: true, mode: "dispatch",
+		heads:   []ckHead{{name: "never-ran", tier: 5, up: true, color: ckCyan}},
+		metrics: ckMetrics{latency: map[string][]float64{}, lastMS: map[string]int64{}},
+	}
+	out := m.dash(120, 30)
+	if !strings.Contains(out, "—") {
+		t.Errorf("a head with no history did not render an em dash:\n%s", out)
+	}
+}
+
+// The real series must actually reach the rendered dashboard.
+func TestDashboard_RendersRealLatency(t *testing.T) {
+	m := Cockpit{
+		w: 120, h: 30, ready: true, mode: "dispatch",
+		heads: []ckHead{{name: "busy", tier: 3, up: true, color: ckCyan}},
+		metrics: ckMetrics{
+			latency: map[string][]float64{"busy": {100, 500, 200, 900}},
+			lastMS:  map[string]int64{"busy": 900},
+		},
+	}
+	out := m.dash(120, 30)
+	if !strings.Contains(out, "900ms") {
+		t.Errorf("real last-latency not rendered:\n%s", out)
+	}
+	if !strings.ContainsAny(out, "▁▂▃▄▅▆▇█") {
+		t.Errorf("real sparkline not rendered:\n%s", out)
+	}
+}
+
+// stubPricer prices tiers deterministically, so the savings arithmetic is
+// tested without depending on a resolvable registry/pricing.yaml.
+type stubPricer struct{}
+
+func (stubPricer) EstimateCost(tier, in, out int) float64 {
+	// Cheap tiers cost proportionally less, mirroring the real ramp.
+	perTok := 0.00002 / float64(tier)
+	return float64(in+out) * perTok
+}
+
+func testPricing(t *testing.T) ckPricer {
+	t.Helper()
+	return stubPricer{}
+}
+
+// A graph that does contain the file must yield real numbers — dependents and
+// κ walked from the graph, never a literal. This is the wiring that replaced
+// the hardcoded "κ=3.1 ⚠ 12 dependents".
+func TestBlastFor_RealGraphYieldsRealNumbers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "graph.json")
+	// hub.go is depended on by three others; leaf.go by none.
+	doc := `{"nodes":[
+	  {"id":"hub","file":"hub.go"},
+	  {"id":"a","file":"a.go"},
+	  {"id":"b","file":"b.go"},
+	  {"id":"c","file":"c.go"},
+	  {"id":"leaf","file":"leaf.go"}
+	],"edges":[
+	  {"from":"a","to":"hub"},
+	  {"from":"b","to":"hub"},
+	  {"from":"c","to":"hub"}
+	]}`
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	g, err := graph.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := ckMetrics{graph: g}
+
+	radius, deps, _, ok := m.ckBlastFor("hub.go")
+	if !ok {
+		t.Fatal("a file with real dependents reported no blast radius")
+	}
+	if deps != 3 {
+		t.Errorf("dependents = %d, want 3 — walked from the graph, not a literal", deps)
+	}
+	if radius <= 1.0 {
+		t.Errorf("radius = %v, want >1 for a file with dependents", radius)
+	}
+
+	// A file nobody depends on must not be dressed up as risky.
+	if _, _, _, ok := m.ckBlastFor("leaf.go"); ok {
+		t.Error("a leaf file reported a blast radius")
+	}
+	// A file absent from the graph reports nothing at all.
+	if _, _, _, ok := m.ckBlastFor("not-in-graph.go"); ok {
+		t.Error("a file absent from the graph reported a blast radius")
+	}
+}

--- a/internal/tui/cockpit_views.go
+++ b/internal/tui/cockpit_views.go
@@ -84,22 +84,44 @@ func (m Cockpit) dash(w, h int) string {
 		if !hd.up {
 			st = ckExpS.Render("● down")
 		}
-		name := lipgloss.NewStyle().Foreground(hd.color).Width(18).Render(truncate(hd.name, 18))
-		price := ckDimS.Render("       —")
-		if hd.price > 0 {
-			price = ckDimS.Render(fmt.Sprintf(" ~$%.4f", hd.price))
+		name := lipgloss.NewStyle().Foreground(hd.color).Width(15).Render(truncate(hd.name, 15))
+
+		// Real latency history from cost.jsonl wall_ms — "—" for a head that
+		// has never run, rather than a zero-filled chart.
+		series, lastMS := m.metrics.ckSeriesFor(hd.name, hd.id)
+		spark := lipgloss.NewStyle().Foreground(hd.color).
+			Render(fmt.Sprintf("%-*s", ckSparkWidth, ckSpark(series)))
+		lat := ckDimS.Render(fmt.Sprintf("%7s", ckFmtMS(lastMS)))
+
+		// Calibrated diagnosticity (nats) where the trust ledger has data.
+		// Keyed by head ID: trust records sources as ids, not display names.
+		diag := ckFaintS.Render("   —")
+		if d := m.metrics.ckDiagnosticity(hd.id, ""); d > 0 {
+			diag = ckCyanS.Render(fmt.Sprintf("%4.2f", d))
 		}
+
 		fleet.WriteString(" " + name + " " + st +
-			ckDimS.Render(fmt.Sprintf(" T%-2d", hd.tier)) + price + "\n")
+			ckDimS.Render(fmt.Sprintf(" T%-2d ", hd.tier)) + spark + lat + " " + diag + "\n")
 	}
-	fleet.WriteString("\n" + ckDimS.Render(fmt.Sprintf("%d head%s · mode ",
+	fleet.WriteString("\n" + ckFaintS.Render(fmt.Sprintf(" %-16s %-6s %-4s %-*s %7s %4s",
+		"", "", "", ckSparkWidth, "latency", "last", "D")) + "\n")
+	fleet.WriteString(ckDimS.Render(fmt.Sprintf("%d head%s · mode ",
 		len(m.heads), plural(len(m.heads)))) + ckCyanS.Render(m.mode))
 
-	// Real spend, from cost.jsonl.
+	// Real spend and real savings, both from cost.jsonl rows priced through the
+	// same pricing DB — so the comparison is like-for-like.
 	spendBox := ckLabelS.Render("SPEND · today") + "\n\n " +
 		lipgloss.NewStyle().Foreground(ckCheap).Bold(true).Render(fmt.Sprintf("$%.4f", m.spend)) + "\n " +
-		ckFaintS.Render("estimated, not billed") + "\n " +
-		ckDimS.Render("`hyctl cost` for the breakdown")
+		ckFaintS.Render("estimated, not billed")
+	if m.metrics.baseUSD > 0 {
+		pct := 0
+		if m.metrics.baseUSD > 0 {
+			pct = int(m.metrics.savedUSD / m.metrics.baseUSD * 100)
+		}
+		spendBox += "\n\n " + ckDimS.Render("saved vs all-T1  ") +
+			ckCheapS.Render(fmt.Sprintf("$%.4f", m.metrics.savedUSD)) + "\n " +
+			ckBar(pct, 20) + ckDimS.Render(fmt.Sprintf("  %d%%", pct))
+	}
 
 	// Real calibration stats, from trust.jsonl.
 	confBox := ckLabelS.Render("TRUST · calibration") + "\n\n " + m.trustSummary()


### PR DESCRIPTION
## Why this exists
#189 deleted four dashboard panels because their numbers were fabricated. Removing the fake values was right; **removing the panels was not**. Every one of them is computable from data Hydra already stores, so that change left the dashboard poorer than it found it. This wires them up for real.

| panel | now reads |
|---|---|
| latency sparkline | `cost.jsonl` `wall_ms` — present on every row |
| savings | real spend vs the same work priced at tier 1, same pricing DB both sides |
| blast radius | `graph.BlastRadiusForFile` / `PercolationFactor` / `DependentCount` |
| per-head D | `trust.Calibrator.D` |

## On your machine
```
 Claude Code     ● up   T1  ▂▁▄▁▂▄▆▃▂▂▂▂▅█  13.8s     saved vs all-T1  $0.3454
 Antigravity     ● up   T4  —               37.7s     ███████████████████░  98%
 Ollama          ● down T9  ▃▁▃▁▅▁▅▁▆▁▃▁█▁ 2103ms
```
Claude Code's trace is 27 real samples, Ollama's is 26, Antigravity has one (so `—`, not a fake trend). The **$0.3454 / 98% saved** is real arithmetic over 55 rows.

## Two bugs found while wiring it
- **A head with 26 recorded runs showed as never having run.** `cost.jsonl` records the model as the executor reported it (`Qwen2.5-Coder:7b (Ollama)`) while probe names heads after their provider (`Ollama`), so exact matching silently missed. Matching is now tolerant (exact → id → substring either way, case-insensitive).
- **Diagnosticity is keyed by head ID**, not display name — `trust` records sources as ids (`qwen`, `claude`). `ckHead` now carries the id.

## Design note
`ckSavings` takes a `ckPricer` interface rather than `*pricing.DB`, mirroring `swarm.PricingReader`, so the arithmetic is testable without a resolvable `registry/pricing.yaml` — which is exactly what made the first version of that test fail.

## The rule is unchanged
Never invent a figure. A head with no history renders `—`, not a zero-filled chart implying it ran and was instant. A file absent from the graph reports **nothing**, not the floor value dressed up as a measurement — verified in tests for both the leaf-file and not-in-graph cases.

## Test plan
- [x] `gofmt`, `go build ./...`, `go vet ./...`, `go test -race ./...` — green
- [x] 13 new tests: latency series (ordering, capping, newest-kept, rows without timing), sparkline (too-few→`—`, range scaling, flat-stays-flat), savings (real comparison, never-negative, nil pricer), blast radius (**real graph → real dependent count**, leaf → nothing, absent → nothing), diagnosticity, `ckFmtMS`, stable model ordering, and that real latency reaches the rendered dashboard
- [x] Rendered against this machine's real 55-row history (above)

**Stacked on #192** — retargets to `develop` as the chain merges.

Closes #193