### PR TITLE
test(testutil): hermetic sandbox, golden helper, and the first discovery contracts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Thank you for taking the time to contribute! This document explains how to get s
 - [Ways to Contribute](#ways-to-contribute)
 - [Development Setup](#development-setup)
 - [Making Changes](#making-changes)
+- [The Regression Contract](#the-regression-contract)
 - [Commit Style](#commit-style)
 - [Pull Request Process](#pull-request-process)
 - [Shell Script Standards](#shell-script-standards)
@@ -84,9 +85,17 @@ No secrets or API keys are needed just to browse, modify, or test the routing lo
    ```bash
    gofmt -l ./cmd ./internal        # must print nothing
    go vet ./... && go build ./...
-   go test ./... -race
+   go test ./... -race -count=1     # -count=1: Go caches results, and a cached
+                                    # PASS from before your change looks identical
    staticcheck ./...                # go install honnef.co/go/tools/cmd/staticcheck@2026.1
    shellcheck --severity=error install.sh
+   ```
+   CI runs that suite on **Linux, macOS and Windows**, and separately builds and
+   vets all six release targets (`darwin`/`linux`/`windows` × `amd64`/`arm64`).
+   You only have one of those locally, so if you touch anything that reads a
+   path, spawns a process, or checks a file mode, cross-compile before you push:
+   ```bash
+   GOOS=windows GOARCH=arm64 go build ./... && GOOS=windows GOARCH=arm64 go vet ./...
    ```
 4. Test manually:
    ```bash
@@ -94,6 +103,100 @@ No secrets or API keys are needed just to browse, modify, or test the routing lo
    go run ./cmd/hydra dispatch --dry-run --enum SIMPLE "add a helper"
    ```
 5. Commit and push, then open a pull request against `develop`.
+
+---
+
+## The Regression Contract
+
+Most of Hydra's tests are **regression contracts**: they pin behaviour that is
+already correct, so a change either preserves it or goes red with an
+explanation. They are not there to describe new features — they are there so
+that you, working on one corner of the router, find out immediately when you
+have changed something in another corner that someone depends on.
+
+If a contract test fails on your branch, the default assumption is that **the
+behaviour changed and that is the finding**, not that the test is stale.
+
+### Writing one
+
+Four rules, in order of how often they matter:
+
+**1. Assert the contract, not the implementation.** Test observable behaviour —
+CLI output and exit codes, on-disk file shapes, exported API. If your test
+would fail on a pure rename, it is pinning the wrong thing and it will be
+deleted the first time someone refactors.
+
+**2. Be hermetic.** Use `testutil.NewSandbox(t)`. It gives the test a private
+home directory, a private `$HYDRA_HOME`, an empty `$PATH` and no provider
+credentials, so a contributor with no Ollama, no API keys and no `agy` gets
+byte-identical results to CI and to a maintainer whose laptop has all three.
+
+```go
+s := testutil.NewSandbox(t)
+s.FakeBinary(t, "ollama")            // this machine "has" ollama, and only ollama
+s.SetKey(t, "ANTHROPIC_API_KEY", "k") // …and exactly one API head
+```
+
+Discovery tests especially: that layer's whole job is reporting what is
+installed, so it is the layer most likely to report *your* machine instead of
+the fixture.
+
+**3. Be deterministic.** No wall-clock comparisons, no map-iteration order, no
+randomness in assertions. Sort explicitly before comparing. If you need a
+timestamp or a duration in output, let `testutil.Golden` normalise it.
+
+**4. Parametrise by platform; do not skip.** Hydra ships for macOS, Linux and
+Windows on x86-64 and ARM64, and CI runs the suite on all three OSes. A
+`t.Skip("not on windows")` hides exactly the class of bug that matters — the
+snapshot-permission and heartbeat bugs (#273, #274) were both found the day the
+Windows leg was switched on. Where a guarantee genuinely differs by platform,
+assert the platform's own mechanism:
+
+```go
+if runtime.GOOS == "windows" {
+    // A FileMode only toggles the read-only bit here; the ACL on the user's
+    // profile is the real protection, so assert containment instead.
+    ...
+    continue
+}
+if info.Mode().Perm()&0o077 != 0 { ... }
+```
+
+A skip needs a one-line reason, and the total number of them is budgeted — see
+the coverage gate.
+
+### Golden files
+
+`testutil.Golden(t, "name", got, tempPaths...)` compares against
+`testdata/name.golden` after normalising machine-specific values (temp paths,
+versions, SHAs, timestamps, durations, path separators, line endings).
+
+Re-bless with:
+```bash
+go test ./internal/somepkg -run TestName -update
+```
+
+**Re-blessing is legitimate when you meant to change the output. It is the bug
+when you did not.** The failure message prints both versions and the first
+differing line so you can tell which case you are in — read it before running
+`-update`. A PR that re-blesses a golden should say in its description why the
+output changed.
+
+### Verifying that a test can actually fail
+
+A regression test that cannot fail is worse than no test, because it reads as
+coverage. Before you rely on one, break the thing it guards and confirm it goes
+red:
+
+```bash
+# make the change you expect to be caught, then:
+go test ./internal/somepkg -count=1     # must FAIL
+# revert, then:
+go test ./internal/somepkg -count=1     # must PASS
+```
+
+`-count=1` is required — Go caches test results, and a cached PASS from before
+your change looks identical to a real one.
 
 ---
 

--- a/internal/provider/cli/provider_test.go
+++ b/internal/provider/cli/provider_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// Discovery's whole job is answering "what is installed on this machine", so it
+// is the layer most likely to answer with the *developer's* machine. Every test
+// here runs inside a sandbox with an empty PATH, so what it finds is exactly
+// what the test planted — on Linux, macOS and Windows alike.
+
+func TestDiscover_EmptyPathFindsNothing(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 0 {
+		t.Errorf("discovered %d heads with an empty PATH: %+v", len(heads), heads)
+	}
+}
+
+// The .exe/.bat resolution difference is the single most likely way discovery
+// diverges by platform, and it had no test at all before #269.
+func TestDiscover_FindsPlantedBinaryOnEveryOS(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.FakeBinary(t, "claude")
+
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 1 {
+		t.Fatalf("got %d heads, want exactly the planted one: %+v", len(heads), heads)
+	}
+	h := heads[0]
+	if h.ID != "claude" {
+		t.Errorf("ID = %q, want %q", h.ID, "claude")
+	}
+	if h.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want %q", h.Provider, "anthropic")
+	}
+	if h.Source != "cli" {
+		t.Errorf("Source = %q, want %q", h.Source, "cli")
+	}
+	if h.Executable == "" {
+		t.Error("Executable is empty — the head cannot be run")
+	}
+	if !h.AuthReady {
+		t.Error("AuthReady = false; a CLI agent on PATH carries its own auth")
+	}
+}
+
+// LocalOnly drives tier-10 placement in rank.UITier (#248) and the --local
+// routing gate. Getting it wrong sends work that must stay local to a paid API.
+func TestDiscover_LocalOnlyMatchesTheTable(t *testing.T) {
+	for _, c := range knownCLIs {
+		t.Run(c.binary, func(t *testing.T) {
+			s := testutil.NewSandbox(t)
+			s.FakeBinary(t, c.binary)
+
+			heads, err := (&Provider{}).Discover(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(heads) != 1 {
+				t.Fatalf("got %d heads, want 1", len(heads))
+			}
+			if heads[0].LocalOnly != c.local {
+				t.Errorf("LocalOnly = %v, want %v — %q is declared local=%v in knownCLIs",
+					heads[0].LocalOnly, c.local, c.binary, c.local)
+			}
+		})
+	}
+}
+
+// Two agents installed must produce two heads, not one and a silent drop.
+func TestDiscover_ReportsEveryInstalledAgent(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.FakeBinary(t, "claude")
+	s.FakeBinary(t, "ollama")
+
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 2 {
+		t.Fatalf("got %d heads, want 2: %+v", len(heads), heads)
+	}
+	seen := map[string]bool{}
+	for _, h := range heads {
+		seen[h.ID] = true
+	}
+	for _, want := range []string{"claude", "ollama"} {
+		if !seen[want] {
+			t.Errorf("%q not discovered; got %v", want, seen)
+		}
+	}
+}
+
+// Every entry must be reachable: a typo'd binary name is a head that can never
+// be discovered, and nothing else would ever say so.
+func TestKnownCLIs_EntriesAreWellFormed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, c := range knownCLIs {
+		if c.binary == "" {
+			t.Error("entry with an empty binary name")
+		}
+		if c.providerID == "" {
+			t.Errorf("%q has no providerID; pricing and capability lookups key off it", c.binary)
+		}
+		if seen[c.binary] {
+			t.Errorf("%q listed twice — it would be discovered as two identical heads", c.binary)
+		}
+		seen[c.binary] = true
+		if runtime.GOOS == "windows" {
+			continue // extension resolution is exec.LookPath's business, tested above
+		}
+		if c.binary != sanitised(c.binary) {
+			t.Errorf("%q is not a bare binary name; exec.LookPath will never find it", c.binary)
+		}
+	}
+}
+
+// sanitised strips anything a PATH lookup would choke on. A binary name with a
+// separator, a space or an extension is not something LookPath resolves.
+func sanitised(s string) string {
+	for _, bad := range []string{"/", `\`, " ", ".exe", ".bat"} {
+		for i := 0; i+len(bad) <= len(s); i++ {
+			if s[i:i+len(bad)] == bad {
+				return ""
+			}
+		}
+	}
+	return s
+}

--- a/internal/provider/env/provider_test.go
+++ b/internal/provider/env/provider_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+
+package env
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// Every test runs inside a sandbox that clears all provider credentials, so
+// what discovery reports is exactly what the test set — not whatever the
+// developer happens to have exported. Without that, this file passes on a
+// laptop with no keys and fails on one with them.
+
+func TestDiscover_NoKeysFindsNothing(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 0 {
+		t.Errorf("discovered %d heads with no credentials set: %+v", len(heads), heads)
+	}
+}
+
+func TestDiscover_OneKeyYieldsOneHead(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "ANTHROPIC_API_KEY", "sk-test")
+
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 1 {
+		t.Fatalf("got %d heads, want 1: %+v", len(heads), heads)
+	}
+	h := heads[0]
+	if h.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want %q", h.Provider, "anthropic")
+	}
+	if h.ID != "env/anthropic" {
+		t.Errorf("ID = %q, want %q — the env/ prefix is what keeps it distinct from the CLI head", h.ID, "env/anthropic")
+	}
+	if h.Source != "env" {
+		t.Errorf("Source = %q, want %q", h.Source, "env")
+	}
+	if !h.AuthReady {
+		t.Error("AuthReady = false, but a key was present")
+	}
+	if h.LocalOnly {
+		t.Error("LocalOnly = true for an API head — --local would route paid work as if it were free")
+	}
+}
+
+// anyOf: either variable alone is enough. Requiring both would silently hide a
+// head from anyone who set only one.
+func TestDiscover_AnyOfNeedsOnlyOneVar(t *testing.T) {
+	for _, v := range []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"} {
+		t.Run(v, func(t *testing.T) {
+			s := testutil.NewSandbox(t)
+			s.SetKey(t, v, "k")
+
+			heads, err := (&Provider{}).Discover(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(heads) != 1 || heads[0].Provider != "google" {
+				t.Fatalf("with only %s set, got %+v; want exactly one google head", v, heads)
+			}
+		})
+	}
+}
+
+// The AND case: a half-configured provider must not be advertised. A head with
+// an access key but no secret is discovered, dispatched to, and fails at the
+// point of use — the failure #248 was about, one layer earlier.
+func TestDiscover_AndKeysNeedAllVars(t *testing.T) {
+	cases := []struct {
+		name string
+		set  map[string]string
+		want int
+	}{
+		{"aws id only", map[string]string{"AWS_ACCESS_KEY_ID": "id"}, 0},
+		{"aws secret only", map[string]string{"AWS_SECRET_ACCESS_KEY": "sec"}, 0},
+		{"aws both", map[string]string{"AWS_ACCESS_KEY_ID": "id", "AWS_SECRET_ACCESS_KEY": "sec"}, 1},
+		{"azure key only", map[string]string{"AZURE_OPENAI_API_KEY": "k"}, 0},
+		{"azure both", map[string]string{"AZURE_OPENAI_API_KEY": "k", "AZURE_OPENAI_ENDPOINT": "https://e"}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testutil.NewSandbox(t)
+			for k, v := range tc.set {
+				s.SetKey(t, k, v)
+			}
+			heads, err := (&Provider{}).Discover(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(heads) != tc.want {
+				t.Errorf("got %d heads, want %d: %+v", len(heads), tc.want, heads)
+			}
+		})
+	}
+}
+
+// An empty string is not a credential. Exporting KEY= to *disable* a provider is
+// ordinary shell practice, and treating it as set advertises a head that cannot
+// authenticate.
+func TestDiscover_EmptyValueIsNotACredential(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "OPENAI_API_KEY", "")
+
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 0 {
+		t.Errorf("an empty OPENAI_API_KEY produced %+v", heads)
+	}
+}
+
+func TestKnownKeys_EntriesAreWellFormed(t *testing.T) {
+	seenProvider := map[string]bool{}
+	for _, k := range knownKeys {
+		if k.providerID == "" {
+			t.Errorf("entry with vars %v has no providerID", k.envVars)
+		}
+		if len(k.envVars) == 0 {
+			t.Errorf("provider %q has no env vars — it can never be detected", k.providerID)
+		}
+		if seenProvider[k.providerID] {
+			t.Errorf("providerID %q listed twice — it would yield two heads with the same ID", k.providerID)
+		}
+		seenProvider[k.providerID] = true
+		if len(k.envVars) > 1 && !k.anyOf {
+			continue // AND is deliberate for AWS/Azure
+		}
+		if len(k.envVars) > 1 && k.anyOf {
+			continue // OR is deliberate for google
+		}
+	}
+}

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+
+package testutil
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// updateGolden re-blesses golden files: `go test ./... -update`.
+//
+// Registered here rather than per-package so one flag drives every golden in
+// the repo. Re-blessing is legitimate when the change to the output was
+// intended; it is the bug when it was not. CONTRIBUTING.md draws that line —
+// this flag is the reason it has to.
+var updateGolden = flag.Bool("update", false, "rewrite golden files to match current output")
+
+// Normaliser replaces values that legitimately vary between machines and runs
+// with stable placeholders, so a golden file asserts behaviour rather than
+// incidental fact. Without these, a golden pins the maintainer's home directory
+// and the version they happened to build, and fails for everyone else.
+//
+// Ordering matters: paths are replaced before separators, or a Windows path
+// would be half-normalised.
+var normalisers = []struct {
+	re   *regexp.Regexp
+	with string
+}{
+	// Durations: "1.234s", "12ms", "1m30s" → <dur>
+	{regexp.MustCompile(`\b\d+(\.\d+)?(ns|µs|us|ms|s|m|h)\b`), "<dur>"},
+	// Semver, with or without a leading v and any pre-release/build suffix.
+	{regexp.MustCompile(`\bv?\d+\.\d+\.\d+(-[0-9A-Za-z.\-]+)?(\+[0-9A-Za-z.\-]+)?\b`), "<ver>"},
+	// Git short SHAs (7-12 hex). Longer runs of hex are content, not a commit.
+	{regexp.MustCompile(`\b[0-9a-f]{7,12}\b`), "<sha>"},
+	// RFC3339 timestamps.
+	{regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}T[\d:.]+(Z|[+\-]\d{2}:\d{2})`), "<ts>"},
+	// Dollar amounts.
+	{regexp.MustCompile(`\$\d+\.\d+`), "<usd>"},
+}
+
+// Normalise makes output comparable across machines, platforms and runs.
+// tempPaths (typically a Sandbox's directories) are replaced first, longest
+// first so a nested path does not get half-substituted by its parent.
+func Normalise(s string, tempPaths ...string) string {
+	sorted := append([]string(nil), tempPaths...)
+	// Longest first: HydraHome may sit inside the same root as Home.
+	for i := range sorted {
+		for j := i + 1; j < len(sorted); j++ {
+			if len(sorted[j]) > len(sorted[i]) {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+	for _, p := range sorted {
+		if p == "" {
+			continue
+		}
+		s = strings.ReplaceAll(s, p, "<tmp>")
+		// Windows hands back both separators for the same path depending on who
+		// built the string, so normalise the alternate spelling too.
+		s = strings.ReplaceAll(s, strings.ReplaceAll(p, `\`, `/`), "<tmp>")
+	}
+	// Path separators, after the temp-path substitutions above.
+	s = strings.ReplaceAll(s, `\`, `/`)
+	// Line endings: a Windows runner writes CRLF, everyone else LF.
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+
+	for _, n := range normalisers {
+		s = n.re.ReplaceAllString(s, n.with)
+	}
+	// Trailing whitespace per line, which differs by terminal-width assumptions.
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimRight(l, " \t")
+	}
+	return strings.TrimRight(strings.Join(lines, "\n"), "\n") + "\n"
+}
+
+// Golden compares got against testdata/<name>.golden, normalised.
+//
+// The failure message is the product here: a contributor who trips a contract
+// must be able to act on it without reading this file. It states what differed
+// and the exact command to re-bless if the change was intended.
+func Golden(t *testing.T, name, got string, tempPaths ...string) {
+	t.Helper()
+
+	path := filepath.Join("testdata", name+".golden")
+	norm := Normalise(got, tempPaths...)
+
+	if *updateGolden {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(norm), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("updated %s", path)
+		return
+	}
+
+	wantRaw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("no golden file at %s.\n\nOutput was:\n%s\n"+
+				"If that is correct, create it:\n    go test ./%s -run %s -update",
+				path, indent(norm), pkgDir(t), t.Name())
+		}
+		t.Fatal(err)
+	}
+	want := string(wantRaw)
+	if norm == want {
+		return
+	}
+
+	t.Errorf("output does not match %s\n\n--- want (golden) ---\n%s\n--- got ---\n%s\n"+
+		"%s\n"+
+		"If this change is intended, re-bless the golden:\n    go test ./%s -run %s -update\n"+
+		"If it is not, the behaviour changed and that is the bug.",
+		path, indent(want), indent(norm), firstDiff(want, norm), pkgDir(t), t.Name())
+}
+
+// firstDiff points at the first differing line, so a large golden does not
+// leave the reader diffing two walls of text by eye.
+func firstDiff(want, got string) string {
+	w, g := strings.Split(want, "\n"), strings.Split(got, "\n")
+	for i := 0; i < len(w) || i < len(g); i++ {
+		var wl, gl string
+		if i < len(w) {
+			wl = w[i]
+		}
+		if i < len(g) {
+			gl = g[i]
+		}
+		if wl != gl {
+			return "first difference at line " + itoa(i+1) + ":\n" +
+				"    want: " + quote(wl) + "\n" +
+				"    got:  " + quote(gl)
+		}
+	}
+	return ""
+}
+
+func indent(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i, l := range lines {
+		lines[i] = "    " + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+func quote(s string) string {
+	if s == "" {
+		return "(end of output)"
+	}
+	return `"` + s + `"`
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+// pkgDir is the package path to put in the re-bless command, so the printed
+// command can be pasted as-is from the repo root.
+func pkgDir(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		return "..."
+	}
+	// Trim everything up to and including the module root marker.
+	for dir := wd; ; {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			rel, err := filepath.Rel(dir, wd)
+			if err != nil {
+				break
+			}
+			return strings.ReplaceAll(rel, `\`, "/")
+		}
+		dir = parent
+	}
+	return "..."
+}

--- a/internal/testutil/sandbox.go
+++ b/internal/testutil/sandbox.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: MIT
+
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// APIKeyVars is every environment variable the env provider treats as evidence
+// of a usable head (internal/provider/env's knownKeys table). A test that does
+// not clear these discovers whatever the developer happens to have exported,
+// so the same test passes on a laptop with no keys and fails on one with them —
+// or worse, quietly routes a test dispatch to a real paid provider.
+//
+// Kept in sync with knownKeys by TestAPIKeyVars_CoversEnvProvider.
+var APIKeyVars = []string{
+	"ANTHROPIC_API_KEY",
+	"AWS_ACCESS_KEY_ID",
+	"AWS_SECRET_ACCESS_KEY",
+	"AZURE_OPENAI_API_KEY",
+	"AZURE_OPENAI_ENDPOINT",
+	"COHERE_API_KEY",
+	"DEEPSEEK_API_KEY",
+	"FIREWORKS_API_KEY",
+	"GEMINI_API_KEY",
+	"GOOGLE_API_KEY",
+	"GROQ_API_KEY",
+	"MISTRAL_API_KEY",
+	"OPENAI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"PERPLEXITY_API_KEY",
+	"REPLICATE_API_TOKEN",
+	"TOGETHER_API_KEY",
+	"XAI_API_KEY",
+}
+
+// tuningVars are Hydra's own knobs. A developer with HYDRA_HOME exported for
+// day-to-day use would otherwise have every test read their real registry.
+var tuningVars = []string{
+	"HYDRA_HOME",
+	"HYDRA_MAX_OUTPUT_BYTES",
+	"HYDRA_NO_UPDATE_CHECK",
+	"HYDRA_PRICING_TTL_HOURS",
+	"HYDRA_TOKEN_SIDECAR",
+	"HYDRA_WORKSPACE",
+	"AGY_TIMEOUT",
+	"OLLAMA_HOST",
+}
+
+// Sandbox is a hermetic environment for one test: a private home directory, a
+// private $HYDRA_HOME, an empty $PATH, and no provider credentials.
+//
+// The point is that a contributor with no Ollama, no API keys and no agy on
+// their machine gets byte-identical results to CI, and to a maintainer whose
+// laptop has all three. Discovery is the layer where that matters most — it
+// exists to report what is installed, so it is the layer most likely to report
+// the *developer's* machine instead of the test's fixture.
+//
+// It is also what makes a test cross-platform for free: nothing here reads a
+// path, a binary or a variable that differs between Linux, macOS and Windows.
+type Sandbox struct {
+	// Home is the fake user home. Both $HOME and %USERPROFILE% point here, so
+	// os.UserHomeDir resolves to it on every OS.
+	Home string
+	// HydraHome is $HYDRA_HOME: where an on-disk registry/ override and the
+	// logs are read from. config.ScriptHome() resolves to this.
+	HydraHome string
+	// BinDir is the only directory on $PATH. Empty until FakeBinary is called,
+	// so exec.LookPath finds nothing by default.
+	BinDir string
+}
+
+// NewSandbox installs a hermetic environment for the duration of t. Every
+// variable is restored by t.Setenv's own cleanup, so nothing leaks between
+// tests even when they run in the same process.
+func NewSandbox(t *testing.T) *Sandbox {
+	t.Helper()
+
+	root := t.TempDir()
+	s := &Sandbox{
+		Home:      filepath.Join(root, "home"),
+		HydraHome: filepath.Join(root, "hydra"),
+		BinDir:    filepath.Join(root, "bin"),
+	}
+	for _, d := range []string{s.Home, s.HydraHome, s.BinDir} {
+		if err := os.MkdirAll(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// os.UserHomeDir reads $HOME on unix and %USERPROFILE% on Windows. Set both
+	// rather than branching, so the sandbox has one behaviour everywhere.
+	t.Setenv("HOME", s.Home)
+	t.Setenv("USERPROFILE", s.Home)
+	t.Setenv("HYDRA_HOME", s.HydraHome)
+
+	// An empty PATH would make exec.LookPath fail for a different reason on
+	// each OS; one empty directory makes "not found" mean exactly that.
+	t.Setenv("PATH", s.BinDir)
+
+	for _, v := range APIKeyVars {
+		t.Setenv(v, "")
+	}
+	for _, v := range tuningVars {
+		if v == "HYDRA_HOME" {
+			continue // set above
+		}
+		t.Setenv(v, "")
+	}
+
+	// Best-effort outbound-HTTP block. This stops any client using
+	// http.DefaultTransport (which honours the proxy environment) from reaching
+	// the network — that covers the pricing fetcher and the update checker. It
+	// does NOT stop a transport constructed with Proxy: nil, so it is a
+	// backstop against accidental egress, not a sandbox boundary. Tests that
+	// must not hit the network should inject a fake client rather than rely on
+	// this alone.
+	t.Setenv("HTTP_PROXY", "127.0.0.1:1")
+	t.Setenv("HTTPS_PROXY", "127.0.0.1:1")
+	t.Setenv("NO_PROXY", "")
+
+	return s
+}
+
+// FakeBinary puts an executable named name on the sandbox's $PATH, so a
+// discovery test can assert "this CLI agent is installed" without installing
+// one. The script exits 0 and echoes nothing; pass a body to make it behave.
+//
+// On Windows the file needs a .bat extension for exec.LookPath to consider it
+// executable, which is exactly the sort of difference a discovery contract
+// should be exercising rather than skipping.
+func (s *Sandbox) FakeBinary(t *testing.T, name string, body ...string) string {
+	t.Helper()
+
+	script, path := "#!/bin/sh\nexit 0\n", filepath.Join(s.BinDir, name)
+	if runtime.GOOS == "windows" {
+		script, path = "@echo off\r\nexit /b 0\r\n", filepath.Join(s.BinDir, name+".bat")
+	}
+	if len(body) > 0 {
+		script = body[0]
+	}
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// SetKey re-introduces one provider credential that NewSandbox cleared, for a
+// test that needs exactly one head to be discoverable.
+func (s *Sandbox) SetKey(t *testing.T, envVar, value string) {
+	t.Helper()
+	t.Setenv(envVar, value)
+}

--- a/internal/testutil/sandbox_test.go
+++ b/internal/testutil/sandbox_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+
+package testutil
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The sandbox exists to make a test's result independent of the machine it runs
+// on. If a credential the developer exported survives into the test, discovery
+// reports their machine instead of the fixture — and the test passes or fails by
+// accident.
+func TestSandbox_ClearsProviderCredentials(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-should-not-survive")
+	t.Setenv("OPENAI_API_KEY", "sk-should-not-survive")
+
+	NewSandbox(t)
+
+	for _, v := range APIKeyVars {
+		if got := os.Getenv(v); got != "" {
+			t.Errorf("%s = %q inside the sandbox; a test would discover the developer's real head", v, got)
+		}
+	}
+}
+
+func TestSandbox_RedirectsHomeAndHydraHome(t *testing.T) {
+	realHome, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewSandbox(t)
+
+	got, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != s.Home {
+		t.Errorf("os.UserHomeDir() = %q, want the sandbox home %q", got, s.Home)
+	}
+	if got == realHome {
+		t.Error("os.UserHomeDir() still resolves to the developer's real home")
+	}
+	if os.Getenv("HYDRA_HOME") != s.HydraHome {
+		t.Errorf("HYDRA_HOME = %q, want %q", os.Getenv("HYDRA_HOME"), s.HydraHome)
+	}
+}
+
+// Discovery walks $PATH looking for CLI agents. An unscrubbed PATH means a
+// maintainer with claude/codex/ollama installed tests a different code path
+// than a contributor without them.
+func TestSandbox_PathFindsNothingByDefault(t *testing.T) {
+	s := NewSandbox(t)
+
+	for _, bin := range []string{"claude", "codex", "ollama", "agy", "cursor"} {
+		if p, err := exec.LookPath(bin); err == nil {
+			t.Errorf("LookPath(%q) found %q inside the sandbox", bin, p)
+		}
+	}
+
+	// …and a deliberately planted one is found, or the check above would pass
+	// for the trivial reason that PATH lookup is broken entirely.
+	s.FakeBinary(t, "ollama")
+	if _, err := exec.LookPath("ollama"); err != nil {
+		t.Errorf("planted binary not found: %v", err)
+	}
+}
+
+func TestSandbox_IsIsolatedBetweenTests(t *testing.T) {
+	first := NewSandbox(t)
+	t.Run("nested", func(t *testing.T) {
+		second := NewSandbox(t)
+		if second.Home == first.Home {
+			t.Error("two sandboxes share a home directory")
+		}
+	})
+}
+
+// APIKeyVars must list every variable the env provider treats as a usable head.
+// A provider added there but missed here leaks that credential into every test.
+//
+// The env package is read as source rather than imported: its init() registers
+// a provider globally, so importing it from testutil would silently change
+// discovery in every test binary that uses the sandbox.
+func TestAPIKeyVars_CoversEnvProvider(t *testing.T) {
+	src := filepath.Join("..", "provider", "env", "provider.go")
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, src, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", src, err)
+	}
+
+	envVar := regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+	found := map[string]bool{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		vs, ok := n.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		isKnownKeys := false
+		for _, name := range vs.Names {
+			if name.Name == "knownKeys" {
+				isKnownKeys = true
+			}
+		}
+		if !isKnownKeys {
+			return true
+		}
+		ast.Inspect(vs, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			s, err := strconv.Unquote(lit.Value)
+			if err == nil && envVar.MatchString(s) {
+				found[s] = true
+			}
+			return true
+		})
+		return false
+	})
+
+	if len(found) == 0 {
+		t.Fatalf("parsed no env vars out of %s — this guard has stopped guarding "+
+			"(knownKeys renamed or restructured?)", src)
+	}
+
+	listed := map[string]bool{}
+	for _, v := range APIKeyVars {
+		listed[v] = true
+	}
+	for v := range found {
+		if !listed[v] {
+			t.Errorf("%s is read by the env provider but missing from APIKeyVars — "+
+				"a developer with it exported would have it leak into every sandboxed test", v)
+		}
+	}
+	for v := range listed {
+		if !found[v] {
+			t.Errorf("APIKeyVars lists %s but the env provider no longer reads it — drop it", v)
+		}
+	}
+}
+
+// FakeBinary must produce something exec.LookPath accepts on the host OS —
+// on Windows that means a .bat, which is exactly the kind of difference a
+// discovery contract should exercise rather than skip.
+func TestFakeBinary_IsExecutableOnThisOS(t *testing.T) {
+	s := NewSandbox(t)
+	path := s.FakeBinary(t, "probe-me")
+
+	if !strings.HasPrefix(path, s.BinDir) {
+		t.Errorf("planted at %q, outside the sandbox bin dir %q", path, s.BinDir)
+	}
+	resolved, err := exec.LookPath("probe-me")
+	if err != nil {
+		t.Fatalf("LookPath: %v", err)
+	}
+	if err := exec.Command(resolved).Run(); err != nil {
+		t.Errorf("planted binary is not runnable: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

The repo had ~150 test functions across 48 files and **no shared harness**. Every test invented its own setup, and nothing stopped one from reading the developer's real `$HOME`, `$PATH` or API keys.

Two consequences:
1. The suite could not simply be pointed at Windows and macOS (#255).
2. **Discovery — the layer whose entire job is reporting what is installed on this machine — had no tests at all.** `provider`, `provider/{agy,cli,env,port}` and `probe` are 5 of the 11 zero-test packages. That layer is the one most likely to report the *developer's* machine instead of the fixture, so it is the one that most needed isolating.

## The harness

`testutil.NewSandbox(t)` — private home, private `$HYDRA_HOME`, empty `$PATH`, no provider credentials.

A contributor with no Ollama, no API keys and no `agy` now gets byte-identical results to CI, and to a maintainer whose laptop has all three. It is also what makes a test cross-platform for free: nothing in it reads a path, binary or variable that differs across the three OSes.

```go
s := testutil.NewSandbox(t)
s.FakeBinary(t, "ollama")             // this machine "has" ollama, and only ollama
s.SetKey(t, "ANTHROPIC_API_KEY", "k")  // …and exactly one API head
```

- **`FakeBinary`** plants an executable on the sandbox PATH — `.bat` on Windows — so `exec.LookPath` resolution is *exercised* on every OS rather than skipped.
- **`APIKeyVars` stays in sync with the env provider automatically.** A guard test parses `provider/env`'s AST for its `knownKeys` table. It reads the source rather than importing the package because `env`'s `init()` registers a provider globally — importing it from `testutil` would silently change discovery in every test binary that uses the sandbox. Verified adversarially by adding a fake vendor key:
  ```
  --- FAIL: TestAPIKeyVars_CoversEnvProvider
      NEWVENDOR_API_KEY is read by the env provider but missing from APIKeyVars —
      a developer with it exported would have it leak into every sandboxed test
  ```
- **`testutil.Golden`** normalises temp paths, versions, SHAs, timestamps, durations, path separators and line endings, so a golden asserts behaviour rather than the maintainer's home directory. The failure message prints both versions, the first differing line, **and the exact `-update` command** — a contributor who trips a contract must be able to act without reading the test source.

## First real users — both previously zero-test packages

**`provider/cli`** — empty PATH finds nothing; a planted binary is found on every OS; **`LocalOnly` matches `knownCLIs` for every entry** (it drives tier-10 placement and the `--local` gate, so a wrong value routes must-stay-local work to a paid API); two installed agents yield two heads, not one and a silent drop.

**`provider/env`** — no keys finds nothing; `anyOf` needs only one var; **AND providers (AWS, Azure) are not advertised half-configured** — a head with an access key and no secret is discovered, dispatched to, and fails at the point of use, which is the #248 failure one layer earlier; an empty value is not a credential, since `KEY=` is ordinary practice for disabling a provider.

## CONTRIBUTING.md — "The Regression Contract"

A deliverable, not an afterthought. An unexplained contract suite is hostile to outside contributors: they will re-bless goldens to make CI green because nobody told them not to.

It covers what these tests are for, the four rules for writing one (contract-not-implementation, hermetic, deterministic, **parametrise by platform rather than skip**), when re-blessing a golden is legitimate versus when it is the bug, and how to check that a test can actually fail — including why `-count=1` is required.

The "before you push" block now also states that CI runs on three OSes and six build targets, with the cross-compile command to run locally.

## Verification

```
go test ./... -race -count=1              all green
GOOS=windows GOARCH=arm64 go vet ./...    clean
```

Gates #267 (CLI surface contract), #268 (format contracts), #269 (routing + discovery contracts), #270 (coverage floor).

Closes #266