### PR TITLE
fix(release): fold the three silent-failure fixes into v1.1.0

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,6 +1,6 @@
 # Gitleaks configuration for Hydra.
 # Extends the full default ruleset, then allowlists values that are PUBLIC by
-# design and therefore NOT secrets.
+# design, or synthetic, and therefore NOT secrets.
 
 title = "Hydra"
 
@@ -8,9 +8,25 @@ title = "Hydra"
 useDefault = true
 
 [allowlist]
-description = "Public, intentional identifiers embedded in the shipped site — not secrets"
+description = "Public identifiers and synthetic test fixtures — not secrets"
+
+# Conditions are OR-ed: a finding is allowed if its content matches a regex
+# below OR its file matches a path below.
+
 regexes = [
   # Ahrefs Web Analytics data-key: a public site identifier embedded in the page
   # <head> and served to every visitor (equivalent to a GA measurement ID).
   '''yRz83E87rXgYWlhmro5mIg''',
+]
+
+paths = [
+  # The corpus for Hydra's own PII detector (#169). Its fixtures are secrets by
+  # construction — a test that a private key is detected has to contain
+  # something shaped like a private key — so gitleaks flags all of them.
+  #
+  # Every value there is synthetic or a vendor's published example
+  # (e.g. AKIAIOSFODNN7EXAMPLE is AWS's documented sample key). Scoped to this
+  # one file rather than to *_test.go, so a real credential pasted into any
+  # other test is still caught.
+  '''^internal/policy/pii_test\.go$''',
 ]

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -31,6 +31,8 @@ import (
 	"github.com/ankit373/hydra/internal/parallel"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/rank"
 	"github.com/ankit373/hydra/internal/review"
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
@@ -446,6 +448,35 @@ func cmdDispatch() *cobra.Command {
 					effectiveConf = derived
 				}
 			}
