### PR TITLE
fix(desktop): GetFleet returned runs:null on a machine that has never dispatched

### DIFF
--- a/desktop/api/dto_test.go
+++ b/desktop/api/dto_test.go
@@ -59,27 +59,67 @@ func TestDTOs_FieldNamesAreExplicitlyTagged(t *testing.T) {
 // deliberate exception: its breakdowns are nil to mean "never ran", and
 // types.ts declares them `Breakdown[] | null` so TypeScript forces the check.
 func TestDTOs_SliceFieldsAreNeverNilOnTheWire(t *testing.T) {
-	s, err := New().GetSession("")
+	// Every DTO the views iterate, not just Session's. Covering one type is how
+	// Fleet.runs shipped as null on a fresh machine while this test stayed green
+	// (#230) — types.ts declares runs as Run[], so the type was lying.
+	//
+	// Run on an empty HOME on purpose: nil slices only appear when there is no
+	// data, which is precisely the state a newly downloaded app starts in.
+	withEmptyHome(t)
+	a := New()
+
+	sess, err := a.GetSession("")
 	if err != nil {
 		t.Fatal(err)
 	}
-	raw, err := json.Marshal(s)
+	fleet, err := a.GetFleet()
 	if err != nil {
 		t.Fatal(err)
 	}
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
+	edits, err := a.GetEdits("")
+	if err != nil {
 		t.Fatal(err)
 	}
-	for _, key := range []string{"timeline", "agents", "edges"} {
-		v, ok := m[key]
-		if !ok {
-			t.Errorf("Session omits %q", key)
-			continue
+	diff, err := a.GetDiff("", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		value any
+		keys  []string
+	}{
+		{"Session", sess, []string{"timeline", "agents", "edges"}},
+		{"Fleet", fleet, []string{"runs"}},
+		{"Diff", diff, []string{"lines"}},
+	}
+	for _, c := range cases {
+		raw, err := json.Marshal(c.value)
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
 		}
-		if v == nil {
-			t.Errorf("Session.%s serialised as null; the view iterates it and would throw", key)
+		var m map[string]any
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("%s: %v", c.name, err)
 		}
+		for _, key := range c.keys {
+			v, ok := m[key]
+			if !ok {
+				t.Errorf("%s omits %q", c.name, key)
+				continue
+			}
+			if v == nil {
+				t.Errorf("%s.%s serialised as null; the view iterates it and would throw", c.name, key)
+			}
+		}
+	}
+
+	// GetEdits returns a bare slice, so check the marshalled form directly.
+	if raw, err := json.Marshal(edits); err != nil {
+		t.Fatal(err)
+	} else if string(raw) == "null" {
+		t.Error("GetEdits serialised as null; the Code view iterates it and would throw")
 	}
 }
 

--- a/desktop/api/firstrun_test.go
+++ b/desktop/api/firstrun_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// withEmptyHome points the process at a home directory containing no ~/.hydra,
+// which is the state of a machine that has just downloaded the app and never
+// run hyctl. config.Dir() resolves through os.UserHomeDir, so setting HOME
+// (USERPROFILE on Windows) is enough to isolate it.
+func withEmptyHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return home
+}
+
+// Every view must render on a machine with no ~/.hydra. This became a shipped
+// user journey when the app started being distributed as a download (#227):
+// before that, the only people launching it had already been running the CLI.
+//
+// The bar is that no entry point errors — an error blanks the view body, so a
+// first-time user would open the app to a wall of red rather than an empty
+// state telling them what to run.
+func TestFirstRun_EveryEntryPointIsSafeWithNoHydraHome(t *testing.T) {
+	withEmptyHome(t)
+	a := New()
+
+	t.Run("dashboard", func(t *testing.T) {
+		d, err := a.GetDashboard()
+		if err != nil {
+			t.Fatalf("GetDashboard errored on a fresh machine: %v", err)
+		}
+		if d.HasData {
+			t.Error("HasData is true with no logs; the view would show a table of zeros instead of the empty state")
+		}
+	})
+
+	t.Run("fleet", func(t *testing.T) {
+		f, err := a.GetFleet()
+		if err != nil {
+			t.Fatalf("GetFleet errored on a fresh machine: %v", err)
+		}
+		if f.HasRuns {
+			t.Error("HasRuns is true with no runs")
+		}
+		if f.Runs == nil {
+			t.Error("Runs is nil, which marshals to null; types.ts declares it Run[]")
+		}
+		if f.GroupThreshold == 0 {
+			t.Error("GroupThreshold is 0; the view uses it to decide when to collapse cards")
+		}
+	})
+
+	t.Run("session", func(t *testing.T) {
+		s, err := a.GetSession("")
+		if err != nil {
+			t.Fatalf("GetSession errored on a fresh machine: %v", err)
+		}
+		if s.Found {
+			t.Error("Found is true for a run that does not exist")
+		}
+		if s.Timeline == nil || s.Agents == nil || s.Edges == nil {
+			t.Error("a Session slice is nil; the view iterates all three")
+		}
+	})
+
+	t.Run("code", func(t *testing.T) {
+		e, err := a.GetEdits("")
+		if err != nil {
+			t.Fatalf("GetEdits errored on a fresh machine: %v", err)
+		}
+		if e == nil {
+			t.Error("GetEdits returned nil rather than an empty slice")
+		}
+		d, err := a.GetDiff("", "", "")
+		if err != nil {
+			t.Fatalf("GetDiff errored on a fresh machine: %v", err)
+		}
+		if d.Reason == "" {
+			t.Error("an unavailable diff must say why; a blank pane explains nothing")
+		}
+	})
+
+	t.Run("chat enums", func(t *testing.T) {
+		if len(a.ChatEnums()) == 0 {
+			t.Error("the chat dock's routing selector would be empty")
+		}
+	})
+
+	// Version is decoration, but it must not be blank — the footer renders it
+	// directly and an empty string looks like a broken build.
+	t.Run("version", func(t *testing.T) {
+		v := a.GetVersion()
+		if v.Version == "" {
+			t.Error("Version is empty")
+		}
+	})
+}
+
+// The whole first-run payload must be marshallable and free of nulls where the
+// frontend expects a list — Wails serialises these across the bridge, so a nil
+// here is a runtime TypeError in the view, not a Go error anyone would see.
+func TestFirstRun_PayloadHasNoNullsWhereTheViewExpectsAList(t *testing.T) {
+	withEmptyHome(t)
+	a := New()
+
+	f, err := a.GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), `"runs":null`) {
+		t.Errorf("Fleet marshalled with runs:null on a fresh machine: %s", raw)
+	}
+}

