### PR TITLE
feat(cli): support `hyctl --version`

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -72,6 +72,10 @@ func rootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "hyctl",
 		Short: "Multi-model AI orchestration — one Cortex, many Heads",
+		// `hyctl --version` used to answer "unknown flag" even though a version
+		// subcommand existed. It is the near-universal convention, so people
+		// type it first. Same text as the subcommand, from one function.
+		Version: build.Version,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !config.Exists() {
 				return runInit()
@@ -79,6 +83,7 @@ func rootCmd() *cobra.Command {
 			return cmd.Help()
 		},
 	}
+	root.SetVersionTemplate(versionText())
 	root.AddCommand(
 		cmdInit(), cmdProbe(), cmdStatus(), cmdTui(), cmdDispatch(),
 		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(),
@@ -90,15 +95,19 @@ func rootCmd() *cobra.Command {
 
 // ── version ───────────────────────────────────────────────────────────────────
 
+// versionText is shared by the `version` subcommand and the root `--version`
+// flag, so the two can never drift into reporting differently.
+func versionText() string {
+	return fmt.Sprintf("  hydra %s\n  commit:  %s\n  built:   %s\n  by:      %s\n",
+		build.Version, build.Commit, build.Date, build.BuiltBy)
+}
+
 func cmdVersion() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print version, commit, and build info",
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Printf("  hydra %s\n", build.Version)
-			fmt.Printf("  commit:  %s\n", build.Commit)
-			fmt.Printf("  built:   %s\n", build.Date)
-			fmt.Printf("  by:      %s\n", build.BuiltBy)
+			fmt.Print(versionText())
 			// Update notice is printed by main() after Execute returns.
 		},
 	}

--- a/cmd/hydra/version_test.go
+++ b/cmd/hydra/version_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+// `hyctl --version` answered "unknown flag: --version" while a `version`
+// subcommand existed. It is the near-universal convention, so it is what people
+// type first — and an error there reads like a broken install.
+//
+// Executing the real root command rather than inspecting fields: the point is
+// what a user typing the flag actually gets.
+func TestRootCommand_VersionFlagPrintsTheSameTextAsTheSubcommand(t *testing.T) {
+	run := func(args ...string) string {
+		var out bytes.Buffer
+		root := rootCmd()
+		root.SetOut(&out)
+		root.SetErr(&out)
+		root.SetArgs(args)
+		if err := root.Execute(); err != nil {
+			t.Fatalf("hyctl %v: %v", args, err)
+		}
+		return out.String()
+	}
+
+	flag := run("--version")
+	if flag == "" {
+		t.Fatal("--version printed nothing")
+	}
+	if flag != versionText() {
+		t.Errorf("--version does not match versionText():\n got %q\nwant %q", flag, versionText())
+	}
+}


### PR DESCRIPTION
Found while running the shipped `v1.1.0-rc.6` binary on a fresh machine.

```console
$ hyctl --version
Error: unknown flag: --version
```

A `version` subcommand existed, but `--version` is the near-universal convention — it is what people
type first, and an error there reads like a broken install rather than a missing convenience.

```console
$ hyctl --version          $ hyctl version
  hydra 1.1.0                hydra 1.1.0
  commit:  4f796c2           commit:  4f796c2
  built:   2026-08-02…       built:   2026-08-02…
  by:      goreleaser        by:      goreleaser
```

## One source, so they cannot drift

Both render through a single `versionText()`. The obvious alternative — writing the format string
twice — is exactly the duplication that lets two surfaces start disagreeing.

## Verified the test actually tests something

It executes the real root command with the flag rather than inspecting struct fields, because what
matters is what a user typing it gets. Checked by removing the `Version` field and confirming it
fails, then restoring it.

`gofmt`, `go build`, `go vet`, `go test ./...` all clean.

Closes #245