### PR TITLE
fix(desktop): stamp the real version into the bundle, publish checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,4 +200,4 @@ jobs:
     uses: ./.github/workflows/desktop-build.yml
     with:
       version: ci
-      targets: '[{"runner":"ubuntu-latest","platform":"linux/amd64","goos":"linux","arch":"amd64","tags":"webkit2_41"},{"runner":"windows-latest","platform":"windows/amd64","goos":"windows","arch":"amd64","tags":""},{"runner":"macos-latest","platform":"darwin/universal","goos":"darwin","arch":"universal","tags":""}]'
+      targets: '[{"runner":"ubuntu-latest","platform":"linux/amd64","goos":"linux","arch":"amd64","tags":"webkit2_41"}]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,4 +200,4 @@ jobs:
     uses: ./.github/workflows/desktop-build.yml
     with:
       version: ci
-      targets: '[{"runner":"ubuntu-latest","platform":"linux/amd64","goos":"linux","arch":"amd64","tags":"webkit2_41"}]'
+      targets: '[{"runner":"ubuntu-latest","platform":"linux/amd64","goos":"linux","arch":"amd64","tags":"webkit2_41"},{"runner":"windows-latest","platform":"windows/amd64","goos":"windows","arch":"amd64","tags":""},{"runner":"macos-latest","platform":"darwin/universal","goos":"darwin","arch":"universal","tags":""}]'

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -91,6 +91,37 @@ jobs:
           echo "Installing Wails CLI $version"
           go install "github.com/wailsapp/wails/v2/cmd/wails@$version"
 
+      # CFBundleVersion and CFBundleShortVersionString are templated from
+      # wails.json's info.productVersion by build/darwin/Info.plist. Nothing
+      # ever set it, so every bundle claimed Wails' 1.0.0 default while the
+      # binary's ldflags reported the real release: Finder disagreed with the
+      # app's own footer, and because macOS compares CFBundleVersion to decide
+      # what is newer, every future release would still look like 1.0.0 (#233).
+      #
+      # Normalised rather than passed straight through — callers send
+      # "v1.1.0-rc.5", "v1.1.0" and literally "ci", and CFBundleVersion has to
+      # be dotted digits. The pre-release suffix is dropped because an rc is a
+      # pre-release *of* that version; the exact build stays visible in the
+      # footer via ldflags, which is the authoritative place for it.
+      - name: Stamp the bundle version
+        shell: bash
+        working-directory: desktop
+        # Through env, not ${{ }} interpolated into the script body: the value
+        # is derived from a branch name upstream, and expression substitution
+        # happens before bash ever parses the line.
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          v="${RAW_VERSION#v}"   # v1.1.0-rc.5 → 1.1.0-rc.5
+          v="${v%%-*}"           # 1.1.0-rc.5  → 1.1.0
+          if ! printf '%s' "$v" | grep -Eq '^[0-9]+(\.[0-9]+){0,2}$'; then
+            echo "::notice::'$RAW_VERSION' is not a release version — stamping 0.0.0"
+            v=0.0.0
+          fi
+          echo "CFBundleVersion=$v (from '$RAW_VERSION')"
+          jq --arg v "$v" '.info.productVersion = $v' wails.json > wails.json.tmp
+          mv wails.json.tmp wails.json
+
       - name: Build
         shell: bash
         working-directory: desktop
@@ -145,7 +176,13 @@ jobs:
         working-directory: desktop/build/bin
         run: |
           shopt -s nullglob
-          found=(hydra-desktop_*)
+          # Checksums are written after this step, but exclude them anyway so a
+          # future reorder cannot fail the size guard on a 100-byte .sha256.
+          found=()
+          for f in hydra-desktop_*; do
+            case "$f" in *.sha256) continue ;; esac
+            found+=("$f")
+          done
           if [ ${#found[@]} -eq 0 ]; then
             echo "::error::no artifact was produced for ${{ matrix.goos }}/${{ matrix.arch }}"
             ls -la
@@ -160,6 +197,30 @@ jobs:
               echo "::error::$f is only $size bytes — that is not a real app bundle"
               exit 1
             fi
+          done
+
+      # goreleaser's checksums.txt covers the hyctl binaries only — it is built
+      # by a different job that never sees these files, so the desktop artifacts
+      # shipped with no way to verify them at all (#233). That matters more
+      # while the app is unsigned, not less: with no Developer ID signature to
+      # check, the checksum is the only integrity evidence a downloader has.
+      #
+      # One sidecar per artifact rather than a shared file: the three platform
+      # jobs run in parallel, and appending to a single checksums.txt would be a
+      # race between them. Each job owns exactly the files it produced.
+      - name: Checksum the artifact
+        shell: bash
+        working-directory: desktop/build/bin
+        run: |
+          shopt -s nullglob
+          for f in hydra-desktop_*; do
+            case "$f" in *.sha256) continue ;; esac
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum "$f" > "$f.sha256"
+            else
+              shasum -a 256 "$f" > "$f.sha256"   # macOS has no sha256sum
+            fi
+            cat "$f.sha256"
           done
 
       - name: Upload to the release

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -217,11 +217,32 @@ jobs:
             case "$f" in *.sha256) continue ;; esac
             if command -v sha256sum >/dev/null 2>&1; then
               sha256sum "$f" > "$f.sha256"
