### PR TITLE
fix(tui): the guided install ran `sh -lc`, which stock Windows does not have

### DIFF
--- a/internal/tui/install.go
+++ b/internal/tui/install.go
@@ -68,11 +68,43 @@ func buildInstallOptions(specs *sysinfo.Specs) []installOption {
 	}
 }
 
-func ollamaInstallCmd() string {
-	if runtime.GOOS == "darwin" {
+// ollamaInstallCmd returns the vendor-documented install command for this OS.
+//
+// The Windows branch is not a guess: ollama.com/download/windows documents
+// `irm https://ollama.com/install.ps1 | iex` and offers no winget package, so
+// the command is PowerShell and must be run by PowerShell — which is why
+// runInstallCmd dispatches on the shell rather than assuming cmd.exe.
+//
+// Before #259 this returned the POSIX curl pipeline on every non-darwin OS,
+// and runInstallCmd handed it to `sh`, which stock Windows does not have.
+func ollamaInstallCmd() string { return ollamaInstallCmdFor(runtime.GOOS) }
+
+// shellFor returns the argv prefix that runs a shell command line on this OS.
+func shellFor(cmd string) []string { return shellForOS(runtime.GOOS, cmd) }
+
+// The two functions below take goos explicitly rather than reading runtime.GOOS
+// so every platform's decision is testable from every platform. That matters
+// here: the bug being fixed only manifests on Windows, so a test that could
+// only exercise the running OS would have passed on the broken version
+// everywhere except the one machine nobody ran it on (#259).
+func ollamaInstallCmdFor(goos string) string {
+	switch goos {
+	case "darwin":
 		return "brew install ollama"
+	case "windows":
+		return "irm https://ollama.com/install.ps1 | iex"
+	default:
+		return "curl -fsSL https://ollama.com/install.sh | sh"
 	}
-	return "curl -fsSL https://ollama.ai/install.sh | sh"
+}
+
+func shellForOS(goos, cmd string) []string {
+	if goos == "windows" {
+		// -NoProfile so a user's profile cannot alter the command; -Command
+		// takes a command line, matching what ollamaInstallCmdFor produces.
+		return []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", cmd}
+	}
+	return []string{"sh", "-lc", cmd}
 }
 
 // ── Steps ─────────────────────────────────────────────────────────────────────
@@ -202,10 +234,31 @@ func runInstallCmd(cmd string) tea.Cmd {
 		if strings.TrimSpace(cmd) == "" {
 			return installDoneMsg{}
 		}
-		c := exec.Command("sh", "-lc", cmd)
-		_, err := c.CombinedOutput()
+		argv := shellFor(cmd)
+		c := exec.Command(argv[0], argv[1:]...)
+		out, err := c.CombinedOutput()
+		if err != nil {
+			// The shell's own output is the only thing that explains *why* an
+			// install failed. Discarding it — as this did — left the user with
+			// a bare exit status and nothing to act on.
+			if msg := lastMeaningfulLine(string(out)); msg != "" {
+				return installDoneMsg{err: fmt.Errorf("%s: %s", err, msg)}
+			}
+		}
 		return installDoneMsg{err: err}
 	}
+}
+
+// lastMeaningfulLine returns the final non-blank line of command output, which
+// for an installer is almost always the error worth showing.
+func lastMeaningfulLine(out string) string {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if l := strings.TrimSpace(lines[i]); l != "" {
+			return l
+		}
+	}
+	return ""
 }
 
 // ── View ──────────────────────────────────────────────────────────────────────

