### PR TITLE
fix(release): carry the bundle-version and checksum fix into v1.1.0

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -91,6 +91,37 @@ jobs:
           echo "Installing Wails CLI $version"
           go install "github.com/wailsapp/wails/v2/cmd/wails@$version"
 
+      # CFBundleVersion and CFBundleShortVersionString are templated from
+      # wails.json's info.productVersion by build/darwin/Info.plist. Nothing
+      # ever set it, so every bundle claimed Wails' 1.0.0 default while the
+      # binary's ldflags reported the real release: Finder disagreed with the
+      # app's own footer, and because macOS compares CFBundleVersion to decide
+      # what is newer, every future release would still look like 1.0.0 (#233).
+      #
+      # Normalised rather than passed straight through — callers send
+      # "v1.1.0-rc.5", "v1.1.0" and literally "ci", and CFBundleVersion has to
+      # be dotted digits. The pre-release suffix is dropped because an rc is a
+      # pre-release *of* that version; the exact build stays visible in the
+      # footer via ldflags, which is the authoritative place for it.
+      - name: Stamp the bundle version
+        shell: bash
+        working-directory: desktop
+        # Through env, not ${{ }} interpolated into the script body: the value
+        # is derived from a branch name upstream, and expression substitution
+        # happens before bash ever parses the line.
+        env:
+          RAW_VERSION: ${{ inputs.version }}
+        run: |
+          v="${RAW_VERSION#v}"   # v1.1.0-rc.5 → 1.1.0-rc.5
+          v="${v%%-*}"           # 1.1.0-rc.5  → 1.1.0
+          if ! printf '%s' "$v" | grep -Eq '^[0-9]+(\.[0-9]+){0,2}$'; then
+            echo "::notice::'$RAW_VERSION' is not a release version — stamping 0.0.0"
+            v=0.0.0
+          fi
+          echo "CFBundleVersion=$v (from '$RAW_VERSION')"
+          jq --arg v "$v" '.info.productVersion = $v' wails.json > wails.json.tmp
+          mv wails.json.tmp wails.json
+
       - name: Build
         shell: bash
         working-directory: desktop
@@ -145,7 +176,13 @@ jobs:
         working-directory: desktop/build/bin
         run: |
           shopt -s nullglob
-          found=(hydra-desktop_*)
+          # Checksums are written after this step, but exclude them anyway so a
+          # future reorder cannot fail the size guard on a 100-byte .sha256.
+          found=()
+          for f in hydra-desktop_*; do
+            case "$f" in *.sha256) continue ;; esac
+            found+=("$f")
+          done
           if [ ${#found[@]} -eq 0 ]; then
             echo "::error::no artifact was produced for ${{ matrix.goos }}/${{ matrix.arch }}"
             ls -la
@@ -161,6 +198,51 @@ jobs:
               exit 1
             fi
           done
+
+      # goreleaser's checksums.txt covers the hyctl binaries only — it is built
+      # by a different job that never sees these files, so the desktop artifacts
+      # shipped with no way to verify them at all (#233). That matters more
+      # while the app is unsigned, not less: with no Developer ID signature to
+      # check, the checksum is the only integrity evidence a downloader has.
+      #
+      # One sidecar per artifact rather than a shared file: the three platform
+      # jobs run in parallel, and appending to a single checksums.txt would be a
+      # race between them. Each job owns exactly the files it produced.
+      - name: Checksum the artifact
+        shell: bash
+        working-directory: desktop/build/bin
+        run: |
+          shopt -s nullglob
+          for f in hydra-desktop_*; do
+            case "$f" in *.sha256) continue ;; esac
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum "$f" > "$f.sha256"
+              sha256sum -c "$f.sha256"
+            else
+              shasum -a 256 "$f" > "$f.sha256"   # macOS has no sha256sum
+              shasum -a 256 -c "$f.sha256"
+            fi
+          done
+
+      # Runs the exact command the docs hand Windows users, against a file
+      # sha256sum wrote in binary mode. Different tool, different hex case, and
+      # a '*' marker in the line — so this proves the documented command really
+      # works rather than restating the step above, and it keeps working: if the
+      # docs and the artifact ever drift apart, this job fails.
+      - name: Verify the checksum the way the docs tell Windows users to
+        if: matrix.goos == 'windows'
+        shell: pwsh
+        working-directory: desktop/build/bin
+        run: |
+          Get-ChildItem hydra-desktop_*.sha256 | ForEach-Object {
+            $expected = (Get-Content $_.FullName).Split(' ')[0].Trim()
+            $file     = $_.FullName -replace '\.sha256$', ''
+            $actual   = (Get-FileHash $file -Algorithm SHA256).Hash
+            if ($actual -ne $expected) {
+              throw "checksum mismatch for $file`n  expected $expected`n  actual   $actual"
+            }
+            "OK  $(Split-Path $file -Leaf)"
+          }
 
       - name: Upload to the release
         if: inputs.upload

--- a/README.md
+++ b/README.md
@@ -648,6 +648,20 @@ Dashboard totals are asserted equal to `hyctl cost` and `hyctl stats` for the sa
 | Windows | `hydra-desktop_<version>_windows_amd64.zip` |
 | Linux | `hydra-desktop_<version>_linux_amd64.tar.gz` |
 
+Each artifact ships a `.sha256` next to it. Until the builds are signed this is the only integrity
+check available, so it is worth the one command:
+
+```bash
+shasum -a 256 -c hydra-desktop_<version>_darwin_universal.zip.sha256   # macOS
+sha256sum   -c hydra-desktop_<version>_linux_amd64.tar.gz.sha256       # Linux
+```
+
+```powershell
+# Windows (PowerShell)
+$f = "hydra-desktop_<version>_windows_amd64.zip"
+(Get-FileHash $f -Algorithm SHA256).Hash -eq (Get-Content "$f.sha256").Split(' ')[0]   # → True
+```
+
 **The builds are not code-signed yet**, so the first launch takes one extra step:
 
 - **macOS** — Gatekeeper will say Hydra "cannot be opened because it is from an unidentified

--- a/desktop/build/darwin/Info.plist
+++ b/desktop/build/darwin/Info.plist
@@ -7,8 +7,14 @@
         <string>{{.Info.ProductName}}</string>
         <key>CFBundleExecutable</key>
         <string>{{.OutputFilename}}</string>
+        <!-- Hardcoded, not the com.wails.<name> the Wails template ships: that
+             namespace belongs to the Wails project, not us, and this is the
+             identity macOS keys preferences, TCC permissions and update
+             comparisons off. Changing it after users have installed resets all
+             of that, and notarization requires it to sit under a domain the
+             signing team owns — hydra.uvansa.com reversed. -->
         <key>CFBundleIdentifier</key>
-        <string>com.wails.{{safeBundleID .Name}}</string>
+        <string>com.uvansa.hydra</string>
         <key>CFBundleVersion</key>
         <string>{{.Info.ProductVersion}}</string>
         <key>CFBundleGetInfoString</key>

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -7,8 +7,11 @@
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",
   "frontend:dev:serverUrl": "auto",
+  "//productVersion": "Deliberately absent. desktop-build.yml injects it from the release version before calling wails build, because it feeds CFBundleVersion/CFBundleShortVersionString in build/darwin/Info.plist. A static value here would be a second source of truth that goes stale the moment a release ships — the same drift that froze every bundle at Wails' 1.0.0 default (#233). Local builds keep that default on purpose: they are not distributed, and their ldflags say 'dev' to match.",
   "info": {
     "productName": "Hydra",
-    "comments": "Local-first, multi-vendor AI control plane."
+    "comments": "Local-first, multi-vendor AI control plane.",
+    "//copyright": "Matches LICENSE. Unset, Wails ships the literal placeholder 'Copyright.........' into NSHumanReadableCopyright, which macOS shows in Get Info.",
+    "copyright": "Copyright (c) 2025 Ankit Jha. MIT licensed."
   }
 }

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -504,10 +504,18 @@ hydra-desktop_&lt;version&gt;_darwin_universal.zip   <span class="c"># macOS, In
 hydra-desktop_&lt;version&gt;_windows_amd64.zip      <span class="c"># Windows</span>
 hydra-desktop_&lt;version&gt;_linux_amd64.tar.gz     <span class="c"># Linux</span>
 
+<span class="c"># Every artifact ships a .sha256 beside it — verify before you run:</span>
+shasum -a 256 -c hydra-desktop_&lt;version&gt;_darwin_universal.zip.sha256   <span class="c"># macOS</span>
+sha256sum   -c hydra-desktop_&lt;version&gt;_linux_amd64.tar.gz.sha256       <span class="c"># Linux</span>
+
+<span class="c"># Windows (PowerShell):</span>
+$f = "hydra-desktop_&lt;version&gt;_windows_amd64.zip"
+(Get-FileHash $f -Algorithm SHA256).Hash -eq (Get-Content "$f.sha256").Split(' ')[0]
+
 <span class="c"># Or build it yourself:</span>
 go install github.com/wailsapp/wails/v2/cmd/wails@latest
 cd desktop &amp;&amp; wails build                <span class="c"># → desktop/build/bin/Hydra.app</span></pre></div>
-      <div class="callout"><b>The builds are not code-signed yet</b>, so the first launch takes one extra step. <b>macOS:</b> Gatekeeper reports an unidentified developer — right-click the app → <b>Open</b> → <b>Open</b>, once. If it still refuses after unzipping from a terminal, run <span class="fx">xattr -dr com.apple.quarantine Hydra.app</span>. <b>Windows:</b> SmartScreen may warn — <b>More info</b> → <b>Run anyway</b>. <b>Linux:</b> needs <span class="fx">libgtk-3-0</span> and <span class="fx">libwebkit2gtk-4.1-0</span>, then <span class="fx">chmod +x Hydra</span>.</div>
+      <div class="callout"><b>The builds are not code-signed yet</b>, so the published <span class="fx">.sha256</span> is the only integrity check available — worth the one command above. The first launch also takes one extra step. <b>macOS:</b> Gatekeeper reports an unidentified developer — right-click the app → <b>Open</b> → <b>Open</b>, once. If it still refuses after unzipping from a terminal, run <span class="fx">xattr -dr com.apple.quarantine Hydra.app</span>. <b>Windows:</b> SmartScreen may warn — <b>More info</b> → <b>Run anyway</b>. <b>Linux:</b> needs <span class="fx">libgtk-3-0</span> and <span class="fx">libwebkit2gtk-4.1-0</span>, then <span class="fx">chmod +x Hydra</span>.</div>
       <div class="callout">The app reads the same logs the CLI writes, so its numbers are the CLI's numbers — Dashboard totals match <span class="fx">hyctl cost</span> and <span class="fx">hyctl stats</span> for the same data. There is no separate daemon and no telemetry: it reads <span class="fx">~/.hydra/logs/</span> on your machine.</div>
     </section>
 


### PR DESCRIPTION
Carries #234 into the release branch. Without it, v1.1.0 ships desktop bundles that report version
`1.0.0`.

## Why this belongs in v1.1.0 rather than the next release

v1.1.0 is the **first release to ship the desktop app**, so each of these would otherwise be shipped
permanently:

- **`CFBundleVersion` frozen at `1.0.0`** (macOS and Windows both) — this is what macOS compares to
  decide which copy is newer. Left as-is, every future release looks identical to every past one.
- **`com.wails.hydra` identifier** — macOS keys preferences and TCC permissions off it, so changing
  it after users install resets theirs. This is the last cheap moment.
- **`Copyright.........`** — Wails' literal placeholder, shown in Get Info.
- **No published checksum** — which matters *more* because the builds are unsigned, not less: with
  no Developer ID signature to verify, it is the only integrity evidence a downloader has.

## Shape

Adopts `develop`'s tree as a single linear commit on top of the previous release commit, as the
`release/v*` ruleset requires. Verified before pushing:

- the new commit's tree is byte-identical to `origin/develop`
- its parent is exactly the current `release/v1.1.0` head
- the only difference between the two branches is #234's five files — no unrelated drift rides along

## Verification

All of #234's evidence applies unchanged: a real local `wails build` reading back
`1.1.0` / `com.uvansa.hydra` / the correct copyright, `codesign --verify --deep --strict` still
sealing, the app launching, and each documented verify command running green on its own platform in
CI — macOS, Linux, and Windows PowerShell.

This PR's own rc build is the first time the full three-platform matrix runs these steps *with a real
release version* rather than `ci`, so `rc.6` is where `CFBundleVersion=1.1.0` gets confirmed on the
actual artifacts.

Refs #233