### PR TITLE
fix(runlog): emit from every producer, start the heartbeat, honour HYDRA_RUN_ID

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/review"
 	"github.com/ankit373/hydra/internal/runid"
+	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/swarm"
 	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/tui"
@@ -394,7 +395,24 @@ func cmdDispatch() *cobra.Command {
 			// One invocation is one run with one logical task, whichever path
 			// below handles it — so a swarm's attempts and the dispatch that
 			// drove them share an identity in the logs (#181).
-			runID, taskID := runid.New(), runid.New()
+			//
+			// Resolve rather than mint: runid ranks explicit > env > generated,
+			// so calling New() here and passing the result as the explicit value
+			// silently outranked HYDRA_RUN_ID and made it dead at the only entry
+			// point that matters (#204).
+			runID, taskID := runid.ResolveRun(""), runid.ResolveTask("")
+
+			// Mark the run live for its whole duration. Without this
+			// runlog.LiveRuns() is always empty and nothing — cockpit or desktop
+			// Fleet — can distinguish a running agent from a finished one.
+			hb := runlog.StartHeartbeat(ctx, runID, runlog.HeartbeatInterval)
+			defer hb.Stop()
+
+			rl := runlog.New(runID)
+			_ = rl.Append(runlog.Event{Kind: runlog.KindRunStarted, TaskID: taskID, Detail: promptPreview(prompt)})
+			defer func() {
+				_ = rl.Append(runlog.Event{Kind: runlog.KindRunFinished, TaskID: taskID})
+			}()
 
 			d, err := dispatch.New(ctx)
 			if err != nil {
@@ -2057,3 +2075,16 @@ var (
 	cortexStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
 	dimStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 )
+
+// promptPreview shortens a prompt for a log Detail field. Run events carry a
+// short human label, never the full text — the atomic-append guarantee that
+// makes the run log safe under concurrency is per write() call, so entries must
+// stay small.
+func promptPreview(s string) string {
+	const max = 80
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -199,7 +199,16 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 			DurationMS: resp.Duration.Milliseconds(),
 		})
 		_ = d.logDispatch(r, prompt, opts)
-		_ = d.writeHandoff(r, prompt)
+		if from, err := d.writeHandoff(r, prompt); err == nil {
+			// last_handoff.json keeps only the newest. Appending the handoff
+			// here is what makes a *chain* of them reconstructable, which is
+			// the stated purpose of KindHandoff and did not happen before #204.
+			_ = rl.Append(runlog.Event{
+				Kind: runlog.KindHandoff, TaskID: taskID,
+				Agent: h.ID, Head: h.ID, Model: h.Name,
+				Ref: from, Detail: "context handed to " + from,
+			})
+		}
 		d.recordBudget(r)
 		d.syncStateJSON(r)
 		return r, nil
@@ -308,7 +317,8 @@ func injectA2A(path, prompt string) (string, error) {
 
 // writeHandoff saves last_handoff.json after a successful dispatch, advancing
 // the vector clock so downstream agents inherit this dispatch's causal history.
-func (d *Dispatcher) writeHandoff(r *Result, prompt string) error {
+// It returns the handoff's From identity so the caller can record the edge.
+func (d *Dispatcher) writeHandoff(r *Result, prompt string) (string, error) {
 	handoffPath := filepath.Join(config.Dir(), "logs", "last_handoff.json")
 
 	// Inherit the prior handoff's clock (if any) and tick for this agent.
@@ -325,7 +335,7 @@ func (d *Dispatcher) writeHandoff(r *Result, prompt string) error {
 		PriorOutput: r.Response.Output,
 		Clock:       base.Tick(from),
 	}
-	return h.Save(handoffPath)
+	return from, h.Save(handoffPath)
 }
 
 // resolveTierHint normalizes a tier hint to a capability number ("1".."10").

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/runid"
+	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/workspace"
 )
 
@@ -110,6 +112,17 @@ func Run(ctx context.Context, tasks []Task, opts Options) ([]Result, error) {
 	results := make([]Result, len(tasks))
 	var mu sync.Mutex
 
+	// A batch is a fan-out, and the tree that renders it needs the fan-out's
+	// shape: one node per task, all under the batch. Before #204 nothing in this
+	// package emitted, so an N-task batch had no structure at all in the run log.
+	// Appends are best-effort throughout — a lost event must never fail a task.
+	rl := runlog.New(runID)
+	_ = rl.Append(runlog.Event{
+		Kind:   runlog.KindTaskStarted,
+		Agent:  batchAgent,
+		Detail: fmt.Sprintf("parallel batch · %d tasks", len(tasks)),
+	})
+
 	g, gctx := errgroup.WithContext(ctx)
 
 	for i, task := range tasks {
@@ -117,6 +130,12 @@ func Run(ctx context.Context, tasks []Task, opts Options) ([]Result, error) {
 		// Each task is its own logical unit of work inside the shared run.
 		taskID := runid.New()
 		g.Go(func() error {
+			_ = rl.Append(runlog.Event{
+				Kind: runlog.KindTaskStarted, TaskID: taskID,
+				Agent: task.Label, Parent: batchAgent, Detail: task.Enum,
+			})
+
+			started := time.Now()
 			var raw json.RawMessage
 			if task.File != "" {
 				raw = runEditTask(gctx, task, runID, taskID)
@@ -126,14 +145,39 @@ func Run(ctx context.Context, tasks []Task, opts Options) ([]Result, error) {
 			mu.Lock()
 			results[i] = Result{raw: raw}
 			mu.Unlock()
+
+			_ = rl.Append(runlog.Event{
+				Kind: runlog.KindTaskFinished, TaskID: taskID,
+				Agent: task.Label, Parent: batchAgent,
+				Status:     statusOf(raw),
+				DurationMS: time.Since(started).Milliseconds(),
+			})
 			return nil // always nil — errors are captured in raw
 		})
 	}
 
 	_ = g.Wait()
 
+	_ = rl.Append(runlog.Event{Kind: runlog.KindTaskFinished, Agent: batchAgent})
+
 	_ = persistResults(results)
 	return results, nil
+}
+
+// batchAgent is the batch's own node in the tree — the parent every task hangs
+// off, so a fan-out renders as a fan-out rather than N unrelated roots.
+const batchAgent = "parallel"
+
+// statusOf recovers a task's outcome from the JSON each runner already
+// produces, rather than threading a second return value through both paths.
+func statusOf(raw json.RawMessage) string {
+	var v struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &v); err != nil || v.Status == "" {
+		return "unknown"
+	}
+	return v.Status
 }
 
 // runTextTask dispatches a prompt and returns the raw JSON result.

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/tree"
 )
 
 func TestRun_EmptyBatch(t *testing.T) {
@@ -69,5 +72,102 @@ func TestResult_MarshalJSON(t *testing.T) {
 	}
 	if string(r.Raw()) != `{"label":"a","status":"ok"}` {
 		t.Errorf("Raw() mismatch")
+	}
+}
+
+// A batch is a fan-out and must reconstruct as one: a batch root with each task
+// as a child. Before #204 this package emitted nothing, so an N-task batch had
+// no structure in the run log at all.
+func TestRun_EmitsBatchTree(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_RUN_ID", "")
+	t.Setenv("HYDRA_TASK_ID", "")
+
+	tasks := []Task{
+		{Label: "alpha", Enum: "SIMPLE", Prompt: "a"},
+		{Label: "beta", Enum: "SIMPLE", Prompt: "b"},
+		{Label: "gamma", Enum: "SIMPLE", Prompt: "c"},
+	}
+	// Dispatch cannot succeed in a test environment; the tree shape is what
+	// matters and it is written either way.
+	if _, err := Run(context.Background(), tasks, Options{RunID: "run-batch"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	events, err := runlog.Load("run-batch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 {
+		t.Fatal("a parallel batch wrote no run-log events")
+	}
+
+	tr, _ := tree.Reconstruct(events)
+	rows := tr.Rows()
+	if len(rows) != len(tasks)+1 {
+		t.Fatalf("%d rows, want %d (batch root + one per task)", len(rows), len(tasks)+1)
+	}
+	if rows[0].Node.ID != batchAgent {
+		t.Errorf("root = %q, want %q", rows[0].Node.ID, batchAgent)
+	}
+
+	seen := map[string]bool{}
+	for _, r := range rows[1:] {
+		if r.Depth != 1 {
+			t.Errorf("task %q at depth %d, want 1", r.Node.ID, r.Depth)
+		}
+		seen[r.Node.ID] = true
+	}
+	for _, task := range tasks {
+		if !seen[task.Label] {
+			t.Errorf("task %q missing from the tree", task.Label)
+		}
+	}
+}
+
+// Every task in a batch shares the batch's run but gets its own task id — that
+// is what lets a reader tell "one batch of three" from "three unrelated runs".
+func TestRun_TasksShareRunAndGetDistinctTaskIDs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	tasks := []Task{
+		{Label: "one", Enum: "SIMPLE", Prompt: "a"},
+		{Label: "two", Enum: "SIMPLE", Prompt: "b"},
+	}
+	if _, err := Run(context.Background(), tasks, Options{RunID: "run-ids"}); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := runlog.Load("run-ids")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	taskIDs := map[string]string{} // label → task id
+	for _, e := range events {
+		if e.RunID != "run-ids" {
+			t.Errorf("event carries run_id %q, want run-ids", e.RunID)
+		}
+		if e.Agent == batchAgent || e.TaskID == "" {
+			continue
+		}
+		if prev, ok := taskIDs[e.Agent]; ok && prev != e.TaskID {
+			t.Errorf("task %q has two task ids: %q and %q", e.Agent, prev, e.TaskID)
+		}
+		taskIDs[e.Agent] = e.TaskID
+	}
+	if len(taskIDs) != len(tasks) {
+		t.Fatalf("saw %d tasks, want %d", len(taskIDs), len(tasks))
+	}
+	seen := map[string]bool{}
+	for label, id := range taskIDs {
+		if seen[id] {
+			t.Errorf("task %q reused task id %q — tasks must be distinguishable", label, id)
+		}
+		seen[id] = true
 	}
 }

--- a/internal/runid/env_test.go
+++ b/internal/runid/env_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+package runid
+
+import "testing"
+
+// The env vars exist so an external orchestrator can group the Hydra
+// invocations it spawns into one run. That only works if the entry point
+// *resolves* instead of minting: resolve ranks explicit > env > generated, so
+// passing a freshly generated id as the "explicit" value silently outranks the
+// env var and makes it dead (#204).
+//
+// This pins the precedence that the CLI depends on.
+func TestResolve_GeneratedValueMustNotBePassedAsExplicit(t *testing.T) {
+	t.Setenv(EnvRunID, "orchestrator-run")
+
+	// What cmd/hydra used to do.
+	minted := New()
+	if got := ResolveRun(minted); got != minted {
+		t.Fatalf("ResolveRun(minted) = %q, want the explicit value — precedence changed", got)
+	}
+	if minted == "orchestrator-run" {
+		t.Fatal("New() collided with the env value; test is meaningless")
+	}
+
+	// What it must do instead.
+	if got := ResolveRun(""); got != "orchestrator-run" {
+		t.Errorf("ResolveRun(\"\") = %q, want the env value %q — HYDRA_RUN_ID is being ignored",
+			got, "orchestrator-run")
+	}
+}
+
+func TestResolveTask_HonoursEnvWhenNotOverridden(t *testing.T) {
+	t.Setenv(EnvTaskID, "orchestrator-task")
+
+	if got := ResolveTask(""); got != "orchestrator-task" {
+		t.Errorf("ResolveTask(\"\") = %q, want %q", got, "orchestrator-task")
+	}
+}

--- a/internal/swarm/runlog.go
+++ b/internal/swarm/runlog.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"fmt"
+
+	"github.com/ankit373/hydra/internal/rank"
+	"github.com/ankit373/hydra/internal/runid"
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+// Node ids for the fan-out's own parent in the supervision tree.
+//
+// A named parent is emitted rather than reusing the task id: tree.Reconstruct
+// links a child to whatever Parent names, so pointing at an id no event ever
+// declares would materialise a phantom node labelled with a raw timestamp. A
+// swarm and an ensemble are also different things to a reader — one is racing
+// candidates, the other is accumulating evidence — so they get different roots.
+const (
+	swarmAgent = "swarm"
+	sprtAgent  = "ensemble"
+)
+
+// logRunEvents appends one runlog event per attempt so a swarm reads as N heads
+// working one task rather than a single opaque node.
+//
+// cost.jsonl already records the spend; this records the *shape* — which head,
+// which tier, which won, how long — because that is what a supervision tree and
+// a Fleet view are reconstructed from. Before #204 nothing in this package
+// emitted, so a five-head swarm collapsed to one tree node.
+//
+// SPRT does not use this — see logSamples, which emits from the LLR ledger so
+// each event carries the running confidence.
+//
+// Every append is best-effort. Losing an observability event must never fail the
+// work being observed.
+func logRunEvents(attempts []Attempt, mode SwarmMode, opts Options) {
+	runID := runid.ResolveRun(opts.RunID)
+	taskID := runid.ResolveTask(opts.TaskID)
+
+	rl := runlog.New(runID)
+	_ = rl.Append(runlog.Event{
+		Kind: runlog.KindTaskStarted, TaskID: taskID,
+		Agent:  swarmAgent,
+		Detail: fmt.Sprintf("swarm · %s · %d heads", mode, len(attempts)),
+	})
+
+	for _, a := range attempts {
+		if a.Status == StatusPending || a.Status == StatusCanceled {
+			continue
+		}
+		detail := string(mode)
+		if a.Status == StatusOK && a.Rank == 1 {
+			detail = string(mode) + " · winner"
+		}
+		_ = rl.Append(runlog.Event{
+			Kind:   runlog.KindAttempt,
+			TaskID: taskID,
+			// Keyed by head id, which is also how dispatch keys its own events —
+			// so a head's selection, execution, and attempt collapse into one
+			// node rather than three.
+			Agent:      a.Head.ID,
+			Parent:     swarmAgent,
+			Head:       a.Head.ID,
+			Model:      a.Head.Name,
+			Tier:       rank.UITier(a.Head),
+			Status:     string(a.Status),
+			CostUSD:    a.EstCostUSD,
+			DurationMS: a.Duration.Milliseconds(),
+			Detail:     detail,
+		})
+	}
+
+	_ = rl.Append(runlog.Event{Kind: runlog.KindTaskFinished, TaskID: taskID, Agent: swarmAgent})
+}
+
+// logSamples appends one runlog event per SPRT ledger entry, carrying the
+// running confidence after that source was weighed.
+//
+// attempts is consulted only to recover the head's display name and tier — the
+// ledger keys on source id alone.
+func logSamples(ledger []trust.Evidence, attempts []Attempt, opts Options) {
+	runID := runid.ResolveRun(opts.RunID)
+	taskID := runid.ResolveTask(opts.TaskID)
+
+	byID := make(map[string]Attempt, len(attempts))
+	for _, a := range attempts {
+		byID[a.Head.ID] = a
+	}
+
+	rl := runlog.New(runID)
+	_ = rl.Append(runlog.Event{
+		Kind: runlog.KindTaskStarted, TaskID: taskID,
+		Agent:  sprtAgent,
+		Detail: fmt.Sprintf("SPRT ensemble · %d samples", len(ledger)),
+	})
+
+	var final float64
+	for _, ev := range ledger {
+		final = ev.ConfidenceAfter
+		e := runlog.Event{
+			Kind:       runlog.KindSample,
+			TaskID:     taskID,
+			Agent:      ev.Source,
+			Parent:     sprtAgent,
+			Head:       ev.Source,
+			CostUSD:    ev.CostUSD,
+			Confidence: ev.ConfidenceAfter,
+			Detail:     sampleDetail(ev),
+		}
+		if a, ok := byID[ev.Source]; ok {
+			e.Model = a.Head.Name
+			e.Tier = rank.UITier(a.Head)
+			e.Status = string(a.Status)
+			e.DurationMS = a.Duration.Milliseconds()
+		}
+		_ = rl.Append(e)
+	}
+
+	_ = rl.Append(runlog.Event{
+		Kind: runlog.KindTaskFinished, TaskID: taskID,
+		Agent: sprtAgent, Confidence: final,
+	})
+}
+
+// sampleDetail says what the source did to the running log-odds, which is the
+// one thing a reader cannot infer from the confidence number alone.
+func sampleDetail(ev trust.Evidence) string {
+	verdict := "disagreed"
+	if ev.Agreed {
+		verdict = "agreed"
+	}
+	return fmt.Sprintf("%s · LLR %+.3f → Λ %.3f", verdict, ev.LLR, ev.LambdaAfter)
+}

--- a/internal/swarm/runlog_test.go
+++ b/internal/swarm/runlog_test.go
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/tree"
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+func rlSandbox(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_RUN_ID", "")
+	t.Setenv("HYDRA_TASK_ID", "")
+}
+
+func rlAttempt(id string, status HeadStatus, rank int) Attempt {
+	return Attempt{
+		Head:       registryHead(id, id, 80),
+		Status:     status,
+		Rank:       rank,
+		EstCostUSD: 0.01,
+		Duration:   250 * time.Millisecond,
+		FinishedAt: time.Now(),
+	}
+}
+
+func kindsOf(events []runlog.Event) map[runlog.Kind]int {
+	out := map[runlog.Kind]int{}
+	for _, e := range events {
+		out[e.Kind]++
+	}
+	return out
+}
+
+// A five-head swarm must read as five heads. Before #204 this package emitted
+// nothing, so the whole fan-out collapsed into whichever single node dispatch
+// happened to log.
+func TestLogRunEvents_OneAttemptPerHead(t *testing.T) {
+	rlSandbox(t)
+
+	attempts := []Attempt{
+		rlAttempt("a", StatusOK, 1),
+		rlAttempt("b", StatusOK, 2),
+		rlAttempt("c", StatusFailed, 0),
+	}
+	logRunEvents(attempts, ModeBest, Options{RunID: "run-sw", TaskID: "task-sw"})
+
+	events, err := runlog.Load("run-sw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := kindsOf(events)[runlog.KindAttempt]; got != 3 {
+		t.Errorf("%d attempt events, want 3 (one per executed head)", got)
+	}
+	for _, e := range events {
+		if e.Kind == runlog.KindAttempt && e.Parent != swarmAgent {
+			t.Errorf("attempt %q has parent %q, want %q", e.Agent, e.Parent, swarmAgent)
+		}
+	}
+}
+
+// Pending and canceled heads never ran. Recording them as attempts would show
+// work that did not happen.
+func TestLogRunEvents_SkipsUnexecutedHeads(t *testing.T) {
+	rlSandbox(t)
+
+	logRunEvents([]Attempt{
+		rlAttempt("ran", StatusOK, 1),
+		rlAttempt("pending", StatusPending, 0),
+		rlAttempt("canceled", StatusCanceled, 0),
+	}, ModeRace, Options{RunID: "run-skip", TaskID: "t"})
+
+	events, err := runlog.Load("run-skip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range events {
+		if e.Kind == runlog.KindAttempt && e.Agent != "ran" {
+			t.Errorf("recorded an attempt for %q, which never executed", e.Agent)
+		}
+	}
+}
+
+// The winner is the one thing a reader cannot derive from the other fields.
+func TestLogRunEvents_MarksWinner(t *testing.T) {
+	rlSandbox(t)
+
+	logRunEvents([]Attempt{
+		rlAttempt("loser", StatusOK, 2),
+		rlAttempt("winner", StatusOK, 1),
+	}, ModeBest, Options{RunID: "run-win", TaskID: "t"})
+
+	events, err := runlog.Load("run-win")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var marked int
+	for _, e := range events {
+		if e.Kind != runlog.KindAttempt {
+			continue
+		}
+		isWinner := e.Agent == "winner"
+		hasMark := e.Detail == string(ModeBest)+" · winner"
+		if isWinner != hasMark {
+			t.Errorf("%q: winner=%v but detail=%q", e.Agent, isWinner, e.Detail)
+		}
+		if hasMark {
+			marked++
+		}
+	}
+	if marked != 1 {
+		t.Errorf("%d heads marked winner, want exactly 1", marked)
+	}
+}
+
+// The emitted events must actually reconstruct — a fan-out has to render as a
+// fan-out. This is what makes the parent a named node rather than the task id:
+// linking to an id no event declares would materialise a phantom node.
+func TestLogRunEvents_ReconstructsAsAFanOut(t *testing.T) {
+	rlSandbox(t)
+
+	logRunEvents([]Attempt{
+		rlAttempt("h1", StatusOK, 1),
+		rlAttempt("h2", StatusOK, 2),
+		rlAttempt("h3", StatusOK, 3),
+	}, ModeAll, Options{RunID: "run-tree", TaskID: "t"})
+
+	events, err := runlog.Load("run-tree")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr, _ := tree.Reconstruct(events)
+	rows := tr.Rows()
+
+	if len(rows) != 4 {
+		t.Fatalf("%d rows, want 4 (one swarm root + three heads): %+v", len(rows), rows)
+	}
+	if rows[0].Node.ID != swarmAgent {
+		t.Errorf("root is %q, want %q — a phantom root means Parent named an undeclared node",
+			rows[0].Node.ID, swarmAgent)
+	}
+	for _, r := range rows[1:] {
+		if r.Depth != 1 {
+			t.Errorf("head %q at depth %d, want 1", r.Node.ID, r.Depth)
+		}
+	}
+}
+
+// SPRT samples come from the LLR ledger, not the attempt list: the running
+// confidence after each source is the whole reason --confidence exists.
+func TestLogSamples_CarriesRunningConfidence(t *testing.T) {
+	rlSandbox(t)
+
+	ledger := []trust.Evidence{
+		{Source: "a", Agreed: true, LLR: 1.2, LambdaAfter: 1.2, ConfidenceAfter: 0.768, CostUSD: 0.01},
+		{Source: "b", Agreed: true, LLR: 0.9, LambdaAfter: 2.1, ConfidenceAfter: 0.891, CostUSD: 0.02},
+		{Source: "c", Agreed: false, LLR: -0.4, LambdaAfter: 1.7, ConfidenceAfter: 0.846, CostUSD: 0.03},
+	}
+	logSamples(ledger, []Attempt{rlAttempt("a", StatusOK, 1)}, Options{RunID: "run-sprt", TaskID: "t"})
+
+	events, err := runlog.Load("run-sprt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var samples []runlog.Event
+	for _, e := range events {
+		if e.Kind == runlog.KindSample {
+			samples = append(samples, e)
+		}
+	}
+	if len(samples) != len(ledger) {
+		t.Fatalf("%d samples, want %d (one per ledger entry)", len(samples), len(ledger))
+	}
+	for i, s := range samples {
+		if s.Confidence != ledger[i].ConfidenceAfter {
+			t.Errorf("sample %d confidence = %v, want %v", i, s.Confidence, ledger[i].ConfidenceAfter)
+		}
+		if s.Agent != ledger[i].Source {
+			t.Errorf("sample %d agent = %q, want %q", i, s.Agent, ledger[i].Source)
+		}
+	}
+	// Disagreement is the one thing the confidence number alone cannot show.
+	if got := samples[2].Detail; got == "" || got[:9] != "disagreed" {
+		t.Errorf("disagreeing sample detail = %q, want it to lead with \"disagreed\"", got)
+	}
+}
+
+// A run must not be attributed to the wrong ensemble root. swarm and SPRT are
+// different things to a reader — racing candidates vs accumulating evidence.
+func TestLogSamples_UsesItsOwnRoot(t *testing.T) {
+	rlSandbox(t)
+
+	logSamples([]trust.Evidence{{Source: "a", ConfidenceAfter: 0.9}}, nil,
+		Options{RunID: "run-root", TaskID: "t"})
+
+	events, err := runlog.Load("run-root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range events {
+		if e.Kind == runlog.KindSample && e.Parent != sprtAgent {
+			t.Errorf("sample parent = %q, want %q", e.Parent, sprtAgent)
+		}
+		if e.Agent == swarmAgent {
+			t.Error("an SPRT run must not hang off the swarm root")
+		}
+	}
+}
+
+// Observability must never fail the work. An unwritable log directory has to be
+// survivable, not a panic or a hang.
+func TestLogRunEvents_SurvivesUnwritableLogDir(t *testing.T) {
+	rlSandbox(t)
+
+	// A file where the runs directory must go: MkdirAll fails, every append
+	// errors, and all of them are dropped at the call site.
+	dir := runlog.Dir()
+	if err := writeBlockingFile(t, dir); err != nil {
+		t.Skipf("could not stage an unwritable log dir: %v", err)
+	}
+
+	logRunEvents([]Attempt{rlAttempt("a", StatusOK, 1)}, ModeBest,
+		Options{RunID: "run-block", TaskID: "t"})
+	logSamples([]trust.Evidence{{Source: "a"}}, nil, Options{RunID: "run-block", TaskID: "t"})
+}
+
+// writeBlockingFile puts a regular file where a directory is required, so
+// MkdirAll cannot succeed.
+func writeBlockingFile(t *testing.T, dir string) error {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(dir), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(dir, []byte("not a directory"), 0o600)
+}

--- a/internal/swarm/sprt.go
+++ b/internal/swarm/sprt.go
@@ -102,6 +102,12 @@ func (s *Swarm) RunSPRT(ctx context.Context, prompt string, opts Options) (*SPRT
 	// `hyctl stats` — only the aggregate trust.jsonl row survives (#175).
 	logAttempts(adapter.attempts, ModeSPRT, opts, truncate(prompt, 80))
 
+	// Samples come from the LLR ledger, not from the attempt list: the ledger is
+	// what carries the running confidence after each source was weighed, which
+	// is the whole reason --confidence exists. Emitting attempts here instead
+	// would record that N heads ran but not what their evidence did (#204).
+	logSamples(res.Ledger, adapter.attempts, opts)
+
 	return &SPRTResult{Trust: res, Attempts: adapter.attempts, Domain: domain, Prompt: prompt, Target: opts.Confidence}, nil
 }
 

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -185,6 +185,7 @@ func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmRes
 
 	// 7. Log to cost.jsonl.
 	logAttempts(result.Attempts, result.Mode, opts, truncate(prompt, 80))
+	logRunEvents(result.Attempts, result.Mode, opts)
 
 	return result, nil
 }

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -28,7 +28,6 @@
 package tree
 
 import (
-	"sort"
 	"time"
 
 	"github.com/ankit373/hydra/internal/runlog"
@@ -155,13 +154,18 @@ func Apply(t *Tree, e runlog.Event) *Tree {
 		t.RunID = e.RunID
 	}
 
+	// Run-level events describe the invocation, not a node in it, so they are
+	// timeline-only. This is keyed on the kind rather than on whether nodeID
+	// happened to come back empty: a run_started that carries a TaskID — which
+	// is legitimate metadata — would otherwise fall through nodeID's TaskID
+	// branch and materialise a phantom root labelled with a raw id (#204).
+	if e.Kind == runlog.KindRunStarted || e.Kind == runlog.KindRunFinished {
+		return t
+	}
+
 	id := nodeID(e)
 	if id == "" {
-		// Run-level events (run_started/run_finished) belong to no node; they
-		// are timeline-only, not a failure.
-		if e.Kind != runlog.KindRunStarted && e.Kind != runlog.KindRunFinished {
-			t.Skipped++
-		}
+		t.Skipped++
 		return t
 	}
 
@@ -393,14 +397,4 @@ func (t *Tree) CountByState() map[State]int {
 		counts[n.State]++
 	}
 	return counts
-}
-
-// SortedEntries returns timeline entries by sequence number. Load already
-// yields append order; this makes the guarantee explicit for callers that
-// merge entries from more than one source.
-func (tl *Timeline) SortedEntries() []Entry {
-	out := make([]Entry, len(tl.Entries))
-	copy(out, tl.Entries)
-	sort.SliceStable(out, func(i, j int) bool { return out[i].Seq < out[j].Seq })
-	return out
 }

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -290,23 +290,35 @@ func TestTree_Aggregates(t *testing.T) {
 	}
 }
 
-func TestTimeline_SortedBySeq(t *testing.T) {
-	// Deliberately out of sequence order, as a merge of two sources could be.
+// One run legitimately has several writers — the CLI logs the run's lifecycle
+// while dispatch logs the routing inside it — so seq values interleave and
+// repeat across them. runlog's own doc says seq "is not the sort key"; file
+// order is. A timeline that re-sorted by seq would put a run's end before a
+// handoff that happened first (#204).
+func TestTimeline_PreservesFileOrderAcrossWriters(t *testing.T) {
+	// Exactly the interleaving a real dispatch produces: writer A is the CLI
+	// (run lifecycle), writer B is dispatch (routing), each counting from 1.
 	events := []runlog.Event{
-		ev(3, runlog.KindAttempt, agent("a")),
-		ev(1, runlog.KindTaskStarted, agent("a")),
-		ev(2, runlog.KindHeadSelected, agent("a")),
+		ev(1, runlog.KindRunStarted),
+		ev(1, runlog.KindHeadSelected, agent("h")),
+		ev(2, runlog.KindDispatchFinished, agent("h"), status("ok")),
+		ev(3, runlog.KindHandoff, agent("h"), ref("next")),
+		ev(2, runlog.KindRunFinished),
 	}
 	_, tl := Reconstruct(events)
-	sorted := tl.SortedEntries()
-	for i, want := range []uint64{1, 2, 3} {
-		if sorted[i].Seq != want {
-			t.Errorf("sorted[%d].Seq = %d, want %d", i, sorted[i].Seq, want)
-		}
+
+	var kinds []runlog.Kind
+	for _, e := range tl.Entries {
+		kinds = append(kinds, e.Kind)
 	}
-	// The original slice must not be reordered under the caller.
-	if tl.Entries[0].Seq != 3 {
-		t.Error("SortedEntries mutated the underlying slice")
+	want := []runlog.Kind{
+		runlog.KindRunStarted, runlog.KindHeadSelected,
+		runlog.KindDispatchFinished, runlog.KindHandoff, runlog.KindRunFinished,
+	}
+	for i := range want {
+		if i >= len(kinds) || kinds[i] != want[i] {
+			t.Fatalf("timeline order = %v, want %v — sorting by seq reorders across writers", kinds, want)
+		}
 	}
 }
 
@@ -335,5 +347,40 @@ func TestReconstruct_FromRealDispatchShape(t *testing.T) {
 	}
 	if tr.Nodes["h2"].TaskID != "t1" && tr.Nodes["h1"].TaskID != "t1" {
 		t.Error("task id was not carried onto the nodes")
+	}
+}
+
+// A run-level event describes the invocation, not a node in it. It carries a
+// TaskID as legitimate metadata, and nodeID falls back to TaskID — so without an
+// explicit kind check the run's own start would appear in the tree as a node
+// named after a raw timestamp id (#204).
+func TestApply_RunLevelEventsNeverCreateNodes(t *testing.T) {
+	events := []runlog.Event{
+		{V: 1, Seq: 1, RunID: "r", TaskID: "task-abc", Kind: runlog.KindRunStarted},
+		{V: 1, Seq: 2, RunID: "r", TaskID: "task-abc", Kind: runlog.KindHeadSelected, Head: "agy"},
+		{V: 1, Seq: 3, RunID: "r", TaskID: "task-abc", Kind: runlog.KindDispatchFinished,
+			Head: "agy", Status: "ok"},
+		{V: 1, Seq: 4, RunID: "r", TaskID: "task-abc", Kind: runlog.KindRunFinished},
+	}
+	tr, tl := Reconstruct(events)
+
+	if _, exists := tr.Nodes["task-abc"]; exists {
+		t.Error("run-level event created a node keyed by its TaskID")
+	}
+	rows := tr.Rows()
+	if len(rows) != 1 {
+		t.Fatalf("%d rows, want 1 (just the head): %+v", len(rows), rows)
+	}
+	if rows[0].Node.ID != "agy" {
+		t.Errorf("row 0 is %q, want the head %q", rows[0].Node.ID, "agy")
+	}
+	if tr.Skipped != 0 {
+		t.Errorf("Skipped = %d; run-level events are expected, not malformed", tr.Skipped)
+	}
+	// They must still appear on the timeline — that is where a run's start and
+	// end belong.
+	if len(tl.Entries) != len(events) {
+		t.Errorf("%d timeline entries, want %d — run-level events belong on the timeline",
+			len(tl.Entries), len(events))
 	}
 }

--- a/internal/trust/sprt.go
+++ b/internal/trust/sprt.go
@@ -70,6 +70,13 @@ type Evidence struct {
 	Candidate   string  `json:"candidate"`
 	LambdaAfter float64 `json:"lambda_after"`
 	CostUSD     float64 `json:"cost_usd"`
+
+	// ConfidenceAfter is σ(LambdaAfter) — the running P(correct) once this
+	// source had been weighed. Stored rather than left for readers to derive:
+	// the ledger is a public JSON type written to trust.jsonl and read by the
+	// run log, and a second copy of the sigmoid in each reader is a third place
+	// for the confidence to drift.
+	ConfidenceAfter float64 `json:"confidence_after"`
 }
 
 // Result is the outcome of Run.
@@ -147,6 +154,7 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 		res.Ledger = append(res.Ledger, Evidence{
 			Source: src.ID, Agreed: agreed, LLR: llr,
 			Candidate: candidate, LambdaAfter: lambda, CostUSD: cost,
+			ConfidenceAfter: sigmoid(lambda),
 		})
 
 		if lambda >= A {


### PR DESCRIPTION
## Correction first

I earlier reported that nothing writes run events. **That was wrong** — `dispatch.go` emits, and a
real `hyctl dispatch` produced `head_selected` and `dispatch_finished` before this change. The gap
is narrower than I said, and still blocking Phase 4.

Everything below is verified by grepping every non-test `Kind:` in the tree and by running real
dispatches, not by reading source.

## What was missing

- **No heartbeat was ever started.** `StartHeartbeat` had no caller outside its own tests, so
  `LiveRuns()` was permanently empty and `ckLoadTree` always took its `runlog.Runs()` fallback.
  Nothing could tell a running agent from a finished one — a Fleet view has no premise without it.
- **`swarm` emitted nothing** — a five-head fan-out collapsed to whatever single node dispatch
  logged.
- **SPRT emitted no samples** — the per-source confidence trace `--confidence` exists to produce was
  invisible.
- **`parallel` emitted nothing** — an N-task batch had no shape at all.
- **No handoff was appended.** `KindHandoff`'s stated purpose is that `last_handoff.json` keeps only
  the newest and appending here is "what makes a chain reconstructable". It never happened.
- **`HYDRA_RUN_ID` / `HYDRA_TASK_ID` were dead.** `runid` ranks explicit > env > generated, and
  `cmd/hydra` minted via `runid.New()` then passed the result as the *explicit* value — always
  outranking the env var whose whole purpose is letting an external orchestrator group the
  invocations it spawns.

## Verified end-to-end, not just unit-tested

```
$ export HYDRA_RUN_ID=20260802T160000Z-9999aaaabbbbcccc
$ hyctl dispatch --tier 10 "reply OK"
$ ls ~/.hydra/logs/runs/
20260802T160000Z-9999aaaabbbbcccc.jsonl        ← env var now honoured
```

Heartbeat, mid-run vs after:

```
t=0s LIVE: [20260802T150000Z-5555666677778888]     ← during the dispatch
never saw a live run                               ← after it ended
```

Cockpit tree, before → after:

```
 ▸ 20260802T063939Z-4917eb0b3d…  T0  · pending      ← phantom root
   agy  T4   Antigravity · ok  ┄1

 ▸ agy  T4   Antigravity · ok  ┄1                   ← after
 SELECTED  agy · T4 · Antigravity · ok
 duration     1551ms
 ┄┄▶ A2A      hydra-tier-4  context handed to hydra-tier-4
```

## Two defects this surfaced in the readers

**`tree.Apply` created a phantom root.** Run-level events are meant to be timeline-only, but the
guard keyed on `nodeID` returning empty — and `nodeID` falls back to `TaskID`, which a `run_started`
legitimately carries. The check is now on the kind.

**`Timeline.SortedEntries` sorted by `Seq`**, which runlog's own doc says "is not the sort key",
precisely because several writers share one run and each counts from 1. Harmless while dispatch was
the only writer; now that the CLI logs the run lifecycle *around* it, sorting by seq puts a run's
end before a handoff that happened first. File order is authoritative and `Load` already preserves
it, so the method is deleted rather than left as a trap for Phase 5's timeline. It had no non-test
caller.

## Design note

Samples come from the **LLR ledger**, not the attempt list — the ledger is what carries the running
confidence after each source is weighed. `trust.Evidence` gains `ConfidenceAfter` so that value is
stored once rather than recomputed per reader; it is a public type written to `trust.jsonl`, and a
second copy of the sigmoid is a second place for the number to drift.

A named parent (`swarm`, `ensemble`, `parallel`) is emitted rather than reusing the task id:
`Reconstruct` links a child to whatever `Parent` names, so pointing at an id no event declares would
materialise exactly the phantom node fixed above.

## Tests

Each producer has a test asserting it emits, so a refactor that drops the calls fails CI rather than
silently emptying the view again:

| Test | Asserts |
|---|---|
| `TestLogRunEvents_OneAttemptPerHead` | one `attempt` per executed head |
| `TestLogRunEvents_SkipsUnexecutedHeads` | pending/canceled heads are not recorded as work that happened |
| `TestLogRunEvents_ReconstructsAsAFanOut` | 3 heads → 1 root + 3 children at depth 1 |
| `TestLogSamples_CarriesRunningConfidence` | one sample per ledger entry, confidence matches, disagreement visible |
| `TestLogSamples_UsesItsOwnRoot` | an ensemble never hangs off the swarm root |
| `TestRun_EmitsBatchTree` | a parallel batch reconstructs as root + one node per task |
| `TestRun_TasksShareRunAndGetDistinctTaskIDs` | one run, N distinct tasks |
| `TestResolve_GeneratedValueMustNotBePassedAsExplicit` | pins the precedence the CLI bug violated |
| `TestApply_RunLevelEventsNeverCreateNodes` | no phantom root; run events still reach the timeline |
| `TestTimeline_PreservesFileOrderAcrossWriters` | the exact interleaving a real dispatch produces |
| `TestLogRunEvents_SurvivesUnwritableLogDir` | logging failure cannot fail the work |

`gofmt`, `go build`, `go vet`, `staticcheck`, `go test -race ./...` clean on both modules.

Closes #204