### PR TITLE
fix(runid): widen the random suffix to 64 bits so run IDs stop colliding

### DIFF
--- a/internal/runid/runid.go
+++ b/internal/runid/runid.go
@@ -32,14 +32,23 @@ const (
 	EnvTaskID = "HYDRA_TASK_ID"
 )
 
-// New returns a fresh identifier, e.g. "20260801T104530Z-3f9c1a".
+// randBytes is the width of New's random suffix.
+//
+// The timestamp only resolves to the second, so every ID minted inside the same
+// second collides unless the suffix separates them — and a parallel batch or a
+// swarm mints many in one second by design. At the original 3 bytes the
+// birthday bound gave 0.7% for 500 IDs and 52% for 5000, which is not a
+// theoretical risk: it silently merged two unrelated runs' rows in cost.jsonl,
+// the exact correlation failure #181 set out to fix (#198). At 8 bytes, 10,000
+// IDs in one second collide with probability ~3e-12.
+const randBytes = 8
+
+// New returns a fresh identifier, e.g. "20260801T104530Z-3f9c1a4b5c6d7e8f".
 func New() string {
-	var b [3]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		// crypto/rand failing is not a reason to lose correlation entirely;
-		// the timestamp alone still groups a run in practice.
-		return time.Now().UTC().Format("20060102T150405Z")
-	}
+	var b [randBytes]byte
+	// rand.Read never returns an error (it panics if the system source fails),
+	// so there is no fallback path to write here.
+	_, _ = rand.Read(b[:])
 	return fmt.Sprintf("%s-%s", time.Now().UTC().Format("20060102T150405Z"), hex.EncodeToString(b[:]))
 }
 

--- a/internal/runid/runid_test.go
+++ b/internal/runid/runid_test.go
@@ -3,14 +3,21 @@
 package runid
 
 import (
+	"encoding/hex"
 	"strings"
 	"sync"
 	"testing"
 )
 
 func TestNew_NonEmptyAndUnique(t *testing.T) {
-	seen := map[string]bool{}
-	for i := 0; i < 500; i++ {
+	// 20k in a tight loop lands well inside one wall-clock second, so this
+	// exercises the suffix alone rather than relying on the timestamp to
+	// separate anything. At 64 bits that collides with probability ~1e-11; at
+	// the 24 bits this package shipped with (#198) it collides essentially
+	// always.
+	const n = 20_000
+	seen := make(map[string]bool, n)
+	for i := range n {
 		id := New()
 		if id == "" {
 			t.Fatal("New() returned empty")
@@ -19,6 +26,43 @@ func TestNew_NonEmptyAndUnique(t *testing.T) {
 			t.Fatalf("New() collided on %q after %d calls", id, i)
 		}
 		seen[id] = true
+	}
+}
+
+// The uniqueness test above is probabilistic — it would still pass at, say, 5
+// bytes. This pins the entropy width itself so narrowing the suffix fails
+// loudly rather than turning New() flaky again.
+func TestNew_SuffixCarriesFullEntropy(t *testing.T) {
+	id := New()
+	_, suffix, ok := strings.Cut(id, "-")
+	if !ok {
+		t.Fatalf("id %q has no %q separator", id, "-")
+	}
+	// Deliberately a literal, not randBytes*2: asserting the constant against
+	// itself would pass at any width and guard nothing.
+	const wantHexChars = 16 // 64 bits
+	if len(suffix) != wantHexChars {
+		t.Errorf("suffix %q is %d hex chars (%d bits), want %d (64 bits) — see #198",
+			suffix, len(suffix), len(suffix)*4, wantHexChars)
+	}
+	if _, err := hex.DecodeString(suffix); err != nil {
+		t.Errorf("suffix %q is not hex: %v", suffix, err)
+	}
+}
+
+// A suffix that is constant, or drawn from a tiny set, would pass both tests
+// above if the timestamp happened to tick. Sampling the first byte across many
+// draws catches a suffix that is not actually random.
+func TestNew_SuffixIsNotConstant(t *testing.T) {
+	firstBytes := map[string]bool{}
+	for range 1000 {
+		_, suffix, _ := strings.Cut(New(), "-")
+		firstBytes[suffix[:2]] = true
+	}
+	// 1000 draws over 256 values: seeing fewer than 200 distinct would mean the
+	// source is badly skewed. A uniform source yields ~254.
+	if len(firstBytes) < 200 {
+		t.Errorf("only %d distinct leading bytes in 1000 draws — suffix is not uniformly random", len(firstBytes))
 	}
 }
 


### PR DESCRIPTION
## Steps to Reproduce

CI on #196:

```
--- FAIL: TestNew_NonEmptyAndUnique
    runid_test.go:19: New() collided on "20260802T052848Z-476d2c" after 307 calls
```

## Expected

Two runs never share an ID. Correlating log rows by `run_id` is the whole point of #181.

## Actual

`New()` timestamps to the **second**, so everything minted inside one second is separated by the
random suffix alone — and that suffix was **3 bytes**. Over 16.7M values the birthday bound bites
immediately:

| IDs in one second | P(collision) |
|---|---|
| 307 | 0.28% |
| 500 | 0.74% |
| 1000 | 2.93% |
| 5000 | 52.5% |

`hyctl parallel` mints a task ID per task and a swarm mints one per attempt, all inside one second.
This was never only a flaky test — a collision silently merges two unrelated runs' rows in
`cost.jsonl`, which is the exact correlation failure #181 set out to fix, now failing quietly
instead of loudly.

## Fix

8-byte suffix. At 10,000 IDs in one second, P(collision) ≈ 3e-12.

Also drops the `crypto/rand` error branch: since Go 1.24 `rand.Read` never returns an error (it
panics if the system source fails), so the fallback returning a bare timestamp — which would collide
on *every* same-second call — was unreachable. CLAUDE.md: a branch that can never execute is a false
statement about the code.

## Verification

Three tests, **each verified to fail** with `randBytes` put back to 3, then pass at 8:

| Test | What it catches | At randBytes=3 |
|---|---|---|
| `TestNew_NonEmptyAndUnique` | 20k IDs in a tight loop — inside one wall-clock second, so it exercises the suffix, not the timestamp | FAIL, collides at ~3.6k |
| `TestNew_SuffixCarriesFullEntropy` | suffix width, asserted against a **literal 16** — `randBytes*2` would compare the constant to itself and pass at any width | FAIL |
| `TestNew_SuffixIsNotConstant` | leading byte over 1000 draws — catches a suffix that is constant or skewed rather than merely wide | passes (correctly — it tests randomness, not width) |

`gofmt -l`, `go build`, `go vet`, `go test -race ./...` all clean.

Closes #198