### PR TITLE
feat(desktop): Fleet view — live runs and the agents inside them

### DIFF
--- a/desktop/api/dto_test.go
+++ b/desktop/api/dto_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// frontend/src/types.ts mirrors these DTOs by hand, because Wails' generated
+// bindings are a build artefact and are gitignored — the source tree could not
+// typecheck against them. That mirror can drift, and it already did once:
+// Agent.Tier and Agent.Confidence were omitempty in Go while TypeScript
+// declared them required, so a tier-0 agent arrived as `undefined` where the
+// view expected a number.
+//
+// This pins the rule that made that a bug: a numeric field the view compares
+// must always be present on the wire. Strings may be omitempty — TypeScript
+// models those naturally as optional.
+func TestDTOs_NumericFieldsAreNeverOmitEmpty(t *testing.T) {
+	for _, v := range []any{Fleet{}, Run{}, Agent{}, Dashboard{}, SpendPanel{}, GovernorPanel{}, TrustPanel{}, Breakdown{}, RecentCall{}} {
+		rt := reflect.TypeOf(v)
+		t.Run(rt.Name(), func(t *testing.T) {
+			for i := range rt.NumField() {
+				f := rt.Field(i)
+				tag := f.Tag.Get("json")
+				if !strings.Contains(tag, ",omitempty") {
+					continue
+				}
+				switch f.Type.Kind() {
+				case reflect.Int, reflect.Int64, reflect.Float64, reflect.Bool:
+					t.Errorf("%s.%s is %s with omitempty — an absent key reaches TypeScript as undefined, "+
+						"not as a zero the view can compare", rt.Name(), f.Name, f.Type.Kind())
+				}
+			}
+		})
+	}
+}
+
+// Every DTO must round-trip through JSON unchanged. A field with no json tag
+// would ship a Go-cased key the hand-written mirror does not declare.
+func TestDTOs_FieldNamesAreExplicitlyTagged(t *testing.T) {
+	for _, v := range []any{Fleet{}, Run{}, Agent{}, Dashboard{}, SpendPanel{}, GovernorPanel{}, TrustPanel{}, Breakdown{}, RecentCall{}, Version{}} {
+		rt := reflect.TypeOf(v)
+		for i := range rt.NumField() {
+			f := rt.Field(i)
+			if f.Tag.Get("json") == "" {
+				t.Errorf("%s.%s has no json tag — it would serialise as %q, which types.ts does not declare",
+					rt.Name(), f.Name, f.Name)
+			}
+		}
+	}
+}
+
+// An empty fleet must serialise as valid JSON with the flags the view branches
+// on, rather than as null.
+func TestFleet_SerialisesEmptyStateForTheView(t *testing.T) {
+	raw, err := json.Marshal(Fleet{GroupThreshold: GroupThreshold})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"hasRuns", "liveCount", "groupThreshold"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("empty Fleet omits %q, which the view branches on", key)
+		}
+	}
+}

