### PR TITLE
ci: run CI on pull requests into release/v*

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, develop]
+    # release/v* is included because it is the UAT gate: it is what a release is
+    # validated on, and where fixes land during validation. Leaving it out meant
+    # a PR into a release branch reported "no checks reported" and was mergeable
+    # with zero verification (#224).
+    branches: [main, develop, "release/v*"]
 
 # Cancel any in-progress run for the same branch when a new commit is pushed.
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,8 +452,10 @@ Features merge to develop (conventional commits)
 Cut release branch: git checkout -b release/v1.2.0 develop
         ↓  (push → rc.yml fires → publishes v1.2.0-rc.1 pre-release)
 UAT testing on release/v1.2.0
-Bug fixes committed directly to release/v1.2.0
-        ↓  (each push → rc.yml publishes v1.2.0-rc.2, rc.3 …)
+Bug fixes land via PR into release/v1.2.0 (direct pushes are rejected — the
+release-branch-protection ruleset requires a PR and linear history, so a merge
+commit cannot land there either; squash or rebase only)
+        ↓  (each merge → rc.yml publishes v1.2.0-rc.2, rc.3 …)
 Sign-off ✓
         ↓
 PR: release/v1.2.0 → main  (squash merge)


### PR DESCRIPTION
## Summary

`release/v*` — the **UAT gate** — was missing from `ci.yml`'s `pull_request` filter, so PRs into a
release branch ran **no CI at all**:

```
no checks reported on the 'fix/release-fold-silent-failure-fixes' branch
```

That PR (#223) was `MERGEABLE` / `CLEAN` with zero verification.

Nothing unverified actually shipped, because #223's tree was byte-identical to a `develop` tip that
had just passed full CI as #222 — I checked that before merging. But that was **luck, not a property
of the setup**. A hotfix authored directly on a release branch would have merged completely
untested, which is the opposite of what a validation gate is for.

## Also: CLAUDE.md documents an impossible workflow

It says bug fixes are "committed directly to release/v1.2.0". They cannot be — the
`release-branch-protection` ruleset carries a `pull_request` rule:

```
! [remote rejected] release/v1.1.0 (push declined due to repository rule violations)
```

The same ruleset also requires linear history, so a merge commit cannot land there either — squash
or rebase only. Corrected to describe what the ruleset actually enforces, so the next person doesn't
lose time discovering it the way I did.

## Verification

- `ci.yml` parses; the filter is now `['main', 'develop', 'release/v*']`
- this PR targets `develop`, so it exercises the existing path; the new one is exercised by the next
  PR into a release branch

Closes #224