+              sha256sum -c "$f.sha256"
             else
               shasum -a 256 "$f" > "$f.sha256"   # macOS has no sha256sum
+              shasum -a 256 -c "$f.sha256"
             fi
-            cat "$f.sha256"
           done
+
+      # Runs the exact command the docs hand Windows users, against a file
+      # sha256sum wrote in binary mode. Different tool, different hex case, and
+      # a '*' marker in the line — so this proves the documented command really
+      # works rather than restating the step above, and it keeps working: if the
+      # docs and the artifact ever drift apart, this job fails.
+      - name: Verify the checksum the way the docs tell Windows users to
+        if: matrix.goos == 'windows'
+        shell: pwsh
+        working-directory: desktop/build/bin
+        run: |
+          Get-ChildItem hydra-desktop_*.sha256 | ForEach-Object {
+            $expected = (Get-Content $_.FullName).Split(' ')[0].Trim()
+            $file     = $_.FullName -replace '\.sha256$', ''
+            $actual   = (Get-FileHash $file -Algorithm SHA256).Hash
+            if ($actual -ne $expected) {
+              throw "checksum mismatch for $file`n  expected $expected`n  actual   $actual"
+            }
+            "OK  $(Split-Path $file -Leaf)"
+          }
 
       - name: Upload to the release
         if: inputs.upload

--- a/README.md
+++ b/README.md
@@ -648,6 +648,14 @@ Dashboard totals are asserted equal to `hyctl cost` and `hyctl stats` for the sa
 | Windows | `hydra-desktop_<version>_windows_amd64.zip` |
 | Linux | `hydra-desktop_<version>_linux_amd64.tar.gz` |
 
+Each artifact ships a `.sha256` next to it. Until the builds are signed this is the only integrity
+check available, so it is worth the one command:
+
+```bash
+shasum -a 256 -c hydra-desktop_<version>_darwin_universal.zip.sha256   # macOS
+sha256sum   -c hydra-desktop_<version>_linux_amd64.tar.gz.sha256       # Linux
+```
+
 **The builds are not code-signed yet**, so the first launch takes one extra step:
 
 - **macOS** — Gatekeeper will say Hydra "cannot be opened because it is from an unidentified