--- a/desktop/api/fleet.go
+++ b/desktop/api/fleet.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"sort"
+	"time"
+
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/tree"
+)
+
+// GroupThreshold is the agent count past which the frontend collapses a run's
+// agents behind a summary instead of rendering every card.
+//
+// Set here rather than in the view so both surfaces agree on when a fan-out
+// stops being readable. A 20-head swarm reaches it on the first run, which is
+// why this exists before the problem is visible rather than after.
+const GroupThreshold = 16
+
+// Fleet is every run this machine knows about, live first.
+type Fleet struct {
+	// HasRuns is false when no run has ever been logged. The view says so
+	// rather than rendering an empty list that looks like a failed load.
+	HasRuns bool `json:"hasRuns"`
+
+	LiveCount int   `json:"liveCount"`
+	Runs      []Run `json:"runs"`
+
+	// GroupThreshold is served to the frontend so the collapse point is defined
+	// once, in Go, rather than duplicated as a magic number in the view.
+	GroupThreshold int `json:"groupThreshold"`
+}
+
+// Run is one invocation and the agents inside it.
+type Run struct {
+	ID   string `json:"id"`
+	Live bool   `json:"live"`
+
+	StartedAt string `json:"startedAt"`
+	ElapsedMS int64  `json:"elapsedMs"`
+
+	CostUSD float64 `json:"costUsd"`
+	// Confidence is the run's final confidence, non-zero only for an SPRT
+	// ensemble. Zero means "not a confidence run", not "no confidence".
+	Confidence float64 `json:"confidence"`
+
+	Agents []Agent `json:"agents"`
+
+	// Counts by state, so a collapsed run still says what is in it.
+	Running  int `json:"running"`
+	OK       int `json:"ok"`
+	Failed   int `json:"failed"`
+	Pending  int `json:"pending"`
+	AllCount int `json:"allCount"`
+
+	// Skipped is events the reconstruction could not attribute to an agent.
+	// Surfaced rather than hidden: silently dropping them renders a partial run
+	// as a complete one.
+	Skipped int `json:"skipped"`
+
+	// Error is set when this run's log could not be read. The run still appears
+	// as a row — a bad file must not blank the whole view.
+	Error string `json:"error,omitempty"`
+}
+
+// Agent is one head or task inside a run.
+type Agent struct {
+	ID     string `json:"id"`
+	Parent string `json:"parent,omitempty"`
+	Depth  int    `json:"depth"`
+
+	Head  string `json:"head,omitempty"`
+	Model string `json:"model,omitempty"`
+	State string `json:"state"`
+
+	// Tier and Confidence are deliberately not omitempty: the view compares
+	// them numerically, and an omitted key arrives as undefined rather than 0.
+	// A tier of 0 also means something — "unknown", the same bucket
+	// `hyctl stats --tier` uses.
+	Tier       int     `json:"tier"`
+	CostUSD    float64 `json:"costUsd"`
+	Confidence float64 `json:"confidence"`
+	DurationMS int64   `json:"durationMs"`
+
+	Detail string `json:"detail,omitempty"`
+}
+
+// GetFleet lists every run, live ones first.
+//
+// Reconstruction goes through tree.Reconstruct — the same call the terminal
+// cockpit makes — so the two surfaces cannot disagree about the same run.
+func (a *API) GetFleet() (*Fleet, error) {
+	ids, err := runlog.Runs()
+	if err != nil {
+		return nil, err
+	}
+
+	f := &Fleet{GroupThreshold: GroupThreshold}
+	if len(ids) == 0 {
+		return f, nil
+	}
+	f.HasRuns = true
+
+	live := make(map[string]bool, len(ids))
+	if liveIDs, err := runlog.LiveRuns(); err == nil {
+		for _, id := range liveIDs {
+			live[id] = true
+		}
+	}
+
+	now := time.Now()
+	for _, id := range ids {
+		r := buildRun(id, live[id], now)
+		if r.Live {
+			f.LiveCount++
+		}
+		f.Runs = append(f.Runs, r)
+	}
+
+	// Live first, then most recent. Run ids are timestamp-prefixed, so a
+	// reverse lexical compare is a reverse chronological one — no parsing, and
+	// it stays correct for ids minted by an external orchestrator that followed
+	// the same format.
+	sort.SliceStable(f.Runs, func(i, j int) bool {
+		if f.Runs[i].Live != f.Runs[j].Live {
+			return f.Runs[i].Live
+		}
+		return f.Runs[i].ID > f.Runs[j].ID
+	})
+
+	return f, nil
+}
+
+func buildRun(id string, live bool, now time.Time) Run {
+	r := Run{ID: id, Live: live}
+
+	events, err := runlog.Load(id)
+	if err != nil {
+		// A row with an error beats a blank view: the run existed, and saying
+		// why it cannot be read is more useful than pretending it does not.
+		r.Error = err.Error()
+		return r
+	}
+	if len(events) == 0 {
+		return r
+	}
+
+	t, _ := tree.Reconstruct(events)
+	r.Skipped = t.Skipped
+
+	for _, row := range t.Rows() {
+		n := row.Node
+		r.Agents = append(r.Agents, Agent{
+			ID: n.ID, Parent: n.Parent, Depth: row.Depth,
+			Head: n.Head, Model: n.Model, Tier: n.Tier,
+			State:      string(n.State),
+			CostUSD:    n.CostUSD,
+			Confidence: n.Confidence,
+			DurationMS: n.DurationMS,
+			Detail:     n.Detail,
+		})
+		r.CostUSD += n.CostUSD
+		// The run's confidence is whichever agent carries one — only an SPRT
+		// ensemble does, and its root records the final value.
+		if n.Confidence > r.Confidence {
+			r.Confidence = n.Confidence
+		}
+		switch n.State {
+		case tree.StateRunning:
+			r.Running++
+		case tree.StateOK:
+			r.OK++
+		case tree.StateFailed:
+			r.Failed++
+		default:
+			r.Pending++
+		}
+	}
+	r.AllCount = len(r.Agents)
+
+	first, last := eventSpan(t)
+	if !first.IsZero() {
+		r.StartedAt = first.UTC().Format(time.RFC3339)
+		// A live run is still accruing, so it is measured to now; a finished one
+		// is measured to its last event. Using now for both would make every
+		// historical run appear to still be growing.
+		end := last
+		if live || end.Before(first) {
+			end = now
+		}
+		r.ElapsedMS = end.Sub(first).Milliseconds()
+	}
+
+	return r
+}
+
+// eventSpan returns the earliest start and latest finish across a run's nodes.
+func eventSpan(t *tree.Tree) (first, last time.Time) {
+	for _, id := range t.Order {
+		n := t.Nodes[id]
+		if !n.StartedAt.IsZero() && (first.IsZero() || n.StartedAt.Before(first)) {
+			first = n.StartedAt
+		}
+		for _, ts := range []time.Time{n.StartedAt, n.FinishedAt} {
+			if !ts.IsZero() && ts.After(last) {
+				last = ts
+			}
+		}
+	}
+	return first, last
+}