--- a/desktop/api/fleet.go
+++ b/desktop/api/fleet.go
@@ -96,7 +96,11 @@ func (a *API) GetFleet() (*Fleet, error) {
 		return nil, err
 	}
 
-	f := &Fleet{GroupThreshold: GroupThreshold}
+	// Runs is initialised rather than left nil: a nil slice marshals to null,
+	// and types.ts declares runs as Run[], so the type would be lying to every
+	// future caller on a machine that has never dispatched (#230). Session
+	// initialises its slices for the same reason.
+	f := &Fleet{GroupThreshold: GroupThreshold, Runs: []Run{}}
 	if len(ids) == 0 {
 		return f, nil
 	}


### PR DESCRIPTION
## Summary

Found while verifying the packaged app. With no `~/.hydra` — **the state of everyone who downloads
it** — `GetFleet` serialised:

```json
{"hasRuns":false,"liveCount":0,"runs":null,"groupThreshold":16}
```

`types.ts:107` declares `runs: Run[]` and `Fleet.tsx:26` calls `data.runs.map(...)`. The type said
the field is always an array; the wire said otherwise.

## Latent, not live — and that's the point

Nothing crashes today: `.map()` sits behind a `!data.hasRuns` branch, and `HasRuns` is only set when
runs exist, so the two stay consistent. But **the type was lying**, so TypeScript would not have
caught the next caller that reads `runs` without checking `hasRuns` first.

`GetSession` already initialises `timeline`, `agents` and `edges`. Fleet was the outlier.

## The guard had a hole

`TestDTOs_SliceFieldsAreNeverNilOnTheWire` exists for exactly this defect class and covered **only
Session** — which is how this shipped green. It now covers every DTO the views iterate (Session,
Fleet, Diff, and the bare slice `GetEdits` returns) and runs against an **empty HOME**, since nil
slices only appear when there is no data.

## First-run coverage

No test covered the empty-`HOME` path at all. That became a shipped user journey when the app started
being distributed as a download (#227) — before that, everyone launching it had already run the CLI.

The new test walks every API entry point. The bar is that **nothing errors**: an error blanks the
view body, so a first-time user would open the app to a wall of red rather than an empty state
telling them what to run.

## Verification

Reintroduced the nil and confirmed all three tests fail, each naming the consequence:

```
dto_test.go:113:      Fleet.runs serialised as null; the view iterates it and would throw
firstrun_test.go:53:  Runs is nil, which marshals to null; types.ts declares it Run[]
--- FAIL: TestFirstRun_PayloadHasNoNullsWhereTheViewExpectsAList
```

`gofmt`, `go vet`, `go test -race ./api/...` green.

Closes #230