### PR TITLE
docs: describe the desktop app, and fix the build command that never worked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,12 @@ jobs:
       # desktop/ is its own module, so the root job's `./...` does not reach it.
       # Without this job its tests would silently never run.
       #
-      # No build tag here: desktop/main.go is the only file that imports Wails
-      # and it is behind `//go:build desktop`, so nothing on this runner needs
-      # libwebkit2gtk. desktop/api — the part with the tests — imports no UI
-      # framework at all.
+      # Scoped to ./api/... deliberately: desktop/main.go imports Wails, which
+      # needs libwebkit2gtk to compile on Linux. A build tag used to exclude it,
+      # but `wails build` generates bindings by compiling that package untagged,
+      # so the tag broke the documented build command (#213). desktop/api — the
+      # part with the tests — imports no UI framework at all, and main.go is
+      # exercised by `wails build` on a machine that has a webview.
       - name: Gofmt
         working-directory: desktop
         run: |
@@ -87,7 +89,7 @@ jobs:
 
       - name: Vet
         working-directory: desktop
-        run: go vet ./...
+        run: go vet ./api/...
 
       # Same reasoning as the root job: staticcheck must be built with the
       # toolchain it analyses.
@@ -97,11 +99,11 @@ jobs:
 
       - name: Staticcheck
         working-directory: desktop
-        run: staticcheck ./...
+        run: staticcheck ./api/...
 
       - name: Test
         working-directory: desktop
-        run: go test ./... -race
+        run: go test ./api/... -race
 
   shellcheck:
     name: Shellcheck

--- a/README.md
+++ b/README.md
@@ -611,12 +611,43 @@ hydra/
 │   ├── review/                  # Code review / approve / reject / QA
 │   ├── util/                    # Shared utilities (bounded Accumulator, 33 MB cap)
 │   ├── sysinfo/                 # Hardware detection + 7-day memory history
+│   ├── runlog/                  # Per-run event log (~/.hydra/logs/runs/) + liveness heartbeat + edit snapshots
+│   ├── tree/                    # Reconstructs a run: supervision tree + timeline, framework-free
+│   ├── runid/                   # Run/task identity — correlates every log a run produces
+│   ├── a2a/                     # Agent handoffs with vector clocks (causal ordering + conflict detection)
+│   ├── graph/                   # Code dependency graph → blast radius + percolation κ
+│   ├── ledger/                  # Local MCP accountability ledger + policy gate
+│   ├── oracle/                  # Verification oracles (tests/compile/lint) as calibrated evidence
+│   ├── optimal/ · entropy/      # Optimal parallel-agent count · context signal density
 │   ├── build/ · update/         # Version stamping + startup update check
