### PR TITLE
fix(sysinfo): detect memory on Windows, and stop inventing it everywhere else

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mattn/go-isatty v0.0.22
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/sync v0.19.0
+	golang.org/x/sys v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -31,6 +32,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/internal/sysinfo/mem_notwindows.go
+++ b/internal/sysinfo/mem_notwindows.go
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package sysinfo
+
+// windowsMemory is never called off Windows; it exists so Detect's switch
+// compiles on every target rather than being wrapped in build tags of its own.
+func windowsMemory() (totalGB, availableGB float64) { return 0, 0 }

--- a/internal/sysinfo/mem_windows.go
+++ b/internal/sysinfo/mem_windows.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package sysinfo
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// GlobalMemoryStatusEx is not exported by golang.org/x/sys/windows (checked at
+// v0.36.0), so it is bound here. NewLazySystemDLL rather than syscall.NewLazyDLL:
+// it resolves out of the system directory only, so the lookup cannot be
+// satisfied by a kernel32.dll dropped next to the binary.
+var (
+	kernel32                 = windows.NewLazySystemDLL("kernel32.dll")
+	procGlobalMemoryStatusEx = kernel32.NewProc("GlobalMemoryStatusEx")
+)
+
+// memoryStatusEx mirrors MEMORYSTATUSEX. Field order and widths are fixed by
+// the Win32 ABI — the call writes into this layout, so it must not be reordered.
+type memoryStatusEx struct {
+	Length               uint32
+	MemoryLoad           uint32
+	TotalPhys            uint64
+	AvailPhys            uint64
+	TotalPageFile        uint64
+	AvailPageFile        uint64
+	TotalVirtual         uint64
+	AvailVirtual         uint64
+	AvailExtendedVirtual uint64
+}
+
+// windowsMemory returns (totalGB, availableGB).
+//
+// AvailPhys is what Windows itself shows as "Available" in Task Manager: free
+// plus standby (cached-but-reclaimable) pages. That is the same notion as the
+// free+inactive figure darwinMemoryState derives from vm_stat, and as the
+// MemAvailable field linuxFreeRAM reads — so all three platforms feed
+// EffectiveVRAMGB comparable numbers rather than three different definitions of
+// "free".
+//
+// A (0, 0) return means detection failed. Callers must treat that as unknown
+// rather than as an empty machine: reporting 0GB as a reading is what made
+// Windows claim "0GB RAM · memory fully occupied" and "pressure: low" at the
+// same time (#258).
+func windowsMemory() (totalGB, availableGB float64) {
+	if err := procGlobalMemoryStatusEx.Find(); err != nil {
+		return 0, 0 // .Call would panic; an unreadable machine is "unknown"
+	}
+	var m memoryStatusEx
+	m.Length = uint32(unsafe.Sizeof(m))
+	// Returns nonzero on success; the error is only meaningful when r == 0.
+	r, _, _ := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(&m)))
+	if r == 0 {
+		return 0, 0
+	}
+	const gb = 1 << 30
+	return float64(m.TotalPhys) / gb, float64(m.AvailPhys) / gb
+}

