### PR TITLE
fix(probe,dispatch): stop advertising heads that cannot be dispatched to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,14 @@ jq '.claude_pct = 52' logs/state.json > logs/state.json.tmp && mv logs/state.jso
 ```
 
 **Same 70%/75%/80% rule applies to ALL delegated models** — `hyctl dispatch` enforces this via the budget governor + fallback chains.
-**Qwen (tier 10) is always the terminal fallback** — it runs locally so is always available regardless of API limits.
+**Local heads are tier 10, the terminal fallback** — they cost nothing, so `rank.UITier` puts any
+`LocalOnly` head at the cheapest tier regardless of its score, and API limits never apply to them.
+
+This holds only while a local head is actually **routable**. Ollama is discovered twice: as a binary
+on `$PATH` (not routable on its own — nothing can drive it) and, once its server answers on `:11434`,
+as one routable head per model via the port provider. With the server down there is no tier-10 head,
+and dispatch degrades to the cheapest routable head and says so. `hyctl probe` marks unroutable
+heads with `✗` and the reason (#248).
 
 ---
 

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/editor"
 	"github.com/ankit373/hydra/internal/entropy"
+	"github.com/ankit373/hydra/internal/executor"
 	"github.com/ankit373/hydra/internal/graph"
 	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/optimal"
@@ -198,12 +199,33 @@ func cmdProbe() *cobra.Command {
 			}
 			fmt.Printf("  %-30s  %-5s  %-5s  %s\n", "Head", "Score", "Src", "Provider")
 			fmt.Println("  " + strings.Repeat("─", 56))
+			// Discovery finding a head is not the same as Hydra being able to
+			// drive it. Listing both identically is what let `probe` advertise
+			// the Ollama binary that `dispatch --local` then refused (#248), so
+			// unroutable heads are marked and carry their reason.
+			var unroutable int
 			for _, h := range result.Heads {
 				marker := "  "
 				if result.Cortex != nil && h.ID == result.Cortex.ID {
 					marker = cortexStyle.Render("→ ")
 				}
-				fmt.Printf("%s%-30s  %-5d  %-5s  %s\n", marker, h.Name, h.CapScore, h.Source, h.Provider)
+				why := executor.Unroutable(h)
+				if why != "" {
+					marker = warnStyle.Render("✗ ")
+					unroutable++
+				}
+				row := fmt.Sprintf("%-30s  %-5d  %-5s  %s", h.Name, h.CapScore, h.Source, h.Provider)
+				if why == "" {
+					fmt.Printf("%s%s\n", marker, row)
+					continue
+				}
+				fmt.Printf("%s%s\n", marker, dimStyle.Render(row))
+				fmt.Printf("    %s\n", dimStyle.Render("↳ "+why))
+			}
+			if unroutable > 0 {
+				fmt.Printf("\n  %s\n", dimStyle.Render(fmt.Sprintf(
+					"✗ = discovered but not routable (%d of %d) — dispatch will skip these.",
+					unroutable, len(result.Heads))))
 			}
 			return nil
 		},

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -149,6 +150,14 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		// Report the effective localOnly (policy may have forced it), not just
 		// the caller's flag, or a PII-forced local-only run points the user at
 		// the wrong cause.
+		// Pointing at `hyctl probe` was actively misleading when the only
+		// matching heads were ones probe listed but no executor can drive:
+		// the user looks, sees the head, and learns nothing (#248). Name the
+		// blocked heads and why instead.
+		if blocked := d.blockedHeads(localOnly); blocked != "" {
+			return nil, fmt.Errorf("no routable heads for tier %q (localOnly=%v).\n%s",
+				tier, localOnly, blocked)
+		}
 		return nil, fmt.Errorf("no available heads for tier %q (localOnly=%v); "+
 			"check `hyctl probe` and the tier names in your config", tier, localOnly)
 	}
@@ -374,6 +383,29 @@ func (d *Dispatcher) resolveTierHint(hint string) string {
 		return hint // named tier has no live heads; let the caller report it
 	}
 	return hint
+}
+
+// blockedHeads describes discovered heads that were excluded because no
+// executor can drive them, formatted for an error message. Returns "" when
+// nothing was excluded for that reason — in which case the real problem is the
+// tier or the config, and the caller says so instead.
+//
+// Respects localOnly so a PII-forced local run does not list cloud heads the
+// user was never going to be allowed to use anyway.
+func (d *Dispatcher) blockedHeads(localOnly bool) string {
+	var b strings.Builder
+	for _, h := range d.heads {
+		if localOnly && !h.LocalOnly {
+			continue
+		}
+		if why := executor.Unroutable(h); why != "" {
+			fmt.Fprintf(&b, "  %s (%s): %s\n", h.Name, h.Provider, why)
+		}
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return "Discovered, but not routable:\n" + b.String()
 }
 
 // selectHeads returns heads to try, in order of preference.

--- a/internal/dispatch/routing_test.go
+++ b/internal/dispatch/routing_test.go
@@ -3,6 +3,7 @@
 package dispatch
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ankit373/hydra/internal/budget"
@@ -187,5 +188,70 @@ func TestSelectHeads_NoCheapHeadFallsBackToCheapest(t *testing.T) {
 	}
 	if got[0].ID != "expert" {
 		t.Errorf("fallback primary = %q, want cheapest (\"expert\")", got[0].ID)
+	}
+}
+
+// The existing tier-10 test uses a local head at score 40, which the score
+// ladder already put at tier 10 — so it passed while the real machine failed.
+// Ollama scores exactly 60, which landed at tier 9, and GRUNT degraded past it
+// to a paid cloud head (#248). Same shape, real number.
+func TestSelectHeads_Tier10PrefersALocalHeadOverAPaidOne(t *testing.T) {
+	d := routingDispatcher()
+	d.heads = []provider.Head{
+		registryHead("paid-cheap", 68, false), // a real Gemini Flash Low score
+		registryHead("ollama", 60, true),      // exactly Ollama's score
+	}
+
+	got := d.selectHeads("10", false)
+	if len(got) == 0 {
+		t.Fatal("tier 10 selected no heads — GRUNT would degrade to a paid head")
+	}
+	if got[0].ID != "ollama" {
+		t.Errorf("tier 10 primary = %q, want \"ollama\" — a free local head must win the cheapest tier", got[0].ID)
+	}
+	// Asserting the ID alone is not enough, and I had this wrong first: with
+	// only two heads the *degraded* fallback also returns ollama, because it
+	// reverses to weakest-first and ollama is weakest. So the test passed with
+	// the fix removed. What actually distinguishes a real tier-10 match from a
+	// degraded pick is the head's own tier.
+	if tier := rank.UITier(got[0]); tier < 10 {
+		t.Errorf("tier 10 was served by a head at tier %d — selected via the degradation path, "+
+			"not because a local head belongs at the cheapest tier", tier)
+	}
+}
+
+// The error a user actually hits when the only local head on the machine is one
+// no executor can drive. Pointing at `hyctl probe` was worse than useless: probe
+// listed the head, so looking there taught them nothing (#248).
+func TestDispatch_NoRoutableHeadsNamesTheBlockedHeadAndWhy(t *testing.T) {
+	d := routingDispatcher()
+	// Exactly how internal/provider/cli registers the PATH-discovered binary.
+	d.heads = []provider.Head{
+		{ID: "ollama", Name: "Ollama", Provider: "local", Source: "cli", LocalOnly: true},
+	}
+
+	msg := d.blockedHeads(true)
+	if msg == "" {
+		t.Fatal("blockedHeads returned nothing for a head no executor can drive")
+	}
+	for _, want := range []string{"Ollama", "server"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message does not mention %q:\n%s", want, msg)
+		}
+	}
+}
+
+// A cloud head must not be listed as the blocker for a local-only run — the
+// user could not have used it either way, so naming it sends them the wrong way.
+func TestDispatch_BlockedHeadsRespectsLocalOnly(t *testing.T) {
+	d := routingDispatcher()
+	d.heads = []provider.Head{
+		{ID: "mystery", Name: "Mystery Cloud", Provider: "nobody", Source: "cli"},
+	}
+	if msg := d.blockedHeads(true); msg != "" {
+		t.Errorf("local-only run listed a cloud head as the blocker:\n%s", msg)
+	}
+	if msg := d.blockedHeads(false); msg == "" {
+		t.Error("a non-local run should still report the undrivable cloud head")
 	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -45,20 +45,43 @@ type Executor interface {
 	Execute(ctx context.Context, req Request) (*Response, error)
 }
 
-// Supports reports whether Hydra can execute a discovered head today.
-func Supports(h provider.Head) bool {
-	if h.Source == "registry" {
-		return true // agy heads — AgyExecutor handles them
-	}
-	if h.Source == "port" || h.Source == "env" || h.Endpoint != "" {
-		return SupportsHTTP(h)
+// Unroutable explains why a discovered head cannot be dispatched to, or returns
+// "" when it can.
+//
+// This is the primary check and Supports delegates to it, so a surface that
+// lists heads and a surface that routes to them cannot disagree. They did:
+// `hyctl probe` advertised the PATH-discovered Ollama binary while
+// `hyctl dispatch --local` refused and told the user to go look at `hyctl probe`
+// (#248). Discovery finding a head and Hydra being able to drive it are
+// different questions, and only one function should answer the second.
+func Unroutable(h provider.Head) string {
+	switch {
+	case h.Source == "registry":
+		return "" // agy tiers — AgyExecutor handles them
+	case h.Source == "port" || h.Source == "env" || h.Endpoint != "":
+		if SupportsHTTP(h) {
+			return ""
+		}
+		return "no API key or default model configured for " + h.Provider
 	}
 	if _, ok := cliTemplates[h.Provider]; ok {
-		return true
+		return ""
 	}
-	_, ok := cliTemplates[h.ID]
-	return ok
+	if _, ok := cliTemplates[h.ID]; ok {
+		return ""
+	}
+	// ollama and llamafile are found on $PATH but driven over HTTP, so the
+	// binary alone is not routable — the port provider registers the real heads
+	// once a server answers. Say that, rather than "no executor", because the
+	// user can act on it.
+	if h.LocalOnly {
+		return "binary only — start its local server (e.g. `ollama serve`) to route to its models"
+	}
+	return "no executor for provider " + h.Provider
 }
+
+// Supports reports whether Hydra can execute a discovered head today.
+func Supports(h provider.Head) bool { return Unroutable(h) == "" }
 
 // For selects the correct Executor for a given Head.
 //   - registry source (agy tiers): AgyExecutor → native (execs the `agy` binary)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -3,6 +3,7 @@
 package executor
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ankit373/hydra/internal/provider"
@@ -83,5 +84,43 @@ func typeName(v interface{}) string {
 		return "cli"
 	default:
 		return "unknown"
+	}
+}
+
+// The PATH-discovered Ollama head is the case that made probe and dispatch
+// disagree (#248): probe listed it, dispatch filtered it out, and the error
+// told the user to go look at probe. The reason must be actionable — "no
+// executor" would leave them no better off than before.
+func TestUnroutable_LocalBinaryWithoutAServerSaysWhatToDo(t *testing.T) {
+	// Exactly how internal/provider/cli registers it: {"ollama", "local", true}.
+	head := provider.Head{ID: "ollama", Name: "Ollama", Provider: "local", Source: "cli", LocalOnly: true}
+
+	why := Unroutable(head)
+	if why == "" {
+		t.Fatal("Unroutable = \"\" for a PATH-only ollama head; dispatch cannot drive it")
+	}
+	if !strings.Contains(why, "server") {
+		t.Errorf("reason %q does not mention the server the user needs to start", why)
+	}
+	if Supports(head) {
+		t.Error("Supports disagrees with Unroutable — the two must never diverge")
+	}
+}
+
+// Supports is defined as Unroutable == "", so this holds by construction today.
+// It is pinned because the previous shape — two functions each walking the same
+// branches — is exactly how a listing surface and a routing surface drift apart.
+func TestSupports_AlwaysAgreesWithUnroutable(t *testing.T) {
+	heads := []provider.Head{
+		{ID: "opus-thinking", Provider: "agy", Source: "registry"},
+		{ID: "ollama", Provider: "local", Source: "cli", LocalOnly: true},
+		{ID: "claude", Provider: "anthropic", Source: "cli"},
+		{ID: "mystery", Provider: "nobody", Source: "cli"},
+		{ID: "env/anthropic", Provider: "anthropic", Source: "env"},
+	}
+	for _, h := range heads {
+		if Supports(h) != (Unroutable(h) == "") {
+			t.Errorf("%s: Supports=%v but Unroutable=%q", h.ID, Supports(h), Unroutable(h))
+		}
 	}
 }

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -86,6 +86,15 @@ func UITier(h provider.Head) int {
 			}
 		}
 	}
+	// A local head costs nothing to run, so for cost routing it belongs at the
+	// cheapest tier regardless of how capable it is. Without this, Ollama's
+	// score of exactly 60 landed it at tier 9 — one short of the bottom — and
+	// `--enum GRUNT` degraded past it to a *paid* cloud head, which is the
+	// inverse of the point (#248). It also makes CLAUDE.md's promise that
+	// tier 10 is the always-available terminal fallback actually true.
+	if h.LocalOnly {
+		return 10
+	}
 	switch {
 	case h.CapScore >= 95:
 		return 1

--- a/internal/rank/rank_test.go
+++ b/internal/rank/rank_test.go
@@ -53,3 +53,34 @@ func TestOllamaCLIKeptWhenNoPortModels(t *testing.T) {
 		t.Errorf("ollama CLI head should be kept when no port models exist")
 	}
 }
+
+// Hydra routes by cost, and a local head costs nothing, so it belongs at the
+// cheapest tier however capable it is. Ollama scores exactly 60, which the score
+// ladder put at tier 9 — one short of the bottom — so `--enum GRUNT` degraded
+// straight past it to a paid cloud head (#248). CLAUDE.md promises tier 10 is
+// the always-available terminal fallback; this is what makes that true.
+func TestUITier_LocalHeadsAreAlwaysTheCheapestTier(t *testing.T) {
+	for _, score := range []int{0, 40, 60, 75, 99} {
+		h := provider.Head{ID: "local-head", CapScore: score, LocalOnly: true}
+		if got := UITier(h); got != 10 {
+			t.Errorf("UITier(local head, score %d) = %d, want 10", score, got)
+		}
+	}
+	// A non-local head at the same score must keep its ladder position, or this
+	// would be a blanket downgrade rather than a local-cost rule.
+	if got := UITier(provider.Head{ID: "cloud", CapScore: 60}); got == 10 {
+		t.Error("a non-local head at score 60 was moved to tier 10")
+	}
+}
+
+// An explicit registry tier still wins: models.yaml is where an operator states
+// intent, and inferring over it would silently ignore their edit.
+func TestUITier_ExplicitRegistryTierBeatsTheLocalRule(t *testing.T) {
+	h := provider.Head{
+		ID: "qwen-grunt", Source: "registry", LocalOnly: true, CapScore: 60,
+		Meta: map[string]string{"tier": "7"},
+	}
+	if got := UITier(h); got != 7 {
+		t.Errorf("UITier = %d, want 7 from the registry meta", got)
+	}
+}


### PR DESCRIPTION
`hyctl probe` listed the PATH-discovered Ollama head; `hyctl dispatch --local` then refused and told
the user to *check `hyctl probe`* — which shows the head that does not work.

**Before**
```console
$ hyctl probe
  Ollama                          60     cli    local
