### PR TITLE
fix(release): carry the routing-honesty fixes into v1.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,14 @@ jq '.claude_pct = 52' logs/state.json > logs/state.json.tmp && mv logs/state.jso
 ```
 
 **Same 70%/75%/80% rule applies to ALL delegated models** — `hyctl dispatch` enforces this via the budget governor + fallback chains.
-**Qwen (tier 10) is always the terminal fallback** — it runs locally so is always available regardless of API limits.
+**Local heads are tier 10, the terminal fallback** — they cost nothing, so `rank.UITier` puts any
+`LocalOnly` head at the cheapest tier regardless of its score, and API limits never apply to them.
+
+This holds only while a local head is actually **routable**. Ollama is discovered twice: as a binary
+on `$PATH` (not routable on its own — nothing can drive it) and, once its server answers on `:11434`,
+as one routable head per model via the port provider. With the server down there is no tier-10 head,
+and dispatch degrades to the cheapest routable head and says so. `hyctl probe` marks unroutable
+heads with `✗` and the reason (#248).
 
 ---
 

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/editor"
 	"github.com/ankit373/hydra/internal/entropy"
+	"github.com/ankit373/hydra/internal/executor"
 	"github.com/ankit373/hydra/internal/graph"
 	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/optimal"
@@ -198,12 +199,33 @@ func cmdProbe() *cobra.Command {
 			}
 			fmt.Printf("  %-30s  %-5s  %-5s  %s\n", "Head", "Score", "Src", "Provider")
 			fmt.Println("  " + strings.Repeat("─", 56))
+			// Discovery finding a head is not the same as Hydra being able to
+			// drive it. Listing both identically is what let `probe` advertise
+			// the Ollama binary that `dispatch --local` then refused (#248), so
+			// unroutable heads are marked and carry their reason.
+			var unroutable int
 			for _, h := range result.Heads {
 				marker := "  "
 				if result.Cortex != nil && h.ID == result.Cortex.ID {
 					marker = cortexStyle.Render("→ ")
 				}
-				fmt.Printf("%s%-30s  %-5d  %-5s  %s\n", marker, h.Name, h.CapScore, h.Source, h.Provider)
+				why := executor.Unroutable(h)
+				if why != "" {
+					marker = warnStyle.Render("✗ ")
+					unroutable++
+				}
+				row := fmt.Sprintf("%-30s  %-5d  %-5s  %s", h.Name, h.CapScore, h.Source, h.Provider)
+				if why == "" {
+					fmt.Printf("%s%s\n", marker, row)
+					continue
+				}
+				fmt.Printf("%s%s\n", marker, dimStyle.Render(row))
+				fmt.Printf("    %s\n", dimStyle.Render("↳ "+why))
+			}
+			if unroutable > 0 {
+				fmt.Printf("\n  %s\n", dimStyle.Render(fmt.Sprintf(
+					"✗ = discovered but not routable (%d of %d) — dispatch will skip these.",
+					unroutable, len(result.Heads))))
 			}
 			return nil
 		},
@@ -453,6 +475,17 @@ func cmdDispatch() *cobra.Command {
 				derived := trust.NewDefectModel().RequiredConfidence(task)
 				fmt.Printf("  %s blast radius %.2f → demands confidence ≥ %.1f%%\n",
 					dimStyle.Render("graph:"), task.BlastRadius, derived*100)
+				// --file exists to RAISE the bar for risky files. With no graph
+				// it silently never raises, while printing a line that reads
+				// exactly like blast-radius-aware routing happened (#251). The
+				// bar itself is unchanged — only the claim about it.
+				if g.Empty() {
+					fmt.Printf("  %s\n", warnStyle.Render(
+						"graph: no graph at "+graphPath+" — radius 1.00 is a default, not a measurement"))
+				} else if !g.Knows(file) {
+					fmt.Printf("  %s\n", warnStyle.Render(
+						"graph: "+file+" is not in the graph — radius 1.00 is a default, not a measurement"))
+				}
 				if derived > effectiveConf {
 					effectiveConf = derived
 				}
@@ -1094,29 +1127,57 @@ func cmdGraph() *cobra.Command {
 				deps += g.DependentCount(id)
 			}
 			pFactor := g.PercolationFactor(file)
+			// A radius of 1.0 means either "nothing depends on this" or "I have
+			// no idea" — opposite conclusions that used to render identically.
+			// internal/a2a reported 6 dependents and 97.4% required confidence
+			// with the graph, and "subcritical — edits stay local" at 90.0%
+			// without it (#251).
+			loaded, known := !g.Empty(), g.Knows(file)
 			if jsonOut {
 				return json.NewEncoder(os.Stdout).Encode(map[string]any{
 					"file": file, "blast_radius": radius, "transitive_dependents": deps,
 					"defect_cost_usd": dm.CostUSD(task), "required_confidence": dm.RequiredConfidence(task),
 					"kappa": g.Kappa(), "percolates": g.Percolates(), "percolation_factor": pFactor,
+					"graph_loaded": loaded, "file_in_graph": known,
 				})
 			}
 			fmt.Printf("\n  %s\n", cortexStyle.Render(file))
-			fmt.Printf("    transitive dependents  %d\n", deps)
-			fmt.Printf("    blast radius           %.2f×\n", radius)
-			if g.Percolates() {
-				core := "periphery"
-				if pFactor > 1.0 {
-					core = fmt.Sprintf("core (+%.0f%%)", (pFactor-1)*100)
-				}
-				fmt.Printf("    graph κ                %.2f  %s\n",
-					g.Kappa(), dimStyle.Render("supercritical — cascades possible; this file is "+core))
-			} else {
-				fmt.Printf("    graph κ                %.2f  %s\n",
-					g.Kappa(), dimStyle.Render("subcritical — edits stay local"))
+			if !loaded {
+				fmt.Printf("    %s\n", warnStyle.Render("no graph at "+graphPath+" — nothing was analysed"))
+			} else if !known {
+				fmt.Printf("    %s\n", warnStyle.Render("not in the graph — check the path, or reindex"))
 			}
-			fmt.Printf("    defect cost            $%.2f\n", dm.CostUSD(task))
-			fmt.Printf("    demands confidence     %.1f%%\n\n", dm.RequiredConfidence(task)*100)
+			measured := loaded && known
+			suffix := func() string {
+				if measured {
+					return ""
+				}
+				return "  " + dimStyle.Render("(default, not measured)")
+			}()
+			fmt.Printf("    transitive dependents  %d%s\n", deps, suffix)
+			fmt.Printf("    blast radius           %.2f×%s\n", radius, suffix)
+			// κ is a property of the whole graph, so it stays meaningful for an
+			// unknown file — but with no graph at all it is 0.0, and rendering
+			// that as "edits stay local" is a safety claim from no data.
+			if loaded {
+				if g.Percolates() {
+					core := "periphery"
+					if pFactor > 1.0 {
+						core = fmt.Sprintf("core (+%.0f%%)", (pFactor-1)*100)
+					}
+					fmt.Printf("    graph κ                %.2f  %s\n",
+						g.Kappa(), dimStyle.Render("supercritical — cascades possible; this file is "+core))
+				} else {
+					fmt.Printf("    graph κ                %.2f  %s\n",
+						g.Kappa(), dimStyle.Render("subcritical — edits stay local"))
+				}
+			}
+			fmt.Printf("    defect cost            $%.2f%s\n", dm.CostUSD(task), suffix)
+			fmt.Printf("    demands confidence     %.1f%%%s\n\n", dm.RequiredConfidence(task)*100, suffix)
+			if !measured {
+				fmt.Printf("  %s\n\n", dimStyle.Render(
+					"A radius of 1.00× here means \"unknown\", not \"safe\" — generate a graph to get a real bar."))
+			}
 			return nil
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,11 +37,19 @@ func Dir() string {
 	return filepath.Join(home, ".hydra")
 }
 
-// ScriptHome returns the directory that contains registry/ (the YAML config root).
+// ScriptHome returns the directory searched for an on-disk registry/ override.
 // Resolution order:
-//  1. $HYDRA_HOME env var (set by Homebrew formula or install.sh)
-//  2. Auto-detect: walk up from binary location looking for registry/routing.yaml
-//  3. ~/.hydra (standalone install copies the registry here)
+//  1. $HYDRA_HOME env var
+//  2. Auto-detect: walk up from the binary looking for registry/routing.yaml
+//     (repo checkout / dev layout)
+//  3. ~/.hydra
+//
+// Step 3 used to be documented as "standalone install copies the registry here".
+// Nothing has ever done that — not install.sh, not the tap formula, not the npm
+// or pip installers — which is why every installed binary ran with no registry
+// at all until #238. It is the embedded copy that makes the files always
+// available now; this path only decides where an operator's *override* is read
+// from, so a miss here is normal rather than a failure.
 func ScriptHome() string {
 	if h := os.Getenv("HYDRA_HOME"); h != "" {
 		return filepath.Clean(h)

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -149,6 +150,14 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		// Report the effective localOnly (policy may have forced it), not just
 		// the caller's flag, or a PII-forced local-only run points the user at
 		// the wrong cause.
+		// Pointing at `hyctl probe` was actively misleading when the only
+		// matching heads were ones probe listed but no executor can drive:
+		// the user looks, sees the head, and learns nothing (#248). Name the
+		// blocked heads and why instead.
+		if blocked := d.blockedHeads(localOnly); blocked != "" {
+			return nil, fmt.Errorf("no routable heads for tier %q (localOnly=%v).\n%s",
+				tier, localOnly, blocked)
+		}
 		return nil, fmt.Errorf("no available heads for tier %q (localOnly=%v); "+
 			"check `hyctl probe` and the tier names in your config", tier, localOnly)
 	}
@@ -374,6 +383,29 @@ func (d *Dispatcher) resolveTierHint(hint string) string {
 		return hint // named tier has no live heads; let the caller report it
 	}
 	return hint
+}
+
+// blockedHeads describes discovered heads that were excluded because no
+// executor can drive them, formatted for an error message. Returns "" when
+// nothing was excluded for that reason — in which case the real problem is the
+// tier or the config, and the caller says so instead.
+//
+// Respects localOnly so a PII-forced local run does not list cloud heads the
+// user was never going to be allowed to use anyway.
+func (d *Dispatcher) blockedHeads(localOnly bool) string {
+	var b strings.Builder
+	for _, h := range d.heads {
+		if localOnly && !h.LocalOnly {
+			continue
+		}
+		if why := executor.Unroutable(h); why != "" {
+			fmt.Fprintf(&b, "  %s (%s): %s\n", h.Name, h.Provider, why)
+		}
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return "Discovered, but not routable:\n" + b.String()
 }
 
 // selectHeads returns heads to try, in order of preference.

--- a/internal/dispatch/routing_test.go
+++ b/internal/dispatch/routing_test.go
@@ -3,6 +3,7 @@
 package dispatch
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ankit373/hydra/internal/budget"
@@ -187,5 +188,70 @@ func TestSelectHeads_NoCheapHeadFallsBackToCheapest(t *testing.T) {
 	}
 	if got[0].ID != "expert" {
 		t.Errorf("fallback primary = %q, want cheapest (\"expert\")", got[0].ID)
+	}
+}
+
+// The existing tier-10 test uses a local head at score 40, which the score
+// ladder already put at tier 10 — so it passed while the real machine failed.
+// Ollama scores exactly 60, which landed at tier 9, and GRUNT degraded past it
+// to a paid cloud head (#248). Same shape, real number.
+func TestSelectHeads_Tier10PrefersALocalHeadOverAPaidOne(t *testing.T) {
+	d := routingDispatcher()
+	d.heads = []provider.Head{
+		registryHead("paid-cheap", 68, false), // a real Gemini Flash Low score
+		registryHead("ollama", 60, true),      // exactly Ollama's score
+	}
+
+	got := d.selectHeads("10", false)
+	if len(got) == 0 {
+		t.Fatal("tier 10 selected no heads — GRUNT would degrade to a paid head")
+	}
+	if got[0].ID != "ollama" {
+		t.Errorf("tier 10 primary = %q, want \"ollama\" — a free local head must win the cheapest tier", got[0].ID)
+	}
+	// Asserting the ID alone is not enough, and I had this wrong first: with
+	// only two heads the *degraded* fallback also returns ollama, because it
+	// reverses to weakest-first and ollama is weakest. So the test passed with
+	// the fix removed. What actually distinguishes a real tier-10 match from a
+	// degraded pick is the head's own tier.
+	if tier := rank.UITier(got[0]); tier < 10 {
+		t.Errorf("tier 10 was served by a head at tier %d — selected via the degradation path, "+
+			"not because a local head belongs at the cheapest tier", tier)
+	}
+}
+
+// The error a user actually hits when the only local head on the machine is one
+// no executor can drive. Pointing at `hyctl probe` was worse than useless: probe
+// listed the head, so looking there taught them nothing (#248).
+func TestDispatch_NoRoutableHeadsNamesTheBlockedHeadAndWhy(t *testing.T) {
+	d := routingDispatcher()
+	// Exactly how internal/provider/cli registers the PATH-discovered binary.
+	d.heads = []provider.Head{
+		{ID: "ollama", Name: "Ollama", Provider: "local", Source: "cli", LocalOnly: true},
+	}
+
+	msg := d.blockedHeads(true)
+	if msg == "" {
+		t.Fatal("blockedHeads returned nothing for a head no executor can drive")
+	}
+	for _, want := range []string{"Ollama", "server"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message does not mention %q:\n%s", want, msg)
+		}
+	}
+}
+
+// A cloud head must not be listed as the blocker for a local-only run — the
+// user could not have used it either way, so naming it sends them the wrong way.
+func TestDispatch_BlockedHeadsRespectsLocalOnly(t *testing.T) {
+	d := routingDispatcher()
+	d.heads = []provider.Head{
+		{ID: "mystery", Name: "Mystery Cloud", Provider: "nobody", Source: "cli"},
+	}
+	if msg := d.blockedHeads(true); msg != "" {
+		t.Errorf("local-only run listed a cloud head as the blocker:\n%s", msg)
+	}
+	if msg := d.blockedHeads(false); msg == "" {
+		t.Error("a non-local run should still report the undrivable cloud head")
 	}
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -45,20 +45,43 @@ type Executor interface {
 	Execute(ctx context.Context, req Request) (*Response, error)
 }
 
-// Supports reports whether Hydra can execute a discovered head today.
-func Supports(h provider.Head) bool {
-	if h.Source == "registry" {
-		return true // agy heads — AgyExecutor handles them
-	}
-	if h.Source == "port" || h.Source == "env" || h.Endpoint != "" {
-		return SupportsHTTP(h)
+// Unroutable explains why a discovered head cannot be dispatched to, or returns
+// "" when it can.
+//
+// This is the primary check and Supports delegates to it, so a surface that
+// lists heads and a surface that routes to them cannot disagree. They did:
+// `hyctl probe` advertised the PATH-discovered Ollama binary while
+// `hyctl dispatch --local` refused and told the user to go look at `hyctl probe`
+// (#248). Discovery finding a head and Hydra being able to drive it are
+// different questions, and only one function should answer the second.
+func Unroutable(h provider.Head) string {
+	switch {
+	case h.Source == "registry":
+		return "" // agy tiers — AgyExecutor handles them
+	case h.Source == "port" || h.Source == "env" || h.Endpoint != "":
+		if SupportsHTTP(h) {
+			return ""
+		}
+		return "no API key or default model configured for " + h.Provider
 	}
 	if _, ok := cliTemplates[h.Provider]; ok {
-		return true
+		return ""
 	}
-	_, ok := cliTemplates[h.ID]
-	return ok
+	if _, ok := cliTemplates[h.ID]; ok {
+		return ""
+	}
+	// ollama and llamafile are found on $PATH but driven over HTTP, so the
+	// binary alone is not routable — the port provider registers the real heads
+	// once a server answers. Say that, rather than "no executor", because the
+	// user can act on it.
+	if h.LocalOnly {
+		return "binary only — start its local server (e.g. `ollama serve`) to route to its models"
+	}
+	return "no executor for provider " + h.Provider
 }
+
+// Supports reports whether Hydra can execute a discovered head today.
+func Supports(h provider.Head) bool { return Unroutable(h) == "" }
 
 // For selects the correct Executor for a given Head.
 //   - registry source (agy tiers): AgyExecutor → native (execs the `agy` binary)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -3,6 +3,7 @@
 package executor
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ankit373/hydra/internal/provider"
@@ -83,5 +84,43 @@ func typeName(v interface{}) string {
 		return "cli"
 	default:
 		return "unknown"
+	}
+}
+
+// The PATH-discovered Ollama head is the case that made probe and dispatch
+// disagree (#248): probe listed it, dispatch filtered it out, and the error
+// told the user to go look at probe. The reason must be actionable — "no
+// executor" would leave them no better off than before.
+func TestUnroutable_LocalBinaryWithoutAServerSaysWhatToDo(t *testing.T) {
+	// Exactly how internal/provider/cli registers it: {"ollama", "local", true}.
+	head := provider.Head{ID: "ollama", Name: "Ollama", Provider: "local", Source: "cli", LocalOnly: true}
+
+	why := Unroutable(head)
+	if why == "" {
+		t.Fatal("Unroutable = \"\" for a PATH-only ollama head; dispatch cannot drive it")
+	}
+	if !strings.Contains(why, "server") {
+		t.Errorf("reason %q does not mention the server the user needs to start", why)
+	}
+	if Supports(head) {
+		t.Error("Supports disagrees with Unroutable — the two must never diverge")
+	}
+}
+
+// Supports is defined as Unroutable == "", so this holds by construction today.
+// It is pinned because the previous shape — two functions each walking the same
+// branches — is exactly how a listing surface and a routing surface drift apart.
+func TestSupports_AlwaysAgreesWithUnroutable(t *testing.T) {
+	heads := []provider.Head{
+		{ID: "opus-thinking", Provider: "agy", Source: "registry"},
+		{ID: "ollama", Provider: "local", Source: "cli", LocalOnly: true},
+		{ID: "claude", Provider: "anthropic", Source: "cli"},
+		{ID: "mystery", Provider: "nobody", Source: "cli"},
+		{ID: "env/anthropic", Provider: "anthropic", Source: "env"},
+	}
+	for _, h := range heads {
+		if Supports(h) != (Unroutable(h) == "") {
+			t.Errorf("%s: Supports=%v but Unroutable=%q", h.ID, Supports(h), Unroutable(h))
+		}
 	}
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -330,3 +330,22 @@ func (g *Graph) NodesInFile(file string) []string {
 	}
 	return g.filesToNodes[file]
 }
+
+// Empty reports whether the graph holds no nodes at all — which is what Load
+// returns when graph.json is absent.
+//
+// Callers that *present* results need this. Degrading a missing graph to a
+// blast radius of 1.0 is the right library behaviour, but a UI that prints that
+// default as "subcritical — edits stay local" is making an affirmative safety
+// claim from no data, and it silently lowered the confidence bar on files that
+// are genuinely cascade risks (#251).
+func (g *Graph) Empty() bool {
+	return g == nil || len(g.degree) == 0
+}
+
+// Knows reports whether the graph contains the given file. A false here means a
+// blast radius of 1.0 is a default, not a measurement — the file may be
+// misspelled, outside the indexed tree, or simply not indexed yet.
+func (g *Graph) Knows(file string) bool {
+	return len(g.seedsForFile(file)) > 0
+}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -242,3 +242,44 @@ func TestLoad_RoundTrip(t *testing.T) {
 		t.Errorf("loaded DependentCount(a) = %d, want 1", got)
 	}
 }
+
+// A blast radius of 1.0 means either "nothing depends on this" or "I have no
+// idea", and those are opposite conclusions. Before #251 they rendered
+// identically: internal/a2a reported 6 dependents and 97.4% required confidence
+// with a graph, and "subcritical — edits stay local" at 90.0% without one.
+// Empty and Knows are what let a UI tell a default from a measurement.
+func TestEmptyAndKnows_DistinguishNoDataFromNoDependents(t *testing.T) {
+	missing, err := Load(filepath.Join(t.TempDir(), "absent.json"))
+	if err != nil {
+		t.Fatalf("Load of a missing graph should not error: %v", err)
+	}
+	if !missing.Empty() {
+		t.Error("a graph loaded from a missing file reports Empty() = false")
+	}
+	if missing.Knows("internal/a2a") {
+		t.Error("an empty graph claims to know a file")
+	}
+	// The degraded radius itself is unchanged — that contract is deliberate.
+	if got := missing.BlastRadiusForFile("internal/a2a"); got != 1.0 {
+		t.Errorf("BlastRadiusForFile on an empty graph = %v, want 1.0", got)
+	}
+
+	populated := fromDoc(Doc{
+		Nodes: []Node{{ID: "a", File: "a.go"}, {ID: "b", File: "b.go"}},
+		Edges: []Edge{{From: "b", To: "a"}},
+	})
+	if populated.Empty() {
+		t.Error("a graph with nodes reports Empty() = true")
+	}
+	if !populated.Knows("a.go") {
+		t.Error("Knows(a.go) = false for an indexed file")
+	}
+	// An unindexed file in a real graph is still a default, not a measurement —
+	// the case a typo or a stale index produces.
+	if populated.Knows("typo.go") {
+		t.Error("Knows(typo.go) = true for a file that is not in the graph")
+	}
+	if got := populated.BlastRadiusForFile("typo.go"); got != 1.0 {
+		t.Errorf("unknown file radius = %v, want the 1.0 default", got)
+	}
+}

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -86,6 +86,15 @@ func UITier(h provider.Head) int {
 			}
 		}
 	}
+	// A local head costs nothing to run, so for cost routing it belongs at the
+	// cheapest tier regardless of how capable it is. Without this, Ollama's
+	// score of exactly 60 landed it at tier 9 — one short of the bottom — and
+	// `--enum GRUNT` degraded past it to a *paid* cloud head, which is the
+	// inverse of the point (#248). It also makes CLAUDE.md's promise that
+	// tier 10 is the always-available terminal fallback actually true.
+	if h.LocalOnly {
+		return 10
+	}
 	switch {
 	case h.CapScore >= 95:
 		return 1

--- a/internal/rank/rank_test.go
+++ b/internal/rank/rank_test.go
@@ -53,3 +53,34 @@ func TestOllamaCLIKeptWhenNoPortModels(t *testing.T) {
 		t.Errorf("ollama CLI head should be kept when no port models exist")
 	}
 }
+
+// Hydra routes by cost, and a local head costs nothing, so it belongs at the
+// cheapest tier however capable it is. Ollama scores exactly 60, which the score
+// ladder put at tier 9 — one short of the bottom — so `--enum GRUNT` degraded
+// straight past it to a paid cloud head (#248). CLAUDE.md promises tier 10 is
+// the always-available terminal fallback; this is what makes that true.
+func TestUITier_LocalHeadsAreAlwaysTheCheapestTier(t *testing.T) {
+	for _, score := range []int{0, 40, 60, 75, 99} {
+		h := provider.Head{ID: "local-head", CapScore: score, LocalOnly: true}
+		if got := UITier(h); got != 10 {
+			t.Errorf("UITier(local head, score %d) = %d, want 10", score, got)
+		}
+	}
+	// A non-local head at the same score must keep its ladder position, or this
+	// would be a blanket downgrade rather than a local-cost rule.
+	if got := UITier(provider.Head{ID: "cloud", CapScore: 60}); got == 10 {
+		t.Error("a non-local head at score 60 was moved to tier 10")
+	}
+}
+
+// An explicit registry tier still wins: models.yaml is where an operator states
+// intent, and inferring over it would silently ignore their edit.
+func TestUITier_ExplicitRegistryTierBeatsTheLocalRule(t *testing.T) {
+	h := provider.Head{
+		ID: "qwen-grunt", Source: "registry", LocalOnly: true, CapScore: 60,
+		Meta: map[string]string{"tier": "7"},
+	}
+	if got := UITier(h); got != 7 {
+		t.Errorf("UITier = %d, want 7 from the registry meta", got)
+	}
+}


### PR DESCRIPTION
Carries #250, #252 and #249 — three surfaces that stated something false about what Hydra knew.

## #250 — probe advertised heads dispatch could never use

```console
$ hyctl probe                        $ hyctl dispatch --local --dry-run "…"
  Ollama    60   cli   local         Error: no available heads …
                                            check `hyctl probe`   ← shows the broken head
