### PR TITLE
refactor(sysinfo): read /proc/meminfo directly, and stop guessing 8GB

### DIFF
--- a/internal/sysinfo/meminfo_test.go
+++ b/internal/sysinfo/meminfo_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+
+package sysinfo
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// A real /proc/meminfo head, verbatim. Parsing is tested against this fixture
+// rather than the host's memory so the test is deterministic and runs on every
+// OS — the previous implementation shelled out to grep and could only be
+// exercised on Linux, with a machine-dependent answer.
+const meminfoFixture = `MemTotal:       16007748 kB
+MemFree:         1234567 kB
+MemAvailable:    8388608 kB
+Buffers:          123456 kB
+Cached:          4194304 kB
+SwapCached:            0 kB
+Active:          6291456 kB
+HugePages_Total:       0
+HugePages_Free:        0
+Hugepagesize:       2048 kB
+`
+
+func TestParseMeminfo_ReadsTheFieldsWeUse(t *testing.T) {
+	got := parseMeminfo(meminfoFixture)
+
+	// 16007748 kB / 2^20 = 15.266… GB
+	if v, ok := got["MemTotal"]; !ok {
+		t.Error("MemTotal missing")
+	} else if v < 15.2 || v > 15.3 {
+		t.Errorf("MemTotal = %.4f GB, want ~15.266", v)
+	}
+	// 8388608 kB is exactly 8 GB.
+	if v, ok := got["MemAvailable"]; !ok {
+		t.Error("MemAvailable missing")
+	} else if v != 8 {
+		t.Errorf("MemAvailable = %v GB, want exactly 8", v)
+	}
+}
+
+// Unitless fields must not be read as memory. HugePages_Total: 0 parses as a
+// number but is a count, not kB — treating it as memory would be silent
+// nonsense if it were ever added to the fields we read.
+func TestParseMeminfo_SkipsUnitlessFields(t *testing.T) {
+	got := parseMeminfo(meminfoFixture)
+	for _, k := range []string{"HugePages_Total", "HugePages_Free"} {
+		if _, ok := got[k]; ok {
+			t.Errorf("%s was parsed as a memory field; it has no kB unit", k)
+		}
+	}
+}
+
+// Absent must be distinguishable from zero. The old `grep | Fields` pipeline
+// collapsed both to 0, so a kernel that did not report MemAvailable was
+// indistinguishable from one reporting none available.
+func TestParseMeminfo_MissingFieldIsAbsentNotZero(t *testing.T) {
+	got := parseMeminfo("MemTotal:       16007748 kB\n")
+	if _, ok := got["MemAvailable"]; ok {
+		t.Error("MemAvailable present in a fixture that does not contain it")
+	}
+	if _, ok := got["MemFree"]; ok {
+		t.Error("MemFree present in a fixture that does not contain it")
+	}
+}
+
+func TestParseMeminfo_GarbageIsIgnoredNotFatal(t *testing.T) {
+	for _, in := range []string{
+		"",
+		"not a meminfo file at all\n",
+		"MemTotal:\n",             // no value
+		"MemTotal: notanumber kB", // unparsable value
+		"MemTotal 16007748 kB\n",  // no colon
+	} {
+		got := parseMeminfo(in)
+		if v, ok := got["MemTotal"]; ok {
+			t.Errorf("parseMeminfo(%q) yielded MemTotal = %v, want it skipped", in, v)
+		}
+	}
+}
+
+// The readers must return 0 — not a fabricated number — when the file cannot be
+// read. linuxRAM used to return a hardcoded 8, which flowed into model-fit
+// recommendations as though someone had measured it (#261, same class as #258).
+func TestLinuxReaders_UnreadableFileYieldsZeroNotAGuess(t *testing.T) {
+	orig := meminfoPath
+	t.Cleanup(func() { meminfoPath = orig })
+	meminfoPath = filepath.Join(t.TempDir(), "definitely-not-here")
+
+	if got := linuxRAM(); got != 0 {
+		t.Errorf("linuxRAM() = %v with no readable meminfo, want 0 so it reports unknown", got)
+	}
+	if got := linuxFreeRAM(); got != 0 {
+		t.Errorf("linuxFreeRAM() = %v with no readable meminfo, want 0", got)
+	}
+
+	// And that zero must surface as unknown rather than as an empty machine.
+	s := &Specs{OS: "linux", Arch: runtime.GOARCH, TotalRAMGB: linuxRAM()}
+	s.MemPressure = s.computePressure()
+	if s.HardwareKnown() {
+		t.Error("HardwareKnown() = true after an unreadable meminfo")
+	}
+	if s.MemPressure != PressureUnknown {
+		t.Errorf("MemPressure = %v, want unknown", s.MemPressure)
+	}
+}
+
+func TestLinuxReaders_ReadFromTheConfiguredPath(t *testing.T) {
+	orig := meminfoPath
+	t.Cleanup(func() { meminfoPath = orig })
+
+	path := filepath.Join(t.TempDir(), "meminfo")
+	if err := os.WriteFile(path, []byte(meminfoFixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	meminfoPath = path
+
+	if got := linuxRAM(); got < 15.2 || got > 15.3 {
+		t.Errorf("linuxRAM() = %.4f, want ~15.266 from the fixture", got)
+	}
+	if got := linuxFreeRAM(); got != 8 {
+		t.Errorf("linuxFreeRAM() = %v, want exactly 8 from the fixture", got)
+	}
+}

--- a/internal/sysinfo/sysinfo.go
+++ b/internal/sysinfo/sysinfo.go
@@ -207,14 +207,19 @@ func (s *Specs) computePressure() Pressure {
 
 // ── macOS ─────────────────────────────────────────────────────────────────────
 
+// darwinRAM returns total RAM in GB, or 0 if it could not be read.
+//
+// Like linuxRAM, this used to return a hardcoded 8 on failure. Fixing one and
+// leaving the other would leave the same fabricated number in the same family
+// of functions, which is how a defect class survives its own fix.
 func darwinRAM() float64 {
 	out, err := exec.Command("sysctl", "-n", "hw.memsize").Output()
 	if err != nil {
-		return 8
+		return 0
 	}
 	bytes, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 64)
 	if err != nil {
-		return 8
+		return 0
 	}
 	return float64(bytes) / (1 << 30)
 }

--- a/internal/sysinfo/sysinfo.go
+++ b/internal/sysinfo/sysinfo.go
@@ -5,6 +5,7 @@ package sysinfo
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -303,32 +304,65 @@ func darwinGPUVRAM() (float64, string) {
 
 // ── Linux ─────────────────────────────────────────────────────────────────────
 
-func linuxRAM() float64 {
-	out, err := exec.Command("grep", "MemTotal", "/proc/meminfo").Output()
-	if err != nil {
-		return 8
+// meminfoPath is the kernel's memory summary. A var so tests can point the
+// readers at a fixture instead of the host's real memory, which is neither
+// deterministic nor present off Linux.
+var meminfoPath = "/proc/meminfo"
+
+// parseMeminfo returns the named /proc/meminfo fields converted from kB to GB.
+// Fields that are absent or unparsable are simply missing from the result, so a
+// caller can tell "not present" from "zero" — a distinction the old
+// `grep | Fields` pipeline collapsed.
+//
+// Kept as a pure function over a string so it is testable against a fixture on
+// every OS, not only on Linux.
+func parseMeminfo(content string) map[string]float64 {
+	out := make(map[string]float64, 2)
+	for _, line := range strings.Split(content, "\n") {
+		// Format is "MemTotal:       16007748 kB" — name, value, unit.
+		name, rest, found := strings.Cut(line, ":")
+		if !found {
+			continue
+		}
+		fields := strings.Fields(rest)
+		if len(fields) == 0 {
+			continue
+		}
+		kb, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil {
+			continue
+		}
+		// The unit must be present and must be kB. Every memory field in
+		// /proc/meminfo carries it; the ones that do not are counts, not sizes
+		// (HugePages_Total is a bare "0"), and reading those as gigabytes would
+		// be silent nonsense.
+		if len(fields) < 2 || !strings.EqualFold(fields[1], "kB") {
+			continue
+		}
+		out[name] = kb / (1 << 20)
 	}
-	fields := strings.Fields(string(out))
-	if len(fields) < 2 {
-		return 8
-	}
-	kb, _ := strconv.ParseFloat(fields[1], 64)
-	return kb / (1 << 20)
+	return out
 }
 
-func linuxFreeRAM() float64 {
-	// MemAvailable is a kernel estimate of how much can be freed without swapping.
-	out, err := exec.Command("grep", "MemAvailable", "/proc/meminfo").Output()
+func readMeminfo() map[string]float64 {
+	raw, err := os.ReadFile(meminfoPath)
 	if err != nil {
-		return 0
+		return nil
 	}
-	fields := strings.Fields(string(out))
-	if len(fields) < 2 {
-		return 0
-	}
-	kb, _ := strconv.ParseFloat(fields[1], 64)
-	return kb / (1 << 20)
+	return parseMeminfo(string(raw))
 }
+
+// linuxRAM returns total RAM in GB, or 0 if it could not be read.
+//
+// It used to return a hardcoded 8 on failure — a number no one measured,
+// presented as a reading, which then flowed into model-fit recommendations. 0
+// routes through HardwareKnown to PressureUnknown instead, so an unreadable
+// machine is reported as unreadable (#261, same class as #258).
+func linuxRAM() float64 { return readMeminfo()["MemTotal"] }
+
+// linuxFreeRAM returns MemAvailable — the kernel's own estimate of how much can
+// be reclaimed without swapping — in GB, or 0 if it could not be read.
+func linuxFreeRAM() float64 { return readMeminfo()["MemAvailable"] }
 
 func nvidiaVRAM() (float64, string) {
 	out, err := exec.Command("nvidia-smi",


### PR DESCRIPTION
## Problem

`linuxRAM` and `linuxFreeRAM` each spawned a process to read a file:

```go
out, err := exec.Command("grep", "MemTotal",     "/proc/meminfo").Output()
out, err := exec.Command("grep", "MemAvailable", "/proc/meminfo").Output()
```

Two problems beyond the needless subprocess.

**1 · `linuxRAM` returned a hardcoded `8` on failure.** A number nobody measured, presented as a reading, flowing straight into memory-pressure classification and model-fit recommendations. Same class as #258 — a default rendered as a measurement. It now returns `0`, which routes through `HardwareKnown` to `PressureUnknown`, so an unreadable machine is *reported* as unreadable.

**2 · In a minimal or distroless container with no coreutils, the `grep` simply fails** — so the fabricated 8 GB was not a remote edge case. It was what every such container got.

## Fix

`parseMeminfo` is a pure function over the file's contents. That matters for more than tidiness: the old pipeline could only be exercised on Linux, against whatever memory the host happened to have. Parsing is now tested against a fixture **on every OS**, deterministically.

It also distinguishes **absent from zero**, which `grep | Fields` collapsed — a kernel that does not report `MemAvailable` was indistinguishable from one reporting none available.

## The fixture caught a bug in my own parser

First version checked the unit only when a unit was present:

```go
if len(fields) > 1 && !strings.EqualFold(fields[1], "kB") { continue }
```

`HugePages_Total:       0` is a bare count with **no unit**, so the check was skipped entirely and it parsed as a memory field. Caught by `TestParseMeminfo_SkipsUnitlessFields` on the first run; the unit is now required. Reading a hugepage *count* as gigabytes would have been silent nonsense the moment anyone added that field to the ones we read.

## Tests

Fixture is a verbatim `/proc/meminfo` head. Covers: the two fields we read (exact values — 8388608 kB is exactly 8 GB), unitless fields skipped, missing ≠ zero, garbage inputs ignored rather than fatal, the configured path is honoured, and an unreadable file yields `0` → `HardwareKnown() == false` → `PressureUnknown` rather than a guess.

## Verification

```
go test ./... -race -count=1                          all green
vet clean on linux/amd64, windows/arm64, darwin/arm64
grep -rn 'exec.Command("grep"'                        none remaining
```

Closes #261