+			// --dry-run must mean "spend nothing" in every mode. It was read only
+			// by the single-dispatch path far below, which neither ensemble
+			// branch reaches — so `--dry-run --confidence 0.95` fired a paid
+			// ensemble and printed no plan at all (#167).
+			if dryRun && (effectiveConf > 0 || doSwarm) {
+				mode := swarm.SwarmMode(swarmMode)
+				if mode == "" {
+					mode = swarm.ModeBest
+				}
+				sw := swarm.New(d, d.Heads(), d)
+				planOpts := swarm.Options{
+					Mode:          mode,
+					TierHint:      tier,
+					HeadIDs:       headIDs,
+					MaxHeads:      swarmMaxHeads,
+					MaxEstCostUSD: swarmMaxCost,
+					LocalOnly:     localOnly,
+					System:        system,
+					Confidence:    effectiveConf,
+					Domain:        domain,
+				}
+				heads, estUSD, err := sw.Plan(prompt, planOpts)
+				if err != nil {
+					return err
+				}
+				printEnsemblePlan(heads, estUSD, effectiveConf, mode, swarmMaxCost)
+				return nil
+			}
+
 			if effectiveConf > 0 {
 				sw := swarm.New(d, d.Heads(), d)
 				res, err := sw.RunSPRT(ctx, prompt, swarm.Options{
@@ -562,7 +593,7 @@ func cmdDispatch() *cobra.Command {
 	// trust / SPRT flags
 	cmd.Flags().Float64Var(&confidence, "confidence", 0, "route via SPRT ensemble until this P(correct) is reached, e.g. 0.95")
 	cmd.Flags().StringVar(&domain, "domain", "", "calibration domain for --confidence (default: \"default\")")
-	cmd.Flags().StringVar(&file, "file", "", "target file — raises the confidence bar by its code blast radius")
+	cmd.Flags().StringVar(&file, "file", "", "target file — derives a confidence target from its blast radius, so this alone selects the SPRT ensemble")
 	cmd.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph used with --file")
 	return cmd
 }
@@ -1192,6 +1223,40 @@ func anyEstimated(attempts []swarm.Attempt) bool {
 }
 
 // printSwarmResult renders the swarm result to stdout.
+// printEnsemblePlan is what --dry-run shows for the swarm and SPRT paths: the
+// heads that would be engaged and the cost of one round, so the flag answers
+// "what would this spend" rather than spending it.
+//
+// The head count is an upper bound in SPRT mode: the ensemble stops as soon as
+// the log-odds cross the target, so it usually queries fewer. Saying so beats
+// printing a number that reads as a promise.
+func printEnsemblePlan(heads []provider.Head, estUSD, confidence float64, mode swarm.SwarmMode, maxCostUSD float64) {
+	sep := dimStyle.Render("  " + strings.Repeat("─", 60))
+
+	label := fmt.Sprintf("swarm · %s", mode)
+	if confidence > 0 {
+		label = fmt.Sprintf("SPRT · target %.1f%%", confidence*100)
+	}
+
+	fmt.Println()
+	fmt.Printf("  %s [%s]\n\n", cortexStyle.Render("▶ DRY RUN"), dimStyle.Render(label))
+	fmt.Printf("  %-28s  %7s  %8s\n", "HEAD", "TIER", "SOURCE")
+	fmt.Println(sep)
+	for _, h := range heads {
+		fmt.Printf("  %-28s  %7d  %8s\n", h.Name, rank.UITier(h), h.Source)
+	}
+	fmt.Println(sep)
+
+	if confidence > 0 {
+		fmt.Printf("  %s\n", dimStyle.Render(fmt.Sprintf("at most %d heads queried; SPRT stops early once the target is met", len(heads))))
+	}
+	fmt.Printf("  %s\n", dimStyle.Render(fmt.Sprintf("estimated cost for one round: $%.4f", estUSD)))
+	if maxCostUSD > 0 && estUSD > maxCostUSD {
+		fmt.Printf("  %s\n", warnStyle.Render(fmt.Sprintf("this exceeds --swarm-max-cost $%.4f and would be refused", maxCostUSD)))
+	}
+	fmt.Printf("  %s\n\n", dimStyle.Render("nothing was executed"))
+}
+
 func printSwarmResult(r *swarm.SwarmResult) {
 	sep := dimStyle.Render("  " + strings.Repeat("─", 60))
 
@@ -2083,6 +2148,7 @@ func cmdTrustDefect() *cobra.Command {
 var (
 	cortexStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
 	dimStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	warnStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 )
 
 // promptPreview shortens a prompt for a log Detail field. Run events carry a

--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -504,6 +504,10 @@ func loadRows(path string) ([]Row, error) {
 
 	var rows []Row
 	scanner := bufio.NewScanner(f)
+	// Match every other jsonl reader here (ledger, runlog, trust): a row with a
+	// long prompt preview would otherwise exceed the 64 KiB default and abort
+	// the whole report, since Err() is returned below.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -5,7 +5,6 @@
 package editor
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/util"
 	"github.com/ankit373/hydra/internal/workspace"
 )
 
@@ -303,12 +303,14 @@ func extractContent(raw string) string {
 }
 
 func extractBetween(raw string) string {
-	scanner := bufio.NewScanner(strings.NewReader(raw))
+	// util.SplitLines, not bufio.Scanner: a Scanner stops at a token longer than
+	// its buffer and only says so via Err(), so a single >64 KiB line — minified
+	// JS, a data URI, one-line JSON — used to yield an empty extraction that was
+	// then written over the user's file as if it had succeeded (#168).
 	var out []string
 	inside := false
 	printed := false
-	for scanner.Scan() {
-		line := scanner.Text()
+	for _, line := range util.SplitLines(raw) {
 		if !printed && strings.Contains(line, markerStart) {
 			inside = true
 			continue

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -5,6 +5,7 @@ package editor
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -104,5 +105,30 @@ func TestDiffStats_InMemory(t *testing.T) {
 	added, removed = diffStats(file, "a\nb\nc\nd\ne\n", "", file+".no-backup", true)
 	if added != 0 || removed != 2 {
 		t.Errorf("diffStats shrink: added=%d removed=%d, want 0/2", added, removed)
+	}
+}
+
+// extractBetween must not lose content to a line longer than bufio.Scanner's
+// 64 KiB default. It used to: the Scanner stopped, its Err() was never checked,
+// and the empty result was written over the user's file as a success (#168).
+// Minified JS, a data URI or one-line JSON all cross that threshold.
+func TestExtractBetween_LineBeyondScannerLimit(t *testing.T) {
+	for _, n := range []int{1000, 65000, 70000, 1 << 20} {
+		long := strings.Repeat("x", n)
+		raw := markerStart + "\n" + long + "\n" + markerEnd + "\n"
+		got := extractBetween(raw)
+		if got != long {
+			t.Errorf("line of %d chars: extracted %d chars, want %d", n, len(got), n)
+		}
+	}
+}
+
+// A long line among ordinary ones must not disturb the surrounding lines.
+func TestExtractBetween_LongLineAmongShort(t *testing.T) {
+	long := strings.Repeat("y", 200000)
+	raw := markerStart + "\nfirst\n" + long + "\nlast\n" + markerEnd + "\ntrailing junk\n"
+	want := "first\n" + long + "\nlast"
+	if got := extractBetween(raw); got != want {
+		t.Errorf("got %d chars, want %d", len(got), len(want))
 	}
 }

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -5,7 +5,6 @@
 package parallel
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -23,6 +22,7 @@ import (
 	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/util"
 	"github.com/ankit373/hydra/internal/workspace"
 )
 
@@ -449,11 +449,13 @@ func extractContent(raw string) string {
 }
 
 func extractBetween(raw string) string {
-	scanner := bufio.NewScanner(strings.NewReader(raw))
+	// util.SplitLines, not bufio.Scanner: a Scanner stops at a token longer than
+	// its buffer and only says so via Err(), so a single >64 KiB line — minified
+	// JS, a data URI, one-line JSON — used to yield an empty extraction that was
+	// then written over the user's file as if it had succeeded (#168).
 	var out []string
 	inside, printed := false, false
-	for scanner.Scan() {
-		line := scanner.Text()
+	for _, line := range util.SplitLines(raw) {
 		if !printed && strings.Contains(line, markerStart) {
 			inside = true
 			continue

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -171,3 +171,17 @@ func TestRun_TasksShareRunAndGetDistinctTaskIDs(t *testing.T) {
 		seen[id] = true
 	}
 }
+
+// Same defect as internal/editor's extractBetween (#168): a line longer than
+// bufio.Scanner's 64 KiB default silently produced an empty extraction, which
+// parallel then wrote over the user's file. Both copies must stay fixed.
+func TestExtractBetween_LineBeyondScannerLimit(t *testing.T) {
+	for _, n := range []int{1000, 65000, 70000, 1 << 20} {
+		long := strings.Repeat("x", n)
+		raw := markerStart + "\n" + long + "\n" + markerEnd + "\n"
+		got := extractBetween(raw)
+		if got != long {
+			t.Errorf("line of %d chars: extracted %d chars, want %d", n, len(got), n)
+		}
+	}
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -4,18 +4,7 @@
 // Rules are evaluated in order; the first match wins.
 package policy
 
-import (
-	"regexp"
-)
-
-// piiPatterns are compiled once at package init to avoid per-call allocations.
-var piiPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`\b\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b`),                                      // SSN
-	regexp.MustCompile(`\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b`),                                // credit card
-	regexp.MustCompile(`\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`),                   // email (fixed: [A-Za-z] not [A-Z|a-z])
-	regexp.MustCompile(`(?i)\b(password|secret|api[-_]?key|token|private[-_]?key)\s*[:=]\s*\S+`), // credentials
-	regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`),                                 // IP address
-}
+// PII detection lives in pii.go.
 
 // Action is what the engine tells the dispatcher to do.
 type Action struct {
@@ -57,20 +46,6 @@ func (e *Engine) Evaluate(req Request) Action {
 		}
 	}
 	return Action{}
-}
-
-// ── Built-in conditions ───────────────────────────────────────────────────────
-
-// ContainsPII returns true if the prompt likely contains personally identifiable
-// information. This is a fast heuristic; replace with Presidio via sidecar for
-// production-grade detection.
-func ContainsPII(req Request) bool {
-	for _, p := range piiPatterns {
-		if p.MatchString(req.Prompt) {
-			return true
-		}
-	}
-	return false
 }
 
 // ── Default rule set ──────────────────────────────────────────────────────────

--- a/internal/policy/pii.go
+++ b/internal/policy/pii.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// PII detection decides whether a prompt is forced to local-only routing, so the
+// two failure directions are not symmetric: a false negative sends a secret to a
+// cloud provider, while a false positive only routes work to a local head. The
+// detectors below lean toward detection wherever the ambiguity is real, and the
+// few places that trade detection away say so explicitly.
+//
+// This is still a heuristic; replace with Presidio via sidecar for
+// production-grade detection.
+
+// detector is a pattern plus an optional validator.
+//
+// Go's regexp is RE2, which has no lookahead or lookbehind, so conditions like
+// "an IPv4 address unless it is a version string" cannot be written as a
+// pattern at all — they need code that sees the match in context (#169).
+type detector struct {
+	name string
+	re   *regexp.Regexp
+	// valid narrows a raw hit. nil means every hit counts. It receives the
+	// whole prompt plus the match bounds so it can inspect surrounding text.
+	valid func(prompt string, loc []int) bool
+}
+
+var detectors = []detector{
+	// ── Secrets with unmistakable prefixes ───────────────────────────────────
+	// These are the highest-confidence signals available and need no validation:
+	// nothing else looks like them. None of them were detected before (#169).
+	{name: "pem private key", re: regexp.MustCompile(`-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----`)},
+	{name: "aws access key id", re: regexp.MustCompile(`\b(?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b`)},
+	{name: "github token", re: regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{36,}\b`)},
+	{name: "slack token", re: regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`)},
+	{name: "openai key", re: regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{20,}\b`)},
+	{name: "google api key", re: regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`)},
+	{name: "jwt", re: regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]+`)},
+	{name: "auth header", re: regexp.MustCompile(`(?i)\bauthorization\s*:\s*(?:bearer|basic|token)\s+\S+`)},
+
+	// ── Personal identifiers ─────────────────────────────────────────────────
+	{name: "email", re: regexp.MustCompile(`\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`)},
+
+	// A separator is required. Nine bare digits are indistinguishable from an
+	// order number, invoice id or primary key, and treating every such run as an
+	// SSN forced local-only routing on ordinary queries like "look up order
+	// 123456789". This does trade away detection of a bare, unformatted SSN —
+	// a real loss, accepted because the formatted spelling is overwhelmingly
+	// more common in text and the unformatted one is unknowable in isolation.
+	{name: "ssn", re: regexp.MustCompile(`\b\d{3}[-.\s]\d{2}[-.\s]\d{4}\b`)},
+
+	// 13–19 digits, optionally grouped, that pass Luhn. Luhn rejects ~90% of
+	// random digit runs, which is what keeps long ids from reading as cards.
+	{name: "credit card", re: regexp.MustCompile(`\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{1,7}\b`), valid: validLuhn},
+
+	// ── Context-dependent ────────────────────────────────────────────────────
+	{name: "credentials", re: regexp.MustCompile(`(?i)\b(?:password|passwd|secret|api[-_]?key|access[-_]?key|auth[-_]?token|token|private[-_]?key)\s*[:=]\s*("[^"]*"|'[^']*'|\S+)`), valid: validCredentialValue},
+	{name: "ip address", re: regexp.MustCompile(`\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b`), valid: validPublicIP},
+}
+
+// ContainsPII reports whether the prompt likely contains sensitive data.
+func ContainsPII(req Request) bool {
+	for _, d := range detectors {
+		for _, loc := range d.re.FindAllStringSubmatchIndex(req.Prompt, -1) {
+			if d.valid == nil || d.valid(req.Prompt, loc) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// validLuhn checks the card checksum. Without it, any 16-digit identifier —
+// order numbers, trace ids — forced local-only routing.
+func validLuhn(prompt string, loc []int) bool {
+	digits := make([]int, 0, 19)
+	for _, r := range prompt[loc[0]:loc[1]] {
+		if r >= '0' && r <= '9' {
+			digits = append(digits, int(r-'0'))
+		}
+	}
+	if len(digits) < 13 || len(digits) > 19 {
+		return false
+	}
+	sum, double := 0, false
+	for i := len(digits) - 1; i >= 0; i-- {
+		d := digits[i]
+		if double {
+			if d *= 2; d > 9 {
+				d -= 9
+			}
+		}
+		sum += d
+		double = !double
+	}
+	return sum%10 == 0
+}
+
+// minCredentialValueLen is the shortest assignment value treated as a secret.
+// "token: 4096" is a buffer size, not a credential; "password: hunter2" is one.
+const minCredentialValueLen = 6
+
+// validCredentialValue rejects assignments whose value cannot plausibly be a
+// secret. The keyword alone is not enough: `token`, `secret` and `key` are all
+// ordinary config names whose values are frequently small integers (#169).
+func validCredentialValue(prompt string, loc []int) bool {
+	if len(loc) < 4 || loc[2] < 0 {
+		return false
+	}
+	v := strings.Trim(prompt[loc[2]:loc[3]], `"'`)
+	if len(v) < minCredentialValueLen {
+		return false
+	}
+	// A purely numeric value is a port, size, timeout or count. Real secrets
+	// are effectively never all-digits, and treating them as such is what made
+	// "set the config: token: 4096" force local-only.
+	if _, err := strconv.Atoi(v); err == nil {
+		return false
+	}
+	// A placeholder is the opposite of a secret — it exists to be substituted.
+	switch strings.ToLower(v) {
+	case "none", "null", "nil", "empty", "false", "true", "changeme", "redacted", "<redacted>", "xxxxxx", "******":
+		return false
+	}
+	return true
+}
+
+// versionContext are words that precede a dotted quad which is a version, not
+// an address. RE2 cannot express "not preceded by", so this is checked in code.
+var versionContext = map[string]bool{
+	"version": true, "v": true, "ver": true, "release": true, "rev": true,
+	"build": true, "tag": true, "upgrade": true, "downgrade": true, "bump": true,
+}
+
+// validPublicIP keeps only dotted quads that are plausibly a real, routable
+// address someone could be identified by.
+//
+// It rejects three classes that were all forcing local-only routing needlessly:
+// octets above 255 and version-like context ("version 1.2.3.4"), addresses that
+// are part of a longer dotted run ("1.2.3.4.5"), and non-public ranges —
+// loopback, private, link-local, multicast and reserved. None of those identify
+// a person, and 127.0.0.1 in particular appears constantly in dev prompts.
+func validPublicIP(prompt string, loc []int) bool {
+	octets := make([]int, 4)
+	for i := 0; i < 4; i++ {
+		s, e := loc[2+i*2], loc[3+i*2]
+		if s < 0 {
+			return false
+		}
+		n, err := strconv.Atoi(prompt[s:e])
+		if err != nil || n > 255 {
+			return false
+		}
+		// A leading zero means it is not a normal address spelling.
+		if len(prompt[s:e]) > 1 && prompt[s] == '0' {
+			return false
+		}
+		octets[i] = n
+	}
+
+	// Part of a longer dotted run, e.g. the "1.2.3.4" inside "1.2.3.4.5".
+	if loc[0] > 0 {
+		if c := prompt[loc[0]-1]; c == '.' || (c >= '0' && c <= '9') {
+			return false
+		}
+	}
+	if loc[1] < len(prompt) && prompt[loc[1]] == '.' {
+		if loc[1]+1 < len(prompt) && prompt[loc[1]+1] >= '0' && prompt[loc[1]+1] <= '9' {
+			return false
+		}
+	}
+
+	if precededByVersionWord(prompt, loc[0]) {
+		return false
+	}
+
+	switch {
+	case octets[0] == 0, // unspecified / "this network"
+		octets[0] == 10,                                        // private
+		octets[0] == 127,                                       // loopback
+		octets[0] >= 224,                                       // multicast + reserved + broadcast
+		octets[0] == 169 && octets[1] == 254,                   // link-local
+		octets[0] == 192 && octets[1] == 168,                   // private
+		octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31: // private
+		return false
+	}
+	return true
+}
+
+// precededByVersionWord reports whether the word immediately before start is one
+// that makes a dotted quad a version rather than an address.
+func precededByVersionWord(prompt string, start int) bool {
+	i := start
+	for i > 0 && (prompt[i-1] == ' ' || prompt[i-1] == '\t') {
+		i--
+	}
+	end := i
+	for i > 0 {
+		c := prompt[i-1]
+		if c == ' ' || c == '\t' || c == '\n' {
+			break
+		}
+		i--
+	}
+	return versionContext[strings.ToLower(strings.Trim(prompt[i:end], ".,:;()[]"))]
+}

--- a/internal/policy/pii_test.go
+++ b/internal/policy/pii_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import "testing"
+
+// The eight strings #169 reported, pinned as fixed expectations. Four were
+// secrets that reached a cloud provider; four were ordinary developer text that
+// was needlessly forced local-only.
+func TestContainsPII_IssueCorpus(t *testing.T) {
+	mustDetect := []string{
+		"-----BEGIN RSA PRIVATE KEY-----",
+		"AKIAIOSFODNN7EXAMPLE",
+		"ghp_16C7e42F292c6912E7710c838347Ae178B4a",
+		"Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc",
+	}
+	mustClear := []string{
+		"upgrade the driver to version 1.2.3.4 and rebuild",
+		"the server is listening on 127.0.0.1",
+		"look up order 123456789 in the orders table",
+		"set the config: token: 4096",
+	}
+	for _, s := range mustDetect {
+		if !ContainsPII(Request{Prompt: s}) {
+			t.Errorf("MISSED (would reach a cloud provider): %q", s)
+		}
+	}
+	for _, s := range mustClear {
+		if ContainsPII(Request{Prompt: s}) {
+			t.Errorf("FALSE POSITIVE (needlessly local-only): %q", s)
+		}
+	}
+}
+
+func TestContainsPII_Detects(t *testing.T) {
+	cases := map[string]string{
+		"pem rsa":            "here is the key\n-----BEGIN RSA PRIVATE KEY-----\nMIIE...",
+		"pem openssh":        "-----BEGIN OPENSSH PRIVATE KEY-----",
+		"pem plain":          "-----BEGIN PRIVATE KEY-----",
+		"pem ec":             "-----BEGIN EC PRIVATE KEY-----",
+		"aws akia":           "export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE",
+		"aws asia":           "ASIAY34FZKBOKMUTVV7A",
+		"github pat":         "ghp_16C7e42F292c6912E7710c838347Ae178B4a",
+		"github oauth":       "gho_16C7e42F292c6912E7710c838347Ae178B4a",
+		"slack bot":          "xoxb-123456789012-abcdefghijkl",
+		"openai":             "sk-abcdefghijklmnopqrstuvwxyz012345",
+		"google":             "AIzaSyD-1234567890abcdefghijklmnopqrstu",
+		"jwt bare":           "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc",
+		"bearer header":      "Authorization: Bearer sometokenvalue",
+		"basic header":       "authorization: Basic dXNlcjpwYXNz",
+		"email":              "mail alice.smith@example.co.uk about it",
+		"ssn dashed":         "his ssn is 123-45-6789",
+		"ssn dotted":         "123.45.6789",
+		"ssn spaced":         "123 45 6789",
+		"real visa":          "card 4111 1111 1111 1111 on file",
+		"real mastercard":    "5500005555555559",
+		"password assign":    "password: hunter2",
+		"api key assign":     "api_key = s3cr3tValue123",
+		"secret quoted":      `secret: "abcdefghijk"`,
+		"private key assign": "private_key=MIIEpAIBAAKCAQEA",
+		"public ip":          "connect to 8.8.8.8 for dns",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			if !ContainsPII(Request{Prompt: in}) {
+				t.Errorf("not detected: %q", in)
+			}
+		})
+	}
+}
+
+func TestContainsPII_Clears(t *testing.T) {
+	cases := map[string]string{
+		"semver 4 part":      "upgrade the driver to version 1.2.3.4 and rebuild",
+		"semver lowercase v": "bump to v10.0.0.1",
+		"loopback":           "the server is listening on 127.0.0.1",
+		"private 192":        "the router is at 192.168.1.1",
+		"private 10":         "the pod ip is 10.0.0.5",
+		"private 172":        "gateway 172.16.254.1",
+		"link local":         "fell back to 169.254.0.1",
+		"unspecified":        "bind to 0.0.0.0 for all interfaces",
+		"broadcast":          "send to 255.255.255.255",
+		"octet overflow":     "the build id is 999.888.777.666",
+		"longer dotted run":  "the oid is 1.2.3.4.5 in the mib",
+		"order number":       "look up order 123456789 in the orders table",
+		"token is a size":    "set the config: token: 4096",
+		"timeout is a size":  "secret = 30",
+		"placeholder":        "password: changeme",
+		"empty placeholder":  "api_key: none",
+		"16 digits not luhn": "trace id 1234567812345678 in the log",
+		"plain prose":        "refactor the dispatcher to use a context",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			if ContainsPII(Request{Prompt: in}) {
+				t.Errorf("false positive: %q", in)
+			}
+		})
+	}
+}
+
+// Luhn is what separates a card number from any other 16-digit run, so pin it
+// directly rather than only through ContainsPII.
+func TestValidLuhn(t *testing.T) {
+	valid := []string{"4111111111111111", "5500 0055 5555 5559", "4111-1111-1111-1111"}
+	invalid := []string{"4111111111111112", "1234567812345678", "1111111111111111"}
+	for _, s := range valid {
+		if !validLuhn(s, []int{0, len(s)}) {
+			t.Errorf("valid card rejected: %q", s)
+		}
+	}
+	for _, s := range invalid {
+		if validLuhn(s, []int{0, len(s)}) {
+			t.Errorf("non-card accepted: %q", s)
+		}
+	}
+}
+
+// A private address is not PII and appears constantly in developer prompts;
+// a public one plausibly identifies someone.
+func TestValidPublicIP_RangeClassification(t *testing.T) {
+	public := []string{"8.8.8.8", "1.1.1.1", "203.0.113.7"}
+	nonPublic := []string{
+		"0.0.0.0", "10.1.2.3", "127.0.0.1", "169.254.1.1",
+		"172.16.0.1", "172.31.255.255", "192.168.0.1", "224.0.0.1", "255.255.255.255",
+	}
+	for _, s := range public {
+		if !ContainsPII(Request{Prompt: "host " + s + " here"}) {
+			t.Errorf("public IP not detected: %q", s)
+		}
+	}
+	for _, s := range nonPublic {
+		if ContainsPII(Request{Prompt: "host " + s + " here"}) {
+			t.Errorf("non-public IP treated as PII: %q", s)
+		}
+	}
+	// 172.15 and 172.32 are outside the private block and stay public.
+	for _, s := range []string{"172.15.0.1", "172.32.0.1"} {
+		if !ContainsPII(Request{Prompt: "host " + s + " here"}) {
+			t.Errorf("%q is outside 172.16/12 and should count as public", s)
+		}
+	}
+}
+
+// A known, deliberate false positive: a version directory inside a path reads as
+// a public address. Suppressing dotted quads after "/" would also suppress real
+// addresses in URLs like http://8.8.8.8/foo, and that trade runs the wrong way —
+// a false positive costs only local routing, a false negative leaks a secret.
+//
+// Pinned so the behaviour is a decision on record rather than an accident, and
+// so anyone tightening it sees what they would break.
+func TestContainsPII_KnownFalsePositive_VersionInPath(t *testing.T) {
+	if !ContainsPII(Request{Prompt: "see /opt/app/1.2.3.4/bin"}) {
+		t.Skip("version-in-path no longer reads as an IP — if that was deliberate, " +
+			"check http://8.8.8.8/foo is still detected and delete this test")
+	}
+	if !ContainsPII(Request{Prompt: "fetch http://8.8.8.8/foo"}) {
+		t.Error("an address inside a URL must still be detected")
+	}
+}

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -23,21 +23,32 @@ type PricingReader interface {
 	EstimateCost(tier int, inputTokens, outputTokens int) float64
 }
 
-// preflightCost estimates the total cost of firing all selected heads before
-// any execution begins. Returns an error if the estimate exceeds maxUSD.
-// Uses prompt character count / 4 as a token estimate (same as agy executor).
-func preflightCost(heads []provider.Head, prompt string, pr PricingReader, maxUSD float64) (float64, error) {
-	if pr == nil || maxUSD <= 0 {
-		return 0, nil
+// estimateFanoutCost estimates the total USD cost of firing every selected
+// head once. Uses prompt character count / 4 as a token estimate (same as the
+// agy executor).
+//
+// Separate from preflightCost because a *guard* can skip the arithmetic when no
+// limit is set, but a *plan* cannot: --dry-run must report the cost even when
+// nothing caps it (#167).
+func estimateFanoutCost(heads []provider.Head, prompt string, pr PricingReader) float64 {
+	if pr == nil {
+		return 0
 	}
-
 	estInputTokens := len(prompt) / 4
 	var total float64
 	for _, h := range heads {
 		total += pr.EstimateCost(rank.UITier(h), estInputTokens, estInputTokens/2)
 	}
+	return round6(total)
+}
 
-	total = round6(total)
+// preflightCost estimates the total cost of firing all selected heads before
+// any execution begins. Returns an error if the estimate exceeds maxUSD.
+func preflightCost(heads []provider.Head, prompt string, pr PricingReader, maxUSD float64) (float64, error) {
+	if pr == nil || maxUSD <= 0 {
+		return 0, nil
+	}
+	total := estimateFanoutCost(heads, prompt, pr)
 	if total > maxUSD {
 		return total, fmt.Errorf("swarm: estimated cost $%.4f exceeds limit $%.4f (%d heads)", total, maxUSD, len(heads))
 	}

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -101,6 +101,32 @@ func New(d *dispatch.Dispatcher, heads []provider.Head, pricing PricingReader) *
 	return &Swarm{d: d, heads: heads, pricing: pricing}
 }
 
+// Plan reports what Run or RunSPRT would do without executing anything: which
+// heads would be engaged, and what one round of fan-out is estimated to cost.
+//
+// It exists so --dry-run can mean the same thing in every mode. It used to mean
+// nothing in swarm and SPRT modes — the flag was read only by the single-dispatch
+// path, which both ensemble branches returned before reaching, so a dry run
+// fired a paid ensemble (#167).
+//
+// Selection deliberately mirrors Run and RunSPRT, which resolve the same
+// selector against the same options; a plan that picked different heads from the
+// run it describes would be worse than no plan.
+func (s *Swarm) Plan(prompt string, opts Options) (heads []provider.Head, estUSD float64, err error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, 0, fmt.Errorf("swarm: config load: %w", err)
+	}
+	selected, err := resolveSelector(opts, cfg).Select(s.heads, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(selected) == 0 {
+		return nil, 0, fmt.Errorf("swarm: no heads available for the requested configuration")
+	}
+	return selected, estimateFanoutCost(selected, prompt, s.pricing), nil
+}
+
 // Run executes the swarm: selects heads, optionally checks cost, fires them,
 // collects results, optionally judges, logs costs.
 func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmResult, error) {

--- a/internal/swarm/swarm_test.go
+++ b/internal/swarm/swarm_test.go
@@ -6,8 +6,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/provider"
 )
 
@@ -268,4 +272,112 @@ func TestCapScoreSelector_MaxHeadsCap(t *testing.T) {
 	if len(got) != 2 {
 		t.Errorf("MaxHeads=2 returned %d heads", len(got))
 	}
+}
+
+// estimateFanoutCost must report a cost even with no --swarm-max-cost limit.
+// preflightCost short-circuits to 0 when no limit is set, which is right for a
+// guard and wrong for the plan --dry-run prints (#167).
+func TestEstimateFanoutCost_IndependentOfAnyLimit(t *testing.T) {
+	heads := []provider.Head{registryHead("a", "A", 90), registryHead("b", "B", 80), registryHead("c", "C", 70)}
+	pr := fakePricing{per: 0.01}
+
+	if got := estimateFanoutCost(heads, "some prompt", pr); got != 0.03 {
+		t.Errorf("estimateFanoutCost = %v, want 0.03", got)
+	}
+	// The guard reports nothing here — that difference is the whole point.
+	if total, _ := preflightCost(heads, "some prompt", pr, 0); total != 0 {
+		t.Errorf("preflightCost with no limit = %v, want 0", total)
+	}
+	if got := estimateFanoutCost(heads, "p", nil); got != 0 {
+		t.Errorf("nil pricing = %v, want 0", got)
+	}
+}
+
+// withTempConfig points config.Dir() at a throwaway home containing a minimal
+// config.toml. config.Load fails outright when the file is missing, so any test
+// touching the selection path is otherwise green only on a machine that happens
+// to have run `hyctl init` — which is exactly how this test passed locally and
+// failed on a clean CI runner.
+func withTempConfig(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
+	dir := filepath.Join(home, ".hydra")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("cortex = \"claude\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Plan must pick exactly the heads the corresponding run would, or --dry-run
+// describes something other than what executing would do.
+func TestPlan_SelectsSameHeadsAsRunAndExecutesNothing(t *testing.T) {
+	withTempConfig(t)
+	all := []provider.Head{registryHead("h1", "H1", 90), registryHead("h2", "H2", 80), registryHead("h3", "H3", 70)}
+	s := New(nil, all, fakePricing{per: 0.01})
+
+	opts := Options{HeadIDs: []string{"h1", "h3"}}
+	heads, est, err := s.Plan("some prompt", opts)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	// Same selector, same options — Plan must not diverge from the run path.
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+	want, err := resolveSelector(opts, cfg).Select(all, opts)
+	if err != nil {
+		t.Fatalf("selector: %v", err)
+	}
+	if len(heads) != len(want) {
+		t.Fatalf("Plan selected %d heads, the run path selects %d", len(heads), len(want))
+	}
+	for i := range want {
+		if heads[i].ID != want[i].ID {
+			t.Errorf("head %d: Plan chose %q, run path chooses %q", i, heads[i].ID, want[i].ID)
+		}
+	}
+	if est != 0.02 {
+		t.Errorf("est = %v, want 0.02 for 2 heads", est)
+	}
+
+	// s was built with a nil dispatcher: had Plan executed anything it would
+	// have panicked rather than reached here.
+}
+
+// Plan must never report "here is your plan" with nothing in it. Two distinct
+// paths reach that state, so both are pinned: the selector rejecting an empty
+// roster outright, and a filter emptying a non-empty one — the latter returns
+// (empty, nil), which is what Plan's own length check exists to catch.
+func TestPlan_EmptyResultIsAlwaysAnError(t *testing.T) {
+	// Without a config the error would come from config.Load instead, and these
+	// would pass without ever reaching the checks they exist to test.
+	withTempConfig(t)
+
+	t.Run("empty roster", func(t *testing.T) {
+		s := New(nil, nil, fakePricing{per: 0.01})
+		_, _, err := s.Plan("p", Options{})
+		if err == nil {
+			t.Fatal("Plan with no heads should error, not report an empty plan as fine")
+		}
+		if !strings.Contains(err.Error(), "heads") {
+			t.Errorf("error was %q, want it to name heads as the problem", err)
+		}
+	})
+
+	t.Run("filter empties a non-empty roster", func(t *testing.T) {
+		// MinCapScore above every head: applyFiltersAndCap returns (empty, nil),
+		// so the selector reports no error and only Plan's own check stops it.
+		all := []provider.Head{registryHead("h1", "H1", 50), registryHead("h2", "H2", 40)}
+		s := New(nil, all, fakePricing{per: 0.01})
+		_, _, err := s.Plan("p", Options{TierHint: "nonexistent-tier", MinCapScore: 99})
+		if err == nil {
+			t.Fatal("every head filtered out should error, not yield an empty plan")
+		}
+	})
 }

--- a/internal/util/lines.go
+++ b/internal/util/lines.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+package util
+
+import "strings"
+
+// SplitLines splits already-in-memory text into lines.
+//
+// It exists because bufio.Scanner refuses any token longer than its buffer —
+// 64 KiB by default — and reports that by simply stopping. Code that scans a
+// string and ignores Err() therefore sees a *silently truncated* result, which
+// is how a >64 KiB line could erase the file being edited (#168). Raising the
+// buffer only moves the cliff; splitting a string that is already in memory
+// needs no size limit at all.
+//
+// The line semantics match bufio.ScanLines exactly, so it is a drop-in for that
+// use: a trailing "\r" is stripped from each line, and a final newline does not
+// produce a trailing empty line.
+func SplitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = strings.TrimSuffix(s, "\n")
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimSuffix(l, "\r")
+	}
+	return lines
+}

--- a/internal/util/lines_test.go
+++ b/internal/util/lines_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+// TestSplitLines_MatchesScanLines pins the semantics to bufio.ScanLines for
+// every input where a Scanner still works, so SplitLines is a safe drop-in.
+// Above the Scanner's limit the two intentionally differ — that is the bug.
+func TestSplitLines_MatchesScanLines(t *testing.T) {
+	cases := map[string]string{
+		"empty":            "",
+		"one line":         "a",
+		"trailing newline": "a\n",
+		"blank lines":      "a\n\nb\n",
+		"crlf":             "a\r\nb\r\n",
+		"lone cr kept":     "a\rb\n",
+		"only newline":     "\n",
+		"leading blank":    "\na\n",
+		"no trailing nl":   "a\nb",
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			sc := bufio.NewScanner(strings.NewReader(in))
+			var want []string
+			for sc.Scan() {
+				want = append(want, sc.Text())
+			}
+			if err := sc.Err(); err != nil {
+				t.Fatalf("scanner failed on a small input: %v", err)
+			}
+			got := SplitLines(in)
+			if len(got) != len(want) {
+				t.Fatalf("SplitLines(%q) = %q (%d lines), scanner gave %q (%d)", in, got, len(got), want, len(want))
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Errorf("line %d: got %q, scanner gave %q", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSplitLines_BeyondScannerLimit is the regression for #168: a line past
+// bufio.Scanner's 64 KiB ceiling must survive intact, where the Scanner returns
+// nothing at all.
+func TestSplitLines_BeyondScannerLimit(t *testing.T) {
+	for _, n := range []int{65000, 70000, 1 << 20} {
+		in := strings.Repeat("x", n) + "\n"
+
+		sc := bufio.NewScanner(strings.NewReader(in))
+		scanned := 0
+		for sc.Scan() {
+			scanned += len(sc.Text())
+		}
+
+		got := SplitLines(in)
+		if len(got) != 1 {
+			t.Fatalf("n=%d: got %d lines, want 1", n, len(got))
+		}
+		if len(got[0]) != n {
+			t.Errorf("n=%d: SplitLines kept %d chars, want %d", n, len(got[0]), n)
+		}
+		// Document the failure this replaces: past the limit the Scanner both
+		// returns nothing and reports an error that the old callers ignored.
+		if n > 64<<10 && (scanned != 0 || sc.Err() == nil) {
+			t.Errorf("n=%d: expected the scanner to fail with 0 bytes, got %d bytes err=%v", n, scanned, sc.Err())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`release/v1.1.0` was cut **before** #220, #221 and #222 landed, so v1.1.0 would ship all three known
bugs. Each fails **silently**, which is what makes shipping them unacceptable rather than untidy:

| issue | what ships without this | how it presents |
|---|---|---|
| #168 | `hyctl edit` overwrites a file with a truncated fragment — or nothing | reports `"status":"ok"` |
| #167 | `--dry-run` fires a paid ensemble in swarm/SPRT modes | prints no plan at all |
| #169 | PEM keys, AWS ids, GitHub tokens and JWTs reach cloud providers | prompt looks clean |

#168 triggers on any single line over 64 KiB — minified JS, a base64 data URI, one-line JSON.

## Diff

Exactly those three fixes against the previous release commit — **15 files, no unrelated drift**.

## Why a single linear commit

Same construction as the original cut: the `release/v*` ruleset requires linear history, so a merge
commit cannot land here. This adopts `develop`'s tree with the previous release commit as its only
parent.

## Why this is a PR and not a direct push

`CLAUDE.md` says bug fixes are "committed directly to release/v1.2.0". That is not possible — the
`release-branch-protection` ruleset carries a `pull_request` rule, so direct pushes are rejected:

```
! [remote rejected] release/v1.1.0 (push declined due to repository rule violations)
```

Worth correcting in `CLAUDE.md` separately; noting it here so the next person does not lose time to
the same thing.

## Verification

- `git diff develop <this branch>` — empty; the tree matches develop exactly
- single parent (linear, satisfies the ruleset)
- `main` is still an ancestor; `git merge-tree` against `main` reports **0 conflicts**, so #219 stays
  clean
- `go build`, `go vet`, `go test -race ./...` green, run with `HOME` pointed at an empty directory to
  reproduce a clean CI runner

## Effect

Merging republishes the RC as **`v1.1.0-rc.2`** and updates #219 in place.
