### PR TITLE
ci: test on macOS and Windows, and guard all six build targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Hydra ships for darwin, linux and windows on both amd64 and arm64, but every
+  # job in this file used to run on ubuntu-latest — so `go test` only ever ran on
+  # Linux. That is how a Windows user came to see "0GB RAM · memory fully
+  # occupied" and "memory pressure: low" at the same time (#258), and how the
+  # non-git diff path came to return ("", nil) — silently indistinguishable from
+  # "no changes" — on any machine without diff(1) (#260). Neither is exotic; both
+  # are simply untested surfaces. The matrix is the fix (#255).
   go:
     name: Go build & test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # One platform's failure must never mask another's: the whole point is to
+      # learn the full list in a single run.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        # Windows runners default to pwsh. Every `run:` block here is bash, and
+        # Git Bash ships on the Windows image, so pinning the shell keeps one
+        # script working on all three rather than forking it per OS.
+        shell: bash
     steps:
       - uses: actions/checkout@v7
 
@@ -26,9 +45,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # Formatting is checked before anything expensive runs — it is the
-      # cheapest failure to produce and the cheapest to fix.
+      # gofmt/vet/staticcheck analyse source, not behaviour — their verdict does
+      # not vary by runner OS, so they run once on Linux rather than three times.
+      # Formatting is checked before anything expensive: cheapest failure to
+      # produce, cheapest to fix.
       - name: Gofmt
+        if: runner.os == 'Linux'
         run: |
           unformatted=$(gofmt -l ./cmd ./internal)
           if [ -n "$unformatted" ]; then
@@ -39,6 +61,7 @@ jobs:
           fi
 
       - name: Vet
+        if: runner.os == 'Linux'
         run: go vet ./...
 
       # staticcheck must be BUILT with the same toolchain it analyses. Its own
@@ -48,20 +71,40 @@ jobs:
       # this module actually resolved to keeps the two in step without
       # hardcoding a version that would drift from go.mod.
       - name: Install staticcheck
+        if: runner.os == 'Linux'
         run: GOTOOLCHAIN=$(go env GOVERSION) go install honnef.co/go/tools/cmd/staticcheck@2026.1
 
       - name: Staticcheck
+        if: runner.os == 'Linux'
         run: staticcheck ./...
 
       - name: Build
         run: go build ./...
 
+      # -count=1 defeats the test cache. setup-go restores the build cache across
+      # runs, so without it a green result can be a replay of a previous run's
+      # verdict rather than a fresh one — which is precisely the failure mode this
+      # matrix exists to rule out.
+      #
+      # The race detector supports windows/amd64, but needs cgo and a C compiler.
+      # If the Windows image ever stops shipping one, drop -race for that leg
+      # rather than dropping the leg — an unraced Windows run still catches every
+      # platform bug listed above.
       - name: Test
-        run: go test ./... -race
+        run: go test ./... -race -count=1
 
+  # The desktop app ships for all three OSes, so its Go backend is tested on all
+  # three too — same reasoning as the root job above (#257).
   desktop:
     name: Desktop backend
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v7
 
@@ -70,6 +113,9 @@ jobs:
         with:
           go-version-file: desktop/go.mod
           cache: true
+          # desktop/ is a separate module; without this the cache key is computed
+          # from the root go.sum and the two modules share a poisoned cache.
+          cache-dependency-path: desktop/go.sum
 
       # desktop/ is its own module, so the root job's `./...` does not reach it.
       # Without this job its tests would silently never run.
@@ -81,6 +127,7 @@ jobs:
       # part with the tests — imports no UI framework at all, and main.go is
       # exercised by `wails build` on a machine that has a webview.
       - name: Gofmt
+        if: runner.os == 'Linux'
         working-directory: desktop
         run: |
           unformatted=$(gofmt -l .)
@@ -92,22 +139,25 @@ jobs:
           fi
 
       - name: Vet
+        if: runner.os == 'Linux'
         working-directory: desktop
         run: go vet ./api/...
 
       # Same reasoning as the root job: staticcheck must be built with the
       # toolchain it analyses.
       - name: Install staticcheck
+        if: runner.os == 'Linux'
         working-directory: desktop
         run: GOTOOLCHAIN=$(go env GOVERSION) go install honnef.co/go/tools/cmd/staticcheck@2026.1
 
       - name: Staticcheck
+        if: runner.os == 'Linux'
         working-directory: desktop
         run: staticcheck ./api/...
 
       - name: Test
         working-directory: desktop
-        run: go test ./api/... -race
+        run: go test ./api/... -race -count=1
 
   shellcheck:
     name: Shellcheck
@@ -154,6 +204,49 @@ jobs:
       - name: Build
         working-directory: desktop/frontend
         run: npm run build
