### PR TITLE
fix(diff): produce diffs in-process — diff(1) does not exist on Windows

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT
+
+// Package diff produces unified diffs in-process.
+//
+// Hydra used to shell out to diff(1) for this. That binary does not exist on a
+// stock Windows install, and every call site discarded the error — so the diff
+// came back as an empty string with a nil error, which is indistinguishable
+// from "this file has no changes". Three of the four call sites then *counted*
+// lines in that output to report added/removed, so a modified file was reported
+// as 0/0 and a reviewer approved changes they were never shown (#260).
+//
+// Doing it here removes the host-binary dependency on every platform, not just
+// Windows, and makes "no changes" and "could not diff" different outcomes.
+package diff
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ContextLines is how many unchanged lines surround each hunk, matching
+// `diff -u`'s default so output stays familiar.
+const ContextLines = 3
+
+// maxCells caps the LCS table. Beyond it the quadratic table would cost more
+// memory than a review diff is worth, so the file is reported as wholly
+// replaced — honest, and still correct as a diff, just not minimal.
+const maxCells = 4 << 20
+
+type opKind int
+
+const (
+	opEqual opKind = iota
+	opDelete
+	opInsert
+)
+
+type op struct {
+	kind opKind
+	line string
+}
+
+// Unified returns a unified diff of old → new. An empty result means the two
+// are identical — callers must treat that as "no changes", which is now a
+// distinct outcome from an error.
+func Unified(oldName, newName string, old, new []byte) string {
+	ops := diffOps(splitLines(string(old)), splitLines(string(new)))
+	hunks := group(ops)
+	if len(hunks) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "--- %s\n", oldName)
+	fmt.Fprintf(&b, "+++ %s\n", newName)
+	for _, h := range hunks {
+		fmt.Fprintf(&b, "@@ -%d,%d +%d,%d @@\n", h.oldStart, h.oldLines, h.newStart, h.newLines)
+		for _, o := range h.ops {
+			switch o.kind {
+			case opEqual:
+				b.WriteString(" " + o.line + "\n")
+			case opDelete:
+				b.WriteString("-" + o.line + "\n")
+			case opInsert:
+				b.WriteString("+" + o.line + "\n")
+			}
+		}
+	}
+	return b.String()
+}
+
+// Stats counts changed lines. It is derived from the same ops as Unified, so
+// the two can never disagree — the previous implementations re-parsed diff(1)'s
+// text in three separate places and could.
+func Stats(old, new []byte) (added, removed int) {
+	for _, o := range diffOps(splitLines(string(old)), splitLines(string(new))) {
+		switch o.kind {
+		case opInsert:
+			added++
+		case opDelete:
+			removed++
+		}
+	}
+	return added, removed
+}
+
+// splitLines splits on \n and drops the trailing empty element a final newline
+// produces, so a file ending in a newline is not treated as having a blank last
+// line. \r\n is normalised so a CRLF file does not diff as entirely changed
+// against an LF one.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	lines := strings.Split(s, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// diffOps returns the edit script. Common prefix and suffix are trimmed first:
+// a small edit in a large file is the normal case, and trimming keeps the
+// quadratic table off all the lines that did not change.
+func diffOps(a, b []string) []op {
+	var ops []op
+
+	pre := 0
+	for pre < len(a) && pre < len(b) && a[pre] == b[pre] {
+		pre++
+	}
+	suf := 0
+	for suf < len(a)-pre && suf < len(b)-pre && a[len(a)-1-suf] == b[len(b)-1-suf] {
+		suf++
+	}
+
+	for _, l := range a[:pre] {
+		ops = append(ops, op{opEqual, l})
+	}
+	ops = append(ops, middle(a[pre:len(a)-suf], b[pre:len(b)-suf])...)
+	for _, l := range a[len(a)-suf:] {
+		ops = append(ops, op{opEqual, l})
+	}
+	return ops
+}
+
+// middle diffs the parts that differ, via an LCS table.
+func middle(a, b []string) []op {
+	switch {
+	case len(a) == 0 && len(b) == 0:
+		return nil
+	case len(a) == 0:
+		return allOf(opInsert, b)
+	case len(b) == 0:
+		return allOf(opDelete, a)
+	case len(a)*len(b) > maxCells:
+		// Too large to diff minimally; report a wholesale replacement rather
+		// than allocating a table proportional to the product of the sizes.
+		return append(allOf(opDelete, a), allOf(opInsert, b)...)
+	}
+
+	// lcs[i][j] = length of the longest common subsequence of a[i:] and b[j:].
+	lcs := make([][]int, len(a)+1)
+	for i := range lcs {
+		lcs[i] = make([]int, len(b)+1)
+	}
+	for i := len(a) - 1; i >= 0; i-- {
+		for j := len(b) - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+
+	var ops []op
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] == b[j]:
+			ops = append(ops, op{opEqual, a[i]})
+			i, j = i+1, j+1
+		case lcs[i+1][j] >= lcs[i][j+1]:
+			// Deletions before insertions at the same position, so a modified
+			// line renders as -old then +new, as diff(1) does.
+			ops = append(ops, op{opDelete, a[i]})
+			i++
+		default:
+			ops = append(ops, op{opInsert, b[j]})
+			j++
+		}
+	}
+	ops = append(ops, allOf(opDelete, a[i:])...)
+	return append(ops, allOf(opInsert, b[j:])...)
+}
+
+func allOf(k opKind, lines []string) []op {
+	out := make([]op, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, op{k, l})
+	}
+	return out
+}
+
+type hunk struct {
+	oldStart, oldLines int
+	newStart, newLines int
+	ops                []op
+}
+
+// group turns a flat edit script into unified-diff hunks: each run of changes
+// plus ContextLines of surrounding equal lines, with adjacent runs merged when
+// their context overlaps.
+func group(ops []op) []hunk {
+	changed := make([]int, 0, len(ops))
+	for i, o := range ops {
+		if o.kind != opEqual {
+			changed = append(changed, i)
+		}
+	}
+	if len(changed) == 0 {
+		return nil
+	}
+
+	// Merge change indices into ranges that share context.
+	type span struct{ lo, hi int }
+	var spans []span
+	cur := span{changed[0], changed[0]}
+	for _, idx := range changed[1:] {
+		if idx-cur.hi <= 2*ContextLines+1 {
+			cur.hi = idx
+			continue
+		}
+		spans = append(spans, cur)
+		cur = span{idx, idx}
+	}
+	spans = append(spans, cur)
+
+	// Line numbers are 1-based and counted separately per side.
+	oldNo, newNo := 1, 1
+	pos := 0
+	var out []hunk
+	for _, sp := range spans {
+		lo := max(0, sp.lo-ContextLines)
+		hi := min(len(ops)-1, sp.hi+ContextLines)
+
+		for ; pos < lo; pos++ {
+			switch ops[pos].kind {
+			case opEqual:
+				oldNo, newNo = oldNo+1, newNo+1
+			case opDelete:
+				oldNo++
+			case opInsert:
+				newNo++
+			}
+		}
+
+		h := hunk{oldStart: oldNo, newStart: newNo}
+		for ; pos <= hi; pos++ {
+			h.ops = append(h.ops, ops[pos])
+			switch ops[pos].kind {
+			case opEqual:
+				h.oldLines, h.newLines = h.oldLines+1, h.newLines+1
+				oldNo, newNo = oldNo+1, newNo+1
+			case opDelete:
+				h.oldLines++
+				oldNo++
+			case opInsert:
+				h.newLines++
+				newNo++
+			}
+		}
+		// An empty side is rendered as start 0 by diff(1); match that so the
+		// header of a pure-insert or pure-delete hunk is not misleading.
+		if h.oldLines == 0 {
+			h.oldStart = 0
+		}
+		if h.newLines == 0 {
+			h.newStart = 0
+		}
+		out = append(out, h)
+	}
+	return out
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+
+package diff
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The bug this package replaces: an empty result must mean "identical", and it
+// must be reachable only when the inputs really are identical. The old
+// shell-out returned "" whenever diff(1) was missing, which made "no changes"
+// and "could not run" the same value.
+func TestUnified_IdenticalInputProducesNothing(t *testing.T) {
+	src := []byte("a\nb\nc\n")
+	if got := Unified("a.go", "a.go", src, src); got != "" {
+		t.Errorf("identical input produced a diff:\n%s", got)
+	}
+	if a, r := Stats(src, src); a != 0 || r != 0 {
+		t.Errorf("Stats = +%d/-%d, want 0/0", a, r)
+	}
+}
+
+func TestUnified_ChangeProducesADiff(t *testing.T) {
+	old := []byte("package main\n\nfunc main() {}\n")
+	new := []byte("package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"hi\") }\n")
+
+	got := Unified("main.go", "main.go", old, new)
+	if got == "" {
+		t.Fatal("a real change produced no diff — this is the #260 failure mode")
+	}
+	for _, want := range []string{"--- main.go", "+++ main.go", "@@", "+import"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("diff missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// The property that matters: a diff is correct iff applying it to old yields
+// new. Counting lines proves nothing about whether the hunks are right.
+func TestUnified_RoundTripsToTheTarget(t *testing.T) {
+	cases := []struct{ name, old, new string }{
+		{"insert at start", "b\nc\n", "a\nb\nc\n"},
+		{"insert at end", "a\nb\n", "a\nb\nc\n"},
+		{"delete from middle", "a\nb\nc\n", "a\nc\n"},
+		{"modify one line", "a\nb\nc\n", "a\nB\nc\n"},
+		{"replace everything", "a\nb\nc\n", "x\ny\nz\n"},
+		{"empty to content", "", "a\nb\n"},
+		{"content to empty", "a\nb\n", ""},
+		{"two distant hunks", lines(1, 30), lines(1, 30, 3, 27)},
+		{"adjacent hunks merge", "a\nb\nc\nd\ne\n", "a\nX\nc\nY\ne\n"},
+		{"no trailing newline", "a\nb", "a\nc"},
+		{"duplicate lines", "a\na\na\n", "a\na\n"},
+		{"crlf vs lf is not a change", "a\r\nb\r\n", "a\nb\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := Unified("old", "new", []byte(tc.old), []byte(tc.new))
+			got, err := applyUnified(splitLines(tc.old), u)
+			if err != nil {
+				t.Fatalf("applying our own diff failed: %v\n%s", err, u)
+			}
+			want := splitLines(tc.new)
+			if strings.Join(got, "\n") != strings.Join(want, "\n") {
+				t.Errorf("round trip lost information\n old:  %q\n new:  %q\n got:  %q\n diff:\n%s",
+					tc.old, tc.new, strings.Join(got, "\n"), u)
+			}
+		})
+	}
+}
+
+// Stats and Unified are derived from one edit script, so they cannot disagree.
+// The three previous implementations each re-parsed diff(1)'s text separately
+// and could.
+func TestStats_AgreesWithUnified(t *testing.T) {
+	old := []byte(lines(1, 20))
+	new := []byte(lines(1, 20, 5, 15))
+
+	added, removed := Stats(old, new)
+	u := Unified("old", "new", old, new)
+
+	var uAdded, uRemoved int
+	for _, l := range strings.Split(u, "\n") {
+		switch {
+		case strings.HasPrefix(l, "+++"), strings.HasPrefix(l, "---"):
+		case strings.HasPrefix(l, "+"):
+			uAdded++
+		case strings.HasPrefix(l, "-"):
+			uRemoved++
+		}
+	}
+	if added != uAdded || removed != uRemoved {
+		t.Errorf("Stats = +%d/-%d but the diff body has +%d/-%d", added, removed, uAdded, uRemoved)
+	}
+	if added == 0 && removed == 0 {
+		t.Error("a changed file reported 0/0 — the exact symptom #260 produced on Windows")
+	}
+}
+
+// Where diff(1) exists, our line counts must match it. This is the check that
+// our replacement is faithful rather than merely self-consistent.
+func TestUnified_MatchesSystemDiffWhereAvailable(t *testing.T) {
+	if _, err := exec.LookPath("diff"); err != nil {
+		t.Skipf("no diff(1) on this platform (%v) — the very reason this package exists", err)
+	}
+
+	cases := []struct{ old, new string }{
+		{"a\nb\nc\n", "a\nB\nc\n"},
+		{lines(1, 40), lines(1, 40, 10, 30)},
+		{"a\nb\nc\nd\ne\nf\n", "a\nc\ne\n"},
+		{"x\n", "x\ny\nz\n"},
+	}
+	dir := t.TempDir()
+	for i, tc := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			oldPath := filepath.Join(dir, fmt.Sprintf("old%d", i))
+			newPath := filepath.Join(dir, fmt.Sprintf("new%d", i))
+			if err := os.WriteFile(oldPath, []byte(tc.old), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(newPath, []byte(tc.new), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			// diff(1) exits 1 when files differ; that is not an error.
+			out, _ := exec.Command("diff", "-u", oldPath, newPath).CombinedOutput()
+
+			var sysAdded, sysRemoved int
+			for _, l := range strings.Split(string(out), "\n") {
+				switch {
+				case strings.HasPrefix(l, "+++"), strings.HasPrefix(l, "---"):
+				case strings.HasPrefix(l, "+"):
+					sysAdded++
+				case strings.HasPrefix(l, "-"):
+					sysRemoved++
+				}
+			}
+			added, removed := Stats([]byte(tc.old), []byte(tc.new))
+			if added != sysAdded || removed != sysRemoved {
+				t.Errorf("Stats = +%d/-%d, diff(1) = +%d/-%d\nsystem output:\n%s",
+					added, removed, sysAdded, sysRemoved, out)
+			}
+		})
+	}
+}
+
+// A file too large for the LCS table must still produce a correct diff, just a
+// non-minimal one — never a silently empty result.
+func TestUnified_OversizedInputStillDiffs(t *testing.T) {
+	var a, b strings.Builder
+	for i := 0; i < 2600; i++ { // 2600² > maxCells
+		fmt.Fprintf(&a, "line %d\n", i)
+		fmt.Fprintf(&b, "LINE %d\n", i)
+	}
+	u := Unified("a", "b", []byte(a.String()), []byte(b.String()))
+	if u == "" {
+		t.Fatal("oversized input produced no diff at all")
+	}
+	added, removed := Stats([]byte(a.String()), []byte(b.String()))
+	if added == 0 || removed == 0 {
+		t.Errorf("oversized input reported +%d/-%d", added, removed)
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// lines builds "1\n2\n…n\n", optionally replacing the half-open range [from,to)
+// with uppercase markers so the two versions differ in a known place.
+func lines(start, end int, replace ...int) string {
+	var b strings.Builder
+	for i := start; i <= end; i++ {
+		if len(replace) == 2 && i >= replace[0] && i < replace[1] {
+			fmt.Fprintf(&b, "CHANGED %d\n", i)
+			continue
+		}
+		fmt.Fprintf(&b, "%d\n", i)
+	}
+	return b.String()
+}
+
+// applyUnified applies a unified diff to old, so a test can prove the diff
+// actually describes the transformation rather than merely looking plausible.
+func applyUnified(old []string, u string) ([]string, error) {
+	if u == "" {
+		return old, nil
+	}
+	var out []string
+	oldIdx := 0 // 0-based cursor into old
+
+	for _, l := range strings.Split(strings.TrimRight(u, "\n"), "\n") {
+		switch {
+		case strings.HasPrefix(l, "---"), strings.HasPrefix(l, "+++"):
+			continue
+		case strings.HasPrefix(l, "@@"):
+			// "@@ -oldStart,oldLines +newStart,newLines @@"
+			var oldStart, oldLines, newStart, newLines int
+			if _, err := fmt.Sscanf(l, "@@ -%d,%d +%d,%d @@", &oldStart, &oldLines, &newStart, &newLines); err != nil {
+				return nil, fmt.Errorf("unparsable hunk header %q: %w", l, err)
+			}
+			target := oldStart - 1
+			if oldLines == 0 {
+				target = oldStart // pure insert: start 0 means "before line 1"
+			}
+			if target < oldIdx {
+				return nil, fmt.Errorf("hunk header %q goes backwards (cursor at %d)", l, oldIdx)
+			}
+			if target > len(old) {
+				return nil, fmt.Errorf("hunk header %q starts past end of file (%d lines)", l, len(old))
+			}
+			out = append(out, old[oldIdx:target]...)
+			oldIdx = target
+		case strings.HasPrefix(l, " "):
+			if oldIdx >= len(old) {
+				return nil, fmt.Errorf("context line %q past end of old file", l)
+			}
+			if old[oldIdx] != l[1:] {
+				return nil, fmt.Errorf("context mismatch at old line %d: have %q, diff says %q",
+					oldIdx+1, old[oldIdx], l[1:])
+			}
+			out = append(out, old[oldIdx])
+			oldIdx++
+		case strings.HasPrefix(l, "-"):
+			if oldIdx >= len(old) {
+				return nil, fmt.Errorf("delete %q past end of old file", l)
+			}
+			if old[oldIdx] != l[1:] {
+				return nil, fmt.Errorf("delete mismatch at old line %d: have %q, diff says %q",
+					oldIdx+1, old[oldIdx], l[1:])
+			}
+			oldIdx++
+		case strings.HasPrefix(l, "+"):
+			out = append(out, l[1:])
+		}
+	}
+	return append(out, old[oldIdx:]...), nil
+}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/diff"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/util"
 	"github.com/ankit373/hydra/internal/workspace"
@@ -407,16 +408,16 @@ func diffStats(file, origContent, gitRoot, backup string, origExisted bool) (add
 		}
 	}
 	if fileExists(backup) {
-		out, err := exec.Command("diff", "-u", backup, file).CombinedOutput()
-		_ = err
-		for _, l := range strings.Split(string(out), "\n") {
-			if strings.HasPrefix(l, "+") && !strings.HasPrefix(l, "+++") {
-				added++
-			} else if strings.HasPrefix(l, "-") && !strings.HasPrefix(l, "---") {
-				removed++
-			}
+		// From the edit script, not by re-parsing diff(1)'s text. The `_ = err`
+		// here was the tell: the error was captured and deliberately dropped,
+		// so a missing diff(1) counted zero lines in empty output and reported
+		// a modified file as 0/0 (#260).
+		before, errBefore := os.ReadFile(backup)
+		after, errAfter := os.ReadFile(file)
+		if errBefore == nil && errAfter == nil {
+			added, removed = diff.Stats(before, after)
+			return
 		}
-		return
 	}
 	newLines := strings.Count(readFileLines(file), "\n")
 	origLines := 0

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/diff"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/runid"
@@ -548,15 +549,15 @@ func diffStats(file, origContent, gitRoot, backup string, origExisted bool) (add
 		}
 	}
 	if fileExists(backup) {
-		out, _ := exec.Command("diff", "-u", backup, file).CombinedOutput()
-		for _, l := range strings.Split(string(out), "\n") {
-			if strings.HasPrefix(l, "+") && !strings.HasPrefix(l, "+++") {
-				added++
-			} else if strings.HasPrefix(l, "-") && !strings.HasPrefix(l, "---") {
-				removed++
-			}
+		// From the edit script, not by re-parsing diff(1)'s text: with no
+		// diff(1) on PATH the old code counted zero lines in empty output and
+		// reported a modified file as 0/0 (#260).
+		before, errBefore := os.ReadFile(backup)
+		after, errAfter := os.ReadFile(file)
+		if errBefore == nil && errAfter == nil {
+			added, removed = diff.Stats(before, after)
+			return
 		}
-		return
 	}
 	newContent, _ := os.ReadFile(file)
 	newLines := strings.Count(string(newContent), "\n")

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/diff"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/workspace"
 )
@@ -128,8 +129,19 @@ func Diff(file string) (string, error) {
 
 	backup := file + ".hydra-bak"
 	if fileExists(backup) {
-		out, _ := exec.Command("diff", "-u", backup, file).CombinedOutput()
-		return string(out), nil
+		// Both reads must succeed. This used to shell out to diff(1) and
+		// discard the error, so a missing binary or an unreadable file
+		// produced ("", nil) — a blank diff a reviewer would read as "no
+		// changes" and approve (#260).
+		before, err := os.ReadFile(backup)
+		if err != nil {
+			return "", fmt.Errorf("reading backup for %s: %w", file, err)
+		}
+		after, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("reading %s: %w", file, err)
+		}
+		return diff.Unified(backup, file, before, after), nil
 	}
 
 	return "", fmt.Errorf("no diff available for %s (no git root, no backup)", file)
@@ -283,14 +295,15 @@ func numstat(file, gitRoot string) (added, removed int, status string) {
 
 	backup := file + ".hydra-bak"
 	if fileExists(backup) {
-		out, _ := exec.Command("diff", "-u", backup, file).CombinedOutput()
-		for _, l := range strings.Split(string(out), "\n") {
-			if strings.HasPrefix(l, "+") && !strings.HasPrefix(l, "+++") {
-				added++
-			} else if strings.HasPrefix(l, "-") && !strings.HasPrefix(l, "---") {
-				removed++
-			}
+		// Counted from the edit script rather than by re-parsing diff(1)'s
+		// text. Without diff(1) on PATH the old code counted zero lines in an
+		// empty output and reported a modified file as 0/0 (#260).
+		before, errBefore := os.ReadFile(backup)
+		after, errAfter := os.ReadFile(file)
+		if errBefore != nil || errAfter != nil {
+			return 0, 0, "no_baseline"
 		}
+		added, removed = diff.Stats(before, after)
 		return added, removed, "modified"
 	}
 


### PR DESCRIPTION
## Problem

Four call sites shelled out to `diff(1)`, and **all four discarded its error**:

```go
internal/review/review.go:131   Diff()       out, _   := exec.Command("diff", "-u", ...)
internal/review/review.go:286   numstat()    out, _   := ...
internal/parallel/parallel.go   diffStats()  out, _   := ...
internal/editor/editor.go:410   diffStats()  out, err := ...; _ = err
```

Stock Windows has no `diff(1)`, so every one of them returned **empty output with no error**. The consequences differ by site, and the second is worse than the issue originally described:

- **`review.Diff` returned `("", nil)`** — a blank diff, indistinguishable from *"this file has no changes"*. A reviewer approves changes they were never shown.
- **The other three *count lines* in that empty output** to produce added/removed. So `hyctl review` and `hyctl parallel` reported a genuinely modified file as **0 added / 0 removed**.

The `_ = err` in `editor.go` is the tell: the error was captured and deliberately dropped.

## Fix

`internal/diff` replaces all four. **No new dependency.**

- Common prefix and suffix are trimmed first, so the quadratic LCS table only ever covers lines that actually changed — a small edit in a large file stays cheap.
- Input too large for the table degrades to a whole-file replacement, which is still a *correct* diff, just not a minimal one. Never a silently empty result.
- `Stats` and `Unified` derive from **one** edit script, so they cannot disagree. The three previous implementations each re-parsed `diff(1)`'s text separately and could.
- `review.Diff` now returns a real error when it cannot read either side, so "no changes" and "could not diff" are finally different outcomes.

This removes a host-binary dependency on **every** platform, not just Windows.

## Correctness — established, not asserted

Two independent checks, because "the output looks like a diff" proves nothing.

**1 · Round-trip property.** For twelve shapes — insert at start/end, delete from middle, modify, whole-file replace, empty↔content, two distant hunks, adjacent hunks that must merge, missing trailing newline, duplicate lines, CRLF vs LF — applying our own unified output back to the old text must reproduce the new text **exactly**. That proves the hunk headers and offsets are right, not merely plausible; the test parses `@@` headers and fails on context mismatch or a cursor that moves backwards.

**2 · Cross-check against the real thing.** Where `diff(1)` exists, its added/removed counts must equal ours. That test skips only on platforms without it — precisely where the old code was broken, and where check 1 still applies.

Plus: identical input produces nothing, a change always produces a diff, `Stats` agrees with the body of `Unified`, and oversized input still diffs.

## Verification

```
go test ./... -race -count=1     all green
go vet ./...                     clean
grep exec.Command("diff"         only the cross-check test remains
```

Closes #260