$ hyctl dispatch --local --dry-run "write a test"
Error: no available heads for tier "" (localOnly=true); check `hyctl probe` and the tier names in your config
```

**After**
```console
$ hyctl probe
✗ Ollama                          60     cli    local
    ↳ binary only — start its local server (e.g. `ollama serve`) to route to its models

  ✗ = discovered but not routable (1 of 11) — dispatch will skip these.

$ hyctl dispatch --local --dry-run "write a test"
Error: no routable heads for tier "" (localOnly=true).
Discovered, but not routable:
  Ollama (local): binary only — start its local server (e.g. `ollama serve`) to route to its models
```

## One function answers "can Hydra drive this?"

Discovery finding a binary and Hydra being able to drive it are different questions, and two
functions were answering the second. `executor.Unroutable` is now primary and
`Supports` is `Unroutable(h) == ""`, so a listing surface and a routing surface cannot drift apart.
The reason is actionable rather than "no executor": `ollama` and `llamafile` are found on `$PATH`
but driven over HTTP, so the binary alone is never routable — the **port** provider registers the
real heads once a server answers on `:11434`.

The dispatch error respects `localOnly`, so a PII-forced local run is not sent chasing cloud heads it
could never have used either way.

## The cost bug underneath

`rank.UITier` now puts any `LocalOnly` head at tier 10. A local head costs nothing, so for cost
routing it belongs at the cheapest tier however capable it is. Ollama scores **exactly 60**, which
the ladder put at tier 9 — one short of the bottom — so `--enum GRUNT` degraded straight past it to a
paid cloud head. For a cost router that is the inverse of the point. An explicit `registry` tier in
`models.yaml` still wins, so an operator's stated intent is never inferred over.

## A test that passed for the wrong reason

My first tier-10 regression test **passed with the fix removed**. With only two heads the
degradation path also returns the local head, because it reverses to weakest-first and the local one
is weakest — so asserting the ID proved nothing. Asserting the *selected head's own tier* is what
distinguishes a real tier-10 match from a degraded pick, and that version does fail without the fix:

```
routing_test.go:218: tier 10 was served by a head at tier 9 — selected via the degradation path,
    not because a local head belongs at the cheapest tier
```

## Verified on a real binary in the failing condition

This machine has exactly the case: `ollama` on `$PATH`, server down. Both surfaces confirmed above.
`GRUNT` still degrades here — correctly, since with the server down there is genuinely no routable
local head — but it now says why instead of silently preferring a paid head over one it listed.

## Docs

`CLAUDE.md` claimed tier 10 is *"always available"*. It is not when the local server is down. Now
documented as it behaves, including that Ollama is discovered twice (unroutable binary vs. routable
per-model port heads).

`gofmt`, `go vet`, `go test ./...` and `go test -race ./...` all clean.

Closes #248