+
+  # Every target Hydra ships (and windows/arm64, which it should — see #262)
+  # compiles and vets clean today. Nothing guarded that, so a Unix-only syscall
+  # or a platform-specific import could land with CI fully green, because CI only
+  # ever built for the runner's own OS.
+  #
+  # This is deliberately build+vet, not test: it is a compile-time guard covering
+  # targets that have no runner (linux/arm64, windows/arm64). Behaviour is the
+  # `go` matrix's job. Together they cover build for 6 targets and behaviour for 3.
+  cross-compile:
+    name: Cross-compile (6 targets)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build and vet every release target
+        run: |
+          set -u
+          failed=""
+          for t in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 \
+                   windows/amd64 windows/arm64; do
+            export GOOS="${t%/*}" GOARCH="${t#*/}"
+            printf '%-16s' "$t"
+            if ! out=$(go build ./... 2>&1); then
+              echo "BUILD FAILED"; echo "$out"
+              failed="$failed $t(build)"; continue
+            fi
+            if ! out=$(go vet ./... 2>&1); then
+              echo "VET FAILED"; echo "$out"
+              failed="$failed $t(vet)"; continue
+            fi
+            echo "ok"
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::cross-compile failed for:$failed"
+            exit 1
+          fi
 
   yaml-lint:
     name: YAML validation

--- a/internal/runlog/edits.go
+++ b/internal/runlog/edits.go
@@ -48,6 +48,12 @@ func SaveEdit(runID, ref string, before, after []byte) error {
 		return err
 	}
 	// 0600: an edit snapshot is a verbatim copy of the user's source.
+	//
+	// Enforced on Unix only. On Windows a FileMode toggles nothing but the
+	// read-only attribute, so this lands as 0666 and the MkdirAll above is a
+	// no-op — the protection there is the ACL on the user's profile directory,
+	// which is why these live under Dir() and not a temp path (#273). Stated
+	// rather than assumed: the mode is not a guarantee on every platform.
 	if err := os.WriteFile(filepath.Join(dir, ref+".before"), before, 0o600); err != nil {
 		return err
 	}

--- a/internal/runlog/edits_test.go
+++ b/internal/runlog/edits_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -113,7 +114,15 @@ func TestLoadEdit_PartialPairIsMissing(t *testing.T) {
 }
 
 // Snapshots are verbatim copies of the user's source, so they must not be
