### PR TITLE
fix(dispatch): make --dry-run mean spend nothing in swarm and SPRT modes too

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -31,6 +31,8 @@ import (
 	"github.com/ankit373/hydra/internal/parallel"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/rank"
 	"github.com/ankit373/hydra/internal/review"
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
@@ -446,6 +448,35 @@ func cmdDispatch() *cobra.Command {
 					effectiveConf = derived
 				}
 			}
+			// --dry-run must mean "spend nothing" in every mode. It was read only
+			// by the single-dispatch path far below, which neither ensemble
+			// branch reaches — so `--dry-run --confidence 0.95` fired a paid
+			// ensemble and printed no plan at all (#167).
+			if dryRun && (effectiveConf > 0 || doSwarm) {
+				mode := swarm.SwarmMode(swarmMode)
+				if mode == "" {
+					mode = swarm.ModeBest
+				}
+				sw := swarm.New(d, d.Heads(), d)
+				planOpts := swarm.Options{
+					Mode:          mode,
+					TierHint:      tier,
+					HeadIDs:       headIDs,
+					MaxHeads:      swarmMaxHeads,
+					MaxEstCostUSD: swarmMaxCost,
+					LocalOnly:     localOnly,
+					System:        system,
+					Confidence:    effectiveConf,
+					Domain:        domain,
+				}
+				heads, estUSD, err := sw.Plan(prompt, planOpts)
+				if err != nil {
+					return err
+				}
+				printEnsemblePlan(heads, estUSD, effectiveConf, mode, swarmMaxCost)
+				return nil
+			}
+
 			if effectiveConf > 0 {
 				sw := swarm.New(d, d.Heads(), d)
 				res, err := sw.RunSPRT(ctx, prompt, swarm.Options{
@@ -562,7 +593,7 @@ func cmdDispatch() *cobra.Command {
 	// trust / SPRT flags
 	cmd.Flags().Float64Var(&confidence, "confidence", 0, "route via SPRT ensemble until this P(correct) is reached, e.g. 0.95")
 	cmd.Flags().StringVar(&domain, "domain", "", "calibration domain for --confidence (default: \"default\")")
-	cmd.Flags().StringVar(&file, "file", "", "target file — raises the confidence bar by its code blast radius")
+	cmd.Flags().StringVar(&file, "file", "", "target file — derives a confidence target from its blast radius, so this alone selects the SPRT ensemble")
 	cmd.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph used with --file")
 	return cmd
 }
@@ -1192,6 +1223,40 @@ func anyEstimated(attempts []swarm.Attempt) bool {
 }
 
 // printSwarmResult renders the swarm result to stdout.
+// printEnsemblePlan is what --dry-run shows for the swarm and SPRT paths: the
+// heads that would be engaged and the cost of one round, so the flag answers
+// "what would this spend" rather than spending it.
+//
+// The head count is an upper bound in SPRT mode: the ensemble stops as soon as
+// the log-odds cross the target, so it usually queries fewer. Saying so beats
+// printing a number that reads as a promise.
+func printEnsemblePlan(heads []provider.Head, estUSD, confidence float64, mode swarm.SwarmMode, maxCostUSD float64) {
+	sep := dimStyle.Render("  " + strings.Repeat("─", 60))
+
+	label := fmt.Sprintf("swarm · %s", mode)
+	if confidence > 0 {
+		label = fmt.Sprintf("SPRT · target %.1f%%", confidence*100)
+	}
+
+	fmt.Println()
+	fmt.Printf("  %s [%s]\n\n", cortexStyle.Render("▶ DRY RUN"), dimStyle.Render(label))
+	fmt.Printf("  %-28s  %7s  %8s\n", "HEAD", "TIER", "SOURCE")
+	fmt.Println(sep)
+	for _, h := range heads {
+		fmt.Printf("  %-28s  %7d  %8s\n", h.Name, rank.UITier(h), h.Source)
+	}
+	fmt.Println(sep)
+
+	if confidence > 0 {
+		fmt.Printf("  %s\n", dimStyle.Render(fmt.Sprintf("at most %d heads queried; SPRT stops early once the target is met", len(heads))))
+	}
+	fmt.Printf("  %s\n", dimStyle.Render(fmt.Sprintf("estimated cost for one round: $%.4f", estUSD)))
+	if maxCostUSD > 0 && estUSD > maxCostUSD {
+		fmt.Printf("  %s\n", warnStyle.Render(fmt.Sprintf("this exceeds --swarm-max-cost $%.4f and would be refused", maxCostUSD)))
+	}
+	fmt.Printf("  %s\n\n", dimStyle.Render("nothing was executed"))
+}
+
 func printSwarmResult(r *swarm.SwarmResult) {
 	sep := dimStyle.Render("  " + strings.Repeat("─", 60))
 
@@ -2083,6 +2148,7 @@ func cmdTrustDefect() *cobra.Command {
 var (
 	cortexStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
 	dimStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	warnStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 )
 
 // promptPreview shortens a prompt for a log Detail field. Run events carry a

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -23,21 +23,32 @@ type PricingReader interface {
 	EstimateCost(tier int, inputTokens, outputTokens int) float64
 }
 
-// preflightCost estimates the total cost of firing all selected heads before
-// any execution begins. Returns an error if the estimate exceeds maxUSD.
-// Uses prompt character count / 4 as a token estimate (same as agy executor).
-func preflightCost(heads []provider.Head, prompt string, pr PricingReader, maxUSD float64) (float64, error) {
-	if pr == nil || maxUSD <= 0 {
-		return 0, nil
+// estimateFanoutCost estimates the total USD cost of firing every selected
+// head once. Uses prompt character count / 4 as a token estimate (same as the
+// agy executor).
+//
+// Separate from preflightCost because a *guard* can skip the arithmetic when no
+// limit is set, but a *plan* cannot: --dry-run must report the cost even when
+// nothing caps it (#167).
+func estimateFanoutCost(heads []provider.Head, prompt string, pr PricingReader) float64 {
+	if pr == nil {
+		return 0
 	}
-
 	estInputTokens := len(prompt) / 4
 	var total float64
 	for _, h := range heads {
 		total += pr.EstimateCost(rank.UITier(h), estInputTokens, estInputTokens/2)
 	}
+	return round6(total)
+}
 
-	total = round6(total)
+// preflightCost estimates the total cost of firing all selected heads before
+// any execution begins. Returns an error if the estimate exceeds maxUSD.
+func preflightCost(heads []provider.Head, prompt string, pr PricingReader, maxUSD float64) (float64, error) {
+	if pr == nil || maxUSD <= 0 {
+		return 0, nil
+	}
+	total := estimateFanoutCost(heads, prompt, pr)
 	if total > maxUSD {
 		return total, fmt.Errorf("swarm: estimated cost $%.4f exceeds limit $%.4f (%d heads)", total, maxUSD, len(heads))
 	}

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -101,6 +101,32 @@ func New(d *dispatch.Dispatcher, heads []provider.Head, pricing PricingReader) *
 	return &Swarm{d: d, heads: heads, pricing: pricing}
 }
 
+// Plan reports what Run or RunSPRT would do without executing anything: which
+// heads would be engaged, and what one round of fan-out is estimated to cost.
+//
+// It exists so --dry-run can mean the same thing in every mode. It used to mean
+// nothing in swarm and SPRT modes — the flag was read only by the single-dispatch
+// path, which both ensemble branches returned before reaching, so a dry run
+// fired a paid ensemble (#167).
+//
+// Selection deliberately mirrors Run and RunSPRT, which resolve the same
+// selector against the same options; a plan that picked different heads from the
+// run it describes would be worse than no plan.
+func (s *Swarm) Plan(prompt string, opts Options) (heads []provider.Head, estUSD float64, err error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, 0, fmt.Errorf("swarm: config load: %w", err)
+	}
+	selected, err := resolveSelector(opts, cfg).Select(s.heads, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(selected) == 0 {
+		return nil, 0, fmt.Errorf("swarm: no heads available for the requested configuration")
+	}
+	return selected, estimateFanoutCost(selected, prompt, s.pricing), nil
+}
+
 // Run executes the swarm: selects heads, optionally checks cost, fires them,
 // collects results, optionally judges, logs costs.
 func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmResult, error) {

--- a/internal/swarm/swarm_test.go
+++ b/internal/swarm/swarm_test.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ankit373/hydra/internal/config"
@@ -290,9 +293,29 @@ func TestEstimateFanoutCost_IndependentOfAnyLimit(t *testing.T) {
 	}
 }
 
+// withTempConfig points config.Dir() at a throwaway home containing a minimal
+// config.toml. config.Load fails outright when the file is missing, so any test
+// touching the selection path is otherwise green only on a machine that happens
+// to have run `hyctl init` — which is exactly how this test passed locally and
+// failed on a clean CI runner.
+func withTempConfig(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
+	dir := filepath.Join(home, ".hydra")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("cortex = \"claude\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Plan must pick exactly the heads the corresponding run would, or --dry-run
 // describes something other than what executing would do.
 func TestPlan_SelectsSameHeadsAsRunAndExecutesNothing(t *testing.T) {
+	withTempConfig(t)
 	all := []provider.Head{registryHead("h1", "H1", 90), registryHead("h2", "H2", 80), registryHead("h3", "H3", 70)}
 	s := New(nil, all, fakePricing{per: 0.01})
 
@@ -327,9 +350,34 @@ func TestPlan_SelectsSameHeadsAsRunAndExecutesNothing(t *testing.T) {
 	// have panicked rather than reached here.
 }
 
-func TestPlan_NoHeadsIsAnError(t *testing.T) {
-	s := New(nil, nil, fakePricing{per: 0.01})
-	if _, _, err := s.Plan("p", Options{}); err == nil {
-		t.Error("Plan with no heads should error, not report an empty plan as fine")
-	}
+// Plan must never report "here is your plan" with nothing in it. Two distinct
+// paths reach that state, so both are pinned: the selector rejecting an empty
+// roster outright, and a filter emptying a non-empty one — the latter returns
+// (empty, nil), which is what Plan's own length check exists to catch.
+func TestPlan_EmptyResultIsAlwaysAnError(t *testing.T) {
+	// Without a config the error would come from config.Load instead, and these
+	// would pass without ever reaching the checks they exist to test.
+	withTempConfig(t)
+
+	t.Run("empty roster", func(t *testing.T) {
+		s := New(nil, nil, fakePricing{per: 0.01})
+		_, _, err := s.Plan("p", Options{})
+		if err == nil {
+			t.Fatal("Plan with no heads should error, not report an empty plan as fine")
+		}
+		if !strings.Contains(err.Error(), "heads") {
+			t.Errorf("error was %q, want it to name heads as the problem", err)
+		}
+	})
+
+	t.Run("filter empties a non-empty roster", func(t *testing.T) {
+		// MinCapScore above every head: applyFiltersAndCap returns (empty, nil),
+		// so the selector reports no error and only Plan's own check stops it.
+		all := []provider.Head{registryHead("h1", "H1", 50), registryHead("h2", "H2", 40)}
+		s := New(nil, all, fakePricing{per: 0.01})
+		_, _, err := s.Plan("p", Options{TierHint: "nonexistent-tier", MinCapScore: 99})
+		if err == nil {
+			t.Fatal("every head filtered out should error, not yield an empty plan")
+		}
+	})
 }

--- a/internal/swarm/swarm_test.go
+++ b/internal/swarm/swarm_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/provider"
 )
 
@@ -267,5 +268,68 @@ func TestCapScoreSelector_MaxHeadsCap(t *testing.T) {
 	}
 	if len(got) != 2 {
 		t.Errorf("MaxHeads=2 returned %d heads", len(got))
+	}
+}
+
+// estimateFanoutCost must report a cost even with no --swarm-max-cost limit.
+// preflightCost short-circuits to 0 when no limit is set, which is right for a
+// guard and wrong for the plan --dry-run prints (#167).
+func TestEstimateFanoutCost_IndependentOfAnyLimit(t *testing.T) {
+	heads := []provider.Head{registryHead("a", "A", 90), registryHead("b", "B", 80), registryHead("c", "C", 70)}
+	pr := fakePricing{per: 0.01}
+
+	if got := estimateFanoutCost(heads, "some prompt", pr); got != 0.03 {
+		t.Errorf("estimateFanoutCost = %v, want 0.03", got)
+	}
+	// The guard reports nothing here — that difference is the whole point.
+	if total, _ := preflightCost(heads, "some prompt", pr, 0); total != 0 {
+		t.Errorf("preflightCost with no limit = %v, want 0", total)
+	}
+	if got := estimateFanoutCost(heads, "p", nil); got != 0 {
+		t.Errorf("nil pricing = %v, want 0", got)
+	}
+}
+
+// Plan must pick exactly the heads the corresponding run would, or --dry-run
+// describes something other than what executing would do.
+func TestPlan_SelectsSameHeadsAsRunAndExecutesNothing(t *testing.T) {
+	all := []provider.Head{registryHead("h1", "H1", 90), registryHead("h2", "H2", 80), registryHead("h3", "H3", 70)}
+	s := New(nil, all, fakePricing{per: 0.01})
+
+	opts := Options{HeadIDs: []string{"h1", "h3"}}
+	heads, est, err := s.Plan("some prompt", opts)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	// Same selector, same options — Plan must not diverge from the run path.
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	want, err := resolveSelector(opts, cfg).Select(all, opts)
+	if err != nil {
+		t.Fatalf("selector: %v", err)
+	}
+	if len(heads) != len(want) {
+		t.Fatalf("Plan selected %d heads, the run path selects %d", len(heads), len(want))
+	}
+	for i := range want {
+		if heads[i].ID != want[i].ID {
+			t.Errorf("head %d: Plan chose %q, run path chooses %q", i, heads[i].ID, want[i].ID)
+		}
+	}
+	if est != 0.02 {
+		t.Errorf("est = %v, want 0.02 for 2 heads", est)
+	}
+
+	// s was built with a nil dispatcher: had Plan executed anything it would
+	// have panicked rather than reached here.
+}
+
+func TestPlan_NoHeadsIsAnError(t *testing.T) {
+	s := New(nil, nil, fakePricing{per: 0.01})
+	if _, _, err := s.Plan("p", Options{}); err == nil {
+		t.Error("Plan with no heads should error, not report an empty plan as fine")
 	}
 }


### PR DESCRIPTION
## Summary

`--dry-run` is the "don't spend money" flag. It was read only by the single-dispatch path near the
end of the command — and both the SPRT branch and the swarm branch `return` before reaching it. So
the flag was silently ignored and a paid multi-model ensemble fired.

Reproduced on a real binary before the fix — no plan printed, ensemble ran:

```
$ hyctl dispatch --dry-run --confidence 0.95 "hello"
  ▶ SPRT [default]

$ hyctl dispatch --dry-run --file internal/dispatch/dispatch.go "hello"
  graph: blast radius 1.00 → demands confidence ≥ 90.0%
  ▶ SPRT [default]
```

The second case is the sharper one: `--file` always derives a confidence ≥ 0.90, so **`--file`
alone switches execution from one dispatch to N**. Its help said only that it "raises the confidence
bar" — never that it changes the mode. Reworded.

## After

```
$ hyctl dispatch --dry-run --confidence 0.95 "hello"

  ▶ DRY RUN [SPRT · target 95.0%]

  HEAD                             TIER    SOURCE
  ────────────────────────────────────────────────────────────
  Claude Code                         1       cli
  Antigravity                         4       cli
  ────────────────────────────────────────────────────────────
  at most 2 heads queried; SPRT stops early once the target is met
  estimated cost for one round: $0.0000
  nothing was executed
```

`--swarm` and `--file` produce the same plan in their own modes.

## Changes

- hoist the dry-run check above both ensemble branches and print a plan
- add `swarm.Plan`, which resolves **the same selector against the same options** as `Run` and
  `RunSPRT`. A plan that picked different heads from the run it describes would be worse than no
  plan, so it shares their selection path rather than reimplementing it
- split `estimateFanoutCost` out of `preflightCost`. The guard short-circuits to zero when no
  `--swarm-max-cost` is set — correct for a guard, wrong for a plan, which must show the cost even
  when nothing caps it
- report when the estimate would trip `--swarm-max-cost`; being refused is exactly what a dry run
  should tell you in advance

In SPRT mode the head count is labelled an **upper bound** — the ensemble stops as soon as the
log-odds cross the target, so a bare number would read as a promise it does not make.

## Verification

End-to-end on the real binary, all three modes:

- a plan is printed and nothing executes
- `cost.jsonl` is **byte-identical** afterwards (24342 bytes before and after)
- the three run logs contain **zero** attempt/sample events

Unit tests: `Plan` selects exactly what the run path's selector selects (guards against the plan
drifting from reality), `Plan` on an empty roster errors rather than reporting an empty plan as
fine, and `estimateFanoutCost` reports a cost where `preflightCost` reports zero.

`go build`, `go vet`, `staticcheck`, `go test -race ./...` all green.

Closes #167