--- a/internal/sysinfo/recommend.go
+++ b/internal/sysinfo/recommend.go
@@ -37,11 +37,25 @@ var ollamaModels = []ModelRecommendation{
 
 // OllamaRecommendations returns models ranked for this machine.
 // The first entry with Fits=true is the primary recommendation.
+//
+// When the hardware could not be read, every model is returned with Fits=false
+// and a reason saying so. Ranking against the zero value would silently compare
+// each model to a 0GB budget and report "insufficient memory" — a hardware
+// verdict drawn from the absence of a hardware reading (#258).
 func (s *Specs) OllamaRecommendations() []ModelRecommendation {
 	effective := s.EffectiveVRAMGB()
+	known := s.HardwareKnown()
 
 	out := make([]ModelRecommendation, len(ollamaModels))
 	for i, m := range ollamaModels {
+		if !known {
+			m.Fits = false
+			m.RAMAfterLoad = 0
+			m.Reason = unknownHardwareNote
+			m.MemoryCost = fmt.Sprintf("needs ~%.0fGB · available memory unknown", m.RAMNeededGB)
+			out[i] = m
+			continue
+		}
 		remaining := effective - m.RAMNeededGB
 		m.Fits = remaining >= 0
 		m.RAMAfterLoad = remaining
@@ -71,6 +85,9 @@ func (s *Specs) BestOllamaModel() ModelRecommendation {
 		if m.Fits {
 			return m
 		}
+	}
+	if !s.HardwareKnown() {
+		return ModelRecommendation{Fits: false, Reason: unknownHardwareNote}
 	}
 	return ModelRecommendation{Fits: false, Reason: "insufficient memory for any local model"}
 }
@@ -113,6 +130,9 @@ func (s *Specs) reason(m ModelRecommendation, effectiveGB float64) string {
 // PressureWarning returns a warning string if memory pressure is high, else "".
 func (s *Specs) PressureWarning() string {
 	switch s.MemPressure {
+	case PressureUnknown:
+		return "Memory could not be detected on this platform — local model sizing is unavailable. " +
+			"API-backed heads are unaffected."
 	case PressureModerate:
 		return fmt.Sprintf("Memory moderate (%.1fGB free) — close other apps for better performance.", s.FreeRAMGB)
 	case PressureHigh:

--- a/internal/sysinfo/sysinfo.go
+++ b/internal/sysinfo/sysinfo.go
@@ -18,15 +18,30 @@ const (
 	PressureLow      Pressure = iota // plenty of headroom
 	PressureModerate                 // usable but getting tight
 	PressureHigh                     // constrained; only small models safe
+	// PressureUnknown means detection failed — no reading was taken.
+	//
+	// Appended rather than inserted so the three values above keep their
+	// numbering. It exists because the alternative is worse than useless:
+	// computePressure used to return PressureLow whenever TotalRAMGB was 0,
+	// so a platform with no detection path (every Windows machine, until this
+	// change) reported the single most permissive verdict from no data at all,
+	// while Summary said "0GB RAM · memory fully occupied" in the same breath.
+	// A default must never be rendered as a measurement (#251, #258).
+	PressureUnknown
 )
 
 func (p Pressure) String() string {
-	names := [...]string{"low", "moderate", "high"}
+	names := [...]string{"low", "moderate", "high", "unknown"}
 	if p < 0 || int(p) >= len(names) {
 		return "unknown"
 	}
 	return names[p]
 }
+
+// HardwareKnown reports whether Detect actually read this machine's memory. When
+// false, every memory-derived field is a placeholder and callers must not
+// present it as a measurement or rank models against it.
+func (s *Specs) HardwareKnown() bool { return s != nil && s.TotalRAMGB > 0 }
 
 // Specs describes the hardware and current memory state relevant to AI model selection.
 type Specs struct {
@@ -89,6 +104,9 @@ func (s *Specs) bestFreeEstimate() float64 {
 
 // MemoryNote returns a human-readable explanation of the effective value.
 func (s *Specs) MemoryNote() string {
+	if !s.HardwareKnown() {
+		return unknownHardwareNote
+	}
 	eff := s.EffectiveVRAMGB()
 	switch {
 	case s.GPUVRAMGB > 0 && !s.IsAppleSilicon:
@@ -106,8 +124,20 @@ func (s *Specs) MemoryNote() string {
 	}
 }
 
+// Text shown wherever hardware could not be read. It says "unknown", not a
+// number, because the number would be 0 and every reader — human or code —
+// would take that as a measurement of an empty machine rather than an absence
+// of one (#258).
+const (
+	unknownHardwareSummary = "hardware unknown · could not read this machine's memory"
+	unknownHardwareNote    = "memory could not be detected on this platform — local model sizing is unavailable"
+)
+
 // Summary returns a one-line hardware description for display.
 func (s *Specs) Summary() string {
+	if !s.HardwareKnown() {
+		return unknownHardwareSummary
+	}
 	eff := s.EffectiveVRAMGB()
 	switch {
 	case s.IsAppleSilicon:
@@ -145,6 +175,9 @@ func Detect() *Specs {
 		s.TotalRAMGB = linuxRAM()
 		s.FreeRAMGB = linuxFreeRAM()
 		s.GPUVRAMGB, s.GPUName = nvidiaVRAM()
+	case "windows":
+		s.TotalRAMGB, s.FreeRAMGB = windowsMemory()
+		s.GPUVRAMGB, s.GPUName = nvidiaVRAM() // nvidia-smi ships on Windows too
 	}
 
 	s.History = LoadHistory()
@@ -154,8 +187,11 @@ func Detect() *Specs {
 }
 
 func (s *Specs) computePressure() Pressure {
+	// No reading was taken. Reporting PressureLow here — as this did until
+	// #258 — is an affirmative "plenty of headroom" claim derived from nothing,
+	// and it is the most permissive verdict the type can express.
 	if s.TotalRAMGB == 0 {
-		return PressureLow
+		return PressureUnknown
 	}
 	ratio := s.EffectiveVRAMGB() / s.TotalRAMGB
 	switch {

--- a/internal/sysinfo/sysinfo_test.go
+++ b/internal/sysinfo/sysinfo_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+
+package sysinfo
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The contract this package exists to keep: Detect either reads this machine's
+// memory or says it could not. It must never produce a number it did not
+// measure.
+//
+// Before #258 there was no windows case in Detect's switch, so on Windows every
+// field kept its zero value and the package reported "0GB RAM · memory fully
+// occupied (0.0GB free)" with MemPressure = low — simultaneously claiming the
+// machine was full and that it had plenty of headroom, from no reading at all.
+// This test runs on all three OSes in CI and would have caught that on day one.
+func TestDetect_ReadsThisMachinesMemory(t *testing.T) {
+	s := Detect()
+
+	if !s.HardwareKnown() {
+		t.Fatalf("Detect() on %s/%s reported unknown hardware — this platform has no working "+
+			"detection path, and every memory-derived number it produces is a placeholder.\n"+
+			"  Summary()   = %q\n  MemPressure = %v",
+			runtime.GOOS, runtime.GOARCH, s.Summary(), s.MemPressure)
+	}
+	if s.TotalRAMGB < 0.5 {
+		t.Errorf("TotalRAMGB = %.2f — no machine that can run this test has under 0.5GB", s.TotalRAMGB)
+	}
+	if s.FreeRAMGB > s.TotalRAMGB {
+		t.Errorf("FreeRAMGB (%.2f) exceeds TotalRAMGB (%.2f)", s.FreeRAMGB, s.TotalRAMGB)
+	}
+	if s.MemPressure == PressureUnknown {
+		t.Errorf("MemPressure = unknown despite TotalRAMGB = %.2f", s.TotalRAMGB)
+	}
+	if s.OS != runtime.GOOS || s.Arch != runtime.GOARCH {
+		t.Errorf("OS/Arch = %s/%s, want %s/%s", s.OS, s.Arch, runtime.GOOS, runtime.GOARCH)
+	}
+}
+
+// The zero value is exactly what a platform with no detection path produces.
+// Every accessor must present it as absence, not as a reading of an empty box.
+func TestUndetectedHardware_IsReportedAsUnknown(t *testing.T) {
+	s := &Specs{Arch: "amd64", OS: "some-future-os"}
+	s.MemPressure = s.computePressure()
+
+	if s.HardwareKnown() {
+		t.Fatal("HardwareKnown() = true with TotalRAMGB = 0")
+	}
+	if s.MemPressure != PressureUnknown {
+		t.Errorf("MemPressure = %v, want unknown. PressureLow is the most permissive verdict "+
+			"the type can express and it would be drawn from no data", s.MemPressure)
+	}
+
+	summary := s.Summary()
+	if strings.Contains(summary, "0GB") || strings.Contains(summary, "0.0GB") {
+		t.Errorf("Summary() = %q — prints a zero as though it were a measurement", summary)
+	}
+	if !strings.Contains(strings.ToLower(summary), "unknown") {
+		t.Errorf("Summary() = %q, want it to say the hardware is unknown", summary)
+	}
+	if strings.Contains(strings.ToLower(summary), "fully occupied") {
+		t.Errorf("Summary() = %q — claims the machine is full, from no reading", summary)
+	}
+
+	if note := s.MemoryNote(); !strings.Contains(strings.ToLower(note), "unknown") &&
+		!strings.Contains(strings.ToLower(note), "could not") {
+		t.Errorf("MemoryNote() = %q, want it to state that detection failed", note)
+	}
+	if w := s.PressureWarning(); w == "" {
+		t.Error("PressureWarning() is empty for unknown hardware — the user is told nothing")
+	}
+}
+
+// Ranking models against a 0GB budget answers a hardware question with the
+// absence of a hardware reading: every model "does not fit", which reads as
+// "your machine is too small" rather than "I could not measure your machine".
+func TestUndetectedHardware_DoesNotRankModels(t *testing.T) {
+	s := &Specs{Arch: "amd64", OS: "some-future-os"}
+	s.MemPressure = s.computePressure()
+
+	recs := s.OllamaRecommendations()
+	if len(recs) == 0 {
+		t.Fatal("no recommendations returned at all")
+	}
+	for _, r := range recs {
+		if r.Fits {
+			t.Errorf("%s reported as fitting with no memory reading", r.Model)
+		}
+		if strings.Contains(strings.ToLower(r.Reason), "only 0.0gb") {
+			t.Errorf("%s reason = %q — states a measured 0GB budget", r.Model, r.Reason)
+		}
+		if !strings.Contains(strings.ToLower(r.Reason), "could not") &&
+			!strings.Contains(strings.ToLower(r.Reason), "unknown") {
+			t.Errorf("%s reason = %q, want it to say memory is unknown", r.Model, r.Reason)
+		}
+	}
+
+	if best := s.BestOllamaModel(); best.Fits {
+		t.Error("BestOllamaModel() claims a fit with no memory reading")
+	} else if strings.Contains(best.Reason, "insufficient memory") {
+		t.Errorf("BestOllamaModel().Reason = %q — a hardware verdict from no hardware reading", best.Reason)
+	}
+	if s.AnyLocalModelFits() {
+		t.Error("AnyLocalModelFits() = true with no memory reading")
+	}
+}
+
+// A detected machine must still rank normally — the guard above must not have
+// turned recommendations off for everyone.
+func TestKnownHardware_StillRanksModels(t *testing.T) {
+	s := &Specs{Arch: "amd64", OS: "linux", TotalRAMGB: 64, FreeRAMGB: 48}
+	s.MemPressure = s.computePressure()
+
+	if !s.HardwareKnown() {
+		t.Fatal("HardwareKnown() = false for a machine with 64GB")
+	}
+	if s.MemPressure == PressureUnknown {
+		t.Error("MemPressure = unknown for a machine with 64GB")
+	}
+	if !s.AnyLocalModelFits() {
+		t.Error("nothing fits in 48GB free — the unknown-hardware guard is firing on known hardware")
+	}
+	if best := s.BestOllamaModel(); !best.Fits {
+		t.Errorf("BestOllamaModel() = %+v, want a fit", best)
+	}
+	if strings.Contains(strings.ToLower(s.Summary()), "unknown") {
+		t.Errorf("Summary() = %q for known hardware", s.Summary())
+	}
+}
+
+func TestPressure_StringCoversEveryValue(t *testing.T) {
+	want := map[Pressure]string{
+		PressureLow:      "low",
+		PressureModerate: "moderate",
+		PressureHigh:     "high",
+		PressureUnknown:  "unknown",
+	}
+	for p, s := range want {
+		if got := p.String(); got != s {
+			t.Errorf("Pressure(%d).String() = %q, want %q", int(p), got, s)
+		}
+	}
+	// Out of range must not panic or index past the table.
+	if got := Pressure(99).String(); got != "unknown" {
+		t.Errorf("Pressure(99).String() = %q, want %q", got, "unknown")
+	}
+}
+
+// PressureUnknown is appended, not inserted: the three real levels keep their
+// numbering. Nothing persists a Pressure today, but a reordering would silently
+// reinterpret any that ever is.
+func TestPressure_ValuesAreStable(t *testing.T) {
+	for _, tc := range []struct {
+		p    Pressure
+		want int
+	}{{PressureLow, 0}, {PressureModerate, 1}, {PressureHigh, 2}, {PressureUnknown, 3}} {
+		if int(tc.p) != tc.want {
+			t.Errorf("%v = %d, want %d — inserting a value renumbers the others", tc.p, int(tc.p), tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`Detect()`'s switch had cases for `darwin` and `linux` and **no default**, so on Windows every hardware field kept its zero value. The package then reported, simultaneously:

```
Summary()   = "0GB RAM · memory fully occupied (0.0GB free)"
MemPressure = low
```

The machine is full, *and* the machine has plenty of headroom — both asserted from no reading at all. `hyctl init` then ranked Ollama models against a 0 GB budget and told the user nothing fits, which reads as *"your machine is too small"* rather than *"I could not measure your machine"*.

`computePressure` returned `PressureLow` whenever `TotalRAMGB == 0` — the **most permissive** verdict the type can express — directly contradicting `Detect()`'s own doc comment: *"Never returns an error — conservative estimates are returned on failure."*

## Two fixes; the second is the one that generalises

**1 · Windows detection via `GlobalMemoryStatusEx`.** `x/sys/windows` does not export it at v0.36.0 (checked), so it is bound through `NewLazySystemDLL` — system directory only, so the lookup cannot be satisfied by a `kernel32.dll` dropped beside the binary. `AvailPhys` is Task Manager's "Available" (free + standby), the same notion as `vm_stat`'s free+inactive on darwin and `MemAvailable` on linux, so all three feed `EffectiveVRAMGB` comparable numbers rather than three different definitions of "free". `x/sys` moves indirect → direct; **no new module enters the graph.**

**2 · `PressureUnknown`** — appended, so the three real levels keep their numbering. `Summary` and `MemoryNote` now say the hardware is unknown instead of printing a zero; `PressureWarning` says so too; `OllamaRecommendations` **refuses to rank** rather than comparing every model to a 0 GB budget.

This is #251's finding in a second subsystem. A blast radius of 1.0 meant both *"safe"* and *"no idea"*; `PressureLow` meant both *"lots of headroom"* and *"I could not look"*. **A default must never be rendered as a measurement.**

## Tests — first ever for this package

`internal/sysinfo` was one of the 11 zero-test packages, and the platform layer is where that costs most.

`TestDetect_ReadsThisMachinesMemory` runs on **all three OSes in CI** and asserts the running machine's memory was actually read. It is precisely what would have caught this on day one.

Verified adversarially by disabling the `darwin` case, putting macOS in Windows' old position:

```
--- FAIL: TestDetect_ReadsThisMachinesMemory
    Detect() on darwin/arm64 reported unknown hardware — this platform has no working
    detection path, and every memory-derived number it produces is a placeholder.
      Summary()   = "hardware unknown · could not read this machine's memory"
      MemPressure = unknown
```

Note the summary in that failure: `"hardware unknown"`, not the old `"0GB RAM · memory fully occupied"`. The honest-reporting half works independently of the detection half — which matters, because it is what protects the *next* platform that has no detection path.

Also covered: undetected hardware is never presented as a reading, undetected hardware does not rank models, **known hardware still ranks normally** (so the guard cannot silently disable recommendations for everyone), and `Pressure` values are numerically stable.

## Verification

```
go test ./... -race -count=1                    all green
darwin/{amd64,arm64} linux/{amd64,arm64} windows/{amd64,arm64}   build + vet clean
```

Closes #258