### PR TITLE
fix(graph): say when a blast radius is a default rather than a measurement

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -475,6 +475,17 @@ func cmdDispatch() *cobra.Command {
 				derived := trust.NewDefectModel().RequiredConfidence(task)
 				fmt.Printf("  %s blast radius %.2f → demands confidence ≥ %.1f%%\n",
 					dimStyle.Render("graph:"), task.BlastRadius, derived*100)
+				// --file exists to RAISE the bar for risky files. With no graph
+				// it silently never raises, while printing a line that reads
+				// exactly like blast-radius-aware routing happened (#251). The
+				// bar itself is unchanged — only the claim about it.
+				if g.Empty() {
+					fmt.Printf("  %s\n", warnStyle.Render(
+						"graph: no graph at "+graphPath+" — radius 1.00 is a default, not a measurement"))
+				} else if !g.Knows(file) {
+					fmt.Printf("  %s\n", warnStyle.Render(
+						"graph: "+file+" is not in the graph — radius 1.00 is a default, not a measurement"))
+				}
 				if derived > effectiveConf {
 					effectiveConf = derived
 				}
@@ -1116,29 +1127,57 @@ func cmdGraph() *cobra.Command {
 				deps += g.DependentCount(id)
 			}
 			pFactor := g.PercolationFactor(file)
+			// A radius of 1.0 means either "nothing depends on this" or "I have
+			// no idea" — opposite conclusions that used to render identically.
+			// internal/a2a reported 6 dependents and 97.4% required confidence
+			// with the graph, and "subcritical — edits stay local" at 90.0%
+			// without it (#251).
+			loaded, known := !g.Empty(), g.Knows(file)
 			if jsonOut {
 				return json.NewEncoder(os.Stdout).Encode(map[string]any{
 					"file": file, "blast_radius": radius, "transitive_dependents": deps,
 					"defect_cost_usd": dm.CostUSD(task), "required_confidence": dm.RequiredConfidence(task),
 					"kappa": g.Kappa(), "percolates": g.Percolates(), "percolation_factor": pFactor,
+					"graph_loaded": loaded, "file_in_graph": known,
 				})
 			}
 			fmt.Printf("\n  %s\n", cortexStyle.Render(file))
-			fmt.Printf("    transitive dependents  %d\n", deps)
-			fmt.Printf("    blast radius           %.2f×\n", radius)
-			if g.Percolates() {
-				core := "periphery"
-				if pFactor > 1.0 {
-					core = fmt.Sprintf("core (+%.0f%%)", (pFactor-1)*100)
-				}
-				fmt.Printf("    graph κ                %.2f  %s\n",
-					g.Kappa(), dimStyle.Render("supercritical — cascades possible; this file is "+core))
-			} else {
-				fmt.Printf("    graph κ                %.2f  %s\n",
-					g.Kappa(), dimStyle.Render("subcritical — edits stay local"))
+			if !loaded {
+				fmt.Printf("    %s\n", warnStyle.Render("no graph at "+graphPath+" — nothing was analysed"))
+			} else if !known {
+				fmt.Printf("    %s\n", warnStyle.Render("not in the graph — check the path, or reindex"))
 			}
-			fmt.Printf("    defect cost            $%.2f\n", dm.CostUSD(task))
-			fmt.Printf("    demands confidence     %.1f%%\n\n", dm.RequiredConfidence(task)*100)
+			measured := loaded && known
+			suffix := func() string {
+				if measured {
+					return ""
+				}
+				return "  " + dimStyle.Render("(default, not measured)")
+			}()
+			fmt.Printf("    transitive dependents  %d%s\n", deps, suffix)
+			fmt.Printf("    blast radius           %.2f×%s\n", radius, suffix)
+			// κ is a property of the whole graph, so it stays meaningful for an
+			// unknown file — but with no graph at all it is 0.0, and rendering
+			// that as "edits stay local" is a safety claim from no data.
+			if loaded {
+				if g.Percolates() {
+					core := "periphery"
+					if pFactor > 1.0 {
+						core = fmt.Sprintf("core (+%.0f%%)", (pFactor-1)*100)
+					}
+					fmt.Printf("    graph κ                %.2f  %s\n",
+						g.Kappa(), dimStyle.Render("supercritical — cascades possible; this file is "+core))
+				} else {
+					fmt.Printf("    graph κ                %.2f  %s\n",
+						g.Kappa(), dimStyle.Render("subcritical — edits stay local"))
+				}
+			}
+			fmt.Printf("    defect cost            $%.2f%s\n", dm.CostUSD(task), suffix)
+			fmt.Printf("    demands confidence     %.1f%%%s\n\n", dm.RequiredConfidence(task)*100, suffix)
+			if !measured {
+				fmt.Printf("  %s\n\n", dimStyle.Render(
+					"A radius of 1.00× here means \"unknown\", not \"safe\" — generate a graph to get a real bar."))
+			}
 			return nil
 		},
 	}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -330,3 +330,22 @@ func (g *Graph) NodesInFile(file string) []string {
 	}
 	return g.filesToNodes[file]
 }
+
+// Empty reports whether the graph holds no nodes at all — which is what Load
+// returns when graph.json is absent.
+//
+// Callers that *present* results need this. Degrading a missing graph to a
+// blast radius of 1.0 is the right library behaviour, but a UI that prints that
+// default as "subcritical — edits stay local" is making an affirmative safety
+// claim from no data, and it silently lowered the confidence bar on files that
+// are genuinely cascade risks (#251).
+func (g *Graph) Empty() bool {
+	return g == nil || len(g.degree) == 0
+}
+
+// Knows reports whether the graph contains the given file. A false here means a
+// blast radius of 1.0 is a default, not a measurement — the file may be
+// misspelled, outside the indexed tree, or simply not indexed yet.
+func (g *Graph) Knows(file string) bool {
+	return len(g.seedsForFile(file)) > 0
+}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -242,3 +242,44 @@ func TestLoad_RoundTrip(t *testing.T) {
 		t.Errorf("loaded DependentCount(a) = %d, want 1", got)
 	}
 }