--- a/desktop/api/fleet_test.go
+++ b/desktop/api/fleet_test.go
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+// writeRun appends events for one run, exactly as a producer would.
+func writeRun(t *testing.T, runID string, events ...runlog.Event) {
+	t.Helper()
+	rl := runlog.New(runID)
+	for _, e := range events {
+		if err := rl.Append(e); err != nil {
+			t.Fatalf("append to %s: %v", runID, err)
+		}
+	}
+}
+
+// markLive touches a run's heartbeat so LiveRuns reports it.
+func markLive(t *testing.T, runID string) {
+	t.Helper()
+	p := runlog.HeartbeatPath(runID)
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func runByID(f *Fleet, id string) *Run {
+	for i := range f.Runs {
+		if f.Runs[i].ID == id {
+			return &f.Runs[i]
+		}
+	}
+	return nil
+}
+
+// A machine that has never dispatched must say so, not render an empty list
+// that looks like a failed load.
+func TestGetFleet_EmptyStateIsHonest(t *testing.T) {
+	sandbox(t)
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatalf("GetFleet on a fresh machine must not error: %v", err)
+	}
+	if f.HasRuns {
+		t.Error("HasRuns = true with no runs on disk")
+	}
+	if len(f.Runs) != 0 || f.LiveCount != 0 {
+		t.Errorf("expected no runs, got %d (%d live)", len(f.Runs), f.LiveCount)
+	}
+	if f.GroupThreshold != GroupThreshold {
+		t.Errorf("GroupThreshold = %d, want %d — the view must not hardcode its own", f.GroupThreshold, GroupThreshold)
+	}
+}
+
+// A swarm's heads must appear as separate agents. Before #205 the fan-out
+// collapsed to one node, which is exactly what a Fleet view cannot show.
+func TestGetFleet_SwarmHeadsAreSeparateAgents(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-aaaa",
+		runlog.Event{Kind: runlog.KindTaskStarted, Agent: "swarm"},
+		runlog.Event{Kind: runlog.KindAttempt, Agent: "h1", Parent: "swarm", Head: "h1", Model: "M1", Tier: 2, Status: "ok", CostUSD: 0.01},
+		runlog.Event{Kind: runlog.KindAttempt, Agent: "h2", Parent: "swarm", Head: "h2", Model: "M2", Tier: 4, Status: "ok", CostUSD: 0.02},
+		runlog.Event{Kind: runlog.KindAttempt, Agent: "h3", Parent: "swarm", Head: "h3", Model: "M3", Tier: 8, Status: "failed"},
+		runlog.Event{Kind: runlog.KindTaskFinished, Agent: "swarm"},
+	)
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := runByID(f, "20260802T100000Z-aaaa")
+	if r == nil {
+		t.Fatal("run missing from the fleet")
+	}
+	if r.AllCount != 4 {
+		t.Fatalf("%d agents, want 4 (swarm root + three heads)", r.AllCount)
+	}
+	if r.OK != 3 { // swarm root finishes ok too
+		t.Errorf("OK = %d, want 3", r.OK)
+	}
+	if r.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", r.Failed)
+	}
+	// Cost is the sum of what the heads actually spent.
+	if r.CostUSD != 0.03 {
+		t.Errorf("CostUSD = %v, want 0.03", r.CostUSD)
+	}
+	// Depth carries the fan-out's shape.
+	for _, a := range r.Agents {
+		if a.ID == "swarm" && a.Depth != 0 {
+			t.Errorf("swarm root at depth %d, want 0", a.Depth)
+		}
+		if a.ID != "swarm" && a.Depth != 1 {
+			t.Errorf("head %q at depth %d, want 1", a.ID, a.Depth)
+		}
+	}
+}
+
+// Live-first ordering is the whole point of the view: what is happening now
+// must not be buried under history.
+func TestGetFleet_OrdersLiveFirstThenRecent(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T090000Z-old", runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"})
+	writeRun(t, "20260802T110000Z-new", runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"})
+	writeRun(t, "20260802T100000Z-mid", runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"})
+	markLive(t, "20260802T090000Z-old") // the OLDEST is the live one
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.LiveCount != 1 {
+		t.Fatalf("LiveCount = %d, want 1", f.LiveCount)
+	}
+	want := []string{"20260802T090000Z-old", "20260802T110000Z-new", "20260802T100000Z-mid"}
+	for i, id := range want {
+		if i >= len(f.Runs) || f.Runs[i].ID != id {
+			got := make([]string, len(f.Runs))
+			for j, r := range f.Runs {
+				got[j] = r.ID
+			}
+			t.Fatalf("order = %v, want %v (live first, then newest)", got, want)
+		}
+	}
+	if !f.Runs[0].Live {
+		t.Error("the live run is not marked live")
+	}
+}
+
+// A stale heartbeat means the process died. It must not read as still running,
+// or a crashed agent stays "live" forever.
+func TestGetFleet_StaleHeartbeatIsNotLive(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-stale", runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"})
+	markLive(t, "20260802T100000Z-stale")
+
+	// Backdate well past StaleAfter, as a killed process leaves behind.
+	old := time.Now().Add(-10 * runlog.StaleAfter)
+	if err := os.Chtimes(runlog.HeartbeatPath("20260802T100000Z-stale"), old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.LiveCount != 0 {
+		t.Errorf("LiveCount = %d, want 0 — a stale marker is a dead process", f.LiveCount)
+	}
+	if r := runByID(f, "20260802T100000Z-stale"); r == nil || r.Live {
+		t.Error("run with a stale heartbeat is still marked live")
+	}
+}
+
+// An SPRT run's final confidence is the number the whole ensemble exists to
+// produce; a plain dispatch has none, and zero must not be shown as one.
+func TestGetFleet_ConfidenceOnlyForEnsembles(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-sprt",
+		runlog.Event{Kind: runlog.KindTaskStarted, Agent: "ensemble"},
+		runlog.Event{Kind: runlog.KindSample, Agent: "a", Parent: "ensemble", Confidence: 0.72},
+		runlog.Event{Kind: runlog.KindSample, Agent: "b", Parent: "ensemble", Confidence: 0.95},
+		runlog.Event{Kind: runlog.KindTaskFinished, Agent: "ensemble", Confidence: 0.95},
+	)
+	writeRun(t, "20260802T090000Z-plain",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"},
+		runlog.Event{Kind: runlog.KindDispatchFinished, Head: "h", Status: "ok"},
+	)
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := runByID(f, "20260802T100000Z-sprt"); r == nil || r.Confidence != 0.95 {
+		t.Errorf("SPRT run confidence = %v, want 0.95", r.Confidence)
+	}
+	if r := runByID(f, "20260802T090000Z-plain"); r == nil || r.Confidence != 0 {
+		t.Errorf("plain dispatch confidence = %v, want 0 (not a confidence run)", r.Confidence)
+	}
+}
+
+// A finished run's elapsed time is fixed at its last event. Measuring it to now
+// would make every historical run appear to still be growing.
+func TestGetFleet_FinishedRunElapsedStopsAtLastEvent(t *testing.T) {
+	sandbox(t)
+
+	start := time.Now().Add(-2 * time.Hour)
+	writeRun(t, "20260802T100000Z-done",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h", TS: start.UTC().Format(time.RFC3339Nano)},
+		runlog.Event{Kind: runlog.KindDispatchFinished, Head: "h", Status: "ok",
+			TS: start.Add(5 * time.Second).UTC().Format(time.RFC3339Nano)},
+	)
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := runByID(f, "20260802T100000Z-done")
+	if r == nil {
+		t.Fatal("run missing")
+	}
+	if r.ElapsedMS < 4_000 || r.ElapsedMS > 6_000 {
+		t.Errorf("ElapsedMS = %d, want ~5000 — a finished run must not keep accruing", r.ElapsedMS)
+	}
+}
+
+// A live run is still accruing, so it is measured to now.
+func TestGetFleet_LiveRunElapsedRunsToNow(t *testing.T) {
+	sandbox(t)
+
+	start := time.Now().Add(-30 * time.Second)
+	writeRun(t, "20260802T100000Z-live",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h", TS: start.UTC().Format(time.RFC3339Nano)},
+	)
+	markLive(t, "20260802T100000Z-live")
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := runByID(f, "20260802T100000Z-live")
+	if r == nil || !r.Live {
+		t.Fatal("live run missing or not live")
+	}
+	if r.ElapsedMS < 29_000 {
+		t.Errorf("ElapsedMS = %d, want ~30000 — a live run is measured to now", r.ElapsedMS)
+	}
+}
+
+// A malformed line must not blank the view, and must not be silently dropped
+// either: a partial run rendered as a complete one is the worse failure.
+func TestGetFleet_MalformedLinesAreSurfacedNotHidden(t *testing.T) {
+	home := sandbox(t)
+
+	writeRun(t, "20260802T100000Z-partial",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"},
+	)
+	// An event attributable to no node — nodeID returns "".
+	writeRun(t, "20260802T100000Z-partial",
+		runlog.Event{Kind: runlog.KindEdit},
+	)
+	if _, err := os.Stat(filepath.Join(home, ".hydra", "logs", "runs", "20260802T100000Z-partial.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := runByID(f, "20260802T100000Z-partial")
+	if r == nil {
+		t.Fatal("run missing")
+	}
+	if r.Skipped == 0 {
+		t.Error("Skipped = 0; an unattributable event was hidden rather than surfaced")
+	}
+	if r.AllCount == 0 {
+		t.Error("the readable part of the run was dropped too")
+	}
+}
+
+// Reading the fleet holds no state and must be safe to poll from several places
+// at once, as the frontend does.
+func TestGetFleet_ConcurrentCallsAreSafe(t *testing.T) {
+	sandbox(t)
+	writeRun(t, "20260802T100000Z-conc", runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"})
+
+	a := New()
+	done := make(chan error, 16)
+	for range cap(done) {
+		go func() {
+			_, err := a.GetFleet()
+			done <- err
+		}()
+	}
+	for range cap(done) {
+		if err := <-done; err != nil {
+			t.Errorf("concurrent GetFleet: %v", err)
+		}
+	}
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,46 +1,64 @@
 import { useCallback, useEffect, useState } from 'react'
-import { GetDashboard, GetVersion } from './bindings'
-import type { Dashboard as DashboardData, Version } from './types'
+import { GetDashboard, GetFleet, GetVersion } from './bindings'
+import type { Dashboard as DashboardData, Fleet as FleetData, Version } from './types'
 import { Dashboard } from './views/Dashboard'
+import { Fleet } from './views/Fleet'
 
 /** Dashboard is retrospective — a slow refresh is enough and costs nothing. */
-const REFRESH_MS = 5000
+const DASHBOARD_MS = 5000
 
-// Fleet, Session, and Code arrive in Phases 4-6. They are listed disabled
-// rather than hidden so the shell's shape is honest about where this is going,
-// and rendered as "soon" rather than as empty views that look broken.
+/**
+ * Fleet polls faster because it answers "what is happening now", and
+ * runlog.StaleAfter is 10s — a slower tick than half that would let a run look
+ * live for seconds after it died.
+ */
+const FLEET_MS = 2000
+
+// Session and Code arrive in Phases 5-6. They are listed disabled rather than
+// hidden so the shell's shape is honest about where this is going, and rendered
+// as "soon" rather than as empty views that look broken.
 const NAV = [
   { id: 'dashboard', label: 'Dashboard', ready: true },
-  { id: 'fleet', label: 'Fleet', ready: false },
+  { id: 'fleet', label: 'Fleet', ready: true },
   { id: 'session', label: 'Session', ready: false },
   { id: 'code', label: 'Code', ready: false },
 ] as const
 
+type ViewID = (typeof NAV)[number]['id']
+
 export default function App() {
-  const [data, setData] = useState<DashboardData | null>(null)
+  const [view, setView] = useState<ViewID>('dashboard')
+  const [dashboard, setDashboard] = useState<DashboardData | null>(null)
+  const [fleet, setFleet] = useState<FleetData | null>(null)
   const [version, setVersion] = useState<Version | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (which: ViewID) => {
     try {
-      setData(await GetDashboard())
+      if (which === 'fleet') setFleet(await GetFleet())
+      else setDashboard(await GetDashboard())
       setError(null)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     }
   }, [])
 
+  // Only the visible view polls: a background tick on a view nobody is looking
+  // at is pure cost.
   useEffect(() => {
-    void load()
-    const t = setInterval(() => void load(), REFRESH_MS)
+    void load(view)
+    const every = view === 'fleet' ? FLEET_MS : DASHBOARD_MS
+    const t = setInterval(() => void load(view), every)
     return () => clearInterval(t)
-  }, [load])
+  }, [load, view])
 
   useEffect(() => {
     GetVersion().then(setVersion).catch(() => {
       /* Version is decoration; failing to read it must not blank the window. */
     })
   }, [])
+
+  const data = view === 'fleet' ? fleet : dashboard
 
   return (
     <div className="shell">
@@ -54,11 +72,15 @@ export default function App() {
             <button
               key={n.id}
               className="rail__item"
-              aria-current={n.ready ? 'page' : undefined}
+              aria-current={view === n.id ? 'page' : undefined}
               disabled={!n.ready}
+              onClick={() => n.ready && setView(n.id)}
             >
               {n.label}
               {!n.ready && <span className="rail__soon">soon</span>}
+              {n.id === 'fleet' && (fleet?.liveCount ?? 0) > 0 && (
+                <span className="rail__live">{fleet?.liveCount}</span>
+              )}
             </button>
           ))}
         </div>
@@ -71,7 +93,8 @@ export default function App() {
         {/* An error replaces the body but never the shell — a broken read
             should not look like a crashed app. */}
         {error && <div className="error">{error}</div>}
-        {!error && data && <Dashboard data={data} />}
+        {!error && view === 'dashboard' && dashboard && <Dashboard data={dashboard} />}
+        {!error && view === 'fleet' && fleet && <Fleet data={fleet} />}
         {!error && !data && <p style={{ color: 'var(--hy-dim)' }}>Reading logs…</p>}
       </main>
     </div>

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -228,3 +228,120 @@ body {
   font-family: var(--hy-font-mono);
   font-size: 12px;
 }
+
+/* ── Fleet ─────────────────────────────────────────────────────────────── */
+
+.rail__live {
+  margin-left: auto;
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  background: var(--hy-aqua);
+  color: var(--hy-bg);
+  border-radius: 999px;
+  padding: 1px 6px;
+  font-weight: 700;
+}
+
+.runs { display: flex; flex-direction: column; gap: 11px; }
+
+.run {
+  background: var(--hy-panel);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius);
+  padding: 14px 17px;
+}
+.run--live { border-color: var(--hy-aqua); }
+
+.run__head { display: flex; align-items: baseline; gap: 9px; flex-wrap: wrap; }
+
+.run__dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--hy-dim);
+  flex: 0 0 auto;
+  align-self: center;
+}
+.run__dot--live {
+  background: var(--hy-aqua);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hy-aqua) 22%, transparent);
+  animation: pulse 1.8s ease-in-out infinite;
+}
+@keyframes pulse { 50% { opacity: .45; } }
+/* A pulsing dot is decoration; for anyone who does not want motion the colour
+   and the live badge already carry the state. */
+@media (prefers-reduced-motion: reduce) {
+  .run__dot--live { animation: none; }
+}
+
+.run__id {
+  font-family: var(--hy-font-mono);
+  font-size: 12px;
+  color: var(--hy-ink);
+}
+.run__meta { margin-left: auto; font-size: 12px; color: var(--hy-dim); font-variant-numeric: tabular-nums; }
+
+.run__error { margin: 9px 0 0; font-size: 12px; color: var(--hy-expensive); font-family: var(--hy-font-mono); }
+.run__warn  { margin: 9px 0 0; font-size: 12px; color: var(--hy-mid); }
+
+.run__toggle {
+  margin-top: 10px;
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius-sm);
+  color: var(--hy-dim);
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 11px;
+  cursor: pointer;
+}
+.run__toggle:hover { color: var(--hy-ink); border-color: var(--hy-aqua); }
+.run__toggle:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 1px; }
+
+.states { display: flex; gap: 7px; flex-wrap: wrap; margin-top: 10px; }
+
+.state {
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  border: 1px solid var(--hy-line);
+  border-radius: 999px;
+  padding: 2px 9px;
+  color: var(--hy-dim);
+}
+.state--running { color: var(--hy-aqua);      border-color: color-mix(in srgb, var(--hy-aqua) 40%, transparent); }
+.state--ok      { color: var(--hy-cheap);     border-color: color-mix(in srgb, var(--hy-cheap) 40%, transparent); }
+.state--failed  { color: var(--hy-expensive); border-color: color-mix(in srgb, var(--hy-expensive) 40%, transparent); }
+
+.agents { list-style: none; margin: 12px 0 0; padding: 0; display: flex; flex-direction: column; gap: 1px; }
+
+.agent {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 13px;
+  padding: 5px 0;
+  border-top: 1px solid var(--hy-line);
+}
+
+.state-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--hy-dim);
+  flex: 0 0 auto;
+  align-self: center;
+}
+.state-dot--running { background: var(--hy-aqua); }
+.state-dot--ok      { background: var(--hy-cheap); }
+.state-dot--failed  { background: var(--hy-expensive); }
+
+.agent__id { font-family: var(--hy-font-mono); font-size: 12px; }
+.agent__tier {
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  color: var(--hy-dim);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius-sm);
+  padding: 0 5px;
+}
+.agent__meta { margin-left: auto; color: var(--hy-dim); font-size: 12px; font-variant-numeric: tabular-nums; }
+.agent__detail { color: var(--hy-dim); font-size: 12px; }

