### PR TITLE
docs: correct the claim that Closes #n auto-closes issues on develop-targeted PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,8 +277,9 @@ hotfix/#{n}-slug    ← branches from main tag. Merged → main, cherry-picked �
 Every issue must be:
 1. **On the GitHub project board** (Project #2 "Hydra Roadmap")
 2. **Linked to its branch** — GitHub auto-links when branch name contains the issue number (`feature/54-hydra-stats` links to #54)
-3. **Linked to its PR** — PR body must contain `Closes #<issue>` for auto-close on merge
+3. **Linked to its PR** — PR body must contain `Closes #<issue>` so the PR shows on the issue
 4. **Moving through board states** at every transition (Todo → In Progress → In Review → Done)
+5. **Closed by hand once the release carrying it reaches `main`** — see below; nothing closes it for you
 
 ### Link a branch to an issue (GitHub auto-detection)
 GitHub automatically links a branch to an issue when the branch name contains the issue number.
@@ -290,10 +291,23 @@ gh issue view 54 --json linkedBranches
 ```
 
 ### Link a PR to an issue
-Always include `Closes #<n>` in the PR body. This:
-- Shows the PR on the issue page
-- Auto-closes the issue when the PR merges
-- Auto-moves the issue to Done on the project board (if configured)
+Always include `Closes #<n>` in the PR body. This shows the PR on the issue page and creates the
+link — that is the whole reason to keep writing it.
+
+**It does not close the issue.** GitHub only honours the closing keyword when the PR merges into the
+**default branch**, which here is `main`. Every feature/fix PR targets `develop` by design, so the
+keyword links but never fires — and it fails silently: the PR merges green and the issue stays open.
+17 issues accumulated this way before anyone noticed (#217).
+
+Close issues explicitly when the release carrying them lands on `main`, which is the board's
+existing `Deploy` → `Done` transition:
+
+```bash
+gh issue close <n> --comment "Shipped in v1.1.0."
+```
+
+(This is unrelated to the project-board columns, which need a `read:project` OAuth scope. Closing
+an issue needs no extra scope.)
 
 ---
 
@@ -406,8 +420,9 @@ gh project item-edit --project-id PVT_kwHOAL1qLc4BZbZZ --id "$ITEM_ID" \
 
 **PR rules:**
 - Title must be a valid conventional commit (e.g. `feat(scope): description`)
-- Body must contain `Closes #<issue>` — auto-links and closes the issue on merge
-- All features/fixes target `develop`. Hotfixes target `main`.
+- Body must contain `Closes #<issue>` — this links the PR to the issue. It does **not** close it:
+  the keyword only fires on merge into the default branch (`main`). Close it by hand at release.
+- All features/fixes target `develop`. Hotfixes target `main` — and there the keyword *does* fire.
 - Never open a PR directly to `main` from a feature branch.
 
 ---
@@ -598,7 +613,13 @@ gh pr create --title "feat(stats): add hyctl stats subcommand" \
 gh project item-edit --project-id PVT_kwHOAL1qLc4BZbZZ --id "$ITEM_ID" \
   --field-id PVTSSF_lAHOAL1qLc4BZbZZzhUaGlE --single-select-option-id 1490e846
 
-# 5. After merge — move to Done
+# 5. After merge to develop — move to Deploy (merged, not yet released)
+gh project item-edit --project-id PVT_kwHOAL1qLc4BZbZZ --id "$ITEM_ID" \
+  --field-id PVTSSF_lAHOAL1qLc4BZbZZzhUaGlE --single-select-option-id bcafa7ca
+
+# 6. After the release carrying it lands on main — close the issue, then move to Done.
+#    Nothing does this for you: "Closes #n" does not fire on a develop-targeted PR (#217).
+gh issue close "${ISSUE}" --comment "Shipped in v1.1.0."
 gh project item-edit --project-id PVT_kwHOAL1qLc4BZbZZ --id "$ITEM_ID" \
   --field-id PVTSSF_lAHOAL1qLc4BZbZZzhUaGlE --single-select-option-id 98236657
 ```


### PR DESCRIPTION
## Summary

`CLAUDE.md` claimed in three places that `Closes #<n>` closes the issue when the PR merges. It never
has, for this repo.

GitHub honours the closing keyword only when a PR merges into the **default branch** — `main` here.
Every feature/fix PR targets `develop` by design, so the keyword links the PR to the issue and stops
there. It fails silently: the PR merges green and the issue just stays open.

**17 issues accumulated this way**, all merged and shipping on `develop`: #175, #177, #181, #183,
#185, #187, #189, #191, #193, #195, #197, #200, #206, #209, #211, #213, #215.

## Changes

- corrected the three auto-close claims (L280, L295, L423) and the fourth, that the board moves
  itself to Done as a consequence
- documented when issues actually close: by hand, when the release carrying them reaches `main` —
  the board's existing `Deploy` → `Done` transition
- fixed the quick-start, which went merge → Done and skipped `Deploy`, the state that exists
  precisely for "merged, waiting for release tag"
- noted that hotfixes target `main`, where the keyword *does* fire

`Closes #n` stays in the template — it still creates the PR↔issue link, which is why the rule exists.

## Not the same problem as the board

The project-board columns are blocked on a `read:project` OAuth scope. Closing an issue needs no
extra scope, so this half is fixable today.

## Note

I have not closed the 17 issues. By this repo's own board semantics they belong in `Deploy` —
merged, awaiting a release tag — and nothing on `develop` has been released yet. They should close
when v1.1.0 lands on `main`.

Closes #217
