### PR TITLE
ci: carry the release-branch CI fix into v1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, develop]
+    # release/v* is included because it is the UAT gate: it is what a release is
+    # validated on, and where fixes land during validation. Leaving it out meant
+    # a PR into a release branch reported "no checks reported" and was mergeable
+    # with zero verification (#224).
+    branches: [main, develop, "release/v*"]
 
 # Cancel any in-progress run for the same branch when a new commit is pushed.
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -452,8 +452,10 @@ Features merge to develop (conventional commits)
 Cut release branch: git checkout -b release/v1.2.0 develop
         ↓  (push → rc.yml fires → publishes v1.2.0-rc.1 pre-release)
 UAT testing on release/v1.2.0
-Bug fixes committed directly to release/v1.2.0
-        ↓  (each push → rc.yml publishes v1.2.0-rc.2, rc.3 …)
+Bug fixes land via PR into release/v1.2.0 (direct pushes are rejected — the
+release-branch-protection ruleset requires a PR and linear history, so a merge
+commit cannot land there either; squash or rebase only)
+        ↓  (each merge → rc.yml publishes v1.2.0-rc.2, rc.3 …)
 Sign-off ✓
         ↓
 PR: release/v1.2.0 → main  (squash merge)


### PR DESCRIPTION
## Summary

#225 added `release/v*` to `ci.yml`'s `pull_request` filter, but landed on `develop` **after** this
branch was folded (#223). Without it here the fix does not apply to this release's own UAT: further
PRs into `release/v1.1.0` would still merge with no checks — the exact gap #224 was about.

Also carries the `CLAUDE.md` correction from the same PR, which replaced the "commit directly to the
release branch" instruction the ruleset rejects.

## Scope

`ci.yml` and `CLAUDE.md` only — **neither affects the shipped binary**. `release/v1.1.0`'s tree
returns to matching `develop` exactly.

## This PR is also the test

If checks appear on this PR, the `pull_request` trigger is evaluated from the head — and the fix is
already working. If they don't, the trigger comes from the base branch, and this merge is what makes
it work for the *next* PR into the release branch. Either result is worth knowing, and I'll report
which one happened.