--- a/internal/tui/install_exec_test.go
+++ b/internal/tui/install_exec_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The bug: runInstallCmd ran `sh -lc`, and stock Windows has no sh, so the
+// entire guided-install path died with an opaque exec error. Whatever shell is
+// chosen for this OS must actually exist on it — a test that only checked the
+// argv shape would have passed on the broken version too.
+func TestShellFor_ShellExistsOnThisOS(t *testing.T) {
+	argv := shellFor("echo hi")
+	if len(argv) < 2 {
+		t.Fatalf("shellFor returned %v, want a shell plus at least one flag", argv)
+	}
+	if _, err := exec.LookPath(argv[0]); err != nil {
+		t.Errorf("shellFor picked %q on %s, but it is not on PATH: %v — this is exactly the "+
+			"`sh -lc` failure (#259), just with a different shell", argv[0], runtime.GOOS, err)
+	}
+	if argv[len(argv)-1] != "echo hi" {
+		t.Errorf("command is not the last argument: %v", argv)
+	}
+}
+
+// End to end: the chosen shell must actually run a command line and return its
+// output. This is the assertion that distinguishes "we picked a plausible
+// shell" from "the install flow works".
+func TestShellFor_ActuallyRunsACommand(t *testing.T) {
+	argv := shellFor("echo hydra-probe")
+	out, err := exec.Command(argv[0], argv[1:]...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %v failed: %v\n%s", argv, err, out)
+	}
+	if !strings.Contains(string(out), "hydra-probe") {
+		t.Errorf("output = %q, want it to contain %q", out, "hydra-probe")
+	}
+}
+
+// The install command and the shell that runs it must agree, for every OS —
+// checked from every OS, which is the point of taking goos as a parameter.
+// The original bug only manifested on Windows, so a test that could exercise
+// only the running OS would have passed everywhere except the one machine
+// nobody ran it on.
+func TestInstallCmdAndShellAgree_ForEveryOS(t *testing.T) {
+	cases := []struct {
+		goos       string
+		wantShell  string
+		wantInCmd  string
+		bannedInfx string // a fragment that must NOT appear in the command
+	}{
+		// ollama.com/download/windows documents `irm … | iex` and ships no
+		// winget package, so the command is PowerShell by necessity — and it
+		// must therefore be run by PowerShell, not cmd.exe or sh.
+		{"windows", "powershell", "iex", "| sh"},
+		{"darwin", "sh", "brew", "iex"},
+		{"linux", "sh", "| sh", "iex"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.goos, func(t *testing.T) {
+			cmd := ollamaInstallCmdFor(tc.goos)
+			if strings.TrimSpace(cmd) == "" {
+				t.Fatalf("no install command for %s", tc.goos)
+			}
+			if !strings.Contains(cmd, tc.wantInCmd) {
+				t.Errorf("%s install command = %q, want it to contain %q", tc.goos, cmd, tc.wantInCmd)
+			}
+			if strings.Contains(cmd, tc.bannedInfx) {
+				t.Errorf("%s install command = %q contains %q — wrong platform's syntax",
+					tc.goos, cmd, tc.bannedInfx)
+			}
+			shell := shellForOS(tc.goos, cmd)[0]
+			if !strings.Contains(strings.ToLower(shell), tc.wantShell) {
+				t.Errorf("%s: command %q would be handed to %q, want a %s shell — "+
+					"this is the #259 mismatch", tc.goos, cmd, shell, tc.wantShell)
+			}
+		})
+	}
+}
+
+// The command must always be the final argument, whatever shell was chosen —
+// otherwise it is passed as a flag and silently not executed.
+func TestShellForOS_CommandIsTheLastArgument(t *testing.T) {
+	for _, goos := range []string{"windows", "darwin", "linux", "freebsd"} {
+		argv := shellForOS(goos, "echo hi")
+		if len(argv) < 2 {
+			t.Errorf("%s: shellForOS returned %v", goos, argv)
+			continue
+		}
+		if argv[len(argv)-1] != "echo hi" {
+			t.Errorf("%s: command is not the last argument: %v", goos, argv)
+		}
+	}
+}
+
+func TestLastMeaningfulLine(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"only line", "only line"},
+		{"first\nsecond\n", "second"},
+		{"first\nreal error\n\n\n", "real error"},
+		{"   \n  \n", ""},
+	}
+	for _, tc := range cases {
+		if got := lastMeaningfulLine(tc.in); got != tc.want {
+			t.Errorf("lastMeaningfulLine(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`internal/tui/install.go:205` ran every install command through a shell that does not exist on the target platform:

```go
c := exec.Command("sh", "-lc", cmd)
```

Stock Windows has no `sh`, so the entire *"install Ollama for me"* path from `hyctl init` died with an opaque exec error.

Compounding it, `ollamaInstallCmd()` returned a POSIX pipeline on **every** non-darwin OS:

```go
if runtime.GOOS == "darwin" { return "brew install ollama" }
return "curl -fsSL https://ollama.ai/install.sh | sh"
```

— a shell pipeline for a platform where neither that shell nor that installer applies.

## Checked, not guessed

`ollama.com/download/windows` documents **`irm https://ollama.com/install.ps1 | iex`** and offers **no winget package**.

That matters for the fix: the Windows install command is PowerShell, so **`cmd.exe` would have been just as wrong as `sh`**. I had been about to reach for `cmd /c`. `shellForOS` dispatches to `powershell -NoProfile -NonInteractive -Command` on Windows and `sh -lc` elsewhere — `-NoProfile` so a user's profile cannot alter what runs.

## Also fixed

`runInstallCmd` captured `CombinedOutput()` and threw it away, so a failed install surfaced a bare exit status with nothing to act on. The last meaningful line of output now travels with the error.

## The testability change is the point

Both helpers take `goos` as a **parameter** instead of reading `runtime.GOOS`.

This bug only manifests on Windows. A test that could exercise only the running OS would have passed on the broken version everywhere except the one machine nobody ran it on — which is precisely how it shipped. I confirmed that directly: reintroducing `sh -lc` and running on macOS **passed**, because on macOS `sh -lc` *is* correct.

With `goos` as a parameter, `TestInstallCmdAndShellAgree_ForEveryOS` checks all three platforms from any platform. Same sabotage, now caught on macOS:

```
--- FAIL: TestInstallCmdAndShellAgree_ForEveryOS/windows
    windows: command "irm https://ollama.com/install.ps1 | iex" would be handed
    to "sh", want a powershell shell — this is the #259 mismatch
```

It also rejects each platform carrying another's syntax (a `| sh` pipeline on Windows, `iex` on Unix), and asserts the command is always the final argument — otherwise it is passed as a flag and silently not executed.

Alongside that, two tests that can only run on the host: the chosen shell **exists on PATH**, and it **actually runs a command and returns its output**. That distinguishes "we picked a plausible shell" from "the install flow works".

## Verification

```
go test ./... -race -count=1     all green
```

Closes #259