### PR TITLE
feat(executor): route to OpenRouter, and fix the keyless-provider gate it exposed

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -527,10 +527,10 @@ hyctl tui <span class="fl">--snapshot</span> <span class="fl">--view</span> 0|1|
       <h2>API providers <span class="tagline">discovered from env keys</span></h2>
       <p class="sum">Set a provider's API key and it becomes a routable head automatically — through the OpenAI-compatible or provider-native HTTP executor. No config file to touch.</p>
       <div class="pill-row">
-        <span class="chip">Anthropic</span><span class="chip">OpenAI</span><span class="chip">Google AI</span><span class="chip">Groq</span>
-        <span class="chip">Together</span><span class="chip">Fireworks</span><span class="chip">Mistral</span><span class="chip">DeepSeek</span>
-        <span class="chip">xAI · Grok</span><span class="chip">AWS Bedrock</span><span class="chip">Azure OpenAI</span><span class="chip">Perplexity</span>
-        <span class="chip">Cohere</span><span class="chip">Replicate</span>
+        <span class="chip">Anthropic</span><span class="chip">OpenAI</span><span class="chip">OpenRouter</span><span class="chip">Google AI</span>
+        <span class="chip">Groq</span><span class="chip">Together</span><span class="chip">Fireworks</span><span class="chip">Mistral</span>
+        <span class="chip">DeepSeek</span><span class="chip">xAI · Grok</span><span class="chip">AWS Bedrock</span><span class="chip">Azure OpenAI</span>
+        <span class="chip">Perplexity</span><span class="chip">Cohere</span><span class="chip">Replicate</span>
       </div>
       <div class="sub"><div class="lbl">Add one</div><pre>export ANTHROPIC_API_KEY=sk-…      <span class="c"># then:</span>
 hyctl probe                        <span class="c"># it shows up as a scored head</span></pre></div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,7 +8,7 @@
   </url>
   <url>
     <loc>https://hydra.uvansa.com/docs.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/internal/capabilities/data.json
+++ b/internal/capabilities/data.json
@@ -16,6 +16,7 @@
 
     {"id": "env/anthropic",  "name": "Anthropic API",      "provider": "anthropic",   "capScore": 90},
     {"id": "env/openai",     "name": "OpenAI API",         "provider": "openai",      "capScore": 85},
+    {"id": "env/openrouter", "name": "OpenRouter API",     "provider": "openrouter",  "capScore": 85},
     {"id": "env/google",     "name": "Google AI API",      "provider": "google",      "capScore": 78},
     {"id": "env/xai",        "name": "xAI API",            "provider": "xai",         "capScore": 76},
     {"id": "env/groq",       "name": "Groq API",           "provider": "groq",        "capScore": 72},

--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -570,35 +570,39 @@ func openAICompatConfigFor(h provider.Head) (openAICompatConfig, error) {
 		}, nil
 	}
 
