### PR TITLE
feat(desktop): Session view — timeline of one run, graph when it is non-linear

### DIFF
--- a/desktop/api/dto_test.go
+++ b/desktop/api/dto_test.go
@@ -54,6 +54,35 @@ func TestDTOs_FieldNamesAreExplicitlyTagged(t *testing.T) {
 	}
 }
 
+// A nil slice marshals to null, and the frontend iterates these fields
+// directly — `for (const e of session.edges)` throws on null. Dashboard is the
+// deliberate exception: its breakdowns are nil to mean "never ran", and
+// types.ts declares them `Breakdown[] | null` so TypeScript forces the check.
+func TestDTOs_SliceFieldsAreNeverNilOnTheWire(t *testing.T) {
+	s, err := New().GetSession("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"timeline", "agents", "edges"} {
+		v, ok := m[key]
+		if !ok {
+			t.Errorf("Session omits %q", key)
+			continue
+		}
+		if v == nil {
+			t.Errorf("Session.%s serialised as null; the view iterates it and would throw", key)
+		}
+	}
+}
+
 // An empty fleet must serialise as valid JSON with the flags the view branches
 // on, rather than as null.
 func TestFleet_SerialisesEmptyStateForTheView(t *testing.T) {

--- a/desktop/api/session.go
+++ b/desktop/api/session.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"time"
+
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/tree"
+)
+
+// Session is one run in detail: its timeline, its agents, and its A2A edges.
+type Session struct {
+	RunID string `json:"runId"`
+	Live  bool   `json:"live"`
+
+	// Found is false when the run id names no log. The view says so rather than
+	// rendering an empty session that looks like a run which did nothing.
+	Found bool   `json:"found"`
+	Error string `json:"error,omitempty"`
+
+	Timeline []TimelineEntry `json:"timeline"`
+	Agents   []Agent         `json:"agents"`
+	Edges    []Edge          `json:"edges"`
+
+	// NonLinear reports whether this run has structure a list cannot show —
+	// a fan-out or an A2A cross-edge. The Graph tab is offered only then;
+	// drawing a graph of a straight line is worse than drawing a list.
+	NonLinear bool `json:"nonLinear"`
+
+	// Skipped is events that could not be attributed to an agent. Surfaced, not
+	// hidden: a partial run rendered as a complete one is the worse failure.
+	Skipped int `json:"skipped"`
+}
+
+// TimelineEntry is one row of the chronological view.
+type TimelineEntry struct {
+	Kind   string `json:"kind"`
+	TS     string `json:"ts"`
+	NodeID string `json:"nodeId,omitempty"`
+
+	Head  string `json:"head,omitempty"`
+	Model string `json:"model,omitempty"`
+	Tier  int    `json:"tier"`
+
+	Status     string  `json:"status,omitempty"`
+	CostUSD    float64 `json:"costUsd"`
+	DurationMS int64   `json:"durationMs"`
+	Confidence float64 `json:"confidence"`
+
+	// Detail is the run log's short human string. For an SPRT sample #205
+	// writes the verifiable part here — "agreed · LLR +1.203 → Λ 1.203" — which
+	// is deliberately what the row leads with rather than narrated intent.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Edge is one A2A handoff: a collaboration edge, distinct from the ownership
+// edges that Agent.Parent describes. Keeping them apart is the whole reason
+// tree.Node has both Children and Handoffs.
+type Edge struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	TS     string `json:"ts"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// GetSession returns one run in full.
+//
+// Reconstruction goes through tree.Reconstruct, the same call Fleet and the
+// terminal cockpit make, so no two surfaces can disagree about one run.
+func (a *API) GetSession(runID string) (*Session, error) {
+	// Slices start empty, never nil: a nil slice marshals to null, and the
+	// frontend iterates these directly. "No edges" and "no session" are
+	// different facts, and Found already carries the second one.
+	s := &Session{
+		RunID: runID, Live: runlog.IsAlive(runID),
+		Timeline: []TimelineEntry{}, Agents: []Agent{}, Edges: []Edge{},
+	}
+	if runID == "" {
+		return s, nil
+	}
+
+	events, err := runlog.Load(runID)
+	if err != nil {
+		// Saying why beats a blank pane: the run may well exist and simply be
+		// unreadable, which is a different problem from it not existing.
+		s.Error = err.Error()
+		return s, nil
+	}
+	if len(events) == 0 {
+		return s, nil
+	}
+	s.Found = true
+
+	t, tl := tree.Reconstruct(events)
+	s.Skipped = t.Skipped
+
+	// Entries in file order. runlog's own doc says Seq "is not the sort key" —
+	// several writers share one run and each counts from 1, so re-sorting by it
+	// puts a run's end before a handoff that happened first (#205).
+	for _, e := range tl.Entries {
+		s.Timeline = append(s.Timeline, TimelineEntry{
+			Kind: string(e.Kind), TS: formatTS(e.TS), NodeID: e.NodeID,
+			Head: e.Head, Model: e.Model, Tier: e.Tier,
+			Status: e.Status, CostUSD: e.CostUSD,
+			DurationMS: e.DurationMS, Confidence: e.Confidence,
+			Detail: e.Detail,
+		})
+	}
+
+	for _, row := range t.Rows() {
+		n := row.Node
+		s.Agents = append(s.Agents, Agent{
+			ID: n.ID, Parent: n.Parent, Depth: row.Depth,
+			Head: n.Head, Model: n.Model, Tier: n.Tier,
+			State:      string(n.State),
+			CostUSD:    n.CostUSD,
+			Confidence: n.Confidence,
+			DurationMS: n.DurationMS,
+			Detail:     n.Detail,
+		})
+		for _, h := range n.Handoffs {
+			s.Edges = append(s.Edges, Edge{
+				From: n.ID, To: h.To, TS: formatTS(h.TS), Detail: h.Detail,
+			})
+		}
+	}
+
+	s.NonLinear = isNonLinear(t, len(s.Edges))
+	return s, nil
+}
+
+// isNonLinear reports whether a run has structure a list cannot convey: an A2A
+// cross-edge, or any node with more than one child. Everything else is a chain,
+// and a chain reads better as a timeline.
+func isNonLinear(t *tree.Tree, edges int) bool {
+	if edges > 0 {
+		return true
+	}
+	if len(t.Roots) > 1 {
+		return true
+	}
+	for _, n := range t.Nodes {
+		if len(n.Children) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+// formatTS renders a timestamp for display, or empty when there is none —
+// never a zero-time string, which reads as a real measurement from year 1.
+func formatTS(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return ts.UTC().Format(time.RFC3339)
+}

--- a/desktop/api/session_test.go
+++ b/desktop/api/session_test.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"testing"
+
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+// A run id that names no log is not the same as a run that did nothing. The
+// view branches on Found so it can say which.
+func TestGetSession_UnknownRunIsNotFound(t *testing.T) {
+	sandbox(t)
+
+	s, err := New().GetSession("20260802T100000Z-nope")
+	if err != nil {
+		t.Fatalf("an unknown run must not error: %v", err)
+	}
+	if s.Found {
+		t.Error("Found = true for a run with no log")
+	}
+	if len(s.Timeline) != 0 || len(s.Agents) != 0 {
+		t.Error("an unknown run produced content")
+	}
+}
+
+func TestGetSession_EmptyRunIDIsHandled(t *testing.T) {
+	sandbox(t)
+
+	s, err := New().GetSession("")
+	if err != nil {
+		t.Fatalf("empty run id must not error: %v", err)
+	}
+	if s.Found {
+		t.Error("Found = true for an empty run id")
+	}
+}
+
+// The timeline must show every event, including the run-level ones the tree
+// deliberately omits — a run's own start and end belong on a timeline.
+func TestGetSession_TimelineIncludesRunLevelEvents(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-full",
+		runlog.Event{Kind: runlog.KindRunStarted, TaskID: "t", Detail: "add pagination"},
+		runlog.Event{Kind: runlog.KindHeadSelected, TaskID: "t", Head: "agy", Model: "Antigravity", Tier: 4},
+		runlog.Event{Kind: runlog.KindDispatchFinished, TaskID: "t", Head: "agy", Status: "ok", DurationMS: 1200},
+		runlog.Event{Kind: runlog.KindRunFinished, TaskID: "t"},
+	)
+
+	s, err := New().GetSession("20260802T100000Z-full")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.Found {
+		t.Fatal("Found = false for a run that exists")
+	}
+	if len(s.Timeline) != 4 {
+		t.Fatalf("%d timeline entries, want 4 — run-level events belong here even though the tree omits them", len(s.Timeline))
+	}
+	if s.Timeline[0].Kind != string(runlog.KindRunStarted) {
+		t.Errorf("first entry is %q, want run_started", s.Timeline[0].Kind)
+	}
+	if s.Timeline[3].Kind != string(runlog.KindRunFinished) {
+		t.Errorf("last entry is %q, want run_finished", s.Timeline[3].Kind)
+	}
+	// The tree still has only the head — run-level events create no node.
+	if len(s.Agents) != 1 || s.Agents[0].ID != "agy" {
+		t.Errorf("agents = %+v, want just the head", s.Agents)
+	}
+}
+
+// Several writers share one run and each counts from 1, so runlog's own doc
+// says seq "is not the sort key". Re-sorting by it puts a run's end before a
+// handoff that happened first (#205).
+func TestGetSession_TimelineIsFileOrderNotSeqOrder(t *testing.T) {
+	sandbox(t)
+
+	// Exactly the interleaving a real dispatch produces: the CLI logs the run
+	// lifecycle (seq 1,2) around dispatch's own events (seq 1,2,3).
+	rl := runlog.New("20260802T100000Z-order")
+	for _, e := range []runlog.Event{
+		{Kind: runlog.KindRunStarted},
+		{Kind: runlog.KindHeadSelected, Head: "h"},
+		{Kind: runlog.KindDispatchFinished, Head: "h", Status: "ok"},
+		{Kind: runlog.KindHandoff, Head: "h", Ref: "next", Detail: "context handed on"},
+		{Kind: runlog.KindRunFinished},
+	} {
+		if err := rl.Append(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s, err := New().GetSession("20260802T100000Z-order")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"run_started", "head_selected", "dispatch_finished", "handoff", "run_finished"}
+	for i, k := range want {
+		if i >= len(s.Timeline) || s.Timeline[i].Kind != k {
+			got := make([]string, len(s.Timeline))
+			for j, e := range s.Timeline {
+				got[j] = e.Kind
+			}
+			t.Fatalf("timeline = %v, want %v", got, want)
+		}
+	}
+}
+
+// A straight chain reads better as a list. Offering a graph of a line is worse
+// than offering nothing.
+func TestGetSession_LinearRunIsNotOfferedAGraph(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-linear",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"},
+		runlog.Event{Kind: runlog.KindDispatchFinished, Head: "h", Status: "ok"},
+	)
+
+	s, err := New().GetSession("20260802T100000Z-linear")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.NonLinear {
+		t.Error("NonLinear = true for a single-head run")
+	}
+}
+
+// A fan-out is exactly what a list cannot show.
+func TestGetSession_FanOutIsNonLinear(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-fan",
+		runlog.Event{Kind: runlog.KindTaskStarted, Agent: "swarm"},
+		runlog.Event{Kind: runlog.KindAttempt, Agent: "a", Parent: "swarm", Status: "ok"},
+		runlog.Event{Kind: runlog.KindAttempt, Agent: "b", Parent: "swarm", Status: "ok"},
+	)
+
+	s, err := New().GetSession("20260802T100000Z-fan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.NonLinear {
+		t.Error("NonLinear = false for a two-way fan-out")
+	}
+}
+
+// An A2A cross-edge makes a run non-linear even when the ownership tree is a
+// chain — that edge is precisely the thing a timeline cannot draw.
+func TestGetSession_HandoffAloneMakesItNonLinear(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-a2a",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "a"},
+		runlog.Event{Kind: runlog.KindHandoff, Agent: "a", Ref: "b", Detail: "context"},
+	)
+
+	s, err := New().GetSession("20260802T100000Z-a2a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.NonLinear {
+		t.Error("NonLinear = false despite an A2A edge")
+	}
+	if len(s.Edges) != 1 {
+		t.Fatalf("%d edges, want 1", len(s.Edges))
+	}
+	if s.Edges[0].From != "a" || s.Edges[0].To != "b" {
+		t.Errorf("edge = %s→%s, want a→b", s.Edges[0].From, s.Edges[0].To)
+	}
+}
+
+// Ownership and collaboration are different relations. An A2A edge must never
+// show up as a parent, which is why tree.Node keeps Children and Handoffs
+// apart.
+func TestGetSession_HandoffIsNotAnOwnershipEdge(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-sep",
+		runlog.Event{Kind: runlog.KindTaskStarted, Agent: "a"},
+		runlog.Event{Kind: runlog.KindTaskStarted, Agent: "b"},
+		runlog.Event{Kind: runlog.KindHandoff, Agent: "a", Ref: "b", Detail: "context"},
+	)
+
+	s, err := New().GetSession("20260802T100000Z-sep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ag := range s.Agents {
+		if ag.ID == "b" && ag.Parent == "a" {
+			t.Error("an A2A handoff was recorded as an ownership edge")
+		}
+	}
+	if len(s.Edges) != 1 {
+		t.Errorf("%d edges, want the handoff to survive as a collaboration edge", len(s.Edges))
+	}
+}
+
+// The SPRT detail is the verifiable part — what the source did to the running
+// log-odds. It must reach the view, because a confidence number with no
+// evidence behind it is the configuration that produces misplaced trust.
+func TestGetSession_SPRTSamplesCarryEvidence(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-sprt",
+		runlog.Event{Kind: runlog.KindTaskStarted, Agent: "ensemble"},
+		runlog.Event{Kind: runlog.KindSample, Agent: "a", Parent: "ensemble",
+			Confidence: 0.768, Detail: "agreed · LLR +1.200 → Λ 1.200"},
+		runlog.Event{Kind: runlog.KindSample, Agent: "b", Parent: "ensemble",
+			Confidence: 0.846, Detail: "disagreed · LLR -0.400 → Λ 1.700"},
+	)
+
+	s, err := New().GetSession("20260802T100000Z-sprt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var samples []TimelineEntry
+	for _, e := range s.Timeline {
+		if e.Kind == string(runlog.KindSample) {
+			samples = append(samples, e)
+		}
+	}
+	if len(samples) != 2 {
+		t.Fatalf("%d samples on the timeline, want 2", len(samples))
+	}
+	if samples[0].Confidence != 0.768 || samples[1].Confidence != 0.846 {
+		t.Errorf("confidences = %v, %v; want 0.768, 0.846", samples[0].Confidence, samples[1].Confidence)
+	}
+	for i, want := range []string{"agreed · LLR +1.200 → Λ 1.200", "disagreed · LLR -0.400 → Λ 1.700"} {
+		if samples[i].Detail != want {
+			t.Errorf("sample %d detail = %q, want %q — the evidence must reach the view", i, samples[i].Detail, want)
+		}
+	}
+}
+
+// Unattributable events must be counted, not dropped: rendering a partial run
+// as a complete one is the worse failure.
+func TestGetSession_SurfacesSkippedEvents(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-skip",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"},
+		runlog.Event{Kind: runlog.KindEdit}, // attributable to no node
+	)
+
+	s, err := New().GetSession("20260802T100000Z-skip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Skipped == 0 {
+		t.Error("Skipped = 0; an unattributable event was hidden")
+	}
+}
+
+// A zero timestamp must render as absent, not as a real-looking date in year 1.
+func TestGetSession_MissingTimestampsRenderEmpty(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-nots",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h", TS: "not-a-timestamp"},
+	)
+
+	s, err := New().GetSession("20260802T100000Z-nots")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Timeline) != 1 {
+		t.Fatalf("%d entries, want 1", len(s.Timeline))
+	}
+	if ts := s.Timeline[0].TS; ts != "" {
+		t.Errorf("TS = %q for an unparseable timestamp, want empty rather than a year-1 date", ts)
+	}
+}
+
+func TestGetSession_ConcurrentCallsAreSafe(t *testing.T) {
+	sandbox(t)
+	writeRun(t, "20260802T100000Z-conc", runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"})
+
+	a := New()
+	done := make(chan error, 16)
+	for range cap(done) {
+		go func() {
+			_, err := a.GetSession("20260802T100000Z-conc")
+			done <- err
+		}()
+	}
+	for range cap(done) {
+		if err := <-done; err != nil {
+			t.Errorf("concurrent GetSession: %v", err)
+		}
+	}
+}

--- a/desktop/frontend/package-lock.json
+++ b/desktop/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hydra-desktop-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -300,6 +301,21 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,26 +1,32 @@
 import { useCallback, useEffect, useState } from 'react'
-import { GetDashboard, GetFleet, GetVersion } from './bindings'
-import type { Dashboard as DashboardData, Fleet as FleetData, Version } from './types'
+import { GetDashboard, GetFleet, GetSession, GetVersion } from './bindings'
+import type {
+  Dashboard as DashboardData,
+  Fleet as FleetData,
+  Session as SessionData,
+  Version,
+} from './types'
 import { Dashboard } from './views/Dashboard'
 import { Fleet } from './views/Fleet'
+import { Session } from './views/Session'
 
 /** Dashboard is retrospective — a slow refresh is enough and costs nothing. */
 const DASHBOARD_MS = 5000
 
 /**
- * Fleet polls faster because it answers "what is happening now", and
- * runlog.StaleAfter is 10s — a slower tick than half that would let a run look
- * live for seconds after it died.
+ * Fleet and an open Session poll faster because they answer "what is happening
+ * now", and runlog.StaleAfter is 10s — a slower tick than half that would let a
+ * run look live for seconds after it died.
  */
-const FLEET_MS = 2000
+const LIVE_MS = 2000
 
-// Session and Code arrive in Phases 5-6. They are listed disabled rather than
-// hidden so the shell's shape is honest about where this is going, and rendered
-// as "soon" rather than as empty views that look broken.
+// Code arrives in Phase 6. It is listed disabled rather than hidden so the
+// shell's shape is honest about where this is going, and rendered as "soon"
+// rather than as an empty view that looks broken.
 const NAV = [
   { id: 'dashboard', label: 'Dashboard', ready: true },
   { id: 'fleet', label: 'Fleet', ready: true },
-  { id: 'session', label: 'Session', ready: false },
+  { id: 'session', label: 'Session', ready: true },
   { id: 'code', label: 'Code', ready: false },
 ] as const
 
@@ -28,14 +34,17 @@ type ViewID = (typeof NAV)[number]['id']
 
 export default function App() {
   const [view, setView] = useState<ViewID>('dashboard')
+  const [runID, setRunID] = useState<string>('')
   const [dashboard, setDashboard] = useState<DashboardData | null>(null)
   const [fleet, setFleet] = useState<FleetData | null>(null)
+  const [session, setSession] = useState<SessionData | null>(null)
   const [version, setVersion] = useState<Version | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const load = useCallback(async (which: ViewID) => {
+  const load = useCallback(async (which: ViewID, id: string) => {
     try {
       if (which === 'fleet') setFleet(await GetFleet())
+      else if (which === 'session') setSession(await GetSession(id))
       else setDashboard(await GetDashboard())
       setError(null)
     } catch (e) {
@@ -46,11 +55,11 @@ export default function App() {
   // Only the visible view polls: a background tick on a view nobody is looking
   // at is pure cost.
   useEffect(() => {
-    void load(view)
-    const every = view === 'fleet' ? FLEET_MS : DASHBOARD_MS
-    const t = setInterval(() => void load(view), every)
+    void load(view, runID)
+    const every = view === 'dashboard' ? DASHBOARD_MS : LIVE_MS
+    const t = setInterval(() => void load(view, runID), every)
     return () => clearInterval(t)
-  }, [load, view])
+  }, [load, view, runID])
 
   useEffect(() => {
     GetVersion().then(setVersion).catch(() => {
@@ -58,7 +67,32 @@ export default function App() {
     })
   }, [])
 
-  const data = view === 'fleet' ? fleet : dashboard
+  const openSession = useCallback((id: string) => {
+    setRunID(id)
+    setSession(null) // don't show the previous run's data under a new id
+    setView('session')
+  }, [])
+
+  // Session is reachable by drilling in from Fleet; selecting it with no run
+  // chosen opens the most recent one, which is what "Session" means with no
+  // further qualification.
+  const selectNav = useCallback(
+    (id: ViewID) => {
+      if (id === 'session' && !runID) {
+        const first = fleet?.runs?.[0]?.id
+        if (!first) return
+        openSession(first)
+        return
+      }
+      setView(id)
+    },
+    [fleet, runID, openSession],
+  )
+
+  const loading =
+    (view === 'dashboard' && !dashboard) ||
+    (view === 'fleet' && !fleet) ||
+    (view === 'session' && !session)
 
   return (
     <div className="shell">
@@ -73,8 +107,8 @@ export default function App() {
               key={n.id}
               className="rail__item"
               aria-current={view === n.id ? 'page' : undefined}
-              disabled={!n.ready}
-              onClick={() => n.ready && setView(n.id)}
+              disabled={!n.ready || (n.id === 'session' && !runID && !fleet?.runs?.length)}
+              onClick={() => n.ready && selectNav(n.id)}
             >
               {n.label}
               {!n.ready && <span className="rail__soon">soon</span>}
@@ -94,8 +128,11 @@ export default function App() {
             should not look like a crashed app. */}
         {error && <div className="error">{error}</div>}
         {!error && view === 'dashboard' && dashboard && <Dashboard data={dashboard} />}
-        {!error && view === 'fleet' && fleet && <Fleet data={fleet} />}
-        {!error && !data && <p style={{ color: 'var(--hy-dim)' }}>Reading logs…</p>}
+        {!error && view === 'fleet' && fleet && <Fleet data={fleet} onOpen={openSession} />}
+        {!error && view === 'session' && session && (
+          <Session session={session} onBack={() => setView('fleet')} />
+        )}
+        {!error && loading && <p style={{ color: 'var(--hy-dim)' }}>Reading logs…</p>}
       </main>
     </div>
   )

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -345,3 +345,124 @@ body {
 }
 .agent__meta { margin-left: auto; color: var(--hy-dim); font-size: 12px; font-variant-numeric: tabular-nums; }
 .agent__detail { color: var(--hy-dim); font-size: 12px; }
+
+/* ── Session ───────────────────────────────────────────────────────────── */
+
+.back {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--hy-dim);
+  font: inherit;
+  font-size: 12px;
+  padding: 0 0 8px;
+  cursor: pointer;
+}
+.back:hover { color: var(--hy-aqua); }
+.back:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; }
+
+.session__id { font-family: var(--hy-font-mono); font-size: 17px; letter-spacing: -0.01em; }
+.session__live {
+  margin-left: 10px;
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  background: var(--hy-aqua);
+  color: var(--hy-bg);
+  border-radius: 999px;
+  padding: 2px 8px;
+  vertical-align: middle;
+}
+
+.run__id--link {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+.run__id--link:hover { color: var(--hy-aqua); }
+.run__id--link:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; }
+
+.tabs { display: flex; gap: 4px; margin: 16px 0 12px; }
+
+.tab {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius-sm);
+  color: var(--hy-dim);
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 13px;
+  cursor: pointer;
+}
+.tab[aria-current="page"] { color: var(--hy-ink); border-color: var(--hy-aqua); background: var(--hy-panel); }
+.tab:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 1px; }
+
+.timeline {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  background: var(--hy-panel);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius);
+  overflow: hidden;
+}
+
+.tl {
+  display: flex;
+  align-items: baseline;
+  gap: 11px;
+  padding: 8px 15px;
+  font-size: 13px;
+  border-bottom: 1px solid var(--hy-line);
+  border-left: 2px solid transparent;
+}
+.tl:last-child { border-bottom: 0; }
+.tl--ok      { border-left-color: var(--hy-cheap); }
+.tl--failed  { border-left-color: var(--hy-expensive); }
+.tl--running { border-left-color: var(--hy-aqua); }
+
+.tl__time { font-family: var(--hy-font-mono); font-size: 11px; color: var(--hy-dim); flex: 0 0 66px; }
+.tl__kind {
+  font-family: var(--hy-font-mono);
+  font-size: 11px;
+  color: var(--hy-dim);
+  flex: 0 0 132px;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+.tl__who { font-family: var(--hy-font-mono); font-size: 12px; display: flex; align-items: baseline; gap: 6px; }
+.tl__detail { color: var(--hy-ink); font-size: 12px; }
+.tl__meta { margin-left: auto; color: var(--hy-dim); font-size: 12px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+/* ── Session graph ─────────────────────────────────────────────────────── */
+
+.graph {
+  margin-top: 16px;
+  background: var(--hy-panel);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius);
+  padding: 12px;
+  overflow: auto;
+}
+
+.edge { stroke: var(--hy-line); stroke-width: 1.5; }
+/* Dashed, not a different arrowhead: an A2A edge is a different *relation*
+   from ownership, and the distinction has to survive at a glance. */
+.edge--a2a { stroke: var(--hy-violet); stroke-dasharray: 4 4; }
+
+.gnode { fill: var(--hy-bg-2); stroke: var(--hy-line); stroke-width: 1; }
+.gnode--ok      { stroke: var(--hy-cheap); }
+.gnode--failed  { stroke: var(--hy-expensive); }
+.gnode--running { stroke: var(--hy-aqua); }
+
+.gnode__label { fill: var(--hy-ink); font-family: var(--hy-font-mono); font-size: 11px; }
+.gnode__sub   { fill: var(--hy-dim); font-family: var(--hy-font-mono); font-size: 10px; }
+
+.graph__legend { margin: 10px 0 0; font-size: 11px; color: var(--hy-dim); }

--- a/desktop/frontend/src/bindings.ts
+++ b/desktop/frontend/src/bindings.ts
@@ -6,13 +6,14 @@
 // harness. Reading the methods off `window.go` at call time — the same object
 // the generated module wraps — keeps the source tree self-contained.
 
-import type { Dashboard, Fleet, Version } from './types'
+import type { Dashboard, Fleet, Session, Version } from './types'
 
 interface WailsGo {
   api: {
     API: {
       GetDashboard(): Promise<Dashboard>
       GetFleet(): Promise<Fleet>
+      GetSession(runID: string): Promise<Session>
       GetVersion(): Promise<Version>
     }
   }
@@ -34,4 +35,5 @@ function backend() {
 
 export const GetDashboard = (): Promise<Dashboard> => backend().GetDashboard()
 export const GetFleet = (): Promise<Fleet> => backend().GetFleet()
+export const GetSession = (runID: string): Promise<Session> => backend().GetSession(runID)
 export const GetVersion = (): Promise<Version> => backend().GetVersion()

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -108,3 +108,41 @@ export interface Fleet {
   /** Agent count past which a run collapses. Defined in Go, not the view. */
   groupThreshold: number
 }
+
+export interface TimelineEntry {
+  kind: string
+  /** Empty when the event carried no parseable timestamp. */
+  ts: string
+  nodeId?: string
+  head?: string
+  model?: string
+  tier: number
+  status?: string
+  costUsd: number
+  durationMs: number
+  confidence: number
+  /** The verifiable part — for an SPRT sample, "agreed · LLR +1.2 → Λ 1.2". */
+  detail?: string
+}
+
+/** An A2A collaboration edge — distinct from Agent.parent, which is ownership. */
+export interface Edge {
+  from: string
+  to: string
+  ts: string
+  detail?: string
+}
+
+export interface Session {
+  runId: string
+  live: boolean
+  /** False when the run id names no log — different from a run that did nothing. */
+  found: boolean
+  error?: string
+  timeline: TimelineEntry[]
+  agents: Agent[]
+  edges: Edge[]
+  /** True only when a list cannot convey the shape: a fan-out or an A2A edge. */
+  nonLinear: boolean
+  skipped: number
+}

--- a/desktop/frontend/src/views/Fleet.tsx
+++ b/desktop/frontend/src/views/Fleet.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import type { Agent, Fleet as FleetData, Run } from '../types'
 import { ms, pct, usdExact } from '../format'
 
-export function Fleet({ data }: { data: FleetData }) {
+export function Fleet({ data, onOpen }: { data: FleetData; onOpen: (runID: string) => void }) {
   return (
     <>
       <header className="view__head">
@@ -24,7 +24,7 @@ export function Fleet({ data }: { data: FleetData }) {
       ) : (
         <div className="runs">
           {data.runs.map((r) => (
-            <RunCard key={r.id} run={r} groupThreshold={data.groupThreshold} />
+            <RunCard key={r.id} run={r} groupThreshold={data.groupThreshold} onOpen={onOpen} />
           ))}
         </div>
       )}
@@ -32,7 +32,15 @@ export function Fleet({ data }: { data: FleetData }) {
   )
 }
 
-function RunCard({ run, groupThreshold }: { run: Run; groupThreshold: number }) {
+function RunCard({
+  run,
+  groupThreshold,
+  onOpen,
+}: {
+  run: Run
+  groupThreshold: number
+  onOpen: (runID: string) => void
+}) {
   // Past the threshold a fan-out stops being readable as cards, so it collapses
   // to its state counts until asked to expand. A live run starts expanded —
   // it is the one you opened the app to watch.
@@ -43,7 +51,9 @@ function RunCard({ run, groupThreshold }: { run: Run; groupThreshold: number }) 
     <section className={`run ${run.live ? 'run--live' : ''}`}>
       <header className="run__head">
         <span className={`run__dot ${run.live ? 'run__dot--live' : ''}`} />
-        <span className="run__id">{run.id}</span>
+        <button className="run__id run__id--link" onClick={() => onOpen(run.id)}>
+          {run.id}
+        </button>
         <span className="run__meta">
           {ms(run.elapsedMs)} · {usdExact(run.costUsd)}
           {run.confidence > 0 && ` · ${pct(run.confidence * 100, 1)} confidence`}

--- a/desktop/frontend/src/views/Session.tsx
+++ b/desktop/frontend/src/views/Session.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import type { Session as SessionData, TimelineEntry } from '../types'
+import { clockTime, ms, pct, usdExact } from '../format'
+import { SessionGraph } from './SessionGraph'
+
+export function Session({
+  session,
+  onBack,
+}: {
+  session: SessionData
+  onBack: () => void
+}) {
+  // Timeline is the default: most runs are linear, and a list is the right
+  // shape for a linear thing.
+  const [tab, setTab] = useState<'timeline' | 'graph'>('timeline')
+
+  return (
+    <>
+      <header className="view__head">
+        <button className="back" onClick={onBack}>
+          ← Fleet
+        </button>
+        <h1 className="view__title">
+          <span className="session__id">{session.runId}</span>
+          {session.live && <span className="session__live">live</span>}
+        </h1>
+      </header>
+
+      {session.error && <div className="error">unreadable: {session.error}</div>}
+
+      {!session.error && !session.found && (
+        <div className="empty">
+          <p className="empty__title">No log for this run</p>
+          <p>It may have been cleaned up, or nothing was ever written for it.</p>
+        </div>
+      )}
+
+      {session.found && (
+        <>
+          {session.skipped > 0 && (
+            <p className="run__warn">
+              {session.skipped} event{session.skipped === 1 ? '' : 's'} could not be attributed to an
+              agent
+            </p>
+          )}
+
+          {/* The Graph tab appears only when a list genuinely cannot show the
+              shape. Drawing a graph of a straight line is worse than a list. */}
+          {session.nonLinear && (
+            <div className="tabs">
+              <button
+                className="tab"
+                aria-current={tab === 'timeline' ? 'page' : undefined}
+                onClick={() => setTab('timeline')}
+              >
+                Timeline
+              </button>
+              <button
+                className="tab"
+                aria-current={tab === 'graph' ? 'page' : undefined}
+                onClick={() => setTab('graph')}
+              >
+                Graph
+              </button>
+            </div>
+          )}
+
+          {tab === 'graph' && session.nonLinear ? (
+            <SessionGraph session={session} />
+          ) : (
+            <Timeline entries={session.timeline} />
+          )}
+        </>
+      )}
+    </>
+  )
+}
+
+function Timeline({ entries }: { entries: TimelineEntry[] }) {
+  if (entries.length === 0) return null
+  return (
+    <ol className="timeline">
+      {entries.map((e, i) => (
+        <li key={i} className={`tl tl--${e.status || kindClass(e.kind)}`}>
+          <span className="tl__time">{e.ts ? clockTime(e.ts) : '—'}</span>
+          <span className="tl__kind">{e.kind.replace(/_/g, ' ')}</span>
+          <span className="tl__who">
+            {e.model || e.head || e.nodeId || ''}
+            {e.tier > 0 && <span className="agent__tier">T{e.tier}</span>}
+          </span>
+          {/* Evidence leads. For an SPRT sample this is
+              "agreed · LLR +1.200 → Λ 1.200" — what actually happened to the
+              log-odds, ahead of any narration. */}
+          {e.detail && <span className="tl__detail">{e.detail}</span>}
+          <span className="tl__meta">
+            {e.confidence > 0 && `${pct(e.confidence * 100, 1)} · `}
+            {e.durationMs > 0 && `${ms(e.durationMs)} · `}
+            {e.costUsd > 0 && usdExact(e.costUsd)}
+          </span>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+function kindClass(kind: string): string {
+  if (kind === 'error') return 'failed'
+  if (kind === 'run_started' || kind === 'task_started') return 'running'
+  return 'pending'
+}

--- a/desktop/frontend/src/views/SessionGraph.tsx
+++ b/desktop/frontend/src/views/SessionGraph.tsx
@@ -1,0 +1,131 @@
+import { useMemo } from 'react'
+import dagre from '@dagrejs/dagre'
+import type { Session } from '../types'
+
+/**
+ * Layered (Sugiyama) layout via dagre.
+ *
+ * Deterministic and near-linear per relayout, and it has a notion of direction —
+ * which matches the causal semantics of a run. A force-directed or
+ * stress-majorization model has neither: it treats edges as springs, so the same
+ * run lays out differently frame to frame and "downstream" means nothing.
+ *
+ * The layout maths is bought, not hand-rolled. Crossing minimisation is NP-hard
+ * and dagre already implements the standard heuristic chain (Brandes-Köpf
+ * coordinate assignment included).
+ */
+const NODE_W = 168
+const NODE_H = 46
+
+interface Placed {
+  id: string
+  x: number
+  y: number
+  label: string
+  sub: string
+  state: string
+}
+
+interface Line {
+  points: string
+  a2a: boolean
+}
+
+export function SessionGraph({ session }: { session: Session }) {
+  const { nodes, lines, width, height } = useMemo(() => layout(session), [session])
+
+  if (nodes.length === 0) return null
+
+  return (
+    <div className="graph">
+      <svg width={width} height={height} role="img" aria-label="Run graph">
+        {lines.map((l, i) => (
+          <polyline
+            key={i}
+            points={l.points}
+            className={l.a2a ? 'edge edge--a2a' : 'edge'}
+            fill="none"
+          />
+        ))}
+        {nodes.map((n) => (
+          <g key={n.id} transform={`translate(${n.x - NODE_W / 2},${n.y - NODE_H / 2})`}>
+            <rect
+              width={NODE_W}
+              height={NODE_H}
+              rx={10}
+              className={`gnode gnode--${n.state || 'pending'}`}
+            />
+            <text x={11} y={19} className="gnode__label">
+              {n.label}
+            </text>
+            <text x={11} y={34} className="gnode__sub">
+              {n.sub}
+            </text>
+          </g>
+        ))}
+      </svg>
+      <p className="graph__legend">
+        solid = ownership · dashed = A2A handoff
+      </p>
+    </div>
+  )
+}
+
+function layout(session: Session) {
+  const g = new dagre.graphlib.Graph()
+  // Top-to-bottom: a run reads as time flowing downward, and that matches the
+  // timeline it sits next to.
+  g.setGraph({ rankdir: 'TB', nodesep: 26, ranksep: 42, marginx: 16, marginy: 16 })
+  g.setDefaultEdgeLabel(() => ({}))
+
+  for (const a of session.agents) {
+    g.setNode(a.id, { width: NODE_W, height: NODE_H })
+  }
+  for (const a of session.agents) {
+    if (a.parent && g.hasNode(a.parent)) g.setEdge(a.parent, a.id, { a2a: false })
+  }
+  // A2A edges are laid out too, so a handoff target is placed sensibly rather
+  // than floating — but they stay visually distinct from ownership.
+  for (const e of session.edges) {
+    if (g.hasNode(e.from) && g.hasNode(e.to)) g.setEdge(e.from, e.to, { a2a: true })
+  }
+
+  dagre.layout(g)
+
+  const byID = new Map(session.agents.map((a) => [a.id, a]))
+  const nodes: Placed[] = []
+  for (const id of g.nodes()) {
+    const p = g.node(id)
+    const a = byID.get(id)
+    if (!p || !a) continue
+    nodes.push({
+      id,
+      x: p.x,
+      y: p.y,
+      label: a.model || a.head || a.id,
+      // Verifiable facts first — tier, state, duration — rather than narration.
+      sub: [a.tier > 0 ? `T${a.tier}` : null, a.state, a.durationMs > 0 ? `${a.durationMs}ms` : null]
+        .filter(Boolean)
+        .join(' · '),
+      state: a.state,
+    })
+  }
+
+  const lines: Line[] = []
+  for (const e of g.edges()) {
+    const pts = g.edge(e)?.points ?? []
+    if (pts.length === 0) continue
+    lines.push({
+      points: pts.map((pt: { x: number; y: number }) => `${pt.x},${pt.y}`).join(' '),
+      a2a: Boolean(g.edge(e)?.a2a),
+    })
+  }
+
+  const graph = g.graph()
+  return {
+    nodes,
+    lines,
+    width: Math.max(graph.width ?? 0, 320),
+    height: Math.max(graph.height ?? 0, 120),
+  }
+}

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -317,9 +317,17 @@ func parseTS(s string) time.Time {
 }
 
 func entryOf(e runlog.Event) Entry {
+	// A run-level event belongs to no node, the same fact Apply encodes by
+	// refusing to create one. nodeID falls back to TaskID, so without this a
+	// run's own start would name a node that does not exist and a renderer
+	// would print a raw id where an agent name belongs (#209).
+	id := nodeID(e)
+	if e.Kind == runlog.KindRunStarted || e.Kind == runlog.KindRunFinished {
+		id = ""
+	}
 	return Entry{
 		Seq: e.Seq, TS: parseTS(e.TS), Kind: e.Kind,
-		NodeID: nodeID(e), TaskID: e.TaskID,
+		NodeID: id, TaskID: e.TaskID,
 		Head: e.Head, Model: e.Model, Tier: e.Tier, Status: e.Status,
 		CostUSD: e.CostUSD, DurationMS: e.DurationMS, Confidence: e.Confidence,
 		Detail: e.Detail,

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -384,3 +384,35 @@ func TestApply_RunLevelEventsNeverCreateNodes(t *testing.T) {
 			len(tl.Entries), len(events))
 	}
 }
+
+// Apply refuses to create a node for a run-level event; entryOf must agree, or
+// the timeline names a node the tree does not have. nodeID falls back to
+// TaskID, which a run_started legitimately carries.
+func TestTimeline_RunLevelEntriesNameNoNode(t *testing.T) {
+	events := []runlog.Event{
+		{V: 1, Seq: 1, RunID: "r", TaskID: "task-abc", Kind: runlog.KindRunStarted},
+		{V: 1, Seq: 2, RunID: "r", TaskID: "task-abc", Kind: runlog.KindHeadSelected, Head: "agy"},
+		{V: 1, Seq: 3, RunID: "r", TaskID: "task-abc", Kind: runlog.KindRunFinished},
+	}
+	tr, tl := Reconstruct(events)
+
+	for _, e := range tl.Entries {
+		switch e.Kind {
+		case runlog.KindRunStarted, runlog.KindRunFinished:
+			if e.NodeID != "" {
+				t.Errorf("%s names node %q; run-level events belong to no node", e.Kind, e.NodeID)
+			}
+			// The task id is still carried — it is real metadata, just not a node.
+			if e.TaskID != "task-abc" {
+				t.Errorf("%s dropped its TaskID", e.Kind)
+			}
+		default:
+			if e.NodeID == "" {
+				t.Errorf("%s has no NodeID", e.Kind)
+			}
+			if _, ok := tr.Nodes[e.NodeID]; !ok {
+				t.Errorf("%s names node %q, which the tree does not have", e.Kind, e.NodeID)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 5. Fleet answers *what is running*. Neither view answered **"what happened inside this run, in
order"** — the question you have once something looks wrong.

**Timeline is the default** and reuses `tree.Reconstruct`'s `Timeline` directly. Most runs are
linear and a list is the right shape for a linear thing.

**Graph is offered only when a list genuinely cannot convey the shape** — a fan-out, more than one
root, or an A2A cross-edge. Drawing a graph of a straight line is worse than drawing a list.

## Layout

Layered/Sugiyama via **dagre**: deterministic, near-linear per relayout, and *directional*, which
matches a run's causal semantics. A force-directed model has no notion of direction and lays the
same run out differently frame to frame. The maths is bought, not hand-rolled — crossing
minimisation is NP-hard and dagre already implements the standard heuristic chain including
Brandes–Köpf coordinate assignment.

Ownership and collaboration stay visually distinct (solid vs dashed) — the same separation
`tree.Node` encodes by keeping `Children` and `Handoffs` apart.

## Evidence before narration

Node labels lead with verifiable facts — tier, state, duration. An SPRT sample's row leads with what
#205 writes: `agreed · LLR +1.200 → Λ 1.200`. Showing AI reasoning prominently *without* the
verifiable artifact is the configuration Buçinca et al. (CSCW 2021) found increases *inappropriate*
trust, so the evidence goes first.

## Verified against a real two-head swarm

```
found=True nonLinear=True edges=[]
run_started        —              say hi
task_started       swarm          swarm · all · 2 heads
attempt            Claude Code    all · winner
attempt            Antigravity    all
task_finished      swarm
run_finished       —
```

Three agents at correct depths, six entries in file order.

## Two bugs verification caught

**`Session.Edges` marshalled to `null`.** Go nil slices become JSON `null`, and `SessionGraph`
iterates that field directly — `for (const e of session.edges)` would have thrown the first time a
run had no handoffs. `Timeline` and `Agents` had the same defect. All three now start empty, and
`TestDTOs_SliceFieldsAreNeverNilOnTheWire` rejects a nil slice on the wire — **verified to fail**
when the initialiser is removed:

```
Session.timeline serialised as null; the view iterates it and would throw
Session.agents   serialised as null; …
Session.edges    serialised as null; …
```

Dashboard stays the deliberate exception: its breakdowns are nil to mean *"never ran"*, and
`types.ts` declares them `Breakdown[] | null` so TypeScript forces the check.

**`tree.entryOf` named a node the tree does not have.** `Apply` refuses to create a node for a
run-level event, but `entryOf` still set `NodeID` from `nodeID`, which falls back to `TaskID` — so a
real run's first and last timeline rows printed a **raw timestamp id where an agent name belongs**.
Visible in the run above as `—` now, previously `20260802T071925Z-9783a7d3b647317d`. The two now
agree; the task id is still carried as metadata, just not as a node.

## Tests

| Test | Asserts |
|---|---|
| `TestGetSession_TimelineIncludesRunLevelEvents` | run start/end reach the timeline though the tree omits them |
| `TestGetSession_TimelineIsFileOrderNotSeqOrder` | the exact multi-writer interleaving a real dispatch produces |
| `TestGetSession_LinearRunIsNotOfferedAGraph` | a chain stays a list |
| `TestGetSession_FanOutIsNonLinear` / `HandoffAloneMakesItNonLinear` | both triggers |
| `TestGetSession_HandoffIsNotAnOwnershipEdge` | an A2A edge never becomes a parent |
| `TestGetSession_SPRTSamplesCarryEvidence` | the LLR detail survives to the view |
| `TestGetSession_SurfacesSkippedEvents` | partial runs are not shown as complete |
| `TestGetSession_MissingTimestampsRenderEmpty` | no year-1 dates |
| `TestGetSession_UnknownRunIsNotFound` | "no such run" ≠ "run did nothing" |
| `TestTimeline_RunLevelEntriesNameNoNode` | `entryOf` and `Apply` agree |

`gofmt`, `go vet`, `staticcheck`, `go test -race` clean on both modules; `tsc -b` and `vite build`
clean; `wails build -tags desktop` produces a working `.app`.

Closes #209