### PR TITLE
fix(editor,parallel): stop a >64KB line silently erasing the file being edited

### DIFF
--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -504,6 +504,10 @@ func loadRows(path string) ([]Row, error) {
 
 	var rows []Row
 	scanner := bufio.NewScanner(f)
+	// Match every other jsonl reader here (ledger, runlog, trust): a row with a
+	// long prompt preview would otherwise exceed the 64 KiB default and abort
+	// the whole report, since Err() is returned below.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -5,7 +5,6 @@
 package editor
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/util"
 	"github.com/ankit373/hydra/internal/workspace"
 )
 
@@ -303,12 +303,14 @@ func extractContent(raw string) string {
 }
 
 func extractBetween(raw string) string {
-	scanner := bufio.NewScanner(strings.NewReader(raw))
+	// util.SplitLines, not bufio.Scanner: a Scanner stops at a token longer than
+	// its buffer and only says so via Err(), so a single >64 KiB line — minified
+	// JS, a data URI, one-line JSON — used to yield an empty extraction that was
+	// then written over the user's file as if it had succeeded (#168).
 	var out []string
 	inside := false
 	printed := false
-	for scanner.Scan() {
-		line := scanner.Text()
+	for _, line := range util.SplitLines(raw) {
 		if !printed && strings.Contains(line, markerStart) {
 			inside = true
 			continue

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -5,6 +5,7 @@ package editor
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -104,5 +105,30 @@ func TestDiffStats_InMemory(t *testing.T) {
 	added, removed = diffStats(file, "a\nb\nc\nd\ne\n", "", file+".no-backup", true)
 	if added != 0 || removed != 2 {
 		t.Errorf("diffStats shrink: added=%d removed=%d, want 0/2", added, removed)
+	}
+}
+
+// extractBetween must not lose content to a line longer than bufio.Scanner's
+// 64 KiB default. It used to: the Scanner stopped, its Err() was never checked,
+// and the empty result was written over the user's file as a success (#168).
+// Minified JS, a data URI or one-line JSON all cross that threshold.
+func TestExtractBetween_LineBeyondScannerLimit(t *testing.T) {
+	for _, n := range []int{1000, 65000, 70000, 1 << 20} {
+		long := strings.Repeat("x", n)
+		raw := markerStart + "\n" + long + "\n" + markerEnd + "\n"
+		got := extractBetween(raw)
+		if got != long {
+			t.Errorf("line of %d chars: extracted %d chars, want %d", n, len(got), n)
+		}
+	}
+}
+
+// A long line among ordinary ones must not disturb the surrounding lines.
+func TestExtractBetween_LongLineAmongShort(t *testing.T) {
+	long := strings.Repeat("y", 200000)
+	raw := markerStart + "\nfirst\n" + long + "\nlast\n" + markerEnd + "\ntrailing junk\n"
+	want := "first\n" + long + "\nlast"
+	if got := extractBetween(raw); got != want {
+		t.Errorf("got %d chars, want %d", len(got), len(want))
 	}
 }

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -5,7 +5,6 @@
 package parallel
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,6 +22,7 @@ import (
 	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/util"
 	"github.com/ankit373/hydra/internal/workspace"
 )
 
@@ -449,11 +449,13 @@ func extractContent(raw string) string {
 }
 
 func extractBetween(raw string) string {
-	scanner := bufio.NewScanner(strings.NewReader(raw))
+	// util.SplitLines, not bufio.Scanner: a Scanner stops at a token longer than
+	// its buffer and only says so via Err(), so a single >64 KiB line — minified
+	// JS, a data URI, one-line JSON — used to yield an empty extraction that was
+	// then written over the user's file as if it had succeeded (#168).
 	var out []string
 	inside, printed := false, false
-	for scanner.Scan() {
-		line := scanner.Text()
+	for _, line := range util.SplitLines(raw) {
 		if !printed && strings.Contains(line, markerStart) {
 			inside = true
 			continue

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -171,3 +171,17 @@ func TestRun_TasksShareRunAndGetDistinctTaskIDs(t *testing.T) {
 		seen[id] = true
 	}
 }
+
+// Same defect as internal/editor's extractBetween (#168): a line longer than
+// bufio.Scanner's 64 KiB default silently produced an empty extraction, which
+// parallel then wrote over the user's file. Both copies must stay fixed.
+func TestExtractBetween_LineBeyondScannerLimit(t *testing.T) {
+	for _, n := range []int{1000, 65000, 70000, 1 << 20} {
+		long := strings.Repeat("x", n)
+		raw := markerStart + "\n" + long + "\n" + markerEnd + "\n"
+		got := extractBetween(raw)
+		if got != long {
+			t.Errorf("line of %d chars: extracted %d chars, want %d", n, len(got), n)
+		}
+	}
+}

--- a/internal/util/lines.go
+++ b/internal/util/lines.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+package util
+
+import "strings"
+
+// SplitLines splits already-in-memory text into lines.
+//
+// It exists because bufio.Scanner refuses any token longer than its buffer —
+// 64 KiB by default — and reports that by simply stopping. Code that scans a
+// string and ignores Err() therefore sees a *silently truncated* result, which
+// is how a >64 KiB line could erase the file being edited (#168). Raising the
+// buffer only moves the cliff; splitting a string that is already in memory
+// needs no size limit at all.
+//
+// The line semantics match bufio.ScanLines exactly, so it is a drop-in for that
+// use: a trailing "\r" is stripped from each line, and a final newline does not
+// produce a trailing empty line.
+func SplitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = strings.TrimSuffix(s, "\n")
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimSuffix(l, "\r")
+	}
+	return lines
+}

--- a/internal/util/lines_test.go
+++ b/internal/util/lines_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+// TestSplitLines_MatchesScanLines pins the semantics to bufio.ScanLines for
+// every input where a Scanner still works, so SplitLines is a safe drop-in.
+// Above the Scanner's limit the two intentionally differ — that is the bug.
+func TestSplitLines_MatchesScanLines(t *testing.T) {
+	cases := map[string]string{
+		"empty":            "",
+		"one line":         "a",
+		"trailing newline": "a\n",
+		"blank lines":      "a\n\nb\n",
+		"crlf":             "a\r\nb\r\n",
+		"lone cr kept":     "a\rb\n",
+		"only newline":     "\n",
+		"leading blank":    "\na\n",
+		"no trailing nl":   "a\nb",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			sc := bufio.NewScanner(strings.NewReader(in))
+			var want []string
+			for sc.Scan() {
+				want = append(want, sc.Text())
+			}
+			if err := sc.Err(); err != nil {
+				t.Fatalf("scanner failed on a small input: %v", err)
+			}
+			got := SplitLines(in)
+			if len(got) != len(want) {
+				t.Fatalf("SplitLines(%q) = %q (%d lines), scanner gave %q (%d)", in, got, len(got), want, len(want))
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Errorf("line %d: got %q, scanner gave %q", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSplitLines_BeyondScannerLimit is the regression for #168: a line past
+// bufio.Scanner's 64 KiB ceiling must survive intact, where the Scanner returns
+// nothing at all.
+func TestSplitLines_BeyondScannerLimit(t *testing.T) {
+	for _, n := range []int{65000, 70000, 1 << 20} {
+		in := strings.Repeat("x", n) + "\n"
+
+		sc := bufio.NewScanner(strings.NewReader(in))
+		scanned := 0
+		for sc.Scan() {
+			scanned += len(sc.Text())
+		}
+
+		got := SplitLines(in)
+		if len(got) != 1 {
+			t.Fatalf("n=%d: got %d lines, want 1", n, len(got))
+		}
+		if len(got[0]) != n {
+			t.Errorf("n=%d: SplitLines kept %d chars, want %d", n, len(got[0]), n)
+		}
+		// Document the failure this replaces: past the limit the Scanner both
+		// returns nothing and reports an error that the old callers ignored.
+		if n > 64<<10 && (scanned != 0 || sc.Err() == nil) {
+			t.Errorf("n=%d: expected the scanner to fail with 0 bytes, got %d bytes err=%v", n, scanned, sc.Err())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`hyctl edit` could **atomically overwrite a file with nothing** and report success.

`extractBetween` parsed the model's marker block with a default `bufio.Scanner`, which refuses any
token longer than its 64 KiB buffer and signals that only through `Err()` — which neither copy
checked. A single long line produced an empty extraction, which was then written over the user's
file with `"status":"ok"`. Rollback only fires when a validator is configured *and* fails, and most
extensions (`.md`, `.json`, `.yaml`, `.py`, `.rs`, `.txt`) have none.

Reproduced before the fix:

```
line of  65000 chars -> extracted  65000 chars
line of  70000 chars -> extracted      0 chars
line of 200000 chars -> extracted      0 chars
```

After:

```
line of  65000 chars -> extracted  65000 chars
line of  70000 chars -> extracted  70000 chars
line of 200000 chars -> extracted 200000 chars
```

This is not a rare shape — minified JS/CSS, a base64 data URI, single-line JSON and generated code
all cross 64 KiB in one line.

## Approach

The issue proposed `scanner.Buffer(…, 32<<20)` plus an `Err()` check. I went further: **remove the
Scanner**. The input is already a string in memory, so splitting it needs no size limit at all — a
bigger buffer just moves the cliff to 32 MB. `util.SplitLines` has no ceiling, so the failure mode
stops existing rather than becoming less likely.

`SplitLines` is pinned to `bufio.ScanLines` semantics by a table test covering CRLF, lone CR, blank
lines, leading blanks and a missing trailing newline, so it is a safe drop-in rather than an
approximation.

## Scope

- both copies of `extractBetween` (`internal/editor`, `internal/parallel`) fixed
- a regression test in **each** package, so they are guarded independently — the editor/parallel
  duplication is still open, and a single shared test would let one copy silently regress
- `internal/cost`'s jsonl reader gains the `Buffer()` call that `ledger`, `runlog` and both `trust`
  readers already have. It was the only one without it. That reader *does* check `Err()`, so it
  failed loudly rather than truncating — but one long prompt preview would abort the whole cost
  report

## Verification

- `go build`, `go vet`, `staticcheck`, `go test -race ./...` all green
- new tests fail against the old code — the 70000-char case returns 0 bytes, which is the repro above

Closes #168