-│   └── tui/                     # Bubbletea init wizard + install guide
+│   └── tui/                     # Bubbletea cockpit + init wizard
+├── desktop/                     # Desktop app (own Go module) — Wails v2 + React/TS
+│   ├── api/                     # Go backend: Dashboard · Fleet · Session · Code · chat (no Wails imports)
+│   └── frontend/                # React views over the same logs the CLI writes
 ├── registry/                    # routing.yaml (the enum) · models · domains · pricing · policy
 ├── docs/                        # GitHub Pages (hydra.uvansa.com) — index.html, llms.txt
 └── Formula/hydra.rb             # Homebrew formula (auto-updated by GoReleaser)
 ```
+
+### The desktop app
+
+A native window over the same engine: **Dashboard** (spend, governor pressure, trust record),
+**Fleet** (runs in flight and the agents inside them), **Session** (one run's timeline, plus a
+layered graph when it fanned out), and **Code** (the file edits a run made, as diffs) — over a
+persistent chat dock.
+
+It reads `~/.hydra/logs/` directly. No daemon, no telemetry, and its numbers are the CLI's numbers:
+Dashboard totals are asserted equal to `hyctl cost` and `hyctl stats` for the same data.
+
+**Built, not yet packaged** — there is no installer or signed build today:
+
+```bash
+go install github.com/wailsapp/wails/v2/cmd/wails@latest
+cd desktop && wails build                   # → desktop/build/bin/
+```
+
+`desktop/` is a separate Go module on purpose: Wails takes the root module from 25 requires to 50,
+and `hyctl` ships via brew/npm/pip/curl and never links a webview.
 
 ---
 

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-//go:build desktop
-
 // Command hydradesk is Hydra's desktop app.
 //
 // It lives in this module rather than its own repo because it binds directly to
@@ -11,7 +9,12 @@
 //
 // This file is the only one that knows Wails exists. Everything it binds lives
 // in desktop/api, which imports no UI framework and is unit-tested without a
-// webview.
+// webview — so CI checks the backend with `./api/...` and never needs
+// libwebkit2gtk on a Linux runner.
+//
+// It carries no build tag. One did exclude it, but `wails build` generates
+// bindings by compiling this package untagged, so the tag made the documented
+// build command fail with "build constraints exclude all Go files" (#213).
 package main
 
 import (

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -442,26 +442,26 @@ hyctl tui <span class="fl">--snapshot</span> <span class="fl">--view</span> 0|1|
 
     <!-- ══ APP ══ -->
     <section class="doc" id="app">
-      <h2>The desktop app <span class="badge prev">design preview</span> <span class="tagline">point-and-click cockpit</span></h2>
-      <p class="sum">The same cockpit as a native window. <b>Click the sidebar</b> — the views swap live. <b>In design; not yet shipped.</b> Here's the direction:</p>
+      <h2>The desktop app <span class="badge prev">build from source</span> <span class="tagline">point-and-click cockpit</span></h2>
+      <p class="sum">A native window over the same engine — Wails v2 + React, in <span class="fx">desktop/</span>. Four views over a persistent chat dock. <b>Built, not yet packaged:</b> there is no installer or signed build, so today you build it yourself. <b>Click the sidebar</b> — the views swap live.</p>
       <div class="appwin">
         <div class="tb"><i style="background:#ff5f57"></i><i style="background:#febc2e"></i><i style="background:#28c840"></i><span class="ttl" id="appTitle">Hydra.app — Dashboard</span></div>
         <div class="appbody">
           <div class="appnav" id="appNav" role="tablist">
-            <div class="item" data-av="av-cockpit" data-title="Cockpit" role="tab" tabindex="0"><span class="dot"></span>Cockpit</div>
             <div class="item on" data-av="av-dash" data-title="Dashboard" role="tab" tabindex="0"><span class="dot"></span>Dashboard</div>
-            <div class="item" data-av="av-tree" data-title="Agent tree" role="tab" tabindex="0"><span class="dot"></span>Agent tree</div>
+            <div class="item" data-av="av-cockpit" data-title="Fleet" role="tab" tabindex="0"><span class="dot"></span>Fleet</div>
+            <div class="item" data-av="av-tree" data-title="Session" role="tab" tabindex="0"><span class="dot"></span>Session</div>
+            <div class="item" data-av="av-code" data-title="Code" role="tab" tabindex="0"><span class="dot"></span>Code</div>
           </div>
           <div class="appview">
             <div class="panes" id="appPanes">
               <div class="pane" id="av-cockpit">
-                <div class="ah">route a task</div>
+                <div class="ah">runs · live first</div>
                 <div class="appcock">
-                  <div class="crow you">❯ rotate the signing key in internal/auth/token.go</div>
-                  <div class="crow">prompt → CORE → T1 → <span style="color:var(--violet)">agy · claude</span></div>
-                  <div class="crow"><span style="color:var(--exp)">κ=3.1 ⚠</span> · 12 dependents → confidence bar raised to 0.95</div>
-                  <div class="crow"><span style="color:var(--cyan)">conf 0.98</span> / target 0.95 · SPRT <span style="color:var(--cheap)">accept</span></div>
-                  <div class="crow"><span style="color:var(--cheap)">✔ done · saved $0.0149 vs all-frontier</span></div>
+                  <div class="crow"><span style="color:var(--aqua)">●</span> 20260802T190000Z-5e55… <span style="color:var(--faint)">4.7s · $0.0031 · 3 agents</span></div>
+                  <div class="crow"><span style="color:var(--faint)">&nbsp;&nbsp;&nbsp;2 running · 1 ok</span></div>
+                  <div class="crow"><span style="color:var(--faint)">○ 20260802T182210Z-ab41… &nbsp;1.3s · $0.0000 · 1 agent · ok</span></div>
+                  <div class="crow"><span style="color:var(--faint)">○ 20260802T175902Z-9d07… &nbsp;8.1s · $0.0142 · 5 agents · ok</span></div>
                 </div>
               </div>
               <div class="pane on" id="av-dash">
@@ -486,11 +486,23 @@ hyctl tui <span class="fl">--snapshot</span> <span class="fl">--view</span> 0|1|
                   <div style="color:var(--faint)">&nbsp;&nbsp;&nbsp;┄▶ A2A token-rotation → tests</div>
                 </div>
               </div>
+              <div class="pane" id="av-code">
+                <div class="ah">internal/auth/token.go &nbsp;<span style="color:var(--cheap)">+2</span> <span style="color:var(--exp)">−1</span></div>
+                <div class="apptree mono">
+                  <div><span style="color:var(--faint)">&nbsp;41&nbsp;&nbsp;41</span> &nbsp; func Rotate(k *Key) error {</div>
+                  <div style="background:rgba(255,90,110,.12)"><span style="color:var(--faint)">&nbsp;42&nbsp;&nbsp;&nbsp;&nbsp;</span> <span style="color:var(--exp)">−</span> return k.rotate()</div>
+                  <div style="background:rgba(63,217,138,.12)"><span style="color:var(--faint)">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;42</span> <span style="color:var(--cheap)">+</span> if err := k.validate(); err != nil {</div>
+                  <div style="background:rgba(63,217,138,.12)"><span style="color:var(--faint)">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;43</span> <span style="color:var(--cheap)">+</span> &nbsp;&nbsp;return err</div>
+                  <div><span style="color:var(--faint)">&nbsp;43&nbsp;&nbsp;44</span> &nbsp; }</div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-      <div class="callout">The TUI ships today (<span class="fx">hyctl tui</span>). The desktop app is a design preview — track it on the roadmap.</div>
+      <div class="sub"><div class="lbl">Build it</div><pre>go install github.com/wailsapp/wails/v2/cmd/wails@latest
+cd desktop &amp;&amp; wails build                <span class="c"># → desktop/build/bin/</span></pre></div>
+      <div class="callout">The app reads the same logs the CLI writes, so its numbers are the CLI's numbers — Dashboard totals match <span class="fx">hyctl cost</span> and <span class="fx">hyctl stats</span> for the same data. There is no separate daemon and no telemetry: it reads <span class="fx">~/.hydra/logs/</span> on your machine.</div>
     </section>
 
     <!-- ══ INTEGRATIONS ══ -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,6 +65,8 @@
       "Automatic fallback chains terminating at always-on local Qwen",
       "Local Ollama + cloud model hybrid — provider-neutral discovery",
       "Interactive TUI cockpit (hyctl tui) — chat, route work, and watch spend live",
+      "Desktop app (Wails v2, build from source) — Dashboard, Fleet, Session and Code views over a chat dock",
+      "Per-run event log — reconstruct any run's supervision tree, timeline and file edits",
       "Swarm dispatch — race, best, and all modes across multiple models simultaneously",
       "Token budget enforcement — per-model context window tracking with pressure modes",
       "Dynamic live pricing — OpenRouter API pricing with 24h cache and tier fallback",
@@ -728,7 +730,7 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
       </tbody>
     </table>
   </div>
-  <p class="cmp-note"><b>The interactive agent-tree cockpit is the one roadmap item here</b> — every row checked above ships today in the CLI (<code>hyctl dispatch --confidence</code>, <code>hyctl graph blast</code>, <code>hyctl mcp</code>).</p>
+  <p class="cmp-note"><b>Every row checked above ships today</b> — <code>hyctl dispatch --confidence</code>, <code>hyctl graph blast</code>, <code>hyctl mcp</code>. The agent-tree cockpit (<code>hyctl tui</code>) now renders real runs from the per-run event log, and the desktop app is built but not yet packaged — you build it from <code>desktop/</code>.</p>
 </section>
 
 <!-- ══ 7 · GETTING STARTED ══════════════════════════════════════════════════ -->

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,6 +6,8 @@
 
 - **10-tier routing**: Claude Opus (tier 1, complex reasoning) down to Qwen3 via Ollama (tier 10, free local)
 - **Interactive TUI cockpit**: `hyctl tui` opens an interactive cockpit — chat with your heads, route work, and watch spend live. Three views: chat+code, dashboard, and agent-tree. `hyctl tui --snapshot` renders one static frame for docs/previews
+- **Desktop app (build from source)**: a Wails v2 GUI in `desktop/` with four views — Dashboard (spend, governor pressure, trust record), Fleet (runs in flight and the agents inside them), Session (one run's timeline, plus a layered graph when the run fanned out), Code (the file edits a run made, as diffs) — over a persistent chat dock. Not yet packaged for distribution: build it with `cd desktop && wails build`
+- **Per-run event log**: every dispatch writes `~/.hydra/logs/runs/<run_id>.jsonl` — head selection, swarm attempts, SPRT samples with their running confidence, A2A handoffs, and file edits — which is what the cockpit's agent-tree and the desktop app reconstruct a run from. `HYDRA_RUN_ID` groups invocations an external orchestrator spawns into one run
 - **~1µs routing overhead**: the Go routing engine (policy eval + head selection + budget check) adds ~1,130 ns per dispatch — benchmarked on Apple M1 via `go test -bench=BenchmarkRoutingPath`
 - **Swarm dispatch**: fan a single prompt to multiple models simultaneously — race (fastest), best (LLM-judged quality), or all (aggregate)
 - **Confidence routing**: `hyctl dispatch --confidence 0.95` runs an SPRT (sequential probability ratio test) ensemble that samples models adaptively and stops as soon as a target confidence of correctness is reached, using per-source calibration (`hyctl trust calibration`) you build up from real outcomes — fewer model calls on easy tasks, more only where accuracy demands it
@@ -13,6 +15,7 @@
 - **Token budget enforcement**: pressure modes (Normal → Emergency) plus a rate-aware first-passage governor auto-downgrade tiers as the orchestrator's context window fills
 - **Cost analytics**: `hyctl stats` shows spend broken down by model, tier, and day
 - **Dynamic pricing**: live rates from OpenRouter API with 24h cache and static YAML offline fallback
+- **Any API key works**: set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, `DEEPSEEK_API_KEY`, `XAI_API_KEY` (or Bedrock/Azure/Cohere/Replicate/Together/Fireworks/Perplexity credentials) and the provider becomes a routable head automatically — no config file to touch
 - **A2A handoff**: structured JSON context (with vector clocks for causal ordering) passed between agents across tasks
 
 ## CLI Commands
@@ -30,7 +33,8 @@
 - `hyctl mcp` — local MCP accountability ledger: `check`, `record`, `verify`, `log`, `report`. Access checks can be classification-aware (PII auto-detected from content) and bind a SHA256 hash of the invocation parameters, so `verify` can later prove the executed parameters match the ones that were approved
 - `hyctl oracle` — verification oracles (tests/compile/lint) as calibrated evidence: `verify`
 - `hyctl models` — model capability registry: `list`, `add`, `remove`, `sync`
-- `hyctl edit` — editor integration
+- `hyctl parallel` — fan N independent tasks out to N heads at once, from a task JSON file
+- `hyctl edit` — scoped, validated, rollback-safe single-file edit
 - `hyctl review` — code review
 - `hyctl init` — first-run wizard: discover heads, choose your cortex
 - `hyctl version` — build and version info

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Phases 3–7 shipped a desktop app (#203, #207, #210, #212) and a per-run event log (#205). The site
never mentioned either, and two claims on it had become false:

- `docs.html` called the app a **"design preview"**, **"In design; not yet shipped"**, and mocked
  three views that are not the four it has.
- `index.html` said **"the interactive agent-tree cockpit is the one roadmap item here"** — it
  renders real runs since #192/#205.

## The bug writing the docs surfaced

`wails build -tags desktop` — the command I was about to document — **fails**:

```
ERROR  package github.com/ankit373/hydra/desktop: build constraints exclude all Go files
```

`wails build` generates bindings by compiling the package **untagged**, so `//go:build desktop` on
`main.go` breaks it. Every successful build during development passed `-skipbindings`, which is
exactly what hid this. Documenting the flag would have papered over it.