--- a/desktop/frontend/src/bindings.ts
+++ b/desktop/frontend/src/bindings.ts
@@ -6,12 +6,13 @@
 // harness. Reading the methods off `window.go` at call time — the same object
 // the generated module wraps — keeps the source tree self-contained.
 
-import type { Dashboard, Version } from './types'
+import type { Dashboard, Fleet, Version } from './types'
 
 interface WailsGo {
   api: {
     API: {
       GetDashboard(): Promise<Dashboard>
+      GetFleet(): Promise<Fleet>
       GetVersion(): Promise<Version>
     }
   }
@@ -32,4 +33,5 @@ function backend() {
 }
 
 export const GetDashboard = (): Promise<Dashboard> => backend().GetDashboard()
+export const GetFleet = (): Promise<Fleet> => backend().GetFleet()
 export const GetVersion = (): Promise<Version> => backend().GetVersion()

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -66,3 +66,45 @@ export interface Version {
   commit: string
   date: string
 }
+
+export interface Agent {
+  id: string
+  parent?: string
+  depth: number
+  head?: string
+  model?: string
+  tier: number
+  state: string
+  costUsd: number
+  confidence: number
+  durationMs: number
+  detail?: string
+}
+
+export interface Run {
+  id: string
+  live: boolean
+  startedAt: string
+  elapsedMs: number
+  costUsd: number
+  /** Zero means "not a confidence run", not "no confidence". */
+  confidence: number
+  agents: Agent[]
+  running: number
+  ok: number
+  failed: number
+  pending: number
+  allCount: number
+  /** Events the reconstruction could not attribute — surfaced, never hidden. */
+  skipped: number
+  /** Set when this run's log could not be read; the row still renders. */
+  error?: string
+}
+
+export interface Fleet {
+  hasRuns: boolean
+  liveCount: number
+  runs: Run[]
+  /** Agent count past which a run collapses. Defined in Go, not the view. */
+  groupThreshold: number
+}

--- a/desktop/frontend/src/views/Fleet.tsx
+++ b/desktop/frontend/src/views/Fleet.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react'
+import type { Agent, Fleet as FleetData, Run } from '../types'
+import { ms, pct, usdExact } from '../format'
+
+export function Fleet({ data }: { data: FleetData }) {
+  return (
+    <>
+      <header className="view__head">
+        <h1 className="view__title">Fleet</h1>
+        <p className="view__sub">
+          {data.liveCount > 0
+            ? `${data.liveCount} run${data.liveCount === 1 ? '' : 's'} in flight`
+            : 'Nothing running right now.'}
+        </p>
+      </header>
+
+      {!data.hasRuns ? (
+        <div className="empty">
+          <p className="empty__title">No runs yet</p>
+          <p>
+            Run <code>hyctl dispatch --enum SIMPLE "…"</code> and it appears here while it works.
+          </p>
+        </div>
+      ) : (
+        <div className="runs">
+          {data.runs.map((r) => (
+            <RunCard key={r.id} run={r} groupThreshold={data.groupThreshold} />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+function RunCard({ run, groupThreshold }: { run: Run; groupThreshold: number }) {
+  // Past the threshold a fan-out stops being readable as cards, so it collapses
+  // to its state counts until asked to expand. A live run starts expanded —
+  // it is the one you opened the app to watch.
+  const large = run.allCount > groupThreshold
+  const [expanded, setExpanded] = useState(!large)
+
+  return (
+    <section className={`run ${run.live ? 'run--live' : ''}`}>
+      <header className="run__head">
+        <span className={`run__dot ${run.live ? 'run__dot--live' : ''}`} />
+        <span className="run__id">{run.id}</span>
+        <span className="run__meta">
+          {ms(run.elapsedMs)} · {usdExact(run.costUsd)}
+          {run.confidence > 0 && ` · ${pct(run.confidence * 100, 1)} confidence`}
+        </span>
+      </header>
+
+      {run.error ? (
+        // A run whose log cannot be read still gets a row. Saying why beats
+        // dropping it and rendering a partial fleet as a complete one.
+        <p className="run__error">unreadable: {run.error}</p>
+      ) : (
+        <>
+          <StateBar run={run} />
+
+          {run.skipped > 0 && (
+            <p className="run__warn">
+              {run.skipped} event{run.skipped === 1 ? '' : 's'} could not be attributed to an agent
+            </p>
+          )}
+
+          {large && (
+            <button className="run__toggle" onClick={() => setExpanded((v) => !v)}>
+              {expanded ? 'Collapse' : `Show all ${run.allCount} agents`}
+            </button>
+          )}
+
+          {expanded && run.agents.length > 0 && (
+            <ul className="agents">
+              {run.agents.map((a) => (
+                <AgentRow key={a.id} agent={a} />
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+function StateBar({ run }: { run: Run }) {
+  const parts: Array<[string, number]> = [
+    ['running', run.running],
+    ['ok', run.ok],
+    ['failed', run.failed],
+    ['pending', run.pending],
+  ]
+  const shown = parts.filter(([, n]) => n > 0)
+  if (shown.length === 0) return null
+  return (
+    <div className="states">
+      {shown.map(([state, n]) => (
+        <span key={state} className={`state state--${state}`}>
+          {n} {state}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function AgentRow({ agent }: { agent: Agent }) {
+  return (
+    <li className="agent" style={{ paddingLeft: `${agent.depth * 18}px` }}>
+      <span className={`state-dot state-dot--${agent.state || 'pending'}`} />
+      <span className="agent__id">{agent.model || agent.head || agent.id}</span>
+      {agent.tier > 0 && <span className="agent__tier">T{agent.tier}</span>}
+      <span className="agent__meta">
+        {agent.durationMs > 0 && ms(agent.durationMs)}
+        {agent.costUsd > 0 && ` · ${usdExact(agent.costUsd)}`}
+        {agent.confidence > 0 && ` · ${pct(agent.confidence * 100, 1)}`}
+      </span>
+      {agent.detail && <span className="agent__detail">{agent.detail}</span>}
+    </li>
+  )
+}


### PR DESCRIPTION
## Summary

Phase 4. Dashboard answers *what was spent*; Fleet answers *what is happening now* — the question
the app exists for.

Only buildable since #205: before it `runlog.LiveRuns()` was permanently empty (no heartbeat was
ever started) and swarm emitted nothing, so a fan-out had no shape to render.

Reconstruction goes through `tree.Reconstruct` — the same call the terminal cockpit makes — so the
two surfaces cannot disagree about the same run.

## Verified against real dispatches

A run mid-flight, then the same run after it ended:

```
live=True  liveCount=1 elapsed=1382ms agents=1 running=1 ok=0
live=False liveCount=0 elapsed=1492ms agents=1 running=0 ok=1
```

Elapsed froze at 1492ms. A finished run measured to `now` would make every historical run appear to
still be growing, so only a live one runs to now.

A real two-head swarm, rendering as a fan-out rather than one node:

```
depth=0 swarm                   T0 ok
depth=1 claude   Claude Code    T1 ok  4763ms
depth=1 agy      Antigravity    T4 ok  1290ms
```

## Scaling

`GroupThreshold` (16) is served **from Go**, not hardcoded in the view, so both agree on when a
fan-out stops being readable as cards. A 20-head swarm reaches it on the first run — which is why
it exists before the problem is visible rather than after.

## Honest degradation

- A run whose log cannot be read still gets a row **carrying the reason**. Dropping it renders a
  partial fleet as a complete one.
- Events the reconstruction cannot attribute surface as a count rather than vanishing.
- A **stale heartbeat reads as dead**: a killed process never runs its cleanup, so existence-based
  liveness would leave a ghost running forever.
- No runs yet says so, rather than rendering an empty list that looks like a failed load.

## The bug this caught

`frontend/src/types.ts` mirrors the Go DTOs by hand — Wails' generated bindings are a gitignored
build artefact, so the source tree cannot typecheck against them. `Agent.Tier` and
`Agent.Confidence` were `omitempty` in Go while TypeScript declared them **required**, so a tier-0
agent arrived as `undefined` where the view expected a number.

Both are now always on the wire, and `TestDTOs_NumericFieldsAreNeverOmitEmpty` rejects `omitempty`
on any numeric DTO field. **Verified to fail** when the tag is put back:

```
--- FAIL: TestDTOs_NumericFieldsAreNeverOmitEmpty/Agent
    Agent.Tier is int with omitempty — an absent key reaches TypeScript as
    undefined, not as a zero the view can compare
```

## Tests

| Test | Asserts |
|---|---|
| `TestGetFleet_SwarmHeadsAreSeparateAgents` | 3 heads → 4 agents with correct depths, states, summed cost |
| `TestGetFleet_OrdersLiveFirstThenRecent` | the *oldest* run, if live, sorts above newer finished ones |
| `TestGetFleet_StaleHeartbeatIsNotLive` | backdated marker → not live |
| `TestGetFleet_ConfidenceOnlyForEnsembles` | SPRT shows 0.95; a plain dispatch shows nothing |
| `TestGetFleet_FinishedRunElapsedStopsAtLastEvent` | ~5s, not 2 hours |
| `TestGetFleet_LiveRunElapsedRunsToNow` | ~30s and still counting |
| `TestGetFleet_MalformedLinesAreSurfacedNotHidden` | `Skipped > 0` **and** the readable part survives |
| `TestGetFleet_EmptyStateIsHonest` / `ConcurrentCallsAreSafe` | first-launch and polling |
| `TestDTOs_*` | the wire contract the hand-written TS mirror depends on |

`gofmt`, `go vet`, `staticcheck`, `go test -race` clean on both modules; `tsc -b` and `vite build`
clean; `wails build -tags desktop` produces a working `.app`.

Closes #206