### PR TITLE
fix(policy): detect real credentials, stop forcing local-only on version strings

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,6 +1,6 @@
 # Gitleaks configuration for Hydra.
 # Extends the full default ruleset, then allowlists values that are PUBLIC by
-# design and therefore NOT secrets.
+# design, or synthetic, and therefore NOT secrets.
 
 title = "Hydra"
 
@@ -8,9 +8,25 @@ title = "Hydra"
 useDefault = true
 
 [allowlist]
-description = "Public, intentional identifiers embedded in the shipped site — not secrets"
+description = "Public identifiers and synthetic test fixtures — not secrets"
+
+# Conditions are OR-ed: a finding is allowed if its content matches a regex
+# below OR its file matches a path below.
+
 regexes = [
   # Ahrefs Web Analytics data-key: a public site identifier embedded in the page
   # <head> and served to every visitor (equivalent to a GA measurement ID).
   '''yRz83E87rXgYWlhmro5mIg''',
+]
+
+paths = [
+  # The corpus for Hydra's own PII detector (#169). Its fixtures are secrets by
+  # construction — a test that a private key is detected has to contain
+  # something shaped like a private key — so gitleaks flags all of them.
+  #
+  # Every value there is synthetic or a vendor's published example
+  # (e.g. AKIAIOSFODNN7EXAMPLE is AWS's documented sample key). Scoped to this
+  # one file rather than to *_test.go, so a real credential pasted into any
+  # other test is still caught.
+  '''^internal/policy/pii_test\.go$''',
 ]

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -4,18 +4,7 @@
 // Rules are evaluated in order; the first match wins.
 package policy
 
-import (
-	"regexp"
-)
-
-// piiPatterns are compiled once at package init to avoid per-call allocations.
-var piiPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\b\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b`),                                      // SSN
-	regexp.MustCompile(`\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b`),                                // credit card
-	regexp.MustCompile(`\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`),                   // email (fixed: [A-Za-z] not [A-Z|a-z])
-	regexp.MustCompile(`(?i)\b(password|secret|api[-_]?key|token|private[-_]?key)\s*[:=]\s*\S+`), // credentials
-	regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`),                                 // IP address
-}
+// PII detection lives in pii.go.
 
 // Action is what the engine tells the dispatcher to do.
 type Action struct {
@@ -57,20 +46,6 @@ func (e *Engine) Evaluate(req Request) Action {
 		}
 	}
 	return Action{}
-}
-
-// ── Built-in conditions ───────────────────────────────────────────────────────
-
-// ContainsPII returns true if the prompt likely contains personally identifiable
-// information. This is a fast heuristic; replace with Presidio via sidecar for
-// production-grade detection.
-func ContainsPII(req Request) bool {
-	for _, p := range piiPatterns {
-		if p.MatchString(req.Prompt) {
-			return true
-		}
-	}
-	return false
 }
 
 // ── Default rule set ──────────────────────────────────────────────────────────