The tag existed so CI's Linux runner would not need `libwebkit2gtk`. Scoping the desktop job to
`./api/...` does the same job — that is the package with the tests and it imports no UI framework —
without breaking the build. `main.go` is a wiring file that `wails build` exercises on a machine
with a webview.

**The command in the docs is now the one that was run to verify it:**

```
$ cd desktop && wails build
Built '…/desktop/build/bin/hydradesk.app/Contents/MacOS/hydradesk' in 22.201s.
```

## Honest about what ships

The app is described as **build from source** everywhere, because that is true: goreleaser does not
build it and there is no signed or notarised artifact. Anything implying an install path would be
the aspirational-feature claim the docs rules forbid.

`docs.html`'s mock now shows the four real destinations (Dashboard, Fleet, Session, Code) with a
real diff pane, and its callout says what the app actually is — no daemon, no telemetry, reads
`~/.hydra/logs/`, and its Dashboard totals are asserted equal to `hyctl cost`/`hyctl stats`.

## Also corrected

- `llms.txt` omitted **`hyctl parallel`**, a real subcommand — verified against `hyctl --help`, every
  command it now lists exists.
- Its provider list predated OpenRouter (#201).
- README documents `desktop/` and **why** it is a separate module (Wails takes the root from 25
  requires to 50; `hyctl` ships via brew/npm/pip/curl and never links a webview), plus the
  `runlog`/`tree`/`runid`/`a2a`/`graph`/`ledger`/`oracle` packages the tree section had never listed.
- `sitemap.xml` `lastmod` bumped for both changed pages.

## Verification

`gofmt`, `go vet`, `staticcheck`, `go test -race` clean on both modules. All JSON-LD blocks,
`sitemap.xml`, and `docs.html` parse. `wails build` verified with no flags.

Closes #213