### PR TITLE
fix(dist): build windows/arm64 — npm and pip installs 404 on Windows-on-ARM

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,9 +28,11 @@ builds:
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
+    # No `ignore` here on purpose. windows/arm64 was excluded, but both the npm
+    # and pip installers map process.arch/platform.machine() "arm64" straight to
+    # windows/arm64 and request an archive that was therefore never uploaded —
+    # so Windows-on-ARM installs 404'd (#262). The target builds and vets clean,
+    # and ci.yml's cross-compile job now guards that for all six targets.
 
 # ── Archives ──────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-8b5cf6.svg)](LICENSE)
 [![Go 1.24](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go&logoColor=white)](go.mod)
-[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey?logo=apple)](https://hydra.uvansa.com)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)](https://hydra.uvansa.com#platform-support)
 [![GitHub Stars](https://img.shields.io/github/stars/ankit373/hydra?style=flat&color=8b5cf6)](https://github.com/ankit373/hydra/stargazers)
 [![GitHub Issues](https://img.shields.io/github/issues/ankit373/hydra?color=06b6d4)](https://github.com/ankit373/hydra/issues)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
@@ -419,6 +419,24 @@ curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install.sh | sh
 ```
 
 **Prebuilt binaries** — download from [github.com/ankit373/hydra/releases](https://github.com/ankit373/hydra/releases).
+
+#### Platform support
+
+Every release builds `hyctl` for all six targets below. This table is kept in step with
+`.goreleaser.yaml`'s build matrix — if a row is here, an artifact exists for it.
+
+| OS | x86-64 | ARM64 | Homebrew | npm / npx | pip | `install.sh` |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|
+| macOS | ✅ | ✅ (Apple Silicon) | ✅ | ✅ | ✅ | ✅ |
+| Linux | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Windows | ✅ | ✅ | — | ✅ | ✅ | — |
+
+Windows has no Homebrew and no `curl \| sh` path — use npm or pip, or download the archive
+directly. A PowerShell installer is [tracked separately](https://github.com/ankit373/hydra/issues/264).
+
+The **desktop app** ships for macOS (universal), Windows x86-64 and Linux x86-64. ARM64 desktop
+builds are [not yet available](https://github.com/ankit373/hydra/issues/263) — the CLI covers ARM64
+on all three OSes.
 
 **From source** (Go 1.22+):
 ```bash

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -55,6 +55,8 @@ pip install hyctl                                                               
 curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install.sh | sh  # standalone
 ```
 
+Platform support: `hyctl` is built for macOS, Linux and Windows on both x86-64 and ARM64 — six targets, every release. Homebrew covers macOS and Linux; npm/npx and pip cover all three OSes; `install.sh` covers macOS and Linux (there is no PowerShell installer yet, so on Windows use npm, pip, or the archive directly). The desktop app ships for macOS (universal), Windows x86-64 and Linux x86-64; ARM64 desktop builds are not yet available.
+
 Or build from source (requires Go 1.22+):
 
 ```bash


### PR DESCRIPTION
## Problem

Both package installers map `arm64` straight to `windows/arm64`:

```js
// npm/scripts/postinstall.js:18-19
const PLATFORM = { darwin: 'darwin', linux: 'linux', win32: 'windows' }[process.platform];
const ARCH     = { x64: 'amd64', arm64: 'arm64' }[process.arch];
```
```python
# pip/hyctl/__init__.py:27-28
_OS   = {"darwin": "darwin", "linux": "linux", "windows": "windows"}
_ARCH = {"x86_64": "amd64", "amd64": "amd64", "arm64": "arm64", "aarch64": "arm64"}
```

…and then request `hydra_<ver>_windows_arm64.zip`, which `.goreleaser.yaml` was configured to never build:

```yaml
    ignore:
      - goos: windows
        goarch: arm64
```

So `npm i -g hyctl` and `pip install hyctl` on a Windows-on-ARM machine **404**. Nothing in the release pipeline noticed, because nothing checks that the installers and the build matrix agree — that contract test is #265.

The exclusion had no justification behind it. The target builds and vets clean, and #271's new cross-compile job now guards that for all six targets.

## Verification

Not from the config — from the artifact. Local snapshot build:

```
hydra_..._darwin_amd64.tar.gz    hydra_..._linux_arm64.tar.gz
hydra_..._darwin_arm64.tar.gz    hydra_..._windows_amd64.zip
hydra_..._linux_amd64.tar.gz     hydra_..._windows_arm64.zip   ← new

$ file dist/hydra_windows_arm64_v8.0/hyctl.exe
PE32+ executable (console) Aarch64, for MS Windows
```

`goreleaser check` passes.

## Docs shipped with it

The platform claims were wrong in three places:

- the README badge advertised **`platform-macOS | Linux`** while Windows binaries have shipped for releases
- README gains a **platform-support table** — all six targets, and which install method reaches each, including the two honest gaps: no Homebrew and no `curl | sh` on Windows (#264), and no ARM64 desktop build yet (#263)
- `docs/llms.txt` states the same, per the rule that it must describe what actually ships

## Remaining Windows gaps (tracked, not silently ignored)

| gap | issue |
|---|---|
| no PowerShell installer | #264 |
| no ARM64 desktop app | #263 |
| installers ↔ goreleaser name contract | #265 |

Closes #262