--- a/README.md
+++ b/README.md
@@ -656,6 +656,12 @@ shasum -a 256 -c hydra-desktop_<version>_darwin_universal.zip.sha256   # macOS
 sha256sum   -c hydra-desktop_<version>_linux_amd64.tar.gz.sha256       # Linux
 ```
 
+```powershell
+# Windows (PowerShell)
+$f = "hydra-desktop_<version>_windows_amd64.zip"
+(Get-FileHash $f -Algorithm SHA256).Hash -eq (Get-Content "$f.sha256").Split(' ')[0]   # → True
+```
+
 **The builds are not code-signed yet**, so the first launch takes one extra step:
 
 - **macOS** — Gatekeeper will say Hydra "cannot be opened because it is from an unidentified

--- a/desktop/build/darwin/Info.plist
+++ b/desktop/build/darwin/Info.plist
@@ -7,8 +7,14 @@
         <string>{{.Info.ProductName}}</string>
         <key>CFBundleExecutable</key>
         <string>{{.OutputFilename}}</string>
+        <!-- Hardcoded, not the com.wails.<name> the Wails template ships: that
+             namespace belongs to the Wails project, not us, and this is the
+             identity macOS keys preferences, TCC permissions and update
+             comparisons off. Changing it after users have installed resets all
+             of that, and notarization requires it to sit under a domain the
+             signing team owns — hydra.uvansa.com reversed. -->
         <key>CFBundleIdentifier</key>
-        <string>com.wails.{{safeBundleID .Name}}</string>
+        <string>com.uvansa.hydra</string>
         <key>CFBundleVersion</key>
         <string>{{.Info.ProductVersion}}</string>
         <key>CFBundleGetInfoString</key>

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -7,6 +7,7 @@
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",
   "frontend:dev:serverUrl": "auto",
+  "//productVersion": "Deliberately absent. desktop-build.yml injects it from the release version before calling wails build, because it feeds CFBundleVersion/CFBundleShortVersionString in build/darwin/Info.plist. A static value here would be a second source of truth that goes stale the moment a release ships — the same drift that froze every bundle at Wails' 1.0.0 default (#233). Local builds keep that default on purpose: they are not distributed, and their ldflags say 'dev' to match.",
   "info": {
     "productName": "Hydra",
     "comments": "Local-first, multi-vendor AI control plane."

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -10,6 +10,8 @@
   "//productVersion": "Deliberately absent. desktop-build.yml injects it from the release version before calling wails build, because it feeds CFBundleVersion/CFBundleShortVersionString in build/darwin/Info.plist. A static value here would be a second source of truth that goes stale the moment a release ships — the same drift that froze every bundle at Wails' 1.0.0 default (#233). Local builds keep that default on purpose: they are not distributed, and their ldflags say 'dev' to match.",
   "info": {
     "productName": "Hydra",
-    "comments": "Local-first, multi-vendor AI control plane."
+    "comments": "Local-first, multi-vendor AI control plane.",
+    "//copyright": "Matches LICENSE. Unset, Wails ships the literal placeholder 'Copyright.........' into NSHumanReadableCopyright, which macOS shows in Get Info.",
+    "copyright": "Copyright (c) 2025 Ankit Jha. MIT licensed."
   }
 }

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -504,10 +504,13 @@ hydra-desktop_&lt;version&gt;_darwin_universal.zip   <span class="c"># macOS, In
 hydra-desktop_&lt;version&gt;_windows_amd64.zip      <span class="c"># Windows</span>
 hydra-desktop_&lt;version&gt;_linux_amd64.tar.gz     <span class="c"># Linux</span>
 
+<span class="c"># Every artifact ships a .sha256 beside it — verify before you run:</span>
+shasum -a 256 -c hydra-desktop_&lt;version&gt;_darwin_universal.zip.sha256
+
 <span class="c"># Or build it yourself:</span>
 go install github.com/wailsapp/wails/v2/cmd/wails@latest
 cd desktop &amp;&amp; wails build                <span class="c"># → desktop/build/bin/Hydra.app</span></pre></div>
-      <div class="callout"><b>The builds are not code-signed yet</b>, so the first launch takes one extra step. <b>macOS:</b> Gatekeeper reports an unidentified developer — right-click the app → <b>Open</b> → <b>Open</b>, once. If it still refuses after unzipping from a terminal, run <span class="fx">xattr -dr com.apple.quarantine Hydra.app</span>. <b>Windows:</b> SmartScreen may warn — <b>More info</b> → <b>Run anyway</b>. <b>Linux:</b> needs <span class="fx">libgtk-3-0</span> and <span class="fx">libwebkit2gtk-4.1-0</span>, then <span class="fx">chmod +x Hydra</span>.</div>
+      <div class="callout"><b>The builds are not code-signed yet</b>, so the published <span class="fx">.sha256</span> is the only integrity check available — worth the one command above. The first launch also takes one extra step. <b>macOS:</b> Gatekeeper reports an unidentified developer — right-click the app → <b>Open</b> → <b>Open</b>, once. If it still refuses after unzipping from a terminal, run <span class="fx">xattr -dr com.apple.quarantine Hydra.app</span>. <b>Windows:</b> SmartScreen may warn — <b>More info</b> → <b>Run anyway</b>. <b>Linux:</b> needs <span class="fx">libgtk-3-0</span> and <span class="fx">libwebkit2gtk-4.1-0</span>, then <span class="fx">chmod +x Hydra</span>.</div>
       <div class="callout">The app reads the same logs the CLI writes, so its numbers are the CLI's numbers — Dashboard totals match <span class="fx">hyctl cost</span> and <span class="fx">hyctl stats</span> for the same data. There is no separate daemon and no telemetry: it reads <span class="fx">~/.hydra/logs/</span> on your machine.</div>
     </section>
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -505,7 +505,12 @@ hydra-desktop_&lt;version&gt;_windows_amd64.zip      <span class="c"># Windows</
 hydra-desktop_&lt;version&gt;_linux_amd64.tar.gz     <span class="c"># Linux</span>
 
 <span class="c"># Every artifact ships a .sha256 beside it — verify before you run:</span>
-shasum -a 256 -c hydra-desktop_&lt;version&gt;_darwin_universal.zip.sha256
+shasum -a 256 -c hydra-desktop_&lt;version&gt;_darwin_universal.zip.sha256   <span class="c"># macOS</span>
+sha256sum   -c hydra-desktop_&lt;version&gt;_linux_amd64.tar.gz.sha256       <span class="c"># Linux</span>
+
+<span class="c"># Windows (PowerShell):</span>
+$f = "hydra-desktop_&lt;version&gt;_windows_amd64.zip"
+(Get-FileHash $f -Algorithm SHA256).Hash -eq (Get-Content "$f.sha256").Split(' ')[0]
 
 <span class="c"># Or build it yourself:</span>
 go install github.com/wailsapp/wails/v2/cmd/wails@latest


### PR DESCRIPTION
Found by inspecting the `v1.1.0-rc.5` artifacts instead of the build log. The release was green;
the bundles were still wrong.

## What was broken

**1. Every build reported version 1.0.0 — on macOS *and* Windows.** Both platforms' version
metadata is templated from `wails.json`'s `info.productVersion`, which nothing ever set, so Wails
substituted its `1.0.0` default — while the binary's ldflags carried the real version.

Read out of the published rc.5 artifacts:

| | before | after |
|---|---|---|
| macOS `CFBundleShortVersionString` | `1.0.0` | `1.1.0` |
| macOS `CFBundleVersion` | `1.0.0` | `1.1.0` |
| macOS `CFBundleIdentifier` | `com.wails.hydra` | `com.uvansa.hydra` |
| macOS `NSHumanReadableCopyright` | `Copyright.........` | matches `LICENSE` |
| Windows PE `ProductVersion` | `1.0.0` | `1.1.0` |
| ldflags version in binary | `1.1.0-rc.5` | `1.1.0-rc.5` |

Finder disagreed with the app's own footer. And `CFBundleVersion` is what macOS compares to decide
which copy is newer — frozen at `1.0.0`, **every future release would look identical to every past
one**. Same defect class as the `dev · none` footer in #227: the ldflags path was wired up, the
bundle-metadata path was not. `Copyright.........` is Wails' literal placeholder, shown in Get Info.

**2. The desktop artifacts had no checksum.** `checksums.txt` is produced by goreleaser and covers
the five `hyctl` binaries only; the three desktop artifacts come from a job it never sees. That gap
matters *more* while the app is unsigned, not less — with no Developer ID signature to verify, a
checksum is the only integrity evidence a downloader has.

**3. The bundle identifier was the scaffold default.** `com.wails.hydra` claims a namespace we do
not own, and it is the identity macOS keys preferences, TCC permissions and update comparison off,
so changing it after users install resets all of that. v1.1.0 is the first release to ship the app —
the last cheap moment to change it.

## Approach notes

- **Version is normalised, not passed through.** Callers send `v1.1.0-rc.5`, `v1.1.0` and literally
  `ci`; `CFBundleVersion` has to be dotted digits. `v1.1.0-rc.5 → 1.1.0`, `ci → 0.0.0`. Dropping the
  pre-release suffix is deliberate — an rc is a pre-release *of* that version, and the exact build
  stays visible in the footer via ldflags.
- **One `.sha256` per artifact, not a shared `checksums.txt`.** The three platform jobs run in
  parallel and would race on a shared file. Each job owns exactly the files it produced.
- **`wails.json` deliberately has no static `productVersion`** — that would be a second source of
  truth that goes stale, which is the same drift that froze the bundle at `1.0.0` in the first
  place. The comment key in the file says so, so nobody re-adds one.

## Verified, not assumed

Ran a real `wails build` locally, since the failure was in template output rather than in code:

- plist reports `1.1.0` / `1.1.0` / `com.uvansa.hydra`, and the copyright reads back from the bundle
- `codesign --verify --deep --strict` passes — Wails templates the plist *before* it self-signs, so
  the change does not break the seal (the build log's `Packaging → Self-signing` order confirms it)
- the built app launches
- the verify command was tested **both ways**: it accepts the published rc.5 artifact and rejects the
  same file with one byte appended
- the published Windows and Linux artifacts were unpacked too — single-file by design (Windows
  embeds the WebView2 loader, Linux links webkit2gtk at runtime), so nothing is missing from them

Then in CI, with the desktop matrix **temporarily** widened to all three platforms — because CI
otherwise builds Linux only, and these steps would first meet Windows and macOS on the release
branch, the same blind spot as #224:

- the version stamp normalised correctly on every runner (`jq` is present on all three)
- every artifact produced a checksum (`sha256sum` on Linux/Windows, `shasum` on macOS)
- **each documented verify command ran green on its own platform**, including the PowerShell one —
  which is why it is in the workflow permanently rather than as a throwaway: it runs `Get-FileHash`
  against a file `sha256sum` wrote in binary mode, so different tool, different hex case and a `*`
  marker in the line. If the docs and the artifact ever drift apart, the job fails.

**The matrix widening is reverted** — `ci.yml` in this branch is byte-identical to `develop`.

## Docs shipped with it

`README.md` and `docs/docs.html` gain the verify command for all three platforms, and the unsigned
callout now says why it is worth running. `sitemap.xml`'s `lastmod` is already today's date.

## Follow-up, not in scope here

The pre-existing `Build` step interpolates `${{ inputs.version }}` directly into its bash body. My
new step passes it through `env` instead, which is the safe pattern; the older one is untouched
because it has been proven through five RCs and this PR should not carry an unrelated rewrite.

Closes #233