### PR TITLE
fix(dist): fail closed when checksums.txt does not list the archive

### DIFF
--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -67,18 +67,27 @@ async function main() {
     fail(`download failed — ${e.message}`);
   }
 
-  // Verify against checksums.txt (skip only if the file is absent).
+  // Verify against checksums.txt. Only an unreachable checksums.txt is a
+  // warning — a network blip should not brick `npm install`. A checksums.txt
+  // that downloads but does not list this archive is a broken release and
+  // fails closed: the realistic cause is drift, since `archive` is built here
+  // from goreleaser's name_template, so a template change would otherwise stop
+  // verification happening for every user while installs kept succeeding (#241).
+  let sums;
   try {
-    const sums = (await get(`${base}/checksums.txt`)).toString('utf8');
-    const line = sums.split('\n').find((l) => l.trim().endsWith(archive));
-    if (line) {
-      const expected = line.trim().split(/\s+/)[0];
-      const actual = crypto.createHash('sha256').update(archiveBuf).digest('hex');
-      if (expected !== actual) fail(`checksum mismatch (expected ${expected}, got ${actual})`);
-      console.log('hyctl: checksum verified');
-    }
+    sums = (await get(`${base}/checksums.txt`)).toString('utf8');
   } catch {
     console.warn('hyctl: checksums.txt unavailable — skipping verification');
+  }
+  if (sums !== undefined) {
+    const line = sums.split('\n').find((l) => l.trim().endsWith(archive));
+    if (!line) {
+      fail(`${archive} is not listed in checksums.txt — refusing to install unverified`);
+    }
+    const expected = line.trim().split(/\s+/)[0];
+    const actual = crypto.createHash('sha256').update(archiveBuf).digest('hex');
+    if (expected !== actual) fail(`checksum mismatch (expected ${expected}, got ${actual})`);
+    console.log('hyctl: checksum verified');
   }
 
   // Extract via the system `tar` (handles .tar.gz on unix and .zip on Win10+).

--- a/pip/hyctl/__init__.py
+++ b/pip/hyctl/__init__.py
@@ -68,6 +68,12 @@ def _verify(archive: bytes, name: str) -> None:
             if expected != actual:
                 _die(f"checksum mismatch (expected {expected}, got {actual})")
             return
+    # checksums.txt downloaded but does not list this archive. That is a broken
+    # release, not a reason to install unverified — and the realistic cause is
+    # drift: the name is constructed here from goreleaser's template, so if the
+    # template changes, verification would otherwise stop happening for every
+    # user on every install while installs kept succeeding (#241).
+    _die(f"{name} is not listed in checksums.txt — refusing to install unverified")
 
 
 def _ensure_binary() -> Path:


### PR DESCRIPTION
Found while verifying the npm and pip install paths end to end against the published `v1.0.1`
release. Both install correctly — and both could skip verification without saying so.

## What was wrong

```js
// npm — "skip only if the file is absent" is not what this does
const line = sums.split('\n').find((l) => l.trim().endsWith(archive));
if (line) { …verify… }
                     // ← no else: entry missing ⇒ installed unverified, silently
```

`pip`'s `_verify` has the same shape — a `for` loop that falls off the end and returns.

## The trigger is real, and it already happened

Not a `name_template` change — the download URL is built from the same string, so that 404s loudly
first. The reachable case is **`checksums.txt` failing to cover an artifact that exists**, which is
exactly the state the desktop artifacts were in until #234: published, downloadable, and absent from
`checksums.txt`, because goreleaser generates it from its own archive list and never saw them.

If the `hyctl` archives ever land in that state — a checksum config change, a partial release, an
asset added out of band — every npm and pip install goes unverified with no indication. In npm's
case the only signal is the *absence* of a `checksum verified` line nobody is watching for.

## This was already decided

`install.sh` has always failed closed:

```sh
[ "${EXPECTED:-}" != "" ] || die "checksum for ${ARCHIVE} not found in checksums.txt"
```

So this is not a design question — npm and pip simply did not match the curl installer. All three
paths agree now.

An **unreachable** `checksums.txt` still warns and continues; a network blip should not brick
`npm install`. Only a `checksums.txt` that downloads and omits the entry is fatal, and the error
names the archive it looked for so the cause is diagnosable.

## Verified both directions, against a real release

Ran the actual installers on darwin/arm64 against published `v1.0.1`:

| | npm | pip |
|---|---|---|
| happy path | downloads, `checksum verified`, installs, `hyctl version` runs | downloads, verifies, runs |
| `checksums.txt` lacking the entry | **exit 1**, nothing installed | **exit 1**, nothing installed |

The failure case was simulated faithfully rather than by stubbing: the installer downloads the real
`v1.0.1` archive but fetches `checksums.txt` from the `rc.7` release, which lists only `rc.7` names.

```console
hyctl: hydra_1.0.1_darwin_arm64.tar.gz is not listed in checksums.txt — refusing to install unverified
```

Closes #241