### PR TITLE
chore(ci): bump pinned actions to current majors, gate on gofmt + staticcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,40 @@ jobs:
     name: Go build & test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
 
+      # Formatting is checked before anything expensive runs — it is the
+      # cheapest failure to produce and the cheapest to fix.
+      - name: Gofmt
+        run: |
+          unformatted=$(gofmt -l ./cmd ./internal)
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files are not gofmt'd:"
+            echo "$unformatted"
+            gofmt -d ./cmd ./internal
+            exit 1
+          fi
+
       - name: Vet
         run: go vet ./...
+
+      # staticcheck must be BUILT with the same toolchain it analyses. Its own
+      # go.mod asks for go1.25, so a plain `go install` builds it on go1.25 and
+      # it then rejects every go1.26 stdlib file it parses ("file requires newer
+      # Go version"), failing the whole run. Pinning GOTOOLCHAIN to whatever
+      # this module actually resolved to keeps the two in step without
+      # hardcoding a version that would drift from go.mod.
+      - name: Install staticcheck
+        run: GOTOOLCHAIN=$(go env GOVERSION) go install honnef.co/go/tools/cmd/staticcheck@2026.1
+
+      - name: Staticcheck
+        run: staticcheck ./...
 
       - name: Build
         run: go build ./...
@@ -35,7 +59,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
@@ -50,7 +74,7 @@ jobs:
     name: TypeScript typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -69,7 +93,7 @@ jobs:
     name: YAML validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install yq
         run: |
@@ -88,7 +112,7 @@ jobs:
     name: Secret scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -47,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build snapshot binaries
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --snapshot --clean --skip=publish,sign,sbom

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
     name: Binaries + checksums (GoReleaser)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -50,7 +50,7 @@ jobs:
                 --json assets -q '[.assets[].name | select(endswith(".tar.gz"))] | length' 2>/dev/null || echo 0)
           echo "has_assets=$n" >> "$GITHUB_OUTPUT"
           echo "Existing archive assets: $n"
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         if: ${{ steps.check.outputs.has_assets == '0' }}
         with:
           go-version-file: go.mod
@@ -59,7 +59,7 @@ jobs:
         if: ${{ steps.check.outputs.has_assets == '0' }}
       - name: GoReleaser (build + upload to the release)
         if: ${{ steps.check.outputs.has_assets == '0' }}
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean
@@ -74,7 +74,7 @@ jobs:
     env:
       TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
       - name: Update tap formula
@@ -93,10 +93,10 @@ jobs:
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
@@ -120,10 +120,10 @@ jobs:
     env:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
       - name: Build + publish

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -43,7 +43,7 @@ jobs:
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Build RC binaries
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --snapshot --clean --skip=publish,sign,sbom

--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -27,7 +27,7 @@ jobs:
     name: Open back-merge PR (main → develop)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -824,7 +824,8 @@ func canonicalHeaders(req *http.Request) (string, string) {
 		case "host":
 			b.WriteString("host:" + req.URL.Host + "\n")
 		default:
-			b.WriteString(key + ":" + strings.TrimSpace(req.Header.Get(http.CanonicalHeaderKey(key))) + "\n")
+			// Header.Get canonicalises its argument itself (S1035).
+			b.WriteString(key + ":" + strings.TrimSpace(req.Header.Get(key)) + "\n")
 		}
 	}
 	return b.String(), strings.Join(keys, ";")

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -3,7 +3,6 @@
 package provider
 
 import (
-	"fmt"
 	"sync"
 )
 
@@ -37,14 +36,4 @@ func (r *Registry) all() []Provider {
 		out = append(out, p)
 	}
 	return out
-}
-
-func (r *Registry) get(id string) (Provider, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	p, ok := r.providers[id]
-	if !ok {
-		return nil, fmt.Errorf("provider %q not registered", id)
-	}
-	return p, nil
 }

--- a/internal/trust/log_test.go
+++ b/internal/trust/log_test.go
@@ -42,8 +42,14 @@ func TestLogRun_ConfigOmittedGracefullyWithoutRegistry(t *testing.T) {
 }
 
 func TestTaskHash_StableAndDistinct(t *testing.T) {
-	if TaskHash("hello") != TaskHash("hello") {
-		t.Error("TaskHash not stable for identical input")
+	// Repeat rather than compare one call to itself: TaskHash must not pick up
+	// map-iteration order or any other per-call nondeterminism, and a single
+	// self-comparison would not catch that (it also trips staticcheck SA4000).
+	want := TaskHash("hello")
+	for i := range 100 {
+		if got := TaskHash("hello"); got != want {
+			t.Fatalf("TaskHash not stable: call %d gave %q, want %q", i, got, want)
+		}
 	}
 	if TaskHash("hello") == TaskHash("world") {
 		t.Error("TaskHash collided on distinct inputs")


### PR DESCRIPTION
## Summary

Replaces five stale Dependabot PRs and closes two real gaps in CI.

**Action bumps.** #170 #171 #172 #173 #174 #73 all targeted `main`, which the branching rules
reserve for release-please. Retargeting them to `develop` put every one into conflict, so the same
bumps land here in one place: `checkout` 4→7, `setup-go` 5→7, `setup-node` 4→7, `setup-python` 5→7,
`goreleaser-action` 6→7 — each verified against the action's current release.

**New gates.** The Go job ran `vet`, `build`, `test -race` and nothing else. It now also runs
`gofmt -l` and `staticcheck`.

## The toolchain trap

staticcheck must be *built* with the toolchain it analyses. Its go.mod asks for go1.25, so a plain
`go install` builds it on go1.25 — after which it rejects every go1.26 stdlib file it parses
(`file requires newer Go version`) and fails the run outright. `GOTOOLCHAIN=$(go env GOVERSION)`
keeps the two in step without hardcoding a version that would drift from `go.mod`.

## Findings the linter surfaced (fixed here)

- `(*Registry).get` — no callers anywhere in the tree. Deleted (U1000).
- `internal/executor/http.go` — `Header.Get` canonicalises its own argument, so the wrapping
  `http.CanonicalHeaderKey` in the AWS SigV4 canonical-header builder was a no-op (S1035).
- `TestTaskHash_StableAndDistinct` compared one call to itself (SA4000) — a weak determinism check
  that cannot catch map-iteration nondeterminism. Now hashes the same input 100 times against a
  fixed expectation.

## Verification

Both gates were verified to fail, not just to pass on a clean tree:

| Gate | Probe | Result |
|---|---|---|
| gofmt | appended a misformatted func to `accumulator.go` | flagged the file, exit 1 |
| staticcheck | added an unused func to `internal/util` | `U1000`, exit 1 |
| staticcheck | probe removed | exit 0 |

`gofmt -l`, `go build`, `go vet`, `staticcheck ./...`, and `go test -race ./...` all clean locally.

Closes #195