-// world-readable.
+// readable by other users.
+//
+// The mechanism differs by platform and the test follows it rather than
+// skipping (#273). On Unix the guarantee is the 0600 mode SaveEdit sets. On
+// Windows a FileMode only toggles the read-only attribute — 0600 becomes 0666 —
+// so the mode proves nothing there, and the actual protection is the ACL on the
+// user's profile directory. Asserting containment under the home directory is
+// what makes that guarantee non-vacuous: it is exactly the property that would
+// break if snapshots ever moved to a shared or temp location.
 func TestSaveEdit_SnapshotsAreNotWorldReadable(t *testing.T) {
 	home := editSandbox(t)
 
@@ -132,6 +141,24 @@ func TestSaveEdit_SnapshotsAreNotWorldReadable(t *testing.T) {
 		info, err := e.Info()
 		if err != nil {
 			t.Fatal(err)
+		}
+		if runtime.GOOS == "windows" {
+			// Mode bits carry no access information here; assert the mechanism
+			// that does. filepath.EvalSymlinks resolves the 8.3/symlinked temp
+			// paths Windows hands out, which would otherwise defeat the compare.
+			got, err := filepath.EvalSymlinks(filepath.Join(dir, e.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := filepath.EvalSymlinks(home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.HasPrefix(got, want) {
+				t.Errorf("%s resolved to %s, outside the user profile %s; on Windows that ACL is "+
+					"the only thing protecting a verbatim copy of the user's source", e.Name(), got, want)
+			}
+			continue
 		}
 		if info.Mode().Perm()&0o077 != 0 {
 			t.Errorf("%s has mode %v; snapshots hold the user's source verbatim", e.Name(), info.Mode().Perm())

--- a/internal/runlog/heartbeat_test.go
+++ b/internal/runlog/heartbeat_test.go
@@ -93,23 +93,45 @@ func TestStaleAfter_ToleratesMissedTicks(t *testing.T) {
 	}
 }
 
+// The whole liveness design rests on mtime advancing: IsAlive is
+// now-ModTime <= StaleAfter, so a marker that never moves ages out and every
+// running agent reports dead.
+//
+// Polled rather than asserted after one fixed sleep (#274). Windows' system
+// clock and timer granularity are both ~15.6ms, so a single 60ms window is
+// within noise there — and a flaky assertion on a real invariant is worse than
+// no assertion, because it gets deleted. Polling keeps the invariant exact (it
+// still fails if the heartbeat genuinely stops) while removing the dependency on
+// how coarse the platform's clock is. On failure it prints the observed
+// timestamps, so CI reports what actually happened instead of a bare verdict.
 func TestHeartbeat_KeepsMarkerFresh(t *testing.T) {
 	tempHome(t)
-	h := StartHeartbeat(context.Background(), "run-fresh", 10*time.Millisecond)
+	const interval = 10 * time.Millisecond
+	h := StartHeartbeat(context.Background(), "run-fresh", interval)
 	defer h.Stop()
 
 	first, err := os.Stat(HeartbeatPath("run-fresh"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(60 * time.Millisecond)
-	second, err := os.Stat(HeartbeatPath("run-fresh"))
-	if err != nil {
-		t.Fatal(err)
+
+	deadline := time.Now().Add(3 * time.Second)
+	var last time.Time
+	for time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+		cur, err := os.Stat(HeartbeatPath("run-fresh"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		last = cur.ModTime()
+		if last.After(first.ModTime()) {
+			return
+		}
 	}
-	if !second.ModTime().After(first.ModTime()) {
-		t.Error("marker mtime did not advance — the heartbeat is not ticking")
-	}
+	t.Errorf("marker mtime did not advance in 3s at a %v interval — the heartbeat is not ticking.\n"+
+		"  first = %s\n  last  = %s\n  delta = %v",
+		interval, first.ModTime().Format(time.RFC3339Nano), last.Format(time.RFC3339Nano),
+		last.Sub(first.ModTime()))
 }
 
 func TestHeartbeat_StopIsIdempotentAndRemovesMarker(t *testing.T) {


### PR DESCRIPTION
## Summary

Every CI job in this repo ran on `ubuntu-latest` — all of them. `go test ./... -race` therefore only ever ran on Linux, while Hydra ships for **darwin, linux and windows on amd64 and arm64**.

That gap is not theoretical. It is why a Windows user sees `"0GB RAM · memory fully occupied (0.0GB free)"` and `MemPressure = low` at the same time (#258), and why the non-git diff path returns `("", nil)` — indistinguishable from *"no changes"* — on any machine without `diff(1)` (#260). Neither is exotic; both are simply untested surfaces.

This is the root-cause fix for the v1.2.0 epic (#254) and ships first deliberately: it produces the *real* defect list rather than the predicted one.

## Changes

**`go` and `desktop` jobs → three-OS matrix** (`ubuntu-latest`, `macos-latest`, `windows-latest`)
- `fail-fast: false` — one platform's failure must never mask another's; the point is to learn the full list in one run.
- `gofmt` / `vet` / `staticcheck` stay Linux-only via `if: runner.os == 'Linux'`. They analyse source, not behaviour — their verdict does not vary by runner, so there is no value in paying 3x.
- `shell: bash` pinned. Windows runners default to `pwsh`; every `run:` block here is bash, and Git Bash ships on the Windows image.
- **`-count=1` added to both test steps.** `setup-go` restores the build cache across runs, so without it a green result can be a *replay* of an earlier verdict rather than a fresh one — precisely the failure mode this matrix exists to rule out.
- `desktop` gains `cache-dependency-path: desktop/go.sum`. It is a separate module; without this the cache key was computed from the root `go.sum`.

**New `cross-compile` job** — build **and** vet for all six targets:
```
darwin/amd64  darwin/arm64  linux/amd64  linux/arm64  windows/amd64  windows/arm64
```
Deliberately build+vet rather than test: it is a compile-time guard covering targets that have no runner (`linux/arm64`, `windows/arm64`). Behaviour is the matrix's job. Together: build for 6 targets, behaviour for 3.

## Verification

All six targets are clean today, run locally:
```
darwin/amd64    ok      linux/arm64     ok
darwin/arm64    ok      windows/amd64   ok
linux/amd64     ok      windows/arm64   ok
ALL 6 TARGETS CLEAN
```

And the guard was checked **adversarially** — a temporary `syscall.Umask` call:
```
linux/amd64     ok
windows/amd64   BUILD FAILED  undefined: syscall.Umask
windows/arm64   BUILD FAILED  undefined: syscall.Umask
```
Removed, and windows/amd64 goes green again. The guard fails for the right reason, not by accident.

Note `windows/arm64` compiles clean today but is excluded from releases by a `.goreleaser.yaml` `ignore` — which is why npm and pip 404 on Windows-on-ARM (#262, next).

## Expected first run

The macOS and Windows legs may well go red. **That is the deliverable.** Failures get triaged into issues under #254 rather than papered over with `t.Skip`.

No status checks are currently required on `develop` or `main`, so renaming jobs breaks nothing. Worth noting separately: that also means CI gates nothing today.

Closes #255
Closes #256
Closes #257