+
+// A blast radius of 1.0 means either "nothing depends on this" or "I have no
+// idea", and those are opposite conclusions. Before #251 they rendered
+// identically: internal/a2a reported 6 dependents and 97.4% required confidence
+// with a graph, and "subcritical — edits stay local" at 90.0% without one.
+// Empty and Knows are what let a UI tell a default from a measurement.
+func TestEmptyAndKnows_DistinguishNoDataFromNoDependents(t *testing.T) {
+	missing, err := Load(filepath.Join(t.TempDir(), "absent.json"))
+	if err != nil {
+		t.Fatalf("Load of a missing graph should not error: %v", err)
+	}
+	if !missing.Empty() {
+		t.Error("a graph loaded from a missing file reports Empty() = false")
+	}
+	if missing.Knows("internal/a2a") {
+		t.Error("an empty graph claims to know a file")
+	}
+	// The degraded radius itself is unchanged — that contract is deliberate.
+	if got := missing.BlastRadiusForFile("internal/a2a"); got != 1.0 {
+		t.Errorf("BlastRadiusForFile on an empty graph = %v, want 1.0", got)
+	}
+
+	populated := fromDoc(Doc{
+		Nodes: []Node{{ID: "a", File: "a.go"}, {ID: "b", File: "b.go"}},
+		Edges: []Edge{{From: "b", To: "a"}},
+	})
+	if populated.Empty() {
+		t.Error("a graph with nodes reports Empty() = true")
+	}
+	if !populated.Knows("a.go") {
+		t.Error("Knows(a.go) = false for an indexed file")
+	}
+	// An unindexed file in a real graph is still a default, not a measurement —
+	// the case a typo or a stale index produces.
+	if populated.Knows("typo.go") {
+		t.Error("Knows(typo.go) = true for a file that is not in the graph")
+	}
+	if got := populated.BlastRadiusForFile("typo.go"); got != 1.0 {
+		t.Errorf("unknown file radius = %v, want the 1.0 default", got)
+	}
+}


### PR DESCRIPTION
A blast radius of `1.0` means either *"nothing depends on this"* or *"I have no idea"* — opposite
conclusions that rendered identically.

**The same file, twice:**

```console
$ hyctl graph blast internal/a2a                 # graph.json present
    transitive dependents  6
    blast radius           3.81×
    graph κ                9.25  supercritical — cascades possible
    demands confidence     97.4%

$ hyctl graph blast internal/a2a --graph /nope.json
    transitive dependents  0
    blast radius           1.00×
    graph κ                0.00  subcritical — edits stay local
    demands confidence     90.0%
```

A file that genuinely has 6 transitive dependents was reported as **safe**, and the required
confidence silently dropped **97.4% → 90.0%**, purely because `graph.json` was absent. A file missing
from an existing graph — a typo, a stale index — produced the same defaults just as quietly.

**After:**

```console
$ hyctl graph blast internal/a2a --graph /nope.json
    no graph at /nope.json — nothing was analysed
    transitive dependents  0  (default, not measured)
    blast radius           1.00×  (default, not measured)
    demands confidence     90.0%  (default, not measured)

  A radius of 1.00× here means "unknown", not "safe" — generate a graph to get a real bar.

$ hyctl graph blast internal/does-not-exist.go
    not in the graph — check the path, or reindex
    transitive dependents  0  (default, not measured)
    graph κ                9.25  supercritical — cascades possible; this file is periphery
```

## What changed, and what deliberately did not

`graph.Load` degrading a missing file to an empty graph **stays as it is** — that library contract is
correct. The bug was the CLI presenting the degraded default as a finding. `Graph.Empty` and
`Graph.Knows` let a caller tell the two apart.

The **κ verdict is suppressed entirely when there is no graph**: κ is a real global property, so it
stays meaningful for an unindexed file in a real graph, but printing `subcritical — edits stay local`
off κ=0.00 from zero data is a safety claim, not a default.

`--json` gains `graph_loaded` and `file_in_graph`, so machine consumers can make the same
distinction:

```json
{"graph_loaded": false, "file_in_graph": false, "blast_radius": 1, "required_confidence": 0.9}
```

## It reached the router

`dispatch --file` printed `graph: blast radius 1.00 → demands confidence ≥ 90.0%` with no hint the
graph was missing. That flag exists to **raise** the bar for risky files, so with no graph it
silently never raised while looking like blast-radius-aware routing had happened. The bar itself is
unchanged — only the claim about it:

```console
  graph: blast radius 1.00 → demands confidence ≥ 90.0%
  graph: no graph at /nope.json — radius 1.00 is a default, not a measurement
```

For a Trust Control Plane this failed **open**: the input deciding how much verification to buy
defaulted to the least, exactly when the risk was unknown.

## Verification

Against the repo's real `graph.json` in all three states — indexed file (unchanged), unindexed file,
no graph — plus both `--json` shapes and the dispatch path. The test pins that an empty graph reports
`Empty()`, does not claim to `Know` a file, and still returns the deliberate 1.0 default.

`gofmt`, `go vet`, `go test ./...`, `go test -race ./...` clean.

Closes #251