```

`executor.Unroutable` is now the single authority, so the surface that *lists* heads and the surface
that *routes* to them cannot disagree. Underneath was a cost bug: Ollama scores **exactly 60**, which
the tier ladder put at 9 — one above the bottom — so `--enum GRUNT` degraded past a free local head
to a paid one. `LocalOnly` heads are tier 10 now; they cost nothing, so for cost routing they belong
at the bottom.

## #252 — a blast radius of 1.0 could mean "safe" or "no idea"

```
internal/a2a  (graph)     6 dependents · 3.81× · demands 97.4%
internal/a2a  (no graph)  0 dependents · 1.00× · demands 90.0%  "edits stay local"
```

A cascade-risk file reported as safe, with the required confidence silently lowered. `dispatch --file`
had the same hole — the flag whose whole job is to **raise** the bar silently never raised it. For a
Trust Control Plane, the input deciding how much verification to buy failed **open**.

Unmeasured values are labelled now, `--json` carries `graph_loaded`/`file_in_graph`, and the κ
verdict is suppressed when there is no graph — κ=0.00 rendered as *"edits stay local"* is a safety
claim from zero data.

## #249 — a comment describing something no installer does

`ScriptHome()` claimed a standalone install copies the registry to `~/.hydra`. Nothing ever has —
the same assumption that let `registry/*.yaml` go unshipped until #238.

## Why in v1.1.0

Neither #250 nor #252 changes a shipped surface that `rc.8` already verified. Both make Hydra stop
asserting things it has no evidence for, which matters most on the release that puts it in front of
people who did not build it and cannot tell a default from a measurement.

## Shape

Adopts `develop`'s tree as a single linear commit on the previous release commit, as the
`release/v*` ruleset requires. Verified before pushing: tree byte-identical to `origin/develop`,
parent exactly the current release head, delta is only these three PRs (11 files, +365/−29).

`rc.9` is where this gets confirmed on the real artifacts.

Refs #248, #251