### PR TITLE
fix(cli): stop telling users to run `hydra`, which is not the binary

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -210,7 +210,7 @@ func cmdStatus() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cfg, err := config.Load()
 			if err != nil {
-				return fmt.Errorf("no config found — run: hydra init")
+				return fmt.Errorf("no config found — run: hyctl init")
 			}
 
 			fmt.Println()
@@ -1000,7 +1000,7 @@ func cmdModels() *cobra.Command {
 			if syncDry {
 				word = "would import"
 			}
-			fmt.Printf("\n  %s %d models (%d already known, skipped). capScores are provisional — refine with `hydra models add`.\n\n", word, added, skipped)
+			fmt.Printf("\n  %s %d models (%d already known, skipped). capScores are provisional — refine with `hyctl models add`.\n\n", word, added, skipped)
 			return nil
 		},
 	}
@@ -1710,17 +1710,17 @@ func cmdStats() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stats",
 		Short: "Spend analytics — model, tier, day, and swarm breakdowns",
-		Long: `hydra stats shows cost.jsonl summaries with rich grouping options.
+		Long: `hyctl stats shows cost.jsonl summaries with rich grouping options.
 
 Examples:
-  hydra stats                  # today summary
-  hydra stats --days 7         # last 7 days, grouped by model
-  hydra stats --model          # all-time by model
-  hydra stats --tier           # all-time by tier
-  hydra stats --day            # all-time by day
-  hydra stats --swarm          # swarm-only stats + winner rate
-  hydra stats --session <id>   # single session/task breakdown
-  hydra stats --json           # machine-readable output`,
+  hyctl stats                  # today summary
+  hyctl stats --days 7         # last 7 days, grouped by model
+  hyctl stats --model          # all-time by model
+  hyctl stats --tier           # all-time by tier
+  hyctl stats --day            # all-time by day
+  hyctl stats --swarm          # swarm-only stats + winner rate
+  hyctl stats --session <id>   # single session/task breakdown
+  hyctl stats --json           # machine-readable output`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			all, err := cost.LoadAll()
 			if err != nil {
@@ -1967,7 +1967,7 @@ func cmdTrustStats() *cobra.Command {
 				return json.NewEncoder(os.Stdout).Encode(s)
 			}
 			if s.Runs == 0 {
-				fmt.Println("\n  No SPRT runs yet. Try `hydra dispatch --confidence 0.95 --prompt ...`.")
+				fmt.Println("\n  No SPRT runs yet. Try `hyctl dispatch --confidence 0.95 --prompt ...`.")
 				return nil
 			}
 			fmt.Printf("\n  Trust stats (%d runs)\n", s.Runs)
@@ -2046,7 +2046,7 @@ func cmdTrustCalibration() *cobra.Command {
 				return json.NewEncoder(os.Stdout).Encode(stats)
 			}
 			if len(stats) == 0 {
-				fmt.Println("\n  No calibration recorded yet. Feed outcomes with `hydra trust record`.")
+				fmt.Println("\n  No calibration recorded yet. Feed outcomes with `hyctl trust record`.")
 				return nil
 			}
 			fmt.Printf("\n  %-28s %-10s %6s %7s %7s %8s\n", "Source", "Domain", "n", "se", "sp", "D(nats)")
@@ -2128,7 +2128,7 @@ func cmdTrustDefect() *cobra.Command {
 			}
 			fmt.Printf("  defect cost ≈ $%.2f  (blast=%.2f [%s] irreversible=%v pii=%v prod=%v)\n",
 				dm.CostUSD(task), blast, blastSource, irreversible, pii, production)
-			fmt.Printf("  → demands confidence ≥ %.1f%%  (use with: hydra dispatch --confidence %.3f)\n",
+			fmt.Printf("  → demands confidence ≥ %.1f%%  (use with: hyctl dispatch --confidence %.3f)\n",
 				dm.RequiredConfidence(task)*100, dm.RequiredConfidence(task))
 			return nil
 		},

--- a/cmd/hydra/naming_test.go
+++ b/cmd/hydra/naming_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// The binary is hyctl. Cobra prints `Use` correctly on its own, but every
+// hand-written error string, help Long and Example is just text nobody
+// recompiles against — so the #150 rename left 37 of them across 12 files still
+// telling users to run `hydra <something>`. `hyctl status` on a fresh machine
+// answered "no config found — run: hydra init", which is a command that does
+// not exist. That is the first thing a new user sees.
+//
+// Command names come from the real tree rather than a hardcoded list, so adding
+// a subcommand extends this guard automatically.
+func TestUserFacingText_NeverNamesABinaryThatDoesNotExist(t *testing.T) {
+	var names []string
+	var collect func(*cobra.Command)
+	collect = func(c *cobra.Command) {
+		for _, sub := range c.Commands() {
+			names = append(names, regexp.QuoteMeta(sub.Name()))
+			collect(sub)
+		}
+	}
+	collect(rootCmd())
+	if len(names) == 0 {
+		t.Fatal("no subcommands found — the guard would silently pass")
+	}
+
+	stale := regexp.MustCompile(`\bhydra (` + strings.Join(names, "|") + `)\b`)
+
+	// Tests run in cmd/hydra; the tree to scan is the module root.
+	roots := []string{filepath.Join("..", "..", "cmd"), filepath.Join("..", "..", "internal")}
+	self := "naming_test.go"
+
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") || d.Name() == self {
+				return nil
+			}
+			src, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			for i, line := range strings.Split(string(src), "\n") {
+				if m := stale.FindString(line); m != "" {
+					t.Errorf("%s:%d says %q — the binary is hyctl, so that command does not exist:\n    %s",
+						path, i+1, m, strings.TrimSpace(line))
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", root, err)
+		}
+	}
+}

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -193,8 +193,8 @@ func RemoveModel(path, id string) (removed bool, err error) {
 }
 
 // HeuristicCapScore estimates a provisional capScore from a model id/name, used
-// by `hydra models sync` when importing from OpenRouter. Deliberately rough —
-// users can override with `hydra models add`.
+// by `hyctl models sync` when importing from OpenRouter. Deliberately rough —
+// users can override with `hyctl models add`.
 func HeuristicCapScore(id string) int {
 	s := strings.ToLower(id)
 	switch {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -82,7 +82,7 @@ func (d *Dispatcher) EstimateCost(tier, inputTokens, outputTokens int) float64 {
 func New(ctx context.Context) (*Dispatcher, error) {
 	cfg, err := config.Load()
 	if err != nil {
-		return nil, fmt.Errorf("no hydra config — run: hydra init")
+		return nil, fmt.Errorf("no hydra config — run: hyctl init")
 	}
 
 	result := probe.Run(ctx)
@@ -498,7 +498,7 @@ func (d *Dispatcher) syncStateJSON(r *Result) {
 	existing["last_tier"] = rank.UITier(r.Head)
 
 	// Append the current orchestrator claude_pct (written by the orchestrator,
-	// e.g. `jq '.claude_pct = 52'`) to a bounded history, so `hydra status` can
+	// e.g. `jq '.claude_pct = 52'`) to a bounded history, so `hyctl status` can
 	// compute a rate-aware first-passage risk from the session trajectory rather
 	// than reacting only to the instantaneous level.
 	if pct := asInt(existing["claude_pct"]); pct > 0 {

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -315,7 +315,7 @@ func jaccard(a, b map[string]bool) float64 {
 	return float64(inter) / float64(union)
 }
 
-// Dependents returns the direct dependents of a node (for `hydra graph blast`).
+// Dependents returns the direct dependents of a node (for `hyctl graph blast`).
 func (g *Graph) Dependents(nodeID string) []string {
 	if g == nil {
 		return nil

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -446,7 +446,7 @@ type Summary struct {
 	ByTool  map[string]int `json:"by_tool"`
 }
 
-// Summarize aggregates events for `hydra mcp report`.
+// Summarize aggregates events for `hyctl mcp report`.
 func Summarize(events []Event) Summary {
 	s := Summary{ByAgent: map[string]int{}, ByTool: map[string]int{}}
 	for _, e := range events {

--- a/internal/trust/defect.go
+++ b/internal/trust/defect.go
@@ -37,8 +37,8 @@ const maxConfidence = 0.999
 
 // DefectModel prices the cost of shipping an incorrect answer for a task. That
 // cost sets how much confidence a task must clear before Hydra stops sampling
-// (RequiredConfidence) and is surfaced in `hydra dispatch --confidence --file`,
-// `hydra trust defect`, and `hydra dispatch --dry-run`.
+// (RequiredConfidence) and is surfaced in `hyctl dispatch --confidence --file`,
+// `hyctl trust defect`, and `hyctl dispatch --dry-run`.
 type DefectModel struct {
 	W DefectWeights
 	// ToleratedLeakUSD is the expected leaked-defect cost held constant by

--- a/internal/trust/log.go
+++ b/internal/trust/log.go
@@ -16,7 +16,7 @@ import (
 )
 
 // RunLog is one persisted SPRT run — the data the "By The Numbers" page
-// graduates from [MODEL] to [MEASURED], and what `hydra trust stats/explain` read.
+// graduates from [MODEL] to [MEASURED], and what `hyctl trust stats/explain` read.
 type RunLog struct {
 	TS         string     `json:"ts"`
 	TaskHash   string     `json:"task_hash"`
@@ -39,7 +39,7 @@ func DefaultLogPath() string {
 }
 
 // TaskHash is a short stable identifier for a prompt, used to correlate a run
-// with `hydra trust explain <task_hash>`.
+// with `hyctl trust explain <task_hash>`.
 func TaskHash(prompt string) string {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(prompt))
@@ -101,7 +101,7 @@ func LoadRuns(path string) ([]RunLog, error) {
 	return runs, scanner.Err()
 }
 
-// Stats is the aggregate view produced by `hydra trust stats`.
+// Stats is the aggregate view produced by `hyctl trust stats`.
 type Stats struct {
 	Runs            int     `json:"runs"`
 	MeanSamples     float64 `json:"mean_samples"`

--- a/internal/trust/sprt_test.go
+++ b/internal/trust/sprt_test.go
@@ -12,7 +12,7 @@ import (
 
 // calibrateSymmetric trains (id,domain) to se=sp≈p using n balanced samples.
 // calibrateSymmetric trains (id,domain) to se=sp≈p; it delegates to the
-// production helper backing `hydra trust benchmark` so the two never diverge.
+// production helper backing `hyctl trust benchmark` so the two never diverge.
 func calibrateSymmetric(c *Calibrator, id, domain string, p float64, n int) {
 	calibrateSynthetic(c, id, domain, p, n)
 }

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -2,7 +2,7 @@
 
 package tui
 
-// cockpit.go — the interactive terminal cockpit (`hydra tui`).
+// cockpit.go — the interactive terminal cockpit (`hyctl tui`).
 // A real Bubble Tea program: chat/console + heads sidebar + live routing
 // decisions, with a dashboard view (Tab). Neon identity, aqua interaction.
 
@@ -143,7 +143,7 @@ func ckTierColor(tier int) lipgloss.Color {
 	}
 }
 
-// Cockpit is the interactive `hydra tui` model.
+// Cockpit is the interactive `hyctl tui` model.
 type Cockpit struct {
 	w, h      int
 	ready     bool
@@ -585,7 +585,7 @@ func CockpitSnapshotView(view int) string {
 }
 
 // CockpitSnapshot renders all three views stacked, each labelled — the
-// representative frame shown by `hydra tui --snapshot`.
+// representative frame shown by `hyctl tui --snapshot`.
 func CockpitSnapshot() string {
 	label := func(s string) string { return ckLabelS.Render("── " + s + " " + strings.Repeat("─", 40)) }
 	return label("VIEW 1/3 · CHAT + CODE (tab)") + "\n" + CockpitSnapshotView(0) + "\n\n" +

--- a/internal/tui/cockpit_test.go
+++ b/internal/tui/cockpit_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// `hydra tui --snapshot --view 3` used to panic with an index-out-of-range:
+// `hyctl tui --snapshot --view 3` used to panic with an index-out-of-range:
 // header() indexed a 3-element slice literal with an unvalidated m.view.
 func TestCockpitSnapshotView_OutOfRangeDoesNotPanic(t *testing.T) {
 	for _, view := range []int{-1, -100, 3, 99} {

--- a/internal/tui/init.go
+++ b/internal/tui/init.go
@@ -245,7 +245,7 @@ func (m InitModel) save() error {
 }
 
 // exportToRoutingYAML appends a discovered_heads block to registry/routing.yaml
-// so that route.sh and human operators can see what hydra init found.
+// so that route.sh and human operators can see what hyctl init found.
 // Any existing auto-discovered block is replaced.
 func exportToRoutingYAML(tiers []config.Tier, cortex *provider.Head) error {
 	routingPath := filepath.Join(config.ScriptHome(), "registry", "routing.yaml")
@@ -256,7 +256,7 @@ func exportToRoutingYAML(tiers []config.Tier, cortex *provider.Head) error {
 	}
 
 	// Strip any previously written discovered block.
-	const marker = "\n# ── Auto-discovered by hydra init"
+	const marker = "\n# ── Auto-discovered by hyctl init"
 	base := string(existing)
 	if idx := strings.Index(base, marker); idx != -1 {
 		base = base[:idx]
@@ -267,7 +267,7 @@ func exportToRoutingYAML(tiers []config.Tier, cortex *provider.Head) error {
 	b.WriteString(marker)
 	b.WriteString(" ────────────────────────────────────────\n")
 	b.WriteString(fmt.Sprintf("# Generated: %s\n", time.Now().UTC().Format("2006-01-02T15:04:05Z")))
-	b.WriteString("# Re-run `hydra init` to refresh.\n")
+	b.WriteString("# Re-run `hyctl init` to refresh.\n")
 	b.WriteString("discovered_heads:\n")
 	if cortex != nil {
 		b.WriteString(fmt.Sprintf("  cortex: %s\n", cortex.ID))

--- a/internal/tui/install.go
+++ b/internal/tui/install.go
@@ -304,7 +304,7 @@ func (m InstallModel) View() string {
 		if opt.envKey != "" || opt.installCmd == "" {
 			b.WriteString(sPrompt.Render("  Manual steps:\n"))
 			b.WriteString("  " + codeStyle.Render(opt.postInstall) + "\n\n")
-			b.WriteString(sDim.Render("  After setting up, run: hydra init\n"))
+			b.WriteString(sDim.Render("  After setting up, run: hyctl init\n"))
 			b.WriteString(sHint.Render("\n  Press enter to exit\n"))
 			return b.String()
 		}
@@ -328,13 +328,13 @@ func (m InstallModel) View() string {
 	case installStepDone:
 		if m.err {
 			b.WriteString(sError.Render("  Install failed.\n\n"))
-			b.WriteString(sDim.Render("  Try running the command manually, then: hydra init\n"))
+			b.WriteString(sDim.Render("  Try running the command manually, then: hyctl init\n"))
 		} else {
 			b.WriteString(successStyle.Render("  Done!\n\n"))
 			if m.selected != nil {
 				b.WriteString("  " + codeStyle.Render(m.selected.postInstall) + "\n\n")
 			}
-			b.WriteString(sDim.Render("  Then run: hydra init\n"))
+			b.WriteString(sDim.Render("  Then run: hyctl init\n"))
 		}
 	}
 


### PR DESCRIPTION
Found by running the shipped `v1.1.0-rc.6` CLI with a fresh `HOME` — the state of someone who has
just installed it.

```console
$ hyctl status
Error: no config found — run: hydra init

$ hydra init
zsh: command not found: hydra
```

#150 renamed the binary to `hyctl`. Cobra prints `Use` on its own, so `hyctl --help` was right —
but every hand-written error string, help `Long` and `Example` is just text that nothing recompiles
against. **37 occurrences across 12 files** still named `hydra`.

They are not obscure corners. That is the *first* message a new user sees. Others:

| command | said |
|---|---|
| `hyctl trust calibration` | ``Feed outcomes with `hydra trust record`.`` |
| `hyctl trust stats` | ``Try `hydra dispatch --confidence 0.95 …`.`` |
| `hyctl models sync` | ``refine with `hydra models add` `` |
| `hyctl stats --help` | eight example lines, every one `hydra stats …` |

## The guard matters more than the fix

A rename that misses strings is invisible to the compiler, so this class recurs by default. The
test derives its command list from the **real cobra tree** (`rootCmd()`), not a hardcoded list — so
adding a subcommand extends the guard automatically, and it cannot rot the way the thing it guards
did.

Verified the way a guard has to be: **reintroduced the defect** in `internal/dispatch/dispatch.go`
and confirmed it fails on the right file and line, then restored it and confirmed it passes.

```
naming_test.go:58: ../../internal/dispatch/dispatch.go:85 says "hydra init" —
    the binary is hyctl, so that command does not exist
```

## Scope

- Docs needed no change — `README.md` and `docs/` already had zero stale names. The #150 rename
  updated them and missed only the Go strings.
- `hyctl version` still prints `hydra <version>`. That names the **product**, not a command to type,
  so it is deliberately left alone.

## Checks

`go build ./...`, `go vet ./...`, `go test ./...` and `go test -race ./...` all clean.

Closes #236