--- a/internal/policy/pii.go
+++ b/internal/policy/pii.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// PII detection decides whether a prompt is forced to local-only routing, so the
+// two failure directions are not symmetric: a false negative sends a secret to a
+// cloud provider, while a false positive only routes work to a local head. The
+// detectors below lean toward detection wherever the ambiguity is real, and the
+// few places that trade detection away say so explicitly.
+//
+// This is still a heuristic; replace with Presidio via sidecar for
+// production-grade detection.
+
+// detector is a pattern plus an optional validator.
+//
+// Go's regexp is RE2, which has no lookahead or lookbehind, so conditions like
+// "an IPv4 address unless it is a version string" cannot be written as a
+// pattern at all — they need code that sees the match in context (#169).
+type detector struct {
+	name string
+	re   *regexp.Regexp
+	// valid narrows a raw hit. nil means every hit counts. It receives the
+	// whole prompt plus the match bounds so it can inspect surrounding text.
+	valid func(prompt string, loc []int) bool
+}
+
+var detectors = []detector{
+	// ── Secrets with unmistakable prefixes ───────────────────────────────────
+	// These are the highest-confidence signals available and need no validation:
+	// nothing else looks like them. None of them were detected before (#169).
+	{name: "pem private key", re: regexp.MustCompile(`-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},
+	{name: "aws access key id", re: regexp.MustCompile(`\b(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b`)},
+	{name: "github token", re: regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}\b`)},
+	{name: "slack token", re: regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`)},
+	{name: "openai key", re: regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}\b`)},
+	{name: "google api key", re: regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`)},
+	{name: "jwt", re: regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]+`)},
+	{name: "auth header", re: regexp.MustCompile(`(?i)\bauthorization\s*:\s*(?:bearer|basic|token)\s+\S+`)},
+
+	// ── Personal identifiers ─────────────────────────────────────────────────
+	{name: "email", re: regexp.MustCompile(`\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`)},
+
+	// A separator is required. Nine bare digits are indistinguishable from an
+	// order number, invoice id or primary key, and treating every such run as an
+	// SSN forced local-only routing on ordinary queries like "look up order
+	// 123456789". This does trade away detection of a bare, unformatted SSN —
+	// a real loss, accepted because the formatted spelling is overwhelmingly
+	// more common in text and the unformatted one is unknowable in isolation.
+	{name: "ssn", re: regexp.MustCompile(`\b\d{3}[-.\s]\d{2}[-.\s]\d{4}\b`)},
+
+	// 13–19 digits, optionally grouped, that pass Luhn. Luhn rejects ~90% of
+	// random digit runs, which is what keeps long ids from reading as cards.
+	{name: "credit card", re: regexp.MustCompile(`\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{1,7}\b`), valid: validLuhn},
+
+	// ── Context-dependent ────────────────────────────────────────────────────
+	{name: "credentials", re: regexp.MustCompile(`(?i)\b(?:password|passwd|secret|api[-_]?key|access[-_]?key|auth[-_]?token|token|private[-_]?key)\s*[:=]\s*("[^"]*"|'[^']*'|\S+)`), valid: validCredentialValue},
+	{name: "ip address", re: regexp.MustCompile(`\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b`), valid: validPublicIP},
+}
+
+// ContainsPII reports whether the prompt likely contains sensitive data.
+func ContainsPII(req Request) bool {
+	for _, d := range detectors {
+		for _, loc := range d.re.FindAllStringSubmatchIndex(req.Prompt, -1) {
+			if d.valid == nil || d.valid(req.Prompt, loc) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// validLuhn checks the card checksum. Without it, any 16-digit identifier —
+// order numbers, trace ids — forced local-only routing.
+func validLuhn(prompt string, loc []int) bool {
+	digits := make([]int, 0, 19)
+	for _, r := range prompt[loc[0]:loc[1]] {
+		if r >= '0' && r <= '9' {
+			digits = append(digits, int(r-'0'))
+		}
+	}
+	if len(digits) < 13 || len(digits) > 19 {
+		return false
+	}
+	sum, double := 0, false
+	for i := len(digits) - 1; i >= 0; i-- {
+		d := digits[i]
+		if double {
+			if d *= 2; d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+		double = !double
+	}
+	return sum%10 == 0
+}
+
+// minCredentialValueLen is the shortest assignment value treated as a secret.
+// "token: 4096" is a buffer size, not a credential; "password: hunter2" is one.
+const minCredentialValueLen = 6
+
+// validCredentialValue rejects assignments whose value cannot plausibly be a
+// secret. The keyword alone is not enough: `token`, `secret` and `key` are all
+// ordinary config names whose values are frequently small integers (#169).
+func validCredentialValue(prompt string, loc []int) bool {
+	if len(loc) < 4 || loc[2] < 0 {
+		return false
+	}
+	v := strings.Trim(prompt[loc[2]:loc[3]], `"'`)
+	if len(v) < minCredentialValueLen {
+		return false
+	}
+	// A purely numeric value is a port, size, timeout or count. Real secrets
+	// are effectively never all-digits, and treating them as such is what made
+	// "set the config: token: 4096" force local-only.
+	if _, err := strconv.Atoi(v); err == nil {
+		return false
+	}
+	// A placeholder is the opposite of a secret — it exists to be substituted.
+	switch strings.ToLower(v) {
+	case "none", "null", "nil", "empty", "false", "true", "changeme", "redacted", "<redacted>", "xxxxxx", "******":
+		return false
+	}
+	return true
+}
+
+// versionContext are words that precede a dotted quad which is a version, not
+// an address. RE2 cannot express "not preceded by", so this is checked in code.
+var versionContext = map[string]bool{
+	"version": true, "v": true, "ver": true, "release": true, "rev": true,
+	"build": true, "tag": true, "upgrade": true, "downgrade": true, "bump": true,
+}
+
+// validPublicIP keeps only dotted quads that are plausibly a real, routable
+// address someone could be identified by.
+//
+// It rejects three classes that were all forcing local-only routing needlessly:
+// octets above 255 and version-like context ("version 1.2.3.4"), addresses that
+// are part of a longer dotted run ("1.2.3.4.5"), and non-public ranges —
+// loopback, private, link-local, multicast and reserved. None of those identify
+// a person, and 127.0.0.1 in particular appears constantly in dev prompts.
+func validPublicIP(prompt string, loc []int) bool {
+	octets := make([]int, 4)
+	for i := 0; i < 4; i++ {
+		s, e := loc[2+i*2], loc[3+i*2]
+		if s < 0 {
+			return false
+		}
+		n, err := strconv.Atoi(prompt[s:e])
+		if err != nil || n > 255 {
+			return false
+		}
+		// A leading zero means it is not a normal address spelling.
+		if len(prompt[s:e]) > 1 && prompt[s] == '0' {
+			return false
+		}
+		octets[i] = n
+	}
+
+	// Part of a longer dotted run, e.g. the "1.2.3.4" inside "1.2.3.4.5".
+	if loc[0] > 0 {
+		if c := prompt[loc[0]-1]; c == '.' || (c >= '0' && c <= '9') {
+			return false
+		}
+	}
+	if loc[1] < len(prompt) && prompt[loc[1]] == '.' {
+		if loc[1]+1 < len(prompt) && prompt[loc[1]+1] >= '0' && prompt[loc[1]+1] <= '9' {
+			return false
+		}
+	}
+
+	if precededByVersionWord(prompt, loc[0]) {
+		return false
+	}
+
+	switch {
+	case octets[0] == 0, // unspecified / "this network"
+		octets[0] == 10,                                        // private
+		octets[0] == 127,                                       // loopback
+		octets[0] >= 224,                                       // multicast + reserved + broadcast
+		octets[0] == 169 && octets[1] == 254,                   // link-local
+		octets[0] == 192 && octets[1] == 168,                   // private
+		octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31: // private
+		return false
+	}
+	return true
+}
+
+// precededByVersionWord reports whether the word immediately before start is one
+// that makes a dotted quad a version rather than an address.
+func precededByVersionWord(prompt string, start int) bool {
+	i := start
+	for i > 0 && (prompt[i-1] == ' ' || prompt[i-1] == '\t') {
+		i--
+	}
+	end := i
+	for i > 0 {
+		c := prompt[i-1]
+		if c == ' ' || c == '\t' || c == '\n' {
+			break
+		}
+		i--
+	}
+	return versionContext[strings.ToLower(strings.Trim(prompt[i:end], ".,:;()[]"))]
+}

--- a/internal/policy/pii_test.go
+++ b/internal/policy/pii_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import "testing"
+
+// The eight strings #169 reported, pinned as fixed expectations. Four were
+// secrets that reached a cloud provider; four were ordinary developer text that
+// was needlessly forced local-only.
+func TestContainsPII_IssueCorpus(t *testing.T) {
+	mustDetect := []string{
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"AKIAIOSFODNN7EXAMPLE",
+		"ghp_16C7e42F292c6912E7710c838347Ae178B4a",
+		"Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc",
+	}
+	mustClear := []string{
+		"upgrade the driver to version 1.2.3.4 and rebuild",
+		"the server is listening on 127.0.0.1",
+		"look up order 123456789 in the orders table",
+		"set the config: token: 4096",
+	}
+	for _, s := range mustDetect {
+		if !ContainsPII(Request{Prompt: s}) {
+			t.Errorf("MISSED (would reach a cloud provider): %q", s)
+		}
+	}
+	for _, s := range mustClear {
+		if ContainsPII(Request{Prompt: s}) {
+			t.Errorf("FALSE POSITIVE (needlessly local-only): %q", s)
+		}
+	}
+}
+
+func TestContainsPII_Detects(t *testing.T) {
+	cases := map[string]string{
+		"pem rsa":            "here is the key\n-----BEGIN RSA PRIVATE KEY-----\nMIIE...",
+		"pem openssh":        "-----BEGIN OPENSSH PRIVATE KEY-----",
+		"pem plain":          "-----BEGIN PRIVATE KEY-----",
+		"pem ec":             "-----BEGIN EC PRIVATE KEY-----",
+		"aws akia":           "export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE",
+		"aws asia":           "ASIAY34FZKBOKMUTVV7A",
+		"github pat":         "ghp_16C7e42F292c6912E7710c838347Ae178B4a",
+		"github oauth":       "gho_16C7e42F292c6912E7710c838347Ae178B4a",
+		"slack bot":          "xoxb-123456789012-abcdefghijkl",
+		"openai":             "sk-abcdefghijklmnopqrstuvwxyz012345",
+		"google":             "AIzaSyD-1234567890abcdefghijklmnopqrstu",
+		"jwt bare":           "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc",
+		"bearer header":      "Authorization: Bearer sometokenvalue",
+		"basic header":       "authorization: Basic dXNlcjpwYXNz",
+		"email":              "mail alice.smith@example.co.uk about it",
+		"ssn dashed":         "his ssn is 123-45-6789",
+		"ssn dotted":         "123.45.6789",
+		"ssn spaced":         "123 45 6789",
+		"real visa":          "card 4111 1111 1111 1111 on file",
+		"real mastercard":    "5500005555555559",
+		"password assign":    "password: hunter2",
+		"api key assign":     "api_key = s3cr3tValue123",
+		"secret quoted":      `secret: "abcdefghijk"`,
+		"private key assign": "private_key=MIIEpAIBAAKCAQEA",
+		"public ip":          "connect to 8.8.8.8 for dns",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			if !ContainsPII(Request{Prompt: in}) {
+				t.Errorf("not detected: %q", in)
+			}
+		})
+	}
+}
+
+func TestContainsPII_Clears(t *testing.T) {
+	cases := map[string]string{
+		"semver 4 part":      "upgrade the driver to version 1.2.3.4 and rebuild",
+		"semver lowercase v": "bump to v10.0.0.1",
+		"loopback":           "the server is listening on 127.0.0.1",
+		"private 192":        "the router is at 192.168.1.1",
+		"private 10":         "the pod ip is 10.0.0.5",
+		"private 172":        "gateway 172.16.254.1",
+		"link local":         "fell back to 169.254.0.1",
+		"unspecified":        "bind to 0.0.0.0 for all interfaces",
+		"broadcast":          "send to 255.255.255.255",
+		"octet overflow":     "the build id is 999.888.777.666",
+		"longer dotted run":  "the oid is 1.2.3.4.5 in the mib",
+		"order number":       "look up order 123456789 in the orders table",
+		"token is a size":    "set the config: token: 4096",
+		"timeout is a size":  "secret = 30",
+		"placeholder":        "password: changeme",
+		"empty placeholder":  "api_key: none",
+		"16 digits not luhn": "trace id 1234567812345678 in the log",
+		"plain prose":        "refactor the dispatcher to use a context",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			if ContainsPII(Request{Prompt: in}) {
+				t.Errorf("false positive: %q", in)
+			}
+		})
+	}
+}
+
+// Luhn is what separates a card number from any other 16-digit run, so pin it
+// directly rather than only through ContainsPII.
+func TestValidLuhn(t *testing.T) {
+	valid := []string{"4111111111111111", "5500 0055 5555 5559", "4111-1111-1111-1111"}
+	invalid := []string{"4111111111111112", "1234567812345678", "1111111111111111"}
+	for _, s := range valid {
+		if !validLuhn(s, []int{0, len(s)}) {
+			t.Errorf("valid card rejected: %q", s)
+		}
+	}
+	for _, s := range invalid {
+		if validLuhn(s, []int{0, len(s)}) {
+			t.Errorf("non-card accepted: %q", s)
+		}
+	}
+}
+
+// A private address is not PII and appears constantly in developer prompts;
+// a public one plausibly identifies someone.
+func TestValidPublicIP_RangeClassification(t *testing.T) {
+	public := []string{"8.8.8.8", "1.1.1.1", "203.0.113.7"}
+	nonPublic := []string{
+		"0.0.0.0", "10.1.2.3", "127.0.0.1", "169.254.1.1",
+		"172.16.0.1", "172.31.255.255", "192.168.0.1", "224.0.0.1", "255.255.255.255",
+	}
+	for _, s := range public {
+		if !ContainsPII(Request{Prompt: "host " + s + " here"}) {
+			t.Errorf("public IP not detected: %q", s)
+		}
+	}
+	for _, s := range nonPublic {
+		if ContainsPII(Request{Prompt: "host " + s + " here"}) {
+			t.Errorf("non-public IP treated as PII: %q", s)
+		}
+	}
+	// 172.15 and 172.32 are outside the private block and stay public.
+	for _, s := range []string{"172.15.0.1", "172.32.0.1"} {
+		if !ContainsPII(Request{Prompt: "host " + s + " here"}) {
+			t.Errorf("%q is outside 172.16/12 and should count as public", s)
+		}
+	}
+}
+
+// A known, deliberate false positive: a version directory inside a path reads as
+// a public address. Suppressing dotted quads after "/" would also suppress real
+// addresses in URLs like http://8.8.8.8/foo, and that trade runs the wrong way —
+// a false positive costs only local routing, a false negative leaks a secret.
+//
+// Pinned so the behaviour is a decision on record rather than an accident, and
+// so anyone tightening it sees what they would break.
+func TestContainsPII_KnownFalsePositive_VersionInPath(t *testing.T) {
+	if !ContainsPII(Request{Prompt: "see /opt/app/1.2.3.4/bin"}) {
+		t.Skip("version-in-path no longer reads as an IP — if that was deliberate, " +
+			"check http://8.8.8.8/foo is still detected and delete this test")
+	}
+	if !ContainsPII(Request{Prompt: "fetch http://8.8.8.8/foo"}) {
+		t.Error("an address inside a URL must still be detected")
+	}
+}


### PR DESCRIPTION
## Summary

The PII gate is the only thing between sensitive content and a cloud provider — it forces
local-only routing. It failed in **both** directions. Verified against the live patterns before
changing anything:

| missed (reached the cloud) | false positive (needlessly local-only) |
|---|---|
| `-----BEGIN RSA PRIVATE KEY-----` | `upgrade the driver to version 1.2.3.4` |
| `AKIAIOSFODNN7EXAMPLE` | `the server is listening on 127.0.0.1` |
| `ghp_16C7e42F292c6912E7710c838347Ae178B4a` | `look up order 123456789 in the orders table` |
| `Authorization: Bearer eyJhbGciOiJIUzI1NiJ9…` | `set the config: token: 4096` |

All eight now behave correctly, pinned as fixed expectations in `TestContainsPII_IssueCorpus`.

## The asymmetry that shapes the fix

A **false negative sends a secret to a third party**. A false positive only routes work to a local
head. These costs are nowhere near equal, so where ambiguity is genuine the detectors lean toward
detecting — and the two places that trade detection away say so explicitly rather than quietly.

## Why validators, not just better patterns

Go's regexp is **RE2 — no lookahead or lookbehind**. "A dotted quad *unless* it is a version
string" cannot be expressed as a pattern at all. Patterns are now paired with validators that see
the match in context:

- **credit card** candidates must pass **Luhn** — this is what stops a 16-digit trace id reading as
  a card
- **dotted quads** must have in-range octets, must not sit inside a longer dotted run (`1.2.3.4.5`),
  must not follow a version-ish word, and must be **publicly routable**. Loopback, private,
  link-local, multicast and reserved ranges identify nobody, and `127.0.0.1` appears constantly in
  developer prompts
- **credential assignments** must have a value that could plausibly be a secret: ≥6 chars, not
  purely numeric, not a placeholder. `token`, `secret` and `key` are ordinary config names whose
  values are usually sizes and ports

New prefix detectors for what was previously invisible: PEM private keys, AWS access key ids,
GitHub/Slack/OpenAI/Google keys, JWTs, and `Authorization` headers.

## Two deliberate trade-offs, both recorded

**1. The SSN pattern now requires a separator.** Nine bare digits are indistinguishable from an
order number or primary key. A bare unformatted SSN is therefore **no longer detected** — a real
loss, stated in the code rather than left to be discovered later.

**2. A version directory in a path still reads as an address** (`/opt/app/1.2.3.4/bin`). Suppressing
quads after `/` would also suppress real addresses in URLs like `http://8.8.8.8/foo`, and that trade
runs the wrong way. Pinned by `TestContainsPII_KnownFalsePositive_VersionInPath`, which fails loudly
if someone tightens it and breaks URL detection.

## Verification

- 25 must-detect cases, 18 must-clear cases, Luhn pinned directly, and public/non-public range
  classification including the `172.15` / `172.32` boundaries either side of `172.16/12`
- `gofmt`, `go vet`, `staticcheck`, `go test -race ./...` green
- run with `HOME` pointed at an empty directory too, reproducing a clean CI runner — the check that
  caught a non-hermetic test in #221

Closes #169