-	type cfg struct {
-		baseURL string
-		model   string
-		header  string
-		key     string
+	// baseURL only. The auth header is built below from the raw key, never
+	// stored pre-formatted: "Bearer " + "" is a non-empty string, so a table
+	// holding the formatted value made the emptiness check below unreachable and
+	// every OpenAI-compatible provider reported as supported with no key set
+	// (#200).
+	baseURLs := map[string]string{
+		"openai": "https://api.openai.com",
+		// OpenRouter speaks the OpenAI chat-completions wire format, so it needs
+		// no executor of its own — only a base URL. Hydra already reads its
+		// catalogue for pricing; this lets it dispatch there too.
+		"openrouter": "https://openrouter.ai/api",
+		"xai":        "https://api.x.ai",
+		"groq":       "https://api.groq.com/openai",
+		"together":   "https://api.together.xyz",
+		"fireworks":  "https://api.fireworks.ai/inference",
+		"mistral":    "https://api.mistral.ai",
+		"deepseek":   "https://api.deepseek.com",
+		"perplexity": "https://api.perplexity.ai",
 	}
-
-	configs := map[string]cfg{
-		"openai":     {baseURL: "https://api.openai.com", model: defaultModelFor("openai"), header: "Authorization", key: "Bearer " + apiKeyFor("openai")},
-		"xai":        {baseURL: "https://api.x.ai", model: defaultModelFor("xai"), header: "Authorization", key: "Bearer " + apiKeyFor("xai")},
-		"groq":       {baseURL: "https://api.groq.com/openai", model: defaultModelFor("groq"), header: "Authorization", key: "Bearer " + apiKeyFor("groq")},
-		"together":   {baseURL: "https://api.together.xyz", model: defaultModelFor("together"), header: "Authorization", key: "Bearer " + apiKeyFor("together")},
-		"fireworks":  {baseURL: "https://api.fireworks.ai/inference", model: defaultModelFor("fireworks"), header: "Authorization", key: "Bearer " + apiKeyFor("fireworks")},
-		"mistral":    {baseURL: "https://api.mistral.ai", model: defaultModelFor("mistral"), header: "Authorization", key: "Bearer " + apiKeyFor("mistral")},
-		"deepseek":   {baseURL: "https://api.deepseek.com", model: defaultModelFor("deepseek"), header: "Authorization", key: "Bearer " + apiKeyFor("deepseek")},
-		"perplexity": {baseURL: "https://api.perplexity.ai", model: defaultModelFor("perplexity"), header: "Authorization", key: "Bearer " + apiKeyFor("perplexity")},
-	}
-	c, ok := configs[h.Provider]
+	baseURL, ok := baseURLs[h.Provider]
 	if !ok {
 		return openAICompatConfig{}, errUnsupportedHTTPProvider
 	}
-	if c.key == "" || c.model == "" {
+
+	key, model := apiKeyFor(h.Provider), defaultModelFor(h.Provider)
+	if key == "" || model == "" {
 		return openAICompatConfig{}, errUnsupportedHTTPProvider
 	}
 
 	return openAICompatConfig{
-		BaseURL: c.baseURL,
-		Model:   c.model,
-		Headers: map[string]string{c.header: c.key},
+		BaseURL: baseURL,
+		Model:   model,
+		Headers: map[string]string{"Authorization": "Bearer " + key},
 	}, nil
 }
 
@@ -684,6 +688,7 @@ func defaultModelFor(providerID string) string {
 	specs := map[string]modelSpec{
 		"anthropic":  {fallback: "claude-sonnet-4-20250514", envs: []string{"ANTHROPIC_MODEL", "HYDRA_MODEL_ANTHROPIC"}},
 		"openai":     {fallback: "gpt-4o", envs: []string{"OPENAI_MODEL", "HYDRA_MODEL_OPENAI"}},
+		"openrouter": {fallback: "anthropic/claude-sonnet-4-5", envs: []string{"OPENROUTER_MODEL", "HYDRA_MODEL_OPENROUTER"}},
 		"google":     {fallback: "gemini-2.5-flash", envs: []string{"GEMINI_MODEL", "GOOGLE_MODEL", "HYDRA_MODEL_GOOGLE"}},
 		"xai":        {fallback: "grok-3-latest", envs: []string{"XAI_MODEL", "HYDRA_MODEL_XAI"}},
 		"groq":       {fallback: "llama-3.3-70b-versatile", envs: []string{"GROQ_MODEL", "HYDRA_MODEL_GROQ"}},
@@ -708,16 +713,17 @@ func defaultModelFor(providerID string) string {
 
 func apiKeyFor(providerID string) string {
 	envs := map[string][]string{
-		"anthropic": {"ANTHROPIC_API_KEY"},
-		"openai":    {"OPENAI_API_KEY"},
-		"google":    {"GEMINI_API_KEY", "GOOGLE_API_KEY"},
-		"xai":       {"XAI_API_KEY"},
-		"groq":      {"GROQ_API_KEY"},
-		"together":  {"TOGETHER_API_KEY"},
-		"fireworks": {"FIREWORKS_API_KEY"},
-		"mistral":   {"MISTRAL_API_KEY"},
-		"deepseek":  {"DEEPSEEK_API_KEY"},
-		"azure":     {"AZURE_OPENAI_API_KEY"},
+		"anthropic":  {"ANTHROPIC_API_KEY"},
+		"openai":     {"OPENAI_API_KEY"},
+		"openrouter": {"OPENROUTER_API_KEY"},
+		"google":     {"GEMINI_API_KEY", "GOOGLE_API_KEY"},
+		"xai":        {"XAI_API_KEY"},
+		"groq":       {"GROQ_API_KEY"},
+		"together":   {"TOGETHER_API_KEY"},
+		"fireworks":  {"FIREWORKS_API_KEY"},
+		"mistral":    {"MISTRAL_API_KEY"},
+		"deepseek":   {"DEEPSEEK_API_KEY"},
+		"azure":      {"AZURE_OPENAI_API_KEY"},
 		"perplexity": {
 			"PERPLEXITY_API_KEY",
 		},

--- a/internal/executor/openrouter_test.go
+++ b/internal/executor/openrouter_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// clearProviderKeys blanks every API key env var the HTTP executor consults, so
+// a key present in the developer's real environment cannot make a test pass
+// that would fail in CI (or vice versa).
+func clearProviderKeys(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "GEMINI_API_KEY",
+		"GOOGLE_API_KEY", "XAI_API_KEY", "GROQ_API_KEY", "TOGETHER_API_KEY",
+		"FIREWORKS_API_KEY", "MISTRAL_API_KEY", "DEEPSEEK_API_KEY", "AZURE_OPENAI_API_KEY",
+		"AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOYMENT", "PERPLEXITY_API_KEY",
+		"COHERE_API_KEY", "REPLICATE_API_TOKEN", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+		"OPENROUTER_MODEL", "HYDRA_MODEL_OPENROUTER",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func openRouterHead() provider.Head {
+	return provider.Head{ID: "env/openrouter", Source: "env", Provider: "openrouter"}
+}
+
+// Hydra reads OpenRouter's catalogue for every cost estimate it makes, but
+// before #200 could not send it a single token.
+func TestOpenRouter_SupportsGatesOnKey(t *testing.T) {
+	clearProviderKeys(t)
+	h := openRouterHead()
+
+	if Supports(h) {
+		t.Fatal("Supports(env/openrouter) = true with no key; want false")
+	}
+
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-test")
+	if !Supports(h) {
+		t.Fatal("Supports(env/openrouter) = false with OPENROUTER_API_KEY set; want true")
+	}
+}
+
+// An env head has no Executable, so routing it to CLIExecutor guarantees a
+// failed exec — the #75 regression, re-asserted for the new provider.
+func TestOpenRouter_RoutesToHTTPExecutor(t *testing.T) {
+	if _, ok := For(openRouterHead()).(*HTTPExecutor); !ok {
+		t.Fatalf("For(env/openrouter) = %T, want *HTTPExecutor", For(openRouterHead()))
+	}
+}
+
+// The base URL must be the one the OpenAI-compat path can append
+// "/v1/chat/completions" to and land on a real endpoint.
+func TestOpenRouter_ResolvesToChatCompletionsEndpoint(t *testing.T) {
+	clearProviderKeys(t)
+	t.Setenv("OPENROUTER_API_KEY", "sk-or-test")
+
+	cfg, err := openAICompatConfigFor(openRouterHead())
+	if err != nil {
+		t.Fatalf("openAICompatConfigFor: %v", err)
+	}
+
+	const want = "https://openrouter.ai/api/v1/chat/completions"
+	// Mirrors how executeOpenAICompatible builds the URL.
+	if got := strings.TrimRight(cfg.BaseURL, "/") + "/v1/chat/completions"; got != want {
+		t.Errorf("endpoint = %q, want %q", got, want)
+	}
+	if got := cfg.Headers["Authorization"]; got != "Bearer sk-or-test" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer sk-or-test")
+	}
+}
+
+func TestOpenRouter_ModelIsOverridable(t *testing.T) {
+	clearProviderKeys(t)
+
+	if got := defaultModelFor("openrouter"); got == "" {
+		t.Fatal("defaultModelFor(openrouter) is empty — SupportsHTTP would reject the head")
+	}
+	// OpenRouter model IDs are vendor-prefixed; a bare name is a wrong default.
+	if got := defaultModelFor("openrouter"); !strings.Contains(got, "/") {
+		t.Errorf("default model %q is not vendor-prefixed — OpenRouter IDs look like \"anthropic/claude-…\"", got)
+	}
+
+	t.Setenv("OPENROUTER_MODEL", "meta-llama/llama-4-scout")
+	if got := defaultModelFor("openrouter"); got != "meta-llama/llama-4-scout" {
+		t.Errorf("OPENROUTER_MODEL = %q, want it to win", got)
+	}
+
+	t.Setenv("OPENROUTER_MODEL", "")
+	t.Setenv("HYDRA_MODEL_OPENROUTER", "google/gemini-2.5-pro")
+	if got := defaultModelFor("openrouter"); got != "google/gemini-2.5-pro" {
+		t.Errorf("HYDRA_MODEL_OPENROUTER = %q, want it to win", got)
+	}
+}
+
+// Adding a provider means touching five separate tables — env.knownKeys,
+// openAICompatConfigFor, defaultModelFor, apiKeyFor, and capabilities. #200
+// existed because OpenRouter was in none of them while pricing depended on it.
+// This asserts the tables agree, so the next provider added to one but not the
+// others fails here instead of silently discovering an unusable head.
+func TestEveryOpenAICompatProviderIsFullyWired(t *testing.T) {
+	clearProviderKeys(t)
+
+	// Providers served by the generic OpenAI-compatible path. The bespoke ones
+	// (anthropic, google, cohere, azure, bedrock, replicate) have their own
+	// Execute branches and their own gates in SupportsHTTP.
+	compat := []struct{ id, keyEnv string }{
+		{"openai", "OPENAI_API_KEY"},
+		{"openrouter", "OPENROUTER_API_KEY"},
+		{"xai", "XAI_API_KEY"},
+		{"groq", "GROQ_API_KEY"},
+		{"together", "TOGETHER_API_KEY"},
+		{"fireworks", "FIREWORKS_API_KEY"},
+		{"mistral", "MISTRAL_API_KEY"},
+		{"deepseek", "DEEPSEEK_API_KEY"},
+		{"perplexity", "PERPLEXITY_API_KEY"},
+	}
+
+	for _, p := range compat {
+		t.Run(p.id, func(t *testing.T) {
+			if got := defaultModelFor(p.id); got == "" {
+				t.Errorf("defaultModelFor(%q) is empty — SupportsHTTP will always reject this provider", p.id)
+			}
+
+			h := provider.Head{ID: "env/" + p.id, Source: "env", Provider: p.id}
+			if Supports(h) {
+				t.Errorf("Supports(%q) = true with no key set; the key gate is missing from apiKeyFor", p.id)
+			}
+
+			t.Setenv(p.keyEnv, "test-key")
+			defer t.Setenv(p.keyEnv, "")
+
+			if !Supports(h) {
+				t.Errorf("Supports(%q) = false with %s set; provider is missing from apiKeyFor or the configs table", p.id, p.keyEnv)
+			}
+			cfg, err := openAICompatConfigFor(h)
+			if err != nil {
+				t.Fatalf("openAICompatConfigFor(%q): %v", p.id, err)
+			}
+			if !strings.HasPrefix(cfg.BaseURL, "https://") {
+				t.Errorf("%q base URL %q is not https", p.id, cfg.BaseURL)
+			}
+			if cfg.Headers["Authorization"] != "Bearer test-key" {
+				t.Errorf("%q Authorization = %q, want %q", p.id, cfg.Headers["Authorization"], "Bearer test-key")
+			}
+		})
+	}
+}

--- a/internal/provider/env/provider.go
+++ b/internal/provider/env/provider.go
@@ -69,6 +69,7 @@ func (k keySpec) detected() bool {
 var knownKeys = []keySpec{
 	{envVars: []string{"ANTHROPIC_API_KEY"}, providerID: "anthropic"},
 	{envVars: []string{"OPENAI_API_KEY"}, providerID: "openai"},
+	{envVars: []string{"OPENROUTER_API_KEY"}, providerID: "openrouter"},
 	{envVars: []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}, anyOf: true, providerID: "google"},
 	{envVars: []string{"XAI_API_KEY"}, providerID: "xai"},
 	{envVars: []string{"GROQ_API_KEY"}, providerID: "groq"},


### PR DESCRIPTION
## Summary

`internal/pricing` fetches the live model catalogue **from OpenRouter** and is the single source of
truth for every cost estimate Hydra makes — yet OpenRouter was absent from all five tables needed to
send it a prompt. A user with only `OPENROUTER_API_KEY` set (the one key that unlocks every frontier
model) got **no heads at all**.

OpenRouter speaks the OpenAI chat-completions wire format, so this is five table entries and no new
executor path: `env.knownKeys`, `openAICompatConfigFor`, `defaultModelFor`, `apiKeyFor`,
`capabilities/data.json`.

## The bug the test found

The cross-table test written to stop this recurring **immediately failed for nine providers**:

```
--- FAIL: TestEveryOpenAICompatProviderIsFullyWired/openai
    Supports("openai") = true with no key set; the key gate is missing from apiKeyFor
--- FAIL: .../xai  .../groq  .../together  .../fireworks  .../mistral  .../deepseek  .../perplexity
```

The `configs` table stored the **already-formatted** header value:

```go
"openai": {…, key: "Bearer " + apiKeyFor("openai")},
…
if c.key == "" || c.model == "" { return …, errUnsupportedHTTPProvider }   // unreachable
```

`"Bearer " + ""` is `"Bearer "` — not empty — so that gate never fired. Every OpenAI-compatible
provider reported `Supports() == true` with no API key set.

Env-discovered heads only exist when their key is present, so the common path was unaffected. But a
**port head** or a **`hyctl models add` overlay entry** carrying one of those provider names was
advertised as executable and would 401 at dispatch — and since #190 the cockpit's `up` column reads
`executor.Supports`, so it would show a green head that cannot run.

The table now holds base URLs only; the header is built from the raw key *after* the emptiness
check.

## Verification

| Test | Asserts |
|---|---|
| `TestOpenRouter_SupportsGatesOnKey` | false with no key, true with one |
| `TestOpenRouter_RoutesToHTTPExecutor` | never `CLIExecutor` — the #75 regression, re-asserted |
| `TestOpenRouter_ResolvesToChatCompletionsEndpoint` | resolves to `https://openrouter.ai/api/v1/chat/completions` with the right `Authorization` |
| `TestOpenRouter_ModelIsOverridable` | `OPENROUTER_MODEL` and `HYDRA_MODEL_OPENROUTER` both win; the fallback is vendor-prefixed, as OpenRouter IDs must be |
| `TestEveryOpenAICompatProviderIsFullyWired` | all 9 compat providers, each with and without a key — **this is the one that caught the bug**, and it makes the next provider added to one table but not the others fail CI |

Every test clears all provider key env vars first, so a key in the developer's real environment
can't make something pass that would fail in CI.

`gofmt -l`, `go build`, `go vet`, `go test -race ./...` all clean.

## Supersedes #72

#72 (June) attempted part of this. Its `executor.go` hunks landed independently, its `ui/state.ts`
change is moot under #197, and its `docs/index.html` edits were overwritten by #180 — only OpenRouter
support was still novel, so it is rebuilt here with tests rather than rebased.

## Docs

OpenRouter added to the provider chips in `docs/docs.html`, `sitemap.xml` `lastmod` bumped to match.

Closes #200