### PR TITLE
fix(dist): ship the registry inside the binary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,11 +44,20 @@ internal/{cost,budget}/ ← Spend reporting (est/actual labeling) + token-budget
 internal/capabilities/  ← Model capability scores: embedded data.json ⊕ runtime user overlay (~/.hydra/models.json). `hyctl models`.
 internal/util/          ← Shared utilities (Accumulator, etc).
 
-registry/routing.yaml   ← THE ENUM. Change tier assignments here only.
-registry/models.yaml    ← Model definitions, token pools, fallback chains (flags are
-                          install-specific defaults — verify against your providers).
-registry/domains.yaml   ← Domain → enum key routing (references routing.yaml).
-registry/pricing.yaml   ← Static tier pricing fallback (used when offline).
+registry/               ← Routing data, compiled into the binary via `go:embed` (registry.go)
+                          and overridable on disk at `$HYDRA_HOME/registry/<file>`. Nothing ships
+                          these files as separate artifacts — brew/npm/pip/curl install the binary
+                          alone, so before #238 every install ran with no registry at all.
+  routing.yaml          ← Enum → tier reference table, and what `hyctl init` writes. NOTE: the
+                          runtime mapping is `dispatch.EnumToTier`, a hardcoded Go switch — editing
+                          this file alone does NOT change how a dispatch routes.
+  models.yaml           ← Model definitions, token pools, context windows, fallback chains (flags
+                          are install-specific defaults — verify against your providers). Read by
+                          the agy provider and the budget governor.
+  domains.yaml          ← Domain → enum key routing (references routing.yaml).
+  pricing.yaml          ← Tier pricing. Prices the CLI-agent heads that never appear in
+                          OpenRouter's catalog, so it is load-bearing, not just an offline fallback.
+  policy.yaml           ← File-policy rules.  workspace.yaml ← workspace roots + validators.
 logs/                   ← Dispatch log + state.json (pool exhaustion, claude_pct).
 ```
 
@@ -59,7 +68,8 @@ logs/                   ← Dispatch log + state.json (pool exhaustion, claude_p
 ### Step 1 — Classify
 Read `registry/domains.yaml` to identify the domain and task type.
 Look up the enum key (e.g. `SIMPLE`, `COMPLEX`).
-Check `registry/routing.yaml` to resolve the enum key to a tier number.
+`registry/routing.yaml` documents which tier that enum resolves to; the mapping the router
+actually applies is `dispatch.EnumToTier`.
 
 ### Step 2 — Check State
 ```bash
@@ -714,6 +724,7 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/cost` | Reads `cost.jsonl`, produces spend summaries |
 | `internal/policy` | Allow/deny rules (PII local-only, etc.) |
 | `internal/rank` | CapScore ranking helpers |
+| `registry` | The routing YAML **and** the `go:embed` that compiles it into the binary. `registry.Read(home, name)` prefers `$HYDRA_HOME/registry/<name>` so operators can retune without a rebuild, and falls back to the embedded copy — which is what every brew/npm/pip/curl install uses, since none of them ship the files (#238). |
 | `internal/config` | Hydra config load/save (`~/.config/hydra/`); `Breadcrumb()` — SHA256 deployment-identity fingerprint over `registry/{routing,models,domains}.yaml`, auto-stamped into ledger/trust/cost log entries so they can be tied back to the exact routing rules in effect. |
 | `internal/capabilities` | Model capability scores: embedded `data.json` ⊕ runtime user overlay (`~/.hydra/models.json`) merged at discovery, so new models are added without a rebuild. Drives `hyctl models list\|add\|remove\|sync`. |
 | `internal/budget` | Token-budget governor: static pressure bands (`ModeFor`) + a rate-aware first-passage-time model on the orchestrator's `claude_pct` session history (`RiskFromHistory`/`EffectiveMode`) that escalates before a threshold is crossed. Feeds `claudeMode` downgrades and `hyctl status`. |
@@ -739,8 +750,10 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 pricing.Load()
   → readCache()           # ~/.config/hydra/pricing_cache.json (24h TTL)
   → fetchFromOpenRouter() # background refresh if stale
-  → loadFallbackTiers()   # registry/pricing.yaml (always loaded)
+  → loadFallbackTiers()   # registry/pricing.yaml — embedded in the binary, on-disk copy wins
 ```
+The tier table is not just an offline fallback: it is what prices the CLI-agent heads (claude, agy,
+codex, cursor…) that never appear in OpenRouter's catalog.
 `HYDRA_PRICING_TTL_HOURS` overrides the 24h TTL.
 `hyctl pricing refresh` forces a synchronous fetch.
 `hyctl pricing list [filter] [--json]` shows all known models.

--- a/README.md
+++ b/README.md
@@ -624,7 +624,8 @@ hydra/
 ├── desktop/                     # Desktop app (own Go module) — Wails v2 + React/TS
 │   ├── api/                     # Go backend: Dashboard · Fleet · Session · Code · chat (no Wails imports)
 │   └── frontend/                # React views over the same logs the CLI writes
-├── registry/                    # routing.yaml (the enum) · models · domains · pricing · policy
+├── registry/                    # routing · models · domains · pricing · policy — go:embed'd into
+│                                #   the binary; $HYDRA_HOME/registry/<file> overrides it
 ├── docs/                        # GitHub Pages (hydra.uvansa.com) — index.html, llms.txt
 └── Formula/hydra.rb             # Homebrew formula (auto-updated by GoReleaser)
 ```

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -3,6 +3,8 @@
 package budget
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 )
@@ -241,14 +243,42 @@ func TestEffectiveMode(t *testing.T) {
 	}
 }
 
-func TestLoadWindows_Fallback(t *testing.T) {
-	// Non-existent path → empty map, no panic.
+// This used to assert an empty map for a missing registry, which described the
+// bug rather than a requirement: models.yaml was absent on every installed
+// binary, so context windows silently fell back to a flat 200k for everything
+// (#238). It is embedded now, so the honest contract is that a machine with no
+// on-disk registry still gets the real windows.
+func TestLoadWindows_UsesEmbeddedRegistryWhenNoneIsOnDisk(t *testing.T) {
 	windows := LoadWindows("/no/such/path")
-	if windows == nil {
-		t.Fatal("LoadWindows should return empty map, not nil")
+	if len(windows) == 0 {
+		t.Fatal("no windows loaded — the embedded registry should always be readable")
 	}
-	if len(windows) != 0 {
-		t.Errorf("want empty map for missing registry, got %d entries", len(windows))
+	for id, w := range windows {
+		if w <= 0 {
+			t.Errorf("%s has a non-positive context window (%d)", id, w)
+		}
+	}
+}
+
+// The override is the reason the files stay editable YAML rather than becoming
+// Go constants; if it stops working, operators lose the ability to retune
+// routing without a rebuild and would have no way to tell.
+func TestLoadWindows_OnDiskRegistryOverridesTheEmbeddedCopy(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "registry"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "models:\n  - id: only-model\n    provider: ollama\n    context_window: 4242\n"
+	if err := os.WriteFile(filepath.Join(home, "registry", "models.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	windows := LoadWindows(home)
+	if got := windows["only-model"]; got != 4242 {
+		t.Errorf("on-disk models.yaml ignored: only-model window = %d, want 4242", got)
+	}
+	if len(windows) != 1 {
+		t.Errorf("embedded entries leaked through the override: got %d windows, want 1", len(windows))
 	}
 }
 

--- a/internal/budget/windows.go
+++ b/internal/budget/windows.go
@@ -5,10 +5,9 @@
 package budget
 
 import (
-	"os"
-	"path/filepath"
-
 	"gopkg.in/yaml.v3"
+
+	"github.com/ankit373/hydra/registry"
 )
 
 const (
@@ -26,13 +25,17 @@ type modelsFile struct {
 	Models []modelEntry `yaml:"models"`
 }
 
-// LoadWindows reads registry/models.yaml relative to the repo root and returns
-// a map of model-id → context window size. Missing entries get provider-based
-// fallbacks (ollama → 32 768, everything else → 200 000).
-func LoadWindows(registryDir string) map[string]int {
+// LoadWindows reads registry/models.yaml — an on-disk copy under home if one
+// exists, otherwise the copy embedded in the binary — and returns a map of
+// model-id → context window size. Missing entries get provider-based fallbacks
+// (ollama → 32 768, everything else → 200 000).
+//
+// home is the Hydra home directory, not the registry directory: Read appends
+// "registry" itself so every caller resolves the override the same way.
+func LoadWindows(home string) map[string]int {
 	out := map[string]int{}
 
-	raw, err := os.ReadFile(filepath.Join(registryDir, "models.yaml"))
+	raw, err := registry.Read(home, "models.yaml")
 	if err != nil {
 		return out
 	}

--- a/internal/config/breadcrumb.go
+++ b/internal/config/breadcrumb.go
@@ -6,8 +6,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"os"
-	"path/filepath"
+
+	"github.com/ankit373/hydra/registry"
 )
 
 // BreadcrumbFiles are the registry files that define this deployment's
@@ -26,11 +26,16 @@ var BreadcrumbFiles = []string{"routing.yaml", "models.yaml", "domains.yaml", "p
 // process-lifetime cache would serve a stale fingerprint to the long-running
 // TUI after `hyctl init` or a registry edit. Freshness is worth more than the
 // microseconds. Revisit only with a profile that says otherwise.
+// Reads each file through registry.Read, so an installed binary fingerprints
+// its embedded rules and an operator with on-disk overrides fingerprints those
+// instead — which is the distinction the breadcrumb exists to record. Before
+// #238 this read disk only and returned an error on every installed binary, so
+// the fingerprint was silently absent from exactly the logs it was added for.
 func Breadcrumb() (string, error) {
-	dir := filepath.Join(ScriptHome(), "registry")
+	home := ScriptHome()
 	h := sha256.New()
 	for _, name := range BreadcrumbFiles {
-		raw, err := os.ReadFile(filepath.Join(dir, name))
+		raw, err := registry.Read(home, name)
 		if err != nil {
 			return "", err
 		}

--- a/internal/config/breadcrumb_test.go
+++ b/internal/config/breadcrumb_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/testutil"
+	"github.com/ankit373/hydra/registry"
 )
 
 func TestBreadcrumb_DeterministicForSameRegistry(t *testing.T) {
@@ -98,9 +99,39 @@ func TestBreadcrumb_CoversPricing(t *testing.T) {
 	}
 }
 
-func TestBreadcrumb_MissingRegistryErrors(t *testing.T) {
+// BreadcrumbFiles and the embedded set are maintained in different packages, so
+// adding a file to one without the other would make Breadcrumb error on every
+// installed binary again — silently, since callers stamp a blank fingerprint
+// rather than failing.
+func TestBreadcrumbFiles_AreAllEmbeddedInTheBinary(t *testing.T) {
+	for _, name := range config.BreadcrumbFiles {
+		if _, err := registry.Read("", name); err != nil {
+			t.Errorf("%s is in BreadcrumbFiles but not embedded in the registry package: %v", name, err)
+		}
+	}
+}
+
+// This used to assert an error for a missing registry — which was every
+// installed binary, so the fingerprint was absent from exactly the ledger,
+// trust and cost logs it exists to stamp (#238). The registry is embedded now,
+// so a machine with nothing on disk must still produce a stable fingerprint:
+// that of the rules the binary actually shipped with.
+func TestBreadcrumb_FingerprintsTheEmbeddedRulesWhenNothingIsOnDisk(t *testing.T) {
 	t.Setenv("HYDRA_HOME", t.TempDir()) // no registry/ dir at all
-	if _, err := config.Breadcrumb(); err == nil {
-		t.Error("Breadcrumb should error when registry files are unreadable")
+
+	first, err := config.Breadcrumb()
+	if err != nil {
+		t.Fatalf("Breadcrumb failed with no on-disk registry: %v", err)
+	}
+	if first == "" {
+		t.Fatal("Breadcrumb returned an empty fingerprint")
+	}
+
+	second, err := config.Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Errorf("embedded fingerprint is not stable: %s then %s", first, second)
 	}
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -92,8 +92,7 @@ func New(ctx context.Context) (*Dispatcher, error) {
 		localOnly = true
 	}
 
-	registryDir := filepath.Join(config.ScriptHome(), "registry")
-	budgetReg := budget.NewRegistry(budget.LoadWindows(registryDir))
+	budgetReg := budget.NewRegistry(budget.LoadWindows(config.ScriptHome()))
 
 	return &Dispatcher{
 		cfg:     cfg,

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -30,16 +30,24 @@ func TestRecord_StampsConfigBreadcrumbWhenBlank(t *testing.T) {
 	}
 }
 
-func TestRecord_ConfigOmittedGracefullyWithoutRegistry(t *testing.T) {
+// The ledger is an accountability record: an event that cannot say which
+// routing rules were in effect is materially weaker evidence. This used to
+// assert Config stays *empty* without an on-disk registry — which was every
+// installed binary, so the field the breadcrumb was built for was blank in
+// practice (#238). With the registry embedded, it must always be stamped.
+func TestRecord_StampsConfigEvenWithNoOnDiskRegistry(t *testing.T) {
 	t.Setenv("HYDRA_HOME", t.TempDir()) // no registry/ present
 
 	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
 	if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
-		t.Fatalf("Record should not fail when the breadcrumb is unavailable: %v", err)
+		t.Fatalf("Record failed: %v", err)
 	}
 	events, _ := Load(path)
-	if len(events) != 1 || events[0].Config != "" {
-		t.Errorf("Config should stay empty when registry files are unreadable, got %+v", events)
+	if len(events) != 1 {
+		t.Fatalf("want 1 event, got %d", len(events))
+	}
+	if events[0].Config == "" {
+		t.Error("Config is empty — the event cannot be tied back to the rules that produced it")
 	}
 }
 

--- a/internal/policy/file_policy.go
+++ b/internal/policy/file_policy.go
@@ -5,12 +5,13 @@ package policy
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/ankit373/hydra/registry"
 )
 
 // Spec is the input to the file policy evaluator — describes the task.
@@ -73,12 +74,12 @@ type FilePolicyEngine struct {
 	pf policyFile
 }
 
-// LoadFilePolicy reads registry/policy.yaml relative to hydraHome.
+// LoadFilePolicy reads registry/policy.yaml — an on-disk copy under hydraHome
+// if one exists, otherwise the copy embedded in the binary (#238).
 func LoadFilePolicy(hydraHome string) (*FilePolicyEngine, error) {
-	path := filepath.Join(hydraHome, "registry", "policy.yaml")
-	raw, err := os.ReadFile(path)
+	raw, err := registry.Read(hydraHome, "policy.yaml")
 	if err != nil {
-		return nil, fmt.Errorf("policy.yaml not found at %s", path)
+		return nil, fmt.Errorf("policy.yaml unreadable: %w", err)
 	}
 	var pf policyFile
 	if err := yaml.Unmarshal(raw, &pf); err != nil {

--- a/internal/pricing/fallback.go
+++ b/internal/pricing/fallback.go
@@ -3,10 +3,8 @@
 package pricing
 
 import (
-	"os"
-	"path/filepath"
-
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/registry"
 	"gopkg.in/yaml.v3"
 )
 
@@ -14,11 +12,15 @@ type fallbackYAML struct {
 	Tiers map[int]TierPrice `yaml:"tiers"`
 }
 
-// loadFallbackTiers reads tier pricing from registry/pricing.yaml.
-// This is always available — it ships with the binary.
+// loadFallbackTiers reads tier pricing from registry/pricing.yaml — an on-disk
+// copy if one exists, otherwise the copy embedded in the binary.
+//
+// This genuinely is always available now. It used to claim that while reading
+// only from disk, so every installed binary fell through to $0.00 for every
+// tier — which is what prices the CLI-agent heads that never appear in
+// OpenRouter's catalog (#238).
 func loadFallbackTiers() (map[int]TierPrice, error) {
-	path := filepath.Join(config.ScriptHome(), "registry", "pricing.yaml")
-	raw, err := os.ReadFile(path)
+	raw, err := registry.Read(config.ScriptHome(), "pricing.yaml")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -294,3 +294,42 @@ func TestParsePerToken(t *testing.T) {
 		}
 	}
 }
+
+// Hydra is a cost router, so a tier that prices at $0.00 is not a missing
+// feature — it is a wrong number presented as a real one. registry/pricing.yaml
+// used to be read from disk only, and no install path ships it, so every
+// installed binary logged a WARNING and then estimated every CLI-agent head at
+// zero (#238). Those heads never appear in OpenRouter's catalog, so the tier
+// table is the only thing that prices them.
+//
+// HYDRA_HOME points at an empty dir to reproduce an installed machine: no
+// registry on disk, nothing to walk up to.
+func TestLoadFallbackTiers_NonZeroOnAMachineWithNoRegistryOnDisk(t *testing.T) {
+	t.Setenv("HYDRA_HOME", t.TempDir())
+
+	tiers, err := loadFallbackTiers()
+	if err != nil {
+		t.Fatalf("tier pricing unreadable with no on-disk registry: %v", err)
+	}
+	if len(tiers) == 0 {
+		t.Fatal("no tiers loaded — every cost estimate would be $0.00")
+	}
+	// Tier 10 is the local Ollama head and is genuinely free — asserting
+	// non-zero across the board would encode a wrong expectation, not a
+	// stronger guarantee. Every paid tier must be priced.
+	const localTier = 10
+	paid := 0
+	for tier, tp := range tiers {
+		if tier == localTier {
+			continue
+		}
+		if tp.InputPerMillion <= 0 && tp.OutputPerMillion <= 0 {
+			t.Errorf("tier %d prices at $0.00 in and out", tier)
+			continue
+		}
+		paid++
+	}
+	if paid == 0 {
+		t.Fatal("no paid tier carries a price — every API head would estimate at $0.00")
+	}
+}

--- a/internal/provider/agy/provider.go
+++ b/internal/provider/agy/provider.go
@@ -11,13 +11,12 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/registry"
 )
 
 // agiTierScores maps registry tier numbers to capability scores.
@@ -37,10 +36,12 @@ type Provider struct{}
 func (p *Provider) ID() string { return "agy" }
 
 func (p *Provider) Discover(_ context.Context) ([]provider.Head, error) {
-	registryPath := filepath.Join(config.ScriptHome(), "registry", "models.yaml")
-	data, err := os.ReadFile(registryPath)
+	// An on-disk registry wins; otherwise the copy embedded in the binary is
+	// used. Before #238 this read disk only and returned nothing when it was
+	// missing, which is every installed binary — so agy, a first-class head,
+	// was silently undiscoverable for anyone who did not clone the repo.
+	data, err := registry.Read(config.ScriptHome(), "models.yaml")
 	if err != nil {
-		// No registry file — binary running without the full repo. Silently return nothing.
 		return nil, nil
 	}
 
@@ -56,7 +57,7 @@ func (p *Provider) Discover(_ context.Context) ([]provider.Head, error) {
 		} `yaml:"models"`
 	}
 	if err := yaml.Unmarshal(data, &reg); err != nil {
-		log.Printf("agy provider: malformed models.yaml at %s: %v — no agy heads available", registryPath, err)
+		log.Printf("agy provider: malformed models.yaml: %v — no agy heads available", err)
 		return nil, nil
 	}
 

--- a/internal/trust/log_test.go
+++ b/internal/trust/log_test.go
@@ -28,16 +28,23 @@ func TestLogRun_StampsConfigBreadcrumbWhenBlank(t *testing.T) {
 	}
 }
 
-func TestLogRun_ConfigOmittedGracefullyWithoutRegistry(t *testing.T) {
+// A trust run's confidence is only interpretable against the routing rules that
+// produced it. This used to assert Config stays *empty* without an on-disk
+// registry — which was every installed binary (#238). With the registry
+// embedded, it must always be stamped.
+func TestLogRun_StampsConfigEvenWithNoOnDiskRegistry(t *testing.T) {
 	t.Setenv("HYDRA_HOME", t.TempDir()) // no registry/ present
 
 	path := filepath.Join(t.TempDir(), "trust.jsonl")
 	if err := LogRun(path, RunLog{TaskHash: "abc"}); err != nil {
-		t.Fatalf("LogRun should not fail when the breadcrumb is unavailable: %v", err)
+		t.Fatalf("LogRun failed: %v", err)
 	}
 	runs, _ := LoadRuns(path)
-	if len(runs) != 1 || runs[0].Config != "" {
-		t.Errorf("Config should stay empty when registry files are unreadable, got %+v", runs)
+	if len(runs) != 1 {
+		t.Fatalf("want 1 run, got %d", len(runs))
+	}
+	if runs[0].Config == "" {
+		t.Error("Config is empty — the run cannot be tied back to the rules that produced it")
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/ankit373/hydra/registry"
 )
 
 // Workspace is a single entry from registry/workspace.yaml.
@@ -50,12 +52,12 @@ type Registry struct {
 	validators map[string]string // ext → command template
 }
 
-// Load reads registry/workspace.yaml relative to hydraHome.
+// Load reads registry/workspace.yaml — an on-disk copy under hydraHome if one
+// exists, otherwise the copy embedded in the binary (#238).
 func Load(hydraHome string) (*Registry, error) {
-	path := filepath.Join(hydraHome, "registry", "workspace.yaml")
-	raw, err := os.ReadFile(path)
+	raw, err := registry.Read(hydraHome, "workspace.yaml")
 	if err != nil {
-		return nil, fmt.Errorf("workspace.yaml not found at %s", path)
+		return nil, fmt.Errorf("workspace.yaml unreadable: %w", err)
 	}
 
 	var rf registryFile

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+
+// Package registry ships Hydra's routing rules inside the binary.
+//
+// These YAML files used to be read from disk only. That works from a repo
+// checkout and fails everywhere else: goreleaser archives just the binary plus
+// LICENSE/NOTICE/README/CHANGELOG, and brew, npm, pip and curl all install the
+// binary alone — so every real install ran with no registry at all. Tier prices
+// silently became $0.00, agy heads silently vanished, and the deployment
+// breadcrumb silently stopped being stamped (#238).
+//
+// Embedding is what makes the files reachable from an installed binary; adding
+// them to the archive would not, because the package managers never copy them
+// anywhere ScriptHome() looks.
+//
+// The Go file lives in the same directory as the YAML on purpose: go:embed
+// cannot reach outside its own package directory, and CLAUDE.md points
+// operators at registry/routing.yaml as the place to change tier assignments.
+// Moving the data to make embedding tidier would invalidate that.
+package registry
+
+import (
+	"embed"
+	"os"
+	"path/filepath"
+)
+
+//go:embed *.yaml
+var embedded embed.FS
+
+// Read returns the contents of registry file name (e.g. "pricing.yaml").
+//
+// A copy on disk at home/registry/name wins, so operators can still edit
+// routing rules without rebuilding — that is the whole point of the registry
+// being YAML. The embedded copy is the fallback, which is what an installed
+// binary uses.
+func Read(home, name string) ([]byte, error) {
+	if home != "" {
+		if raw, err := os.ReadFile(filepath.Join(home, "registry", name)); err == nil {
+			return raw, nil
+		}
+	}
+	return embedded.ReadFile(name)
+}
+
+// Names lists the registry files compiled into the binary.
+func Names() []string {
+	entries, err := embedded.ReadDir(".")
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// An embedded file that fails to parse is worse than a missing one: the binary
+// would ship rules nothing can read, and every consumer would silently fall
+// back to its own defaults — which is the failure #238 was about.
+func TestEmbedded_EveryFileParsesAndIsNotEmpty(t *testing.T) {
+	names := Names()
+	if len(names) == 0 {
+		t.Fatal("no files embedded — go:embed matched nothing")
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			raw, err := Read("", name)
+			if err != nil {
+				t.Fatalf("embedded %s unreadable: %v", name, err)
+			}
+			if len(raw) == 0 {
+				t.Fatalf("embedded %s is empty", name)
+			}
+			var doc any
+			if err := yaml.Unmarshal(raw, &doc); err != nil {
+				t.Fatalf("embedded %s is not valid YAML: %v", name, err)
+			}
+			if doc == nil {
+				t.Fatalf("embedded %s parses to nothing", name)
+			}
+		})
+	}
+}
+
+// The registry stays editable YAML precisely so operators can retune routing
+// without a rebuild. If the override silently stopped winning, edits would
+// appear to do nothing and there would be no error to notice.
+func TestRead_OnDiskCopyOverridesTheEmbeddedOne(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "registry")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := "tiers:\n  1:\n    in: 42.0\n"
+	if err := os.WriteFile(filepath.Join(dir, "pricing.yaml"), []byte(want), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Read(home, "pricing.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("on-disk copy ignored:\n got %q\nwant %q", got, want)
+	}
+
+	// A file the operator has not overridden still comes from the binary.
+	other, err := Read(home, "models.yaml")
+	if err != nil {
+		t.Fatalf("un-overridden file unreadable: %v", err)
+	}
+	embeddedModels, _ := Read("", "models.yaml")
+	if string(other) != string(embeddedModels) {
+		t.Error("un-overridden file did not come from the embedded copy")
+	}
+}
+
+// A home with no registry/ directory is the normal case for an installed
+// binary, and must not be an error.
+func TestRead_FallsBackToEmbeddedWhenHomeHasNoRegistry(t *testing.T) {
+	raw, err := Read(t.TempDir(), "routing.yaml")
+	if err != nil {
+		t.Fatalf("Read failed with no on-disk registry: %v", err)
+	}
+	if len(raw) == 0 {
+		t.Fatal("Read returned nothing")
+	}
+}
+
+func TestRead_UnknownFileIsAnError(t *testing.T) {
+	if _, err := Read("", "nope.yaml"); err == nil {
+		t.Error("Read should fail for a file that is neither on disk nor embedded")
+	}
+}


### PR DESCRIPTION
Found by running the shipped `v1.1.0-rc.6` tarball with a fresh `HOME` — the state of someone who
has just installed Hydra.

```console
$ hyctl pricing list
WARNING — could not load registry/pricing.yaml: … All tier cost estimates will be $0.00.
```

## The gap

`registry/*.yaml` was read from disk only. goreleaser archives the binary plus
LICENSE/NOTICE/README/CHANGELOG, and brew, npm, pip and curl each install **the binary alone** — so
no install path has ever put these files anywhere `config.ScriptHome()` looks. Only a repo clone
had them, which is why this never surfaced in development.

## What it cost, by severity

| file | consequence |
|---|---|
| `pricing.yaml` | **every tier priced at $0.00.** Not merely an offline fallback — this is what prices the CLI-agent heads (claude, agy, codex, cursor) that never appear in OpenRouter's catalog. A cost router was reporting $0.00 for them. |
| `models.yaml` | the agy provider returned no heads — *silently and by design* (`// binary running without the full repo`) — so a documented first-class head was undiscoverable for every installed user. Context windows also collapsed to a flat 200k. |
| `routing/models/domains/pricing` | `Breadcrumb()` errored, so ledger, trust and cost entries carried a **blank deployment fingerprint** — absent from exactly the logs it was added for. |

Model-level pricing was always fine (`pricing refresh` pulls 332 models from OpenRouter). It was the
tier table that was dead. **Routing was never affected** — `dispatch.EnumToTier` is a hardcoded Go
switch.

## Why embed rather than add to the archive

Adding `registry/` to goreleaser's `files:` would not help: brew/npm/pip install the binary alone
and would never copy the YAML anywhere `ScriptHome()` looks. Embedding is what actually makes it
reachable.

The on-disk copy still wins, so operators keep editing YAML instead of rebuilding — that is the
whole reason these are files and not Go constants.

`registry.go` sits beside the YAML because `go:embed` cannot reach outside its own package
directory, and `CLAUDE.md` points operators at `registry/routing.yaml`. Moving the data to make the
embed tidier would have invalidated that.

## About the four changed tests

They asserted the old behaviour — *"registry missing → degrade silently"* — a precondition this
change makes unreachable. They are **re-pointed, not deleted**, at the contract that replaced it,
including the override path, which is the part of this change that could actually be wrong.

One deliberate exemption: the tier-pricing guard skips tier 10. The local Ollama head genuinely is
free, and asserting non-zero across the board would encode a wrong expectation rather than a
stronger guarantee. (I wrote that assertion first, and the test caught me.)

## Verified against an installed binary, not the repo

Built to a directory with no repo above it and run with an empty `HOME` — the installed condition:

- no WARNING on any command
- tier prices load; `hyctl status`, `trust calibration`, `pricing list` all clean
- an on-disk `$HYDRA_HOME/registry/pricing.yaml` still overrides the embedded copy

`go build`, `go vet`, `gofmt`, `go test ./...` and `go test -race ./...` all clean.

## Docs corrected while here

`CLAUDE.md` said `registry/routing.yaml` is *"THE ENUM. Change tier assignments here only."* That is
false — the runtime mapping is `dispatch.EnumToTier`, so editing that file alone changes nothing
about how a dispatch routes. Both the layout table and the Step 1 orchestration instructions now say
what actually happens, and `README.md`'s tree notes the embed.

Closes #238