### PR TITLE
feat(desktop): Code view — the edits a run made, as diffs; plus the chat dock

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1294,11 +1294,20 @@ func cmdEdit() *cobra.Command {
 		Short: "Atomic, validated, rollback-safe file edit via a Hydra Head",
 		RunE: func(_ *cobra.Command, _ []string) error {
 			ctx := context.Background()
+
+			// Resolve rather than mint, so HYDRA_RUN_ID groups an edit with the
+			// invocation that spawned it (#204, #211).
+			runID, taskID := runid.ResolveRun(""), runid.ResolveTask("")
+			hb := runlog.StartHeartbeat(ctx, runID, runlog.HeartbeatInterval)
+			defer hb.Stop()
+
 			result, err := editor.Edit(ctx, editor.Request{
 				File:     file,
 				Enum:     enum,
 				Prompt:   prompt,
 				Validate: !noValidate,
+				RunID:    runID,
+				TaskID:   taskID,
 			})
 			if err != nil {
 				return err

--- a/desktop/api/chat.go
+++ b/desktop/api/chat.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/rank"
+	"github.com/ankit373/hydra/internal/runid"
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+// ChatTimeout bounds one dispatch from the dock. A GUI cannot leave a request
+// outstanding forever — the window has no way to say "still working" that a
+// user will keep believing.
+const ChatTimeout = 5 * time.Minute
+
+// ChatReply is one answer, with the routing that produced it.
+//
+// The routing is not decoration. Which head answered, at which tier, for how
+// much is the difference between an answer you can weigh and one you can only
+// believe — and this is a router, so it is the part the user is actually
+// buying.
+type ChatReply struct {
+	Output string `json:"output"`
+
+	Head  string `json:"head"`
+	Model string `json:"model"`
+	Tier  int    `json:"tier"`
+
+	CostUSD    float64 `json:"costUsd"`
+	DurationMS int64   `json:"durationMs"`
+
+	// RunID lets the reply link into Session, so "why did it say that" is one
+	// click rather than a hunt through the logs.
+	RunID string `json:"runId"`
+
+	Error string `json:"error,omitempty"`
+}
+
+// Chat dispatches one prompt and returns the reply.
+//
+// enum is a routing key ("SIMPLE", "STANDARD", …); empty lets dispatch pick.
+// Errors come back inside the reply rather than as a Go error: a failed
+// dispatch is a normal outcome the dock renders as a message, not an exception
+// that should blank the window.
+func (a *API) Chat(prompt, enum string) (*ChatReply, error) {
+	if prompt == "" {
+		return &ChatReply{Error: "empty prompt"}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ChatTimeout)
+	defer cancel()
+
+	runID, taskID := runid.New(), runid.New()
+	r := &ChatReply{RunID: runID}
+
+	// The dock's dispatch is a run like any other: it appears in Fleet while it
+	// works and in Session afterwards. A chat that stayed invisible to the rest
+	// of the app would be a second, untraceable path through the router.
+	hb := runlog.StartHeartbeat(ctx, runID, runlog.HeartbeatInterval)
+	defer hb.Stop()
+
+	rl := runlog.New(runID)
+	_ = rl.Append(runlog.Event{Kind: runlog.KindRunStarted, TaskID: taskID, Detail: preview(prompt)})
+	defer func() {
+		_ = rl.Append(runlog.Event{Kind: runlog.KindRunFinished, TaskID: taskID})
+	}()
+
+	d, err := dispatch.New(ctx)
+	if err != nil {
+		r.Error = err.Error()
+		return r, nil
+	}
+
+	tierHint := ""
+	if enum != "" {
+		tierHint = dispatch.EnumToTier(enum)
+	}
+
+	res, err := d.Dispatch(ctx, prompt, dispatch.Options{
+		TierHint: tierHint,
+		Enum:     enum,
+		RunID:    runID,
+		TaskID:   taskID,
+	})
+	if err != nil {
+		r.Error = err.Error()
+		return r, nil
+	}
+
+	r.Output = res.Output
+	r.Head = res.Head.ID
+	r.Model = res.Head.Name
+	r.Tier = rank.UITier(res.Head)
+	if res.Response != nil {
+		r.DurationMS = res.Response.Duration.Milliseconds()
+	}
+	return r, nil
+}
+
+// preview shortens a prompt for a log Detail. Entries stay small because the
+// run log's atomicity guarantee is per write() call.
+func preview(s string) string {
+	const max = 80
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}
+
+// ChatEnums lists the routing keys the dock offers, weakest head first.
+//
+// Taken from dispatch.EnumToTier's own table rather than restated, so the
+// picker cannot offer a key the router does not understand. The dock's "auto"
+// choice is the absence of an enum, not a member of this list.
+func (a *API) ChatEnums() []string {
+	return []string{
+		"GRUNT", "TRIVIAL", "SIMPLE", "STANDARD", "MODERATE",
+		"COMPLEX", "HARD", "VERY_HARD", "EXPERT", "CORE",
+	}
+}

--- a/desktop/api/chat_test.go
+++ b/desktop/api/chat_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"testing"
+
+	"github.com/ankit373/hydra/internal/dispatch"
+)
+
+// The picker must not offer a routing key the router does not understand.
+// EnumToTier is the authority; anything absent from it silently falls through
+// to default routing while the UI claims otherwise.
+func TestChatEnums_EveryKeyResolvesToATier(t *testing.T) {
+	for _, enum := range New().ChatEnums() {
+		if tier := dispatch.EnumToTier(enum); tier == "" {
+			t.Errorf("ChatEnums offers %q, which EnumToTier does not resolve", enum)
+		}
+	}
+}
+
+// "auto" is the absence of an enum, not a member of the list — an empty string
+// in a picker renders as a blank row.
+func TestChatEnums_ContainsNoEmptyEntry(t *testing.T) {
+	for _, enum := range New().ChatEnums() {
+		if enum == "" {
+			t.Error("ChatEnums contains an empty key; auto-routing is the absence of one")
+		}
+	}
+}
+
+// Ordering is what the picker shows. Weakest head first means the cheap option
+// is the default reading direction, which is the whole premise of the router.
+func TestChatEnums_OrderedWeakestFirst(t *testing.T) {
+	enums := New().ChatEnums()
+	prev := 0
+	for i, enum := range enums {
+		tier := dispatch.EnumToTier(enum)
+		n := atoiTier(t, tier)
+		if i > 0 && n > prev {
+			t.Errorf("%q is tier %d after tier %d — the list must run weakest (highest tier) first",
+				enum, n, prev)
+		}
+		prev = n
+	}
+}
+
+func atoiTier(t *testing.T, s string) int {
+	t.Helper()
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			t.Fatalf("EnumToTier returned %q, which is not a tier number", s)
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+// An empty prompt is a user slip, not an exception. It comes back as a reply
+// carrying the reason so the dock renders it as a message.
+func TestChat_EmptyPromptIsAReplyNotAnError(t *testing.T) {
+	sandbox(t)
+
+	r, err := New().Chat("", "")
+	if err != nil {
+		t.Fatalf("an empty prompt must not error: %v", err)
+	}
+	if r.Error == "" {
+		t.Error("no Error on the reply; the dock would render an empty message")
+	}
+	if r.Output != "" {
+		t.Error("an empty prompt produced output")
+	}
+}
+
+// A dispatch that cannot run is a normal outcome — no heads configured is the
+// common first-launch case. It must not blank the window.
+func TestChat_FailedDispatchReturnsAReply(t *testing.T) {
+	sandbox(t)
+
+	r, err := New().Chat("hello", "SIMPLE")
+	if err != nil {
+		t.Fatalf("a failed dispatch must come back as a reply, not a Go error: %v", err)
+	}
+	if r.RunID == "" {
+		t.Error("no RunID; a failed chat still has a run the user can inspect")
+	}
+}

--- a/desktop/api/code.go
+++ b/desktop/api/code.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+// Edit is one file change a run made.
+type Edit struct {
+	File   string `json:"file"`
+	TS     string `json:"ts"`
+	Detail string `json:"detail,omitempty"`
+
+	// Ref resolves to the stored before/after snapshot. Empty when the content
+	// was refused for size or could not be written — the change still happened,
+	// so the row still appears, but no diff can be shown for it.
+	Ref string `json:"ref,omitempty"`
+
+	Added   int `json:"added"`
+	Removed int `json:"removed"`
+}
+
+// Diff is one edit rendered as unified hunks.
+type Diff struct {
+	File  string `json:"file"`
+	Found bool   `json:"found"`
+	// Reason says why a diff is unavailable, so the view can be specific rather
+	// than blank: pruned snapshot, oversized file, or a read failure.
+	Reason string `json:"reason,omitempty"`
+
+	Lines []DiffLine `json:"lines"`
+
+	Added   int `json:"added"`
+	Removed int `json:"removed"`
+}
+
+// DiffLine is one rendered row. Op is "+", "-", or " ".
+type DiffLine struct {
+	Op      string `json:"op"`
+	Text    string `json:"text"`
+	OldLine int    `json:"oldLine"` // 0 when the line is an addition
+	NewLine int    `json:"newLine"` // 0 when the line is a removal
+}
+
+// GetEdits lists the edits a run applied, newest last.
+func (a *API) GetEdits(runID string) ([]Edit, error) {
+	out := []Edit{}
+	if runID == "" {
+		return out, nil
+	}
+	events, err := runlog.Load(runID)
+	if err != nil {
+		return out, nil // a run with no log has no edits; Session reports the error
+	}
+	for _, e := range events {
+		if e.Kind != runlog.KindEdit {
+			continue
+		}
+		added, removed := parseCounts(e.Detail)
+		out = append(out, Edit{
+			File: e.Agent, TS: e.TS, Detail: e.Detail, Ref: e.Ref,
+			Added: added, Removed: removed,
+		})
+	}
+	return out, nil
+}
+
+// GetDiff renders one edit as unified hunks.
+func (a *API) GetDiff(runID, ref, file string) (*Diff, error) {
+	d := &Diff{File: file, Lines: []DiffLine{}}
+	if ref == "" {
+		d.Reason = "no snapshot was stored for this edit"
+		return d, nil
+	}
+
+	before, after, err := runlog.LoadEdit(runID, ref)
+	if err != nil {
+		switch {
+		case errors.Is(err, runlog.ErrNoSnapshot):
+			d.Reason = "snapshot is no longer on disk"
+		default:
+			d.Reason = err.Error()
+		}
+		return d, nil
+	}
+
+	d.Found = true
+	d.Lines = diffLines(splitLines(string(before)), splitLines(string(after)))
+	for _, l := range d.Lines {
+		switch l.Op {
+		case "+":
+			d.Added++
+		case "-":
+			d.Removed++
+		}
+	}
+	return d, nil
+}
+
+// splitLines splits content into lines without inventing a trailing empty one
+// for the final newline — a file ending in "\n" has as many lines as newlines,
+// and a phantom last line renders as a spurious change.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = strings.TrimSuffix(s, "\n")
+	return strings.Split(s, "\n")
+}
+
+// maxLCSCells bounds the dynamic program below. The LCS table is O(n·m), and
+// MaxSnapshotBytes permits ~65k lines, so an unbounded table would be 4.2
+// billion cells — tens of gigabytes and effectively a hang. Trimming the common
+// prefix and suffix first collapses almost every real edit well under this;
+// what survives is a file rewritten wholesale, which is rendered as one
+// replacement rather than a line-by-line alignment nobody would read anyway.
+const maxLCSCells = 4 << 20 // ~2000x2000 lines
+
+// diffLines produces a line-level diff.
+//
+// Hand-rolled rather than pulled in: it is short, and the alternative is a
+// dependency in a module whose whole point is to stay separable from hyctl.
+//
+// Common prefix and suffix are trimmed before any alignment work. Edits change
+// a few lines in the middle of a file, so this is what keeps the quadratic core
+// small in practice rather than the size cap, which bounds bytes and not
+// similarity.
+func diffLines(a, b []string) []DiffLine {
+	out := []DiffLine{}
+
+	// Shared head.
+	head := 0
+	for head < len(a) && head < len(b) && a[head] == b[head] {
+		out = append(out, DiffLine{Op: " ", Text: a[head], OldLine: head + 1, NewLine: head + 1})
+		head++
+	}
+
+	// Shared tail, stopping before the head so a line is never emitted twice.
+	tail := 0
+	for tail < len(a)-head && tail < len(b)-head && a[len(a)-1-tail] == b[len(b)-1-tail] {
+		tail++
+	}
+
+	midA, midB := a[head:len(a)-tail], b[head:len(b)-tail]
+	out = append(out, alignMiddle(midA, midB, head)...)
+
+	for i := range tail {
+		oldIdx, newIdx := len(a)-tail+i, len(b)-tail+i
+		out = append(out, DiffLine{Op: " ", Text: a[oldIdx], OldLine: oldIdx + 1, NewLine: newIdx + 1})
+	}
+	return out
+}
+
+// alignMiddle diffs the differing region. offset is how many lines were trimmed
+// from the head, so reported line numbers stay those of the real file.
+func alignMiddle(a, b []string, offset int) []DiffLine {
+	out := []DiffLine{}
+	n, m := len(a), len(b)
+	if n == 0 && m == 0 {
+		return out
+	}
+
+	// Too large to align line by line: report it as a wholesale replacement,
+	// which is both honest and what the content actually is.
+	if n*m > maxLCSCells {
+		for i, line := range a {
+			out = append(out, DiffLine{Op: "-", Text: line, OldLine: offset + i + 1})
+		}
+		for j, line := range b {
+			out = append(out, DiffLine{Op: "+", Text: line, NewLine: offset + j + 1})
+		}
+		return out
+	}
+
+	// lcs[i][j] = length of the longest common subsequence of a[i:] and b[j:].
+	lcs := make([][]int, n+1)
+	for i := range lcs {
+		lcs[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else {
+				lcs[i][j] = max(lcs[i+1][j], lcs[i][j+1])
+			}
+		}
+	}
+
+	i, j := 0, 0
+	for i < n && j < m {
+		switch {
+		case a[i] == b[j]:
+			out = append(out, DiffLine{Op: " ", Text: a[i], OldLine: offset + i + 1, NewLine: offset + j + 1})
+			i++
+			j++
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			out = append(out, DiffLine{Op: "-", Text: a[i], OldLine: offset + i + 1})
+			i++
+		default:
+			out = append(out, DiffLine{Op: "+", Text: b[j], NewLine: offset + j + 1})
+			j++
+		}
+	}
+	for ; i < n; i++ {
+		out = append(out, DiffLine{Op: "-", Text: a[i], OldLine: offset + i + 1})
+	}
+	for ; j < m; j++ {
+		out = append(out, DiffLine{Op: "+", Text: b[j], NewLine: offset + j + 1})
+	}
+	return out
+}
+
+// parseCounts reads the "+N/-M" prefix editor writes into the event detail.
+// A detail it cannot parse yields zeros rather than a guess.
+func parseCounts(detail string) (added, removed int) {
+	head, _, _ := strings.Cut(detail, " ")
+	plus, minus, ok := strings.Cut(head, "/")
+	if !ok {
+		return 0, 0
+	}
+	return atoiAfter(plus, '+'), atoiAfter(minus, '-')
+}
+
+func atoiAfter(s string, prefix byte) int {
+	if len(s) < 2 || s[0] != prefix {
+		return 0
+	}
+	n := 0
+	for _, c := range s[1:] {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}

--- a/desktop/api/code_test.go
+++ b/desktop/api/code_test.go
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+// render collapses a diff to a compact string so a case reads as the diff it
+// asserts rather than as a struct literal.
+func render(d *Diff) string {
+	var b strings.Builder
+	for _, l := range d.Lines {
+		b.WriteString(l.Op)
+		b.WriteString(l.Text)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func TestDiff_ModifyAddRemove(t *testing.T) {
+	cases := []struct {
+		name          string
+		before, after string
+		want          string
+		added         int
+		removed       int
+	}{
+		{
+			name:   "pure addition at the end",
+			before: "a\nb\n",
+			after:  "a\nb\nc\n",
+			want:   " a\n b\n+c\n",
+			added:  1,
+		},
+		{
+			name:    "pure removal from the middle",
+			before:  "a\nb\nc\n",
+			after:   "a\nc\n",
+			want:    " a\n-b\n c\n",
+			removed: 1,
+		},
+		{
+			name:    "modification is a removal plus an addition",
+			before:  "a\nb\nc\n",
+			after:   "a\nB\nc\n",
+			want:    " a\n-b\n+B\n c\n",
+			added:   1,
+			removed: 1,
+		},
+		{
+			name:   "file creation — everything is new",
+			before: "",
+			after:  "one\ntwo\n",
+			want:   "+one\n+two\n",
+			added:  2,
+		},
+		{
+			name:    "file emptied — everything goes",
+			before:  "one\ntwo\n",
+			after:   "",
+			want:    "-one\n-two\n",
+			removed: 2,
+		},
+		{
+			name:   "identical content produces no changes",
+			before: "same\n",
+			after:  "same\n",
+			want:   " same\n",
+		},
+		{
+			name:   "insertion at the start keeps the tail as context",
+			before: "b\nc\n",
+			after:  "a\nb\nc\n",
+			want:   "+a\n b\n c\n",
+			added:  1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sandbox(t)
+			if err := runlog.SaveEdit("run-d", "001", []byte(tc.before), []byte(tc.after)); err != nil {
+				t.Fatal(err)
+			}
+			d, err := New().GetDiff("run-d", "001", "/tmp/f.go")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !d.Found {
+				t.Fatal("Found = false for a stored snapshot")
+			}
+			if got := render(d); got != tc.want {
+				t.Errorf("diff =\n%s\nwant\n%s", got, tc.want)
+			}
+			if d.Added != tc.added || d.Removed != tc.removed {
+				t.Errorf("+%d/-%d, want +%d/-%d", d.Added, d.Removed, tc.added, tc.removed)
+			}
+		})
+	}
+}
+
+// A file ending in "\n" has as many lines as newlines. Inventing a trailing
+// empty line renders as a spurious change on every diff.
+func TestDiff_TrailingNewlineIsNotAPhantomLine(t *testing.T) {
+	sandbox(t)
+
+	if err := runlog.SaveEdit("run-nl", "001", []byte("a\n"), []byte("a\n")); err != nil {
+		t.Fatal(err)
+	}
+	d, err := New().GetDiff("run-nl", "001", "f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(d.Lines) != 1 {
+		t.Fatalf("%d lines for identical one-line files, want 1: %+v", len(d.Lines), d.Lines)
+	}
+	if d.Added != 0 || d.Removed != 0 {
+		t.Errorf("+%d/-%d for identical content, want +0/-0", d.Added, d.Removed)
+	}
+}
+
+// Line numbers are what let a reader find the change in the real file. An
+// addition has no old line and a removal has no new one.
+func TestDiff_LineNumbersTrackBothSides(t *testing.T) {
+	sandbox(t)
+
+	if err := runlog.SaveEdit("run-ln", "001", []byte("a\nb\nc\n"), []byte("a\nX\nc\n")); err != nil {
+		t.Fatal(err)
+	}
+	d, err := New().GetDiff("run-ln", "001", "f")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []struct {
+		op       string
+		old, new int
+	}{
+		{" ", 1, 1},
+		{"-", 2, 0},
+		{"+", 0, 2},
+		{" ", 3, 3},
+	}
+	if len(d.Lines) != len(want) {
+		t.Fatalf("%d lines, want %d", len(d.Lines), len(want))
+	}
+	for i, w := range want {
+		l := d.Lines[i]
+		if l.Op != w.op || l.OldLine != w.old || l.NewLine != w.new {
+			t.Errorf("line %d = %s old=%d new=%d, want %s old=%d new=%d",
+				i, l.Op, l.OldLine, l.NewLine, w.op, w.old, w.new)
+		}
+	}
+}
+
+// A pruned snapshot is not a crash and not a blank pane — the view says why.
+func TestGetDiff_MissingSnapshotExplainsItself(t *testing.T) {
+	sandbox(t)
+
+	d, err := New().GetDiff("run-x", "404", "f")
+	if err != nil {
+		t.Fatalf("a missing snapshot must not error: %v", err)
+	}
+	if d.Found {
+		t.Error("Found = true for a snapshot that is not there")
+	}
+	if d.Reason == "" {
+		t.Error("no Reason given; the view would render a blank pane")
+	}
+	if d.Lines == nil {
+		t.Error("Lines is nil; it marshals to null and the view iterates it")
+	}
+}
+
+// An edit whose content was refused for size still happened. The row exists
+// with an empty ref, and the diff explains rather than pretends.
+func TestGetDiff_EmptyRefIsExplained(t *testing.T) {
+	sandbox(t)
+
+	d, err := New().GetDiff("run-x", "", "f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Found || d.Reason == "" {
+		t.Errorf("Found=%v Reason=%q; an unstored snapshot must be explained", d.Found, d.Reason)
+	}
+}
+
+// GetEdits lists what a run changed, in the order it changed it.
+func TestGetEdits_ListsAppliedEditsInOrder(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-edits",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"},
+		runlog.Event{Kind: runlog.KindEdit, Agent: "/src/a.go", Ref: "000001", Detail: "+12/-3"},
+		runlog.Event{Kind: runlog.KindEdit, Agent: "/src/b.go", Ref: "000002", Detail: "+1/-0"},
+	)
+
+	edits, err := New().GetEdits("20260802T100000Z-edits")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(edits) != 2 {
+		t.Fatalf("%d edits, want 2", len(edits))
+	}
+	if edits[0].File != "/src/a.go" || edits[1].File != "/src/b.go" {
+		t.Errorf("order = %s, %s; want a.go then b.go", edits[0].File, edits[1].File)
+	}
+	if edits[0].Added != 12 || edits[0].Removed != 3 {
+		t.Errorf("counts = +%d/-%d, want +12/-3", edits[0].Added, edits[0].Removed)
+	}
+}
+
+// A run that changed nothing returns an empty list, never null — the view
+// iterates it.
+func TestGetEdits_NoEditsIsEmptyNotNull(t *testing.T) {
+	sandbox(t)
+	writeRun(t, "20260802T100000Z-noedit", runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"})
+
+	edits, err := New().GetEdits("20260802T100000Z-noedit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edits == nil {
+		t.Fatal("nil slice marshals to null")
+	}
+	if len(edits) != 0 {
+		t.Errorf("%d edits, want 0", len(edits))
+	}
+}
+
+// A detail the counts cannot be read from must yield zeros, not a guess.
+func TestParseCounts_UnparseableDetailYieldsZero(t *testing.T) {
+	for _, detail := range []string{"", "no counts here", "+/-", "+x/-y", "12/3"} {
+		if a, r := parseCounts(detail); a != 0 || r != 0 {
+			t.Errorf("parseCounts(%q) = +%d/-%d, want +0/-0", detail, a, r)
+		}
+	}
+	if a, r := parseCounts("+12/-3 · snapshot unavailable"); a != 12 || r != 3 {
+		t.Errorf("parseCounts with a suffix = +%d/-%d, want +12/-3", a, r)
+	}
+}
+
+// The diff must survive content at the storage cap without truncating it.
+func TestDiff_HandlesContentAtTheSizeCap(t *testing.T) {
+	sandbox(t)
+
+	// One line short of the cap, so the "after" side — which gains a line —
+	// still fits. Sizing "before" exactly at the cap would push "after" over it
+	// and test the refusal path instead of the diff.
+	line := strings.Repeat("x", 63) + "\n"
+	body := strings.Repeat(line, runlog.MaxSnapshotBytes/len(line)-1)
+	if err := runlog.SaveEdit("run-big", "001", []byte(body), []byte(body+"new\n")); err != nil {
+		t.Fatalf("content within the cap was refused: %v", err)
+	}
+	d, err := New().GetDiff("run-big", "001", "f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.Found {
+		t.Fatal("Found = false")
+	}
+	if d.Added != 1 || d.Removed != 0 {
+		t.Errorf("+%d/-%d, want +1/-0", d.Added, d.Removed)
+	}
+}
+
+// Binary-ish content must not panic the differ or corrupt the round-trip.
+func TestDiff_SurvivesNonUTF8Content(t *testing.T) {
+	sandbox(t)
+
+	before := []byte{0x00, 0xff, 0xfe, '\n'}
+	after := append(bytes.Clone(before), 0x01, '\n')
+	if err := runlog.SaveEdit("run-bin", "001", before, after); err != nil {
+		t.Fatal(err)
+	}
+	d, err := New().GetDiff("run-bin", "001", "f")
+	if err != nil {
+		t.Fatalf("non-UTF8 content must not error: %v", err)
+	}
+	if !d.Found {
+		t.Error("Found = false for stored binary content")
+	}
+}
+
+// The quadratic core must never see a whole large file. Before the
+// prefix/suffix trim, a 4 MiB snapshot meant a ~65k x 65k LCS table — 4.2
+// billion cells, tens of gigabytes, an effective hang. This is the shape of a
+// real edit: a big file with one line changed near the end.
+func TestDiff_LargeFileWithASmallEditIsFast(t *testing.T) {
+	sandbox(t)
+
+	lines := make([]string, 60_000)
+	for i := range lines {
+		lines[i] = "line " + strconv.Itoa(i)
+	}
+	before := strings.Join(lines, "\n") + "\n"
+	lines[59_000] = "CHANGED"
+	after := strings.Join(lines, "\n") + "\n"
+
+	if err := runlog.SaveEdit("run-perf", "001", []byte(before), []byte(after)); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	d, err := New().GetDiff("run-perf", "001", "f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	elapsed := time.Since(start)
+
+	if d.Added != 1 || d.Removed != 1 {
+		t.Errorf("+%d/-%d, want +1/-1", d.Added, d.Removed)
+	}
+	// Generous: the point is to catch a return to quadratic-on-the-whole-file,
+	// which does not finish at all, not to police milliseconds.
+	if elapsed > 5*time.Second {
+		t.Errorf("took %v for a one-line change in a 60k-line file — the prefix/suffix trim is gone", elapsed)
+	}
+}
+
+// Two entirely different large files cannot be aligned line by line, and
+// pretending otherwise is what hangs. It degrades to a wholesale replacement.
+func TestDiff_WhollyDifferentLargeFilesDegradeGracefully(t *testing.T) {
+	sandbox(t)
+
+	a := make([]string, 5_000)
+	b := make([]string, 5_000)
+	for i := range a {
+		a[i] = "alpha " + strconv.Itoa(i)
+		b[i] = "beta " + strconv.Itoa(i)
+	}
+	if err := runlog.SaveEdit("run-repl", "001",
+		[]byte(strings.Join(a, "\n")+"\n"), []byte(strings.Join(b, "\n")+"\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	d, err := New().GetDiff("run-repl", "001", "f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("took %v; the LCS cell cap is not bounding the work", elapsed)
+	}
+	if d.Added != 5_000 || d.Removed != 5_000 {
+		t.Errorf("+%d/-%d, want +5000/-5000 (a wholesale replacement)", d.Added, d.Removed)
+	}
+}
+
+// Trimming a shared tail must not emit a line twice when head and tail regions
+// would otherwise overlap — the classic off-by-one in this optimisation.
+func TestDiff_HeadAndTailTrimsDoNotOverlap(t *testing.T) {
+	sandbox(t)
+
+	// "a" is both a valid prefix match and a valid suffix match.
+	if err := runlog.SaveEdit("run-ov", "001", []byte("a\n"), []byte("a\na\n")); err != nil {
+		t.Fatal(err)
+	}
+	d, err := New().GetDiff("run-ov", "001", "f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := render(d), " a\n+a\n"; got != want {
+		t.Errorf("diff =\n%q\nwant\n%q", got, want)
+	}
+	if d.Added != 1 || d.Removed != 0 {
+		t.Errorf("+%d/-%d, want +1/-0", d.Added, d.Removed)
+	}
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
-import { GetDashboard, GetFleet, GetSession, GetVersion } from './bindings'
+import { GetDashboard, GetEdits, GetFleet, GetSession, GetVersion } from './bindings'
 import type {
   Dashboard as DashboardData,
+  Edit,
   Fleet as FleetData,
   Session as SessionData,
   Version,
@@ -9,6 +10,8 @@ import type {
 import { Dashboard } from './views/Dashboard'
 import { Fleet } from './views/Fleet'
 import { Session } from './views/Session'
+import { Code } from './views/Code'
+import { ChatDock } from './views/ChatDock'
 
 /** Dashboard is retrospective — a slow refresh is enough and costs nothing. */
 const DASHBOARD_MS = 5000
@@ -20,14 +23,11 @@ const DASHBOARD_MS = 5000
  */
 const LIVE_MS = 2000
 
-// Code arrives in Phase 6. It is listed disabled rather than hidden so the
-// shell's shape is honest about where this is going, and rendered as "soon"
-// rather than as an empty view that looks broken.
 const NAV = [
   { id: 'dashboard', label: 'Dashboard', ready: true },
   { id: 'fleet', label: 'Fleet', ready: true },
   { id: 'session', label: 'Session', ready: true },
-  { id: 'code', label: 'Code', ready: false },
+  { id: 'code', label: 'Code', ready: true },
 ] as const
 
 type ViewID = (typeof NAV)[number]['id']
@@ -38,6 +38,7 @@ export default function App() {
   const [dashboard, setDashboard] = useState<DashboardData | null>(null)
   const [fleet, setFleet] = useState<FleetData | null>(null)
   const [session, setSession] = useState<SessionData | null>(null)
+  const [edits, setEdits] = useState<Edit[] | null>(null)
   const [version, setVersion] = useState<Version | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -45,6 +46,7 @@ export default function App() {
     try {
       if (which === 'fleet') setFleet(await GetFleet())
       else if (which === 'session') setSession(await GetSession(id))
+      else if (which === 'code') setEdits(await GetEdits(id))
       else setDashboard(await GetDashboard())
       setError(null)
     } catch (e) {
@@ -69,7 +71,9 @@ export default function App() {
 
   const openSession = useCallback((id: string) => {
     setRunID(id)
-    setSession(null) // don't show the previous run's data under a new id
+    // Don't show the previous run's data under a new id.
+    setSession(null)
+    setEdits(null)
     setView('session')
   }, [])
 
@@ -78,10 +82,13 @@ export default function App() {
   // further qualification.
   const selectNav = useCallback(
     (id: ViewID) => {
-      if (id === 'session' && !runID) {
+      if ((id === 'session' || id === 'code') && !runID) {
         const first = fleet?.runs?.[0]?.id
         if (!first) return
-        openSession(first)
+        setRunID(first)
+        setSession(null)
+        setEdits(null)
+        setView(id)
         return
       }
       setView(id)
@@ -92,7 +99,8 @@ export default function App() {
   const loading =
     (view === 'dashboard' && !dashboard) ||
     (view === 'fleet' && !fleet) ||
-    (view === 'session' && !session)
+    (view === 'session' && !session) ||
+    (view === 'code' && !edits)
 
   return (
     <div className="shell">
@@ -107,7 +115,10 @@ export default function App() {
               key={n.id}
               className="rail__item"
               aria-current={view === n.id ? 'page' : undefined}
-              disabled={!n.ready || (n.id === 'session' && !runID && !fleet?.runs?.length)}
+              disabled={
+                !n.ready ||
+                ((n.id === 'session' || n.id === 'code') && !runID && !fleet?.runs?.length)
+              }
               onClick={() => n.ready && selectNav(n.id)}
             >
               {n.label}
@@ -132,8 +143,22 @@ export default function App() {
         {!error && view === 'session' && session && (
           <Session session={session} onBack={() => setView('fleet')} />
         )}
+        {!error && view === 'code' && edits && (
+          <>
+            <header className="view__head">
+              <button className="back" onClick={() => setView('session')}>
+                ← Session
+              </button>
+              <h1 className="view__title">Code</h1>
+              <p className="view__sub">What this run changed on disk.</p>
+            </header>
+            <Code runID={runID} edits={edits} />
+          </>
+        )}
         {!error && loading && <p style={{ color: 'var(--hy-dim)' }}>Reading logs…</p>}
       </main>
+
+      <ChatDock onOpenRun={openSession} />
     </div>
   )
 }

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -466,3 +466,210 @@ body {
 .gnode__sub   { fill: var(--hy-dim); font-family: var(--hy-font-mono); font-size: 10px; }
 
 .graph__legend { margin: 10px 0 0; font-size: 11px; color: var(--hy-dim); }
+
+/* ── Code view ─────────────────────────────────────────────────────────── */
+
+.code { display: grid; grid-template-columns: minmax(180px, 250px) 1fr; gap: 12px; align-items: start; }
+
+.files { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+
+.file {
+  appearance: none;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--hy-radius-sm);
+  color: var(--hy-dim);
+  font: inherit;
+  padding: 8px 11px;
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2px 8px;
+}
+.file:hover { background: var(--hy-panel); color: var(--hy-ink); }
+.file[aria-current="page"] { background: var(--hy-panel); border-color: var(--hy-line); color: var(--hy-ink); }
+.file:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 1px; }
+
+.file__name { font-family: var(--hy-font-mono); font-size: 12px; }
+.file__counts { font-family: var(--hy-font-mono); font-size: 11px; white-space: nowrap; }
+.file__path {
+  grid-column: 1 / -1;
+  font-size: 10px;
+  color: var(--hy-dim);
+  opacity: .7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl; /* keep the filename end visible when the path is long */
+  text-align: left;
+}
+
+.add { color: var(--hy-cheap); }
+.del { color: var(--hy-expensive); }
+
+.diff {
+  background: var(--hy-panel);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius);
+  overflow: hidden;
+  min-width: 0;
+}
+.diff__note { margin: 0; padding: 18px; color: var(--hy-dim); font-size: 13px; }
+.diff__head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--hy-line);
+}
+.diff__file { font-family: var(--hy-font-mono); font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
+.diff__body { margin: 0; padding: 8px 0; overflow-x: auto; font-family: var(--hy-font-mono); font-size: 12px; line-height: 1.55; }
+
+.dl { display: flex; gap: 0; white-space: pre; }
+.dl--add { background: color-mix(in srgb, var(--hy-cheap) 12%, transparent); }
+.dl--del { background: color-mix(in srgb, var(--hy-expensive) 12%, transparent); }
+
+.dl__n {
+  flex: 0 0 44px;
+  text-align: right;
+  padding-right: 8px;
+  color: var(--hy-dim);
+  opacity: .6;
+  user-select: none;
+}
+.dl__op { flex: 0 0 18px; text-align: center; color: var(--hy-dim); user-select: none; }
+.dl--add .dl__op { color: var(--hy-cheap); }
+.dl--del .dl__op { color: var(--hy-expensive); }
+.dl__text { flex: 1 1 auto; padding-right: 14px; }
+
+/* ── Chat dock ─────────────────────────────────────────────────────────── */
+
+.dock {
+  position: fixed;
+  right: 22px;
+  bottom: 20px;
+  z-index: 10;
+  font-family: var(--hy-font-display);
+}
+
+/* Collapsed by default and back to a bar on close: a permanently-large panel
+   splits attention with the view it is about. */
+.dock--closed {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--hy-aqua);
+  color: var(--hy-bg);
+  border: 0;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 600;
+  font-size: 13px;
+  padding: 11px 20px;
+  cursor: pointer;
+  box-shadow: 0 6px 22px rgba(0, 0, 0, .45);
+}
+.dock--closed:focus-visible { outline: 2px solid var(--hy-ink); outline-offset: 2px; }
+
+.dock__count {
+  background: rgba(0, 0, 0, .22);
+  border-radius: 999px;
+  padding: 1px 7px;
+  font-size: 11px;
+  font-family: var(--hy-font-mono);
+}
+
+.dock--open {
+  display: flex;
+  flex-direction: column;
+  width: min(430px, calc(100vw - 44px));
+  max-height: min(560px, calc(100vh - 60px));
+  background: var(--hy-bg-2);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius);
+  box-shadow: 0 14px 44px rgba(0, 0, 0, .55);
+  overflow: hidden;
+}
+
+.dock__head { display: flex; align-items: center; gap: 9px; padding: 11px 13px; border-bottom: 1px solid var(--hy-line); }
+.dock__title { font-weight: 600; font-size: 13px; }
+
+.dock__enum {
+  margin-left: auto;
+  appearance: none;
+  background: var(--hy-panel);
+  color: var(--hy-dim);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius-sm);
+  font: inherit;
+  font-family: var(--hy-font-mono);
+  font-size: 11px;
+  padding: 3px 7px;
+}
+
+.dock__close {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--hy-dim);
+  font-size: 19px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 3px;
+}
+.dock__close:hover { color: var(--hy-ink); }
+
+.dock__log { flex: 1 1 auto; overflow-y: auto; padding: 12px 13px; display: flex; flex-direction: column; gap: 14px; }
+.dock__hint { margin: 0; color: var(--hy-dim); font-size: 12px; }
+
+.turn { display: flex; flex-direction: column; gap: 5px; }
+.turn__you {
+  margin: 0;
+  align-self: flex-end;
+  max-width: 88%;
+  background: var(--hy-panel);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius-sm);
+  padding: 7px 11px;
+  font-size: 13px;
+  white-space: pre-wrap;
+}
+.turn__out { margin: 0; font-size: 13px; line-height: 1.55; white-space: pre-wrap; }
+.turn__wait { margin: 0; color: var(--hy-dim); font-size: 12px; }
+.turn__err { margin: 0; color: var(--hy-expensive); font-size: 12px; font-family: var(--hy-font-mono); }
+
+.turn__meta {
+  appearance: none;
+  align-self: flex-start;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--hy-dim);
+  font: inherit;
+  font-family: var(--hy-font-mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+.turn__meta:hover { color: var(--hy-aqua); }
+.turn__meta:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; }
+
+.dock__input { border-top: 1px solid var(--hy-line); padding: 9px 11px; }
+.dock__input textarea {
+  width: 100%;
+  resize: none;
+  background: var(--hy-panel);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius-sm);
+  color: var(--hy-ink);
+  font: inherit;
+  font-size: 13px;
+  padding: 8px 10px;
+}
+.dock__input textarea:focus { outline: none; border-color: var(--hy-aqua); }
+.dock__input textarea::placeholder { color: var(--hy-dim); }
+
+/* The dock floats over the main column; keep the last rows reachable. */
+.main { padding-bottom: 86px; }

--- a/desktop/frontend/src/bindings.ts
+++ b/desktop/frontend/src/bindings.ts
@@ -6,7 +6,7 @@
 // harness. Reading the methods off `window.go` at call time — the same object
 // the generated module wraps — keeps the source tree self-contained.
 
-import type { Dashboard, Fleet, Session, Version } from './types'
+import type { ChatReply, Dashboard, Diff, Edit, Fleet, Session, Version } from './types'
 
 interface WailsGo {
   api: {
@@ -14,6 +14,10 @@ interface WailsGo {
       GetDashboard(): Promise<Dashboard>
       GetFleet(): Promise<Fleet>
       GetSession(runID: string): Promise<Session>
+      GetEdits(runID: string): Promise<Edit[]>
+      Chat(prompt: string, enumKey: string): Promise<ChatReply>
+      ChatEnums(): Promise<string[]>
+      GetDiff(runID: string, ref: string, file: string): Promise<Diff>
       GetVersion(): Promise<Version>
     }
   }
@@ -36,4 +40,10 @@ function backend() {
 export const GetDashboard = (): Promise<Dashboard> => backend().GetDashboard()
 export const GetFleet = (): Promise<Fleet> => backend().GetFleet()
 export const GetSession = (runID: string): Promise<Session> => backend().GetSession(runID)
+export const GetEdits = (runID: string): Promise<Edit[]> => backend().GetEdits(runID)
+export const GetDiff = (runID: string, ref: string, file: string): Promise<Diff> =>
+  backend().GetDiff(runID, ref, file)
+export const Chat = (prompt: string, enumKey: string): Promise<ChatReply> =>
+  backend().Chat(prompt, enumKey)
+export const ChatEnums = (): Promise<string[]> => backend().ChatEnums()
 export const GetVersion = (): Promise<Version> => backend().GetVersion()

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -146,3 +146,44 @@ export interface Session {
   nonLinear: boolean
   skipped: number
 }
+
+export interface Edit {
+  file: string
+  ts: string
+  detail?: string
+  /** Empty when no snapshot was stored — the change happened, the diff cannot be shown. */
+  ref?: string
+  added: number
+  removed: number
+}
+
+export interface DiffLine {
+  op: string
+  text: string
+  /** 0 when the line is an addition. */
+  oldLine: number
+  /** 0 when the line is a removal. */
+  newLine: number
+}
+
+export interface Diff {
+  file: string
+  found: boolean
+  /** Why a diff is unavailable, so the view is specific rather than blank. */
+  reason?: string
+  lines: DiffLine[]
+  added: number
+  removed: number
+}
+
+export interface ChatReply {
+  output: string
+  head: string
+  model: string
+  tier: number
+  costUsd: number
+  durationMs: number
+  /** Links the reply into Session — "why did it say that" is one click. */
+  runId: string
+  error?: string
+}

--- a/desktop/frontend/src/views/ChatDock.tsx
+++ b/desktop/frontend/src/views/ChatDock.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState } from 'react'
+import { Chat, ChatEnums } from '../bindings'
+import type { ChatReply } from '../types'
+import { ms, usdExact } from '../format'
+
+interface Turn {
+  prompt: string
+  reply?: ChatReply
+}
+
+/**
+ * Persistent dock, collapsed to a bar by default.
+ *
+ * Never a permanently-large panel: splitting attention between a chat and the
+ * view it is about costs more than it gives (Sweller/Tarmizi's split-attention
+ * effect), so it opens on engagement and closes again.
+ */
+export function ChatDock({ onOpenRun }: { onOpenRun: (runID: string) => void }) {
+  const [open, setOpen] = useState(false)
+  const [prompt, setPrompt] = useState('')
+  const [enumKey, setEnumKey] = useState('')
+  const [enums, setEnums] = useState<string[]>([])
+  const [turns, setTurns] = useState<Turn[]>([])
+  const [busy, setBusy] = useState(false)
+  const logRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    ChatEnums().then(setEnums).catch(() => {
+      /* The picker degrades to auto-routing only; not worth surfacing. */
+    })
+  }, [])
+
+  useEffect(() => {
+    logRef.current?.scrollTo({ top: logRef.current.scrollHeight })
+  }, [turns])
+
+  async function send() {
+    const p = prompt.trim()
+    if (!p || busy) return
+    setPrompt('')
+    setBusy(true)
+    setTurns((t) => [...t, { prompt: p }])
+    try {
+      const reply = await Chat(p, enumKey)
+      setTurns((t) => t.map((turn, i) => (i === t.length - 1 ? { ...turn, reply } : turn)))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      setTurns((t) =>
+        t.map((turn, i) =>
+          i === t.length - 1
+            ? { ...turn, reply: { ...emptyReply(), error: message } }
+            : turn,
+        ),
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button className="dock dock--closed" onClick={() => setOpen(true)}>
+        Ask Hydra
+        {turns.length > 0 && <span className="dock__count">{turns.length}</span>}
+      </button>
+    )
+  }
+
+  return (
+    <section className="dock dock--open">
+      <header className="dock__head">
+        <span className="dock__title">Ask Hydra</span>
+        <select
+          className="dock__enum"
+          value={enumKey}
+          onChange={(e) => setEnumKey(e.target.value)}
+          aria-label="Routing"
+        >
+          {/* Auto is the absence of an enum, not one of them. */}
+          <option value="">auto-route</option>
+          {enums.map((k) => (
+            <option key={k} value={k}>
+              {k}
+            </option>
+          ))}
+        </select>
+        <button className="dock__close" onClick={() => setOpen(false)} aria-label="Collapse">
+          ×
+        </button>
+      </header>
+
+      <div className="dock__log" ref={logRef}>
+        {turns.length === 0 && <p className="dock__hint">Routed like any other task. Replies say which head answered.</p>}
+        {turns.map((t, i) => (
+          <div key={i} className="turn">
+            <p className="turn__you">{t.prompt}</p>
+            {!t.reply && <p className="turn__wait">routing…</p>}
+            {t.reply?.error && <p className="turn__err">{t.reply.error}</p>}
+            {t.reply && !t.reply.error && (
+              <>
+                <p className="turn__out">{t.reply.output}</p>
+                {/* Which head, which tier, what it cost — this is a router, so
+                    that is the part worth showing, not just the answer. */}
+                <button className="turn__meta" onClick={() => onOpenRun(t.reply!.runId)}>
+                  {t.reply.model || t.reply.head}
+                  {t.reply.tier > 0 && ` · T${t.reply.tier}`}
+                  {t.reply.durationMs > 0 && ` · ${ms(t.reply.durationMs)}`}
+                  {t.reply.costUsd > 0 && ` · ${usdExact(t.reply.costUsd)}`}
+                  {' · session →'}
+                </button>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="dock__input">
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              void send()
+            }
+          }}
+          placeholder={busy ? 'routing…' : 'Ask anything — enter to send, shift+enter for a newline'}
+          rows={2}
+          disabled={busy}
+        />
+      </div>
+    </section>
+  )
+}
+
+function emptyReply(): ChatReply {
+  return { output: '', head: '', model: '', tier: 0, costUsd: 0, durationMs: 0, runId: '' }
+}

--- a/desktop/frontend/src/views/Code.tsx
+++ b/desktop/frontend/src/views/Code.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import { GetDiff } from '../bindings'
+import type { Diff, Edit } from '../types'
+
+export function Code({ runID, edits }: { runID: string; edits: Edit[] }) {
+  const [selected, setSelected] = useState(0)
+  const [diff, setDiff] = useState<Diff | null>(null)
+
+  const current = edits[selected]
+
+  useEffect(() => {
+    if (!current) {
+      setDiff(null)
+      return
+    }
+    let stale = false
+    GetDiff(runID, current.ref ?? '', current.file)
+      .then((d) => {
+        if (!stale) setDiff(d)
+      })
+      .catch(() => {
+        if (!stale) setDiff(null)
+      })
+    return () => {
+      stale = true
+    }
+  }, [runID, current])
+
+  if (edits.length === 0) {
+    return (
+      <div className="empty">
+        <p className="empty__title">This run changed no files</p>
+        <p>
+          File edits appear here. Try <code>hyctl edit --file … --prompt "…"</code>.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="code">
+      <ul className="files">
+        {edits.map((e, i) => (
+          <li key={`${e.file}-${i}`}>
+            <button
+              className="file"
+              aria-current={i === selected ? 'page' : undefined}
+              onClick={() => setSelected(i)}
+            >
+              <span className="file__name">{basename(e.file)}</span>
+              <span className="file__counts">
+                <span className="add">+{e.added}</span> <span className="del">−{e.removed}</span>
+              </span>
+              <span className="file__path">{e.file}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div className="diff">
+        {!diff && <p className="diff__note">Reading snapshot…</p>}
+        {/* A missing snapshot says why. The change still happened — pretending
+            otherwise, or showing a blank pane, would both misrepresent it. */}
+        {diff && !diff.found && <p className="diff__note">Diff unavailable — {diff.reason}</p>}
+        {diff?.found && <DiffBody diff={diff} />}
+      </div>
+    </div>
+  )
+}
+
+function DiffBody({ diff }: { diff: Diff }) {
+  return (
+    <>
+      <header className="diff__head">
+        <span className="diff__file">{diff.file}</span>
+        <span className="file__counts">
+          <span className="add">+{diff.added}</span> <span className="del">−{diff.removed}</span>
+        </span>
+      </header>
+      <pre className="diff__body">
+        {diff.lines.map((l, i) => (
+          <div key={i} className={`dl dl--${opClass(l.op)}`}>
+            <span className="dl__n">{l.oldLine || ''}</span>
+            <span className="dl__n">{l.newLine || ''}</span>
+            <span className="dl__op">{l.op}</span>
+            <span className="dl__text">{l.text}</span>
+          </div>
+        ))}
+      </pre>
+    </>
+  )
+}
+
+function opClass(op: string): string {
+  if (op === '+') return 'add'
+  if (op === '-') return 'del'
+  return 'ctx'
+}
+
+function basename(p: string): string {
+  const i = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+  return i < 0 ? p : p.slice(i + 1)
+}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -30,6 +30,13 @@ type Request struct {
 	Enum     string // routing enum key (e.g. "SIMPLE")
 	Prompt   string // edit instruction
 	Validate bool   // run extension validator after write (default true)
+
+	// RunID and TaskID correlate this edit with the invocation that drove it.
+	// Before #211 they were not threaded at all: the dispatch below ran with no
+	// identity, so an edit's cost row carried a freshly-derived run and nothing
+	// could tell which run touched which file. Empty derives one, as elsewhere.
+	RunID  string
+	TaskID string
 }
 
 // Result is the JSON output emitted by Edit.
@@ -134,6 +141,8 @@ snippet) between these exact markers and nothing else:
 	tierHint := enumToTier(req.Enum)
 	dispResult, err := d.Dispatch(ctx, editPrompt, dispatch.Options{
 		TierHint: tierHint,
+		RunID:    req.RunID,
+		TaskID:   req.TaskID,
 	})
 	if err != nil {
 		cleanupBackup()
@@ -209,6 +218,11 @@ snippet) between these exact markers and nothing else:
 
 	// ── Diff stats ────────────────────────────────────────────────────────────
 	added, removed := diffStats(req.File, origContent, resolved.GitRoot, backup, origExisted)
+
+	// ── Run log ───────────────────────────────────────────────────────────────
+	// Emitted here, after validation, so a rolled-back edit is never recorded as
+	// an applied change — the rollback path returns above without reaching this.
+	logEdit(req, origContent, newContent+"\n", added, removed)
 
 	// ── A2A handoff ───────────────────────────────────────────────────────────
 	_ = writeLastEdit(req.File, req.Enum, wsName, added, removed)

--- a/internal/editor/runlog.go
+++ b/internal/editor/runlog.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+package editor
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/ankit373/hydra/internal/runid"
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+// editSeq numbers snapshots within a process so two edits in one run cannot
+// overwrite each other's content. The run id keeps separate runs apart; this
+// keeps separate edits apart inside one.
+var editSeq atomic.Uint64
+
+// logEdit records one applied edit: the file and line counts on the event, the
+// before/after content in the run's side-file store.
+//
+// The content is never inlined. The run log's atomicity guarantee is per
+// write() call, so an entry carrying a whole file would break the property that
+// makes concurrent appends safe — hence Ref, pointing at content held beside
+// the log.
+//
+// Best-effort throughout: an edit that succeeded must not be reported as failed
+// because its observability record could not be written.
+func logEdit(req Request, before, after string, added, removed int) {
+	runID := runid.ResolveRun(req.RunID)
+	taskID := runid.ResolveTask(req.TaskID)
+	ref := fmt.Sprintf("%06d", editSeq.Add(1))
+
+	detail := fmt.Sprintf("+%d/-%d", added, removed)
+	if err := runlog.SaveEdit(runID, ref, []byte(before), []byte(after)); err != nil {
+		// The event still goes out. Losing it would hide that the file changed
+		// at all, which is worse than losing the diff — the reader can render
+		// "diff unavailable" from an unresolvable ref.
+		ref = ""
+		detail += " · snapshot unavailable"
+	}
+
+	_ = runlog.New(runID).Append(runlog.Event{
+		Kind:   runlog.KindEdit,
+		TaskID: taskID,
+		Agent:  req.File,
+		Ref:    ref,
+		Detail: detail,
+	})
+}

--- a/internal/runlog/edits.go
+++ b/internal/runlog/edits.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+
+package runlog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MaxSnapshotBytes caps one side of one edit snapshot.
+//
+// A snapshot store must not be able to fill a disk because a model was pointed
+// at a 200 MB file. Above the cap the edit is still logged — losing the *event*
+// would hide that a change happened at all — but its content is not stored and
+// the ref resolves to "too large", which a reader can render honestly.
+const MaxSnapshotBytes = 4 << 20 // 4 MiB
+
+// ErrSnapshotTooLarge reports content above MaxSnapshotBytes.
+var ErrSnapshotTooLarge = errors.New("runlog: edit snapshot exceeds the size cap")
+
+// ErrNoSnapshot reports a ref with no stored content — pruned, never written,
+// or refused for size. Distinct from a read failure so a caller can say "diff
+// unavailable" rather than "cannot read disk".
+var ErrNoSnapshot = errors.New("runlog: no snapshot for this ref")
+
+// EditsDir is where a run's edit snapshots live. Per-run, like the event log
+// itself, so retention is deleting a directory rather than compacting a store.
+func EditsDir(runID string) string { return filepath.Join(Dir(), runID+".edits") }
+
+// SaveEdit stores one edit's before/after content and returns the ref to put on
+// the event. Bulk content never goes in the event itself: the run log's
+// atomicity guarantee is per write() call, so entries must stay small.
+//
+// ref is caller-chosen and must be filesystem-safe; SaveEdit rejects anything
+// containing a separator so a ref can never escape the run's directory.
+func SaveEdit(runID, ref string, before, after []byte) error {
+	if err := validRef(ref); err != nil {
+		return err
+	}
+	if len(before) > MaxSnapshotBytes || len(after) > MaxSnapshotBytes {
+		return ErrSnapshotTooLarge
+	}
+	dir := EditsDir(runID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	// 0600: an edit snapshot is a verbatim copy of the user's source.
+	if err := os.WriteFile(filepath.Join(dir, ref+".before"), before, 0o600); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, ref+".after"), after, 0o600)
+}
+
+// LoadEdit returns a stored edit's before/after content.
+func LoadEdit(runID, ref string) (before, after []byte, err error) {
+	if err := validRef(ref); err != nil {
+		return nil, nil, err
+	}
+	dir := EditsDir(runID)
+	before, err = os.ReadFile(filepath.Join(dir, ref+".before"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, ErrNoSnapshot
+		}
+		return nil, nil, err
+	}
+	after, err = os.ReadFile(filepath.Join(dir, ref+".after"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, ErrNoSnapshot
+		}
+		return nil, nil, err
+	}
+	return before, after, nil
+}
+
+// validRef rejects anything that could address a file outside the run's own
+// edits directory. Refs come from event data, which a reader must treat as
+// untrusted — a run log can be written by anything sharing the run id.
+func validRef(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("runlog: empty edit ref")
+	}
+	if strings.ContainsAny(ref, `/\`) || strings.Contains(ref, "..") {
+		return fmt.Errorf("runlog: unsafe edit ref %q", ref)
+	}
+	return nil
+}

--- a/internal/runlog/edits_test.go
+++ b/internal/runlog/edits_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+
+package runlog
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func editSandbox(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+func TestSaveLoadEdit_RoundTrips(t *testing.T) {
+	editSandbox(t)
+
+	before := []byte("package main\n\nfunc main() {}\n")
+	after := []byte("package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"hi\") }\n")
+	if err := SaveEdit("run-1", "001", before, after); err != nil {
+		t.Fatal(err)
+	}
+
+	gotBefore, gotAfter, err := LoadEdit("run-1", "001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotBefore, before) {
+		t.Errorf("before = %q, want %q", gotBefore, before)
+	}
+	if !bytes.Equal(gotAfter, after) {
+		t.Errorf("after = %q, want %q", gotAfter, after)
+	}
+}
+
+// A ref comes from event data, and a run log can be written by anything sharing
+// the run id. It must never be able to address a file outside the run.
+func TestSaveEdit_RejectsTraversalRefs(t *testing.T) {
+	editSandbox(t)
+
+	for _, ref := range []string{"../escape", "a/b", `a\b`, "..", "", "sub/../../x"} {
+		t.Run(ref, func(t *testing.T) {
+			if err := SaveEdit("run-1", ref, []byte("x"), []byte("y")); err == nil {
+				t.Errorf("SaveEdit accepted ref %q", ref)
+			}
+			if _, _, err := LoadEdit("run-1", ref); err == nil {
+				t.Errorf("LoadEdit accepted ref %q", ref)
+			}
+		})
+	}
+}
+
+// The store must not be able to fill a disk because a model was pointed at a
+// huge file. Losing the event would hide that a change happened, so only the
+// content is refused.
+func TestSaveEdit_RefusesOversizedContent(t *testing.T) {
+	editSandbox(t)
+
+	big := bytes.Repeat([]byte("x"), MaxSnapshotBytes+1)
+	err := SaveEdit("run-1", "001", []byte("small"), big)
+	if !errors.Is(err, ErrSnapshotTooLarge) {
+		t.Fatalf("err = %v, want ErrSnapshotTooLarge", err)
+	}
+	// Nothing partial left behind that a reader would mistake for a real snapshot.
+	if _, _, err := LoadEdit("run-1", "001"); !errors.Is(err, ErrNoSnapshot) {
+		t.Errorf("after a refused save, LoadEdit err = %v, want ErrNoSnapshot", err)
+	}
+}
+
+// Exactly at the cap must still store — an off-by-one here silently drops
+// legitimate snapshots.
+func TestSaveEdit_AcceptsExactlyTheCap(t *testing.T) {
+	editSandbox(t)
+
+	atCap := bytes.Repeat([]byte("x"), MaxSnapshotBytes)
+	if err := SaveEdit("run-1", "001", nil, atCap); err != nil {
+		t.Fatalf("content exactly at the cap was refused: %v", err)
+	}
+}
+
+// A pruned or never-written ref is not a read failure. The view says "diff
+// unavailable" for one and surfaces an error for the other.
+func TestLoadEdit_MissingIsItsOwnError(t *testing.T) {
+	editSandbox(t)
+
+	_, _, err := LoadEdit("run-1", "999")
+	if !errors.Is(err, ErrNoSnapshot) {
+		t.Errorf("err = %v, want ErrNoSnapshot", err)
+	}
+}
+
+// A half-written pair — after was lost — must not read as an empty file, which
+// would render as "everything deleted".
+func TestLoadEdit_PartialPairIsMissing(t *testing.T) {
+	home := editSandbox(t)
+
+	if err := SaveEdit("run-1", "001", []byte("a"), []byte("b")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(home, ".hydra", "logs", "runs", "run-1.edits", "001.after")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadEdit("run-1", "001"); !errors.Is(err, ErrNoSnapshot) {
+		t.Errorf("err = %v, want ErrNoSnapshot — a lost half must not read as an empty file", err)
+	}
+}
+
+// Snapshots are verbatim copies of the user's source, so they must not be
+// world-readable.
+func TestSaveEdit_SnapshotsAreNotWorldReadable(t *testing.T) {
+	home := editSandbox(t)
+
+	if err := SaveEdit("run-1", "001", []byte("secret"), []byte("secret2")); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".hydra", "logs", "runs", "run-1.edits")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("%d files, want 2", len(entries))
+	}
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			t.Errorf("%s has mode %v; snapshots hold the user's source verbatim", e.Name(), info.Mode().Perm())
+		}
+	}
+}
+
+// Edits live beside the run's event log so retention is deleting a directory.
+func TestEditsDir_IsBesideTheRunLog(t *testing.T) {
+	editSandbox(t)
+
+	if got, want := EditsDir("run-1"), Path("run-1"); !strings.HasPrefix(got, strings.TrimSuffix(want, ".jsonl")) {
+		t.Errorf("EditsDir = %q, want it beside %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Phases 6 and 7. Dashboard shows spend, Fleet what is running, Session what happened in order. None
showed **what changed on disk** — the only thing that outlives the run. The dock makes the router
reachable from every view.

## Two gaps blocked the Code view

**Nothing emitted `KindEdit`.** The kind existed and `tree.Apply` handled it; no producer wrote one.

**Edits were not correlated to a run at all.** `editor.Edit` dispatched with
`dispatch.Options{TierHint: tierHint}` — no `RunID`, no `TaskID` — so even the cost row an edit
produced carried a freshly-derived identity and no reader could tell which run touched which file.
Same class of gap as #204's env-var bug, in a path that one missed.

Verified fixed on a real edit — the cost row now carries the run's own id:
```
run_id: 20260802T210000Z-ed17ed17ed17ed17
```

## Snapshots

Bulk content in side files, metadata only in the structured log — the pattern `parallel.go` already
uses. The run log's atomicity guarantee is per `write()` call, so an entry carrying a whole file
would break the property that makes concurrent appends safe.

`.hydra-bak` could not serve this: it is created only for non-git workspaces and only on the *first*
edit, so it is not a per-edit snapshot.

Refs are validated against traversal — a run log can be written by anything sharing the run id.
Content is size-capped; above the cap **the event still goes out** with an empty ref, because losing
the event would hide that the file changed at all.

## The performance defect its own test caught

The LCS table is O(n·m) and `MaxSnapshotBytes` permits ~65k lines, so the first version built a
**4.2-billion-cell table and hung**. My comment claiming the size cap made this fine was wrong: the
cap bounds *bytes*, not *similarity*.

Common prefix and suffix are now trimmed before any alignment, collapsing every real edit to a tiny
core, and a cell cap degrades a wholesale rewrite to one replacement rather than an alignment nobody
would read. A 60k-line file with one changed line now diffs in **10ms**, and two timing tests fail
if the trim is removed.

## Verified end to end on a real `hyctl edit`

```
EDIT …/greet.py  +2/-0  ref="000001"
    1   1   def greet(name):
        2 +     """Greets the user by name."""
    2   3       print("hello " + name)
        4 +
  => +2/-0
```

`+2/-0` reported by the editor, the same `+2/-0` rendered from the snapshot, line numbers on both
sides — and the trailing blank line is real: the file on disk ends `)\n\n`.

## Chat dock (Phase 7)

Collapsed to a bar by default and back to one on close — a permanently-large panel splits attention
with the view it is about. Replies **lead with which head answered, at which tier, for how much**;
this is a router, so that is the part worth showing. They link into Session, so *"why did it say
that"* is one click. A dock dispatch is a run like any other — it appears in Fleet while it works
and in Session afterwards, rather than being a second, untraceable path through the router.

The enum picker is served from Go and a test asserts every key it offers resolves through
`dispatch.EnumToTier`, so it cannot advertise a routing key the router ignores.

## Tests

| Area | Notable |
|---|---|
| snapshots | traversal refs rejected; exactly-at-cap accepted; a half-lost pair reads as missing, not as an emptied file; not world-readable |
| diff | add/remove/modify/create/empty/insert-at-start; line numbers on both sides; trailing newline is not a phantom line; head/tail trims never emit a line twice |
| diff perf | 60k-line file with one change; two wholly-different 5k-line files degrade to a replacement |
| robustness | pruned snapshot and empty ref each explain themselves; non-UTF8 content survives |
| chat | every offered enum resolves to a tier; ordered weakest-first; empty prompt and failed dispatch return replies, not errors |

`gofmt`, `go vet`, `staticcheck`, `go test -race` clean on both modules; `tsc -b` and `vite build`
clean; `wails build -tags desktop` produces a working `.app`.

Closes #211