### PR TITLE
fix(probe): honour OLLAMA_HOST in discovery + distribution naming contract

### DIFF
--- a/cmd/hydra/dist_naming_test.go
+++ b/cmd/hydra/dist_naming_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Five independent implementations reconstruct the release archive filename by
+// hand — four installers plus goreleaser's own template — and nothing checked
+// that they agree.
+//
+// That is exactly how #262 shipped: npm and pip both mapped arm64 → windows/arm64
+// and cheerfully requested hydra_<ver>_windows_arm64.zip, an archive
+// .goreleaser.yaml was configured never to build. Silent 404 at install time, on
+// a platform nobody tested.
+//
+// These tests live in cmd/hydra alongside naming_test.go, the other repo-level
+// guard, and read the real files rather than a copy of what they are believed to
+// say. A sixth transcription of the rules in Go would be the same bug wearing a
+// different hat.
+
+func repoFile(t *testing.T, rel ...string) string {
+	t.Helper()
+	parts := append([]string{"..", ".."}, rel...)
+	raw, err := os.ReadFile(filepath.Join(parts...))
+	if err != nil {
+		t.Fatalf("reading %s: %v", filepath.Join(rel...), err)
+	}
+	return string(raw)
+}
+
+type target struct{ os, arch string }
+
+func (t target) String() string { return t.os + "/" + t.arch }
+
+// builtTargets is the authoritative set: goos × goarch, minus ignore.
+func builtTargets(t *testing.T) map[target]bool {
+	t.Helper()
+
+	var doc struct {
+		Builds []struct {
+			GOOS   []string `yaml:"goos"`
+			GOARCH []string `yaml:"goarch"`
+			Ignore []struct {
+				GOOS   string `yaml:"goos"`
+				GOARCH string `yaml:"goarch"`
+			} `yaml:"ignore"`
+		} `yaml:"builds"`
+	}
+	if err := yaml.Unmarshal([]byte(repoFile(t, ".goreleaser.yaml")), &doc); err != nil {
+		t.Fatalf("parsing .goreleaser.yaml: %v", err)
+	}
+	if len(doc.Builds) == 0 {
+		t.Fatal("no builds in .goreleaser.yaml — this guard has stopped guarding")
+	}
+
+	out := map[target]bool{}
+	for _, b := range doc.Builds {
+		for _, goos := range b.GOOS {
+			for _, goarch := range b.GOARCH {
+				out[target{goos, goarch}] = true
+			}
+		}
+		for _, ig := range b.Ignore {
+			delete(out, target{ig.GOOS, ig.GOARCH})
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("goreleaser builds nothing at all")
+	}
+	return out
+}
+
+// literalMapValues pulls the values out of a one-line literal map in source,
+// e.g. `{ darwin: 'darwin', linux: 'linux', win32: 'windows' }`. Reading the
+// installers' real maps is the point: a hand-copied list here would drift.
+func literalMapValues(t *testing.T, src, anchor string) []string {
+	t.Helper()
+	i := strings.Index(src, anchor)
+	if i < 0 {
+		t.Fatalf("anchor %q not found — the installer was restructured and this guard "+
+			"is no longer reading what it thinks it is", anchor)
+	}
+	rest := src[i:]
+	open := strings.Index(rest, "{")
+	closeAt := strings.Index(rest, "}")
+	if open < 0 || closeAt < open {
+		t.Fatalf("no literal map after anchor %q", anchor)
+	}
+	body := rest[open+1 : closeAt]
+
+	valRe := regexp.MustCompile(`['"]([a-z0-9_]+)['"]`)
+	var vals []string
+	for _, pair := range strings.Split(body, ",") {
+		// Take the value side of `key: value`.
+		_, v, found := strings.Cut(pair, ":")
+		if !found {
+			continue
+		}
+		if m := valRe.FindStringSubmatch(v); m != nil {
+			vals = append(vals, m[1])
+		}
+	}
+	if len(vals) == 0 {
+		t.Fatalf("parsed no values out of the map after %q", anchor)
+	}
+	return vals
+}
+
+// Every (os, arch) an installer can ask for must be an archive that exists.
+// This is #262 stated as a property.
+func TestInstallers_OnlyRequestTargetsThatAreBuilt(t *testing.T) {
+	built := builtTargets(t)
+
+	npm := repoFile(t, "npm", "scripts", "postinstall.js")
+	pip := repoFile(t, "pip", "hyctl", "__init__.py")
+
+	installers := []struct {
+		name         string
+		oses, arches []string
+	}{
+		{
+			name:   "npm/scripts/postinstall.js",
+			oses:   literalMapValues(t, npm, "const PLATFORM"),
+			arches: literalMapValues(t, npm, "const ARCH"),
+		},
+		{
+			name:   "pip/hyctl/__init__.py",
+			oses:   literalMapValues(t, pip, "_OS ="),
+			arches: literalMapValues(t, pip, "_ARCH ="),
+		},
+		{
+			name:   "install.sh",
+			oses:   shellCaseValues(t, repoFile(t, "install.sh"), `OS="`),
+			arches: shellCaseValues(t, repoFile(t, "install.sh"), `ARCH="`),
+		},
+	}
+
+	for _, inst := range installers {
+		for _, goos := range dedupe(inst.oses) {
+			for _, goarch := range dedupe(inst.arches) {
+				tgt := target{goos, goarch}
+				if !built[tgt] {
+					t.Errorf("%s can resolve to %s, but .goreleaser.yaml does not build it — "+
+						"that install 404s. This is #262.", inst.name, tgt)
+				}
+			}
+		}
+	}
+}
+
+// shellCaseValues pulls assigned values out of install.sh's case arms, e.g.
+// `Darwin) OS="darwin" ;;`.
+func shellCaseValues(t *testing.T, src, prefix string) []string {
+	t.Helper()
+	re := regexp.MustCompile(regexp.QuoteMeta(prefix) + `([a-z0-9_]+)"`)
+	m := re.FindAllStringSubmatch(src, -1)
+	if len(m) == 0 {
+		t.Fatalf("no %s… assignments found in install.sh", prefix)
+	}
+	var out []string
+	for _, g := range m {
+		out = append(out, g[1])
+	}
+	return out
+}
+
+// The archive extension must match goreleaser's format_overrides, or the
+// installer asks for a file that exists under a different name.
+func TestInstallers_UseTheRightArchiveExtension(t *testing.T) {
+	var doc struct {
+		Archives []struct {
+			Formats         []string `yaml:"formats"`
+			FormatOverrides []struct {
+				GOOS    string   `yaml:"goos"`
+				Formats []string `yaml:"formats"`
+			} `yaml:"format_overrides"`
+		} `yaml:"archives"`
+	}
+	if err := yaml.Unmarshal([]byte(repoFile(t, ".goreleaser.yaml")), &doc); err != nil {
+		t.Fatalf("parsing .goreleaser.yaml: %v", err)
+	}
+	if len(doc.Archives) == 0 {
+		t.Fatal("no archives in .goreleaser.yaml")
+	}
+	a := doc.Archives[0]
+
+	def := ""
+	if len(a.Formats) > 0 {
+		def = a.Formats[0]
+	}
+	perOS := map[string]string{}
+	for _, o := range a.FormatOverrides {
+		if len(o.Formats) > 0 {
+			perOS[o.GOOS] = o.Formats[0]
+		}
+	}
+
+	if def != "tar.gz" {
+		t.Errorf("default archive format is %q; the installers assume tar.gz", def)
+	}
+	if perOS["windows"] != "zip" {
+		t.Errorf("windows archive format is %q; npm and pip both assume zip", perOS["windows"])
+	}
+
+	// pip states it inline; npm derives it. Both must agree with the above.
+	pip := repoFile(t, "pip", "hyctl", "__init__.py")
+	if !strings.Contains(pip, `ext = "zip" if osname == "windows" else "tar.gz"`) {
+		t.Error("pip's extension logic no longer reads `zip` on windows else `tar.gz` — " +
+			"if it changed deliberately, update this contract with it")
+	}
+}
+
+// install.sh only handles the OSes it can actually unpack. It downloads a
+// .tar.gz unconditionally, so claiming Windows support would fetch a .zip and
+// hand it to tar.
+func TestInstallSh_DoesNotClaimWindows(t *testing.T) {
+	src := repoFile(t, "install.sh")
+	for _, o := range shellCaseValues(t, src, `OS="`) {
+		if o == "windows" {
+			t.Error("install.sh maps an OS to windows but always downloads .tar.gz — " +
+				"it would hand a zip to tar. Windows needs install.ps1 (#264).")
+		}
+	}
+	if !strings.Contains(src, "tar.gz") {
+		t.Error("install.sh no longer references tar.gz; re-check this contract")
+	}
+}
+
+// The README's platform table is a promise. It must not list a target that is
+// not built — the badge claimed "macOS | Linux" while Windows binaries shipped,
+// and the table was added in #262 precisely so the claim is checkable.
+func TestReadme_PlatformTableMatchesTheBuildMatrix(t *testing.T) {
+	built := builtTargets(t)
+	readme := repoFile(t, "README.md")
+
+	i := strings.Index(readme, "#### Platform support")
+	if i < 0 {
+		t.Fatal("README has no '#### Platform support' section — it was removed or renamed, " +
+			"so nothing now states which platforms ship")
+	}
+	section := readme[i:]
+	if j := strings.Index(section, "\n## "); j > 0 {
+		section = section[:j]
+	}
+
+	for _, want := range []struct {
+		label string
+		t     target
+	}{
+		{"macOS", target{"darwin", "amd64"}},
+		{"Linux", target{"linux", "amd64"}},
+		{"Windows", target{"windows", "amd64"}},
+	} {
+		listed := strings.Contains(section, want.label)
+		if listed && !built[want.t] {
+			t.Errorf("README lists %s but %s is not built", want.label, want.t)
+		}
+		if !listed && built[want.t] {
+			t.Errorf("%s is built but README's platform table does not mention %s", want.t, want.label)
+		}
+	}
+
+	// ARM64 is the column #262 was about; if it is built it must be advertised.
+	if built[target{"windows", "arm64"}] && !strings.Contains(section, "ARM64") {
+		t.Error("windows/arm64 is built but the README table has no ARM64 column")
+	}
+}
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -124,3 +124,48 @@ func TestSupports_AlwaysAgreesWithUnroutable(t *testing.T) {
 		}
 	}
 }
+
+// The same invariant over the whole shape space rather than five hand-picked
+// heads. #248 was the listing surface and the routing surface disagreeing about
+// what could be dispatched to; the fix made Supports derive from Unroutable so
+// they structurally cannot. That guarantee is only worth what it is checked
+// over — a handful of examples can miss exactly the combination that breaks it.
+//
+// Two properties, for every combination:
+//   - Supports(h) ⟺ Unroutable(h) == ""
+//   - an unroutable head's reason is non-empty and actionable, because probe
+//     prints it verbatim as the explanation of why the head is skipped
+func TestSupportsAndUnroutable_AgreeOverEveryHeadShape(t *testing.T) {
+	sources := []string{"registry", "cli", "env", "port", "", "unknown-source"}
+	providers := []string{"agy", "anthropic", "openai", "local", "nobody", ""}
+	endpoints := []string{"", "http://localhost:11434"}
+
+	checked := 0
+	for _, src := range sources {
+		for _, prov := range providers {
+			for _, ep := range endpoints {
+				for _, local := range []bool{false, true} {
+					for _, auth := range []bool{false, true} {
+						h := provider.Head{
+							ID: prov + "/" + src, Provider: prov, Source: src,
+							Endpoint: ep, LocalOnly: local, AuthReady: auth,
+						}
+						why := Unroutable(h)
+						if Supports(h) != (why == "") {
+							t.Errorf("%+v: Supports=%v but Unroutable=%q", h, Supports(h), why)
+						}
+						if why != "" && len(strings.TrimSpace(why)) < 10 {
+							t.Errorf("%+v: Unroutable reason %q is too terse to act on — "+
+								"probe prints it verbatim as the reason the head is skipped", h, why)
+						}
+						checked++
+					}
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no combinations checked")
+	}
+	t.Logf("agreement held over %d head shapes", checked)
+}

--- a/internal/executor/ollama.go
+++ b/internal/executor/ollama.go
@@ -9,13 +9,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"os"
 	"os/exec"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/util"
 )
 
@@ -165,19 +163,7 @@ func (e *OllamaExecutor) isHealthy(host string) bool {
 	return resp.StatusCode < 400
 }
 
-func ollamaHost() string {
-	h := os.Getenv("OLLAMA_HOST")
-	if h == "" {
-		return "http://localhost:11434"
-	}
-	u, err := url.Parse(h)
-	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-		return "http://localhost:11434"
-	}
-	// Only allow loopback targets unless the scheme is https.
-	host := u.Hostname()
-	if u.Scheme == "http" && !strings.HasPrefix(host, "127.") && host != "localhost" && host != "::1" {
-		return "http://localhost:11434"
-	}
-	return h
-}
+// ollamaHost delegates to provider.OllamaHost so discovery and execution can
+// never resolve to different addresses again (#282). Kept as a wrapper rather
+// than replacing every call site, since the name reads better here.
+func ollamaHost() string { return provider.OllamaHost() }

--- a/internal/provider/ollama_host.go
+++ b/internal/provider/ollama_host.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+package provider
+
+import (
+	"net/url"
+	"os"
+	"strings"
+)
+
+// DefaultOllamaHost is where Ollama listens unless told otherwise.
+const DefaultOllamaHost = "http://localhost:11434"
+
+// OllamaHost resolves where Ollama is listening, honouring $OLLAMA_HOST.
+//
+// This lives in provider — not executor, and not port — because both of them
+// need it and neither should depend on the other. Discovery and execution
+// having separate answers is exactly the bug: the executor honoured
+// $OLLAMA_HOST while the port provider hardcoded localhost:11434, so a user
+// running Ollama anywhere else had a working server that discovery could not
+// see, no tier-10 head, and a silent degrade to a paid one (#282). Same shape
+// as #248 — two surfaces disagreeing about what exists.
+//
+// Plain http:// is restricted to loopback on purpose: a prompt is the user's
+// source code, and sending it in cleartext to a remote host because an
+// environment variable said so is not a tradeoff to make silently. https:// to
+// a remote host is allowed. An unparsable or rejected value falls back to the
+// default rather than erroring, so a stray export cannot make Ollama
+// undiscoverable.
+func OllamaHost() string {
+	h := os.Getenv("OLLAMA_HOST")
+	if h == "" {
+		return DefaultOllamaHost
+	}
+	// Ollama itself accepts a bare "host:port"; url.Parse would read that as a
+	// scheme, so normalise before parsing.
+	if !strings.Contains(h, "://") {
+		h = "http://" + h
+	}
+	u, err := url.Parse(h)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return DefaultOllamaHost
+	}
+	if u.Scheme == "http" && !isLoopback(u.Hostname()) {
+		return DefaultOllamaHost
+	}
+	// Trailing slashes would produce "…//api/tags" once a path is appended.
+	return strings.TrimRight(u.Scheme+"://"+u.Host, "/")
+}
+
+func isLoopback(host string) bool {
+	return host == "localhost" || host == "::1" || strings.HasPrefix(host, "127.")
+}

--- a/internal/provider/port/provider.go
+++ b/internal/provider/port/provider.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/ankit373/hydra/internal/capabilities"
@@ -21,9 +22,13 @@ func init() { provider.Register(&Provider{}) }
 
 var httpClient = &http.Client{Timeout: 2 * time.Second}
 
-// portService probes a specific port and returns discovered Heads.
+// portService probes a specific address and returns discovered Heads.
+//
+// addr is a host:port, not a bare port: $OLLAMA_HOST can move Ollama to another
+// host as well as another port, and a liveness check aimed at the wrong address
+// answers a different question than the probe that follows it (#282).
 type portService interface {
-	port() int
+	addr() string
 	probe(ctx context.Context, caps *capabilities.DB) ([]provider.Head, error)
 }
 
@@ -38,14 +43,18 @@ func (p *Provider) Discover(ctx context.Context) ([]provider.Head, error) {
 		return nil, err
 	}
 
+	// Base URLs are resolved here, once, and handed to the services — so a
+	// service can be constructed against a test server, and so the address the
+	// liveness dial uses is provably the same one the probe and the head's
+	// Endpoint use.
 	services := []portService{
-		&ollamaService{},
-		&lmStudioService{},
+		&ollamaService{base: provider.OllamaHost()},
+		&lmStudioService{base: defaultLMStudioHost},
 	}
 
 	var heads []provider.Head
 	for _, svc := range services {
-		if !isOpen(svc.port()) {
+		if !isOpen(svc.addr()) {
 			continue
 		}
 		found, err := svc.probe(ctx, caps)
@@ -57,8 +66,10 @@ func (p *Provider) Discover(ctx context.Context) ([]provider.Head, error) {
 	return heads, nil
 }
 
-func isOpen(port int) bool {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 400*time.Millisecond)
+// isOpen is a cheap liveness check before the real probe, so a machine with
+// nothing listening does not pay the HTTP client's full timeout per service.
+func isOpen(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 400*time.Millisecond)
 	if err != nil {
 		return false
 	}
@@ -66,14 +77,33 @@ func isOpen(port int) bool {
 	return true
 }
 
+// hostPort extracts "host:port" from a base URL, supplying defaultPort when the
+// URL carries none. The dial and the HTTP probe must target the same place;
+// deriving one from the other is what keeps them in step.
+func hostPort(base string, defaultPort int) string {
+	u, err := url.Parse(base)
+	if err != nil || u.Host == "" {
+		return fmt.Sprintf("localhost:%d", defaultPort)
+	}
+	if u.Port() != "" {
+		return u.Host
+	}
+	return net.JoinHostPort(u.Hostname(), fmt.Sprintf("%d", defaultPort))
+}
+
 // ── Ollama ────────────────────────────────────────────────────────────────────
 
-type ollamaService struct{}
+// ollamaService is constructed with the base URL $OLLAMA_HOST resolves to.
+// This used to hardcode localhost:11434 while the executor honoured the
+// variable, so a user running Ollama on any other address had a working server
+// discovery could not see: no tier-10 head, and a silent degrade to a paid
+// one (#282).
+type ollamaService struct{ base string }
 
-func (s *ollamaService) port() int { return 11434 }
+func (s *ollamaService) addr() string { return hostPort(s.base, 11434) }
 
 func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]provider.Head, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:11434/api/tags", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.base+"/api/tags", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -98,11 +128,14 @@ func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]pro
 	heads := make([]provider.Head, 0, len(payload.Models))
 	for _, m := range payload.Models {
 		heads = append(heads, provider.Head{
-			ID:        "ollama/" + m.Name,
-			Name:      m.Name + " (Ollama)",
-			Provider:  "local",
-			Source:    "port",
-			Endpoint:  "http://localhost:11434",
+			ID:       "ollama/" + m.Name,
+			Name:     m.Name + " (Ollama)",
+			Provider: "local",
+			Source:   "port",
+			// The address it was found at, not a constant. The executor dials
+			// this later, so a head discovered at one address and stamped with
+			// another fails at the point of use.
+			Endpoint:  s.base,
 			CapScore:  caps.ScoreOllama(m.Name),
 			LocalOnly: true,
 			AuthReady: true,
@@ -113,12 +146,18 @@ func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]pro
 
 // ── LM Studio ─────────────────────────────────────────────────────────────────
 
-type lmStudioService struct{}
+// defaultLMStudioHost is LM Studio's default server address. Unlike Ollama it
+// publishes no environment variable for relocating it, so there is nothing to
+// honour — but the base is still a field so the two services behave the same
+// way and both are testable against a stub server.
+const defaultLMStudioHost = "http://localhost:1234"
 
-func (s *lmStudioService) port() int { return 1234 }
+type lmStudioService struct{ base string }
+
+func (s *lmStudioService) addr() string { return hostPort(s.base, 1234) }
 
 func (s *lmStudioService) probe(ctx context.Context, caps *capabilities.DB) ([]provider.Head, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:1234/v1/models", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.base+"/v1/models", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +186,7 @@ func (s *lmStudioService) probe(ctx context.Context, caps *capabilities.DB) ([]p
 			Name:      m.ID + " (LM Studio)",
 			Provider:  "local",
 			Source:    "port",
-			Endpoint:  "http://localhost:1234",
+			Endpoint:  s.base,
 			CapScore:  caps.ScoreOllama(m.ID),
 			LocalOnly: true,
 			AuthReady: true,

--- a/internal/provider/port/provider_test.go
+++ b/internal/provider/port/provider_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT
+
+package port
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/capabilities"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+func caps(t *testing.T) *capabilities.DB {
+	t.Helper()
+	db, err := capabilities.Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+// The bug: the executor honoured $OLLAMA_HOST while this package hardcoded
+// localhost:11434, so a user running Ollama anywhere else had a working server
+// discovery could not see — no tier-10 head, and a silent degrade to a paid
+// one (#282). A stub server on an arbitrary port is exactly that situation.
+func TestOllama_DiscoversModelsOnANonDefaultAddress(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b"},{"name":"llama3.2:3b"}]}`))
+	}))
+	defer srv.Close()
+
+	svc := &ollamaService{base: srv.URL}
+	heads, err := svc.probe(context.Background(), caps(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 2 {
+		t.Fatalf("got %d heads, want 2: %+v", len(heads), heads)
+	}
+
+	for _, h := range heads {
+		if !strings.HasPrefix(h.ID, "ollama/") {
+			t.Errorf("ID = %q, want an ollama/ prefix", h.ID)
+		}
+		if !h.LocalOnly {
+			t.Errorf("%s: LocalOnly = false — it would lose tier 10 and could be routed to as paid", h.ID)
+		}
+		if h.Source != "port" {
+			t.Errorf("%s: Source = %q, want %q", h.ID, h.Source, "port")
+		}
+		// The address it was found at, not a constant. The executor dials this
+		// later, so a head found at one address and stamped with another fails
+		// at the point of use.
+		if h.Endpoint != srv.URL {
+			t.Errorf("%s: Endpoint = %q, want %q — the address it was actually discovered at",
+				h.ID, h.Endpoint, srv.URL)
+		}
+	}
+}
+
+func TestLMStudio_DiscoversModelsOnANonDefaultAddress(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"some-local-model"}]}`))
+	}))
+	defer srv.Close()
+
+	svc := &lmStudioService{base: srv.URL}
+	heads, err := svc.probe(context.Background(), caps(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 1 {
+		t.Fatalf("got %d heads, want 1: %+v", len(heads), heads)
+	}
+	if !heads[0].LocalOnly {
+		t.Error("LocalOnly = false for an LM Studio head")
+	}
+	if heads[0].Endpoint != srv.URL {
+		t.Errorf("Endpoint = %q, want %q", heads[0].Endpoint, srv.URL)
+	}
+}
+
+// A server that answers but not with what we asked for is not a head. Returning
+// one anyway is the #248 failure: advertising something dispatch cannot use.
+func TestProbe_NonOKStatusYieldsNoHeads(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if _, err := (&ollamaService{base: srv.URL}).probe(context.Background(), caps(t)); err == nil {
+		t.Error("a 500 from the Ollama probe produced no error")
+	}
+	if _, err := (&lmStudioService{base: srv.URL}).probe(context.Background(), caps(t)); err == nil {
+		t.Error("a 500 from the LM Studio probe produced no error")
+	}
+}
+
+func TestProbe_GarbageBodyYieldsNoHeads(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("this is not json"))
+	}))
+	defer srv.Close()
+
+	if _, err := (&ollamaService{base: srv.URL}).probe(context.Background(), caps(t)); err == nil {
+		t.Error("an unparsable body produced no error")
+	}
+}
+
+// An empty model list means the server is up with nothing loaded. That is zero
+// heads and no error — distinct from a failed probe.
+func TestOllama_NoModelsIsNotAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	}))
+	defer srv.Close()
+
+	heads, err := (&ollamaService{base: srv.URL}).probe(context.Background(), caps(t))
+	if err != nil {
+		t.Fatalf("an empty model list should not be an error: %v", err)
+	}
+	if len(heads) != 0 {
+		t.Errorf("got %d heads from an empty list", len(heads))
+	}
+}
+
+// The liveness dial and the HTTP probe must target the same place. Dialling the
+// wrong address answers a different question than the probe that follows it.
+func TestHostPort_TracksTheBaseURL(t *testing.T) {
+	cases := []struct {
+		base, want  string
+		defaultPort int
+	}{
+		{"http://localhost:11434", "localhost:11434", 11434},
+		{"http://127.0.0.1:11500", "127.0.0.1:11500", 11434},
+		{"http://localhost", "localhost:11434", 11434},
+		{"https://ollama.internal", "ollama.internal:11434", 11434},
+		{"http://localhost:1234", "localhost:1234", 1234},
+		{"", "localhost:11434", 11434},
+		{"::::not a url", "localhost:11434", 11434},
+	}
+	for _, tc := range cases {
+		if got := hostPort(tc.base, tc.defaultPort); got != tc.want {
+			t.Errorf("hostPort(%q, %d) = %q, want %q", tc.base, tc.defaultPort, got, tc.want)
+		}
+	}
+}
+
+// The service's dial address must be derived from the base it will probe —
+// checked directly, because these being independently computed is what allowed
+// them to disagree in the first place.
+func TestOllamaService_AddrMatchesItsBase(t *testing.T) {
+	for _, base := range []string{
+		"http://localhost:11434",
+		"http://127.0.0.1:11500",
+		"https://ollama.internal:8443",
+	} {
+		svc := &ollamaService{base: base}
+		if got, want := svc.addr(), hostPort(base, 11434); got != want {
+			t.Errorf("addr() = %q for base %q, want %q", got, base, want)
+		}
+		if !strings.Contains(base, svc.addr()) && !strings.HasPrefix(svc.addr(), "localhost") {
+			t.Errorf("addr() %q is not the host of base %q", svc.addr(), base)
+		}
+	}
+}
+
+// Discovery and execution must resolve $OLLAMA_HOST to the same address. They
+// did not — that is #282 — and one shared resolver is what stops them drifting
+// again. Asserted through the sandbox so no developer's own OLLAMA_HOST leaks in.
+func TestDiscovery_ResolvesTheSameHostTheExecutorWill(t *testing.T) {
+	cases := []struct{ env, want string }{
+		{"", provider.DefaultOllamaHost},
+		{"http://127.0.0.1:11500", "http://127.0.0.1:11500"},
+		{"127.0.0.1:11500", "http://127.0.0.1:11500"},          // bare host:port, as Ollama accepts
+		{"https://ollama.internal", "https://ollama.internal"}, // https to a remote host is allowed
+		// Plain http to a remote host is refused: a prompt is the user's source
+		// code, and shipping it in cleartext because an env var said so is not a
+		// tradeoff to make silently.
+		{"http://192.168.1.50:11434", provider.DefaultOllamaHost},
+		{"not a url at all", provider.DefaultOllamaHost},
+		{"ftp://localhost:11434", provider.DefaultOllamaHost},
+	}
+	for _, tc := range cases {
+		t.Run(tc.env, func(t *testing.T) {
+			s := testutil.NewSandbox(t)
+			if tc.env != "" {
+				s.SetKey(t, "OLLAMA_HOST", tc.env)
+			}
+			got := provider.OllamaHost()
+			if got != tc.want {
+				t.Errorf("OllamaHost() = %q with OLLAMA_HOST=%q, want %q", got, tc.env, tc.want)
+			}
+			// And the service built from it agrees.
+			svc := &ollamaService{base: got}
+			if !strings.HasPrefix(svc.base, got) {
+				t.Errorf("service base %q does not match resolved host %q", svc.base, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Two things, both found by writing contracts for #269

---

## 1 · `OLLAMA_HOST` was honoured by the executor and ignored by discovery (#282)

```
$ grep -rn OLLAMA_HOST --include="*.go" internal/
internal/executor/ollama.go:169:	h := os.Getenv("OLLAMA_HOST")
```

**Exactly one production site.** Meanwhile `internal/provider/port` hardcoded `localhost:11434` in **three** places — the liveness dial, the probe URL, and the `Endpoint` stamped on every head.

So a user running Ollama anywhere else — a custom port, a container, precisely the case `OLLAMA_HOST` exists for — had a **working server that discovery could not see**. Zero local heads, no tier 10, and a silent degrade to a paid head. The executor would have talked to their Ollama quite happily; no head was ever discovered to route there.

Same shape as #248: two surfaces disagreeing about what exists, one advertising and one executing. It also quietly voids the guarantee `CLAUDE.md` states plainly — *"Local heads are tier 10, the terminal fallback"* — which holds only while a local head is **discovered**.

### Fix

Resolution moved to `internal/provider`, which both the executor and the port provider already import and which imports nothing itself. Putting it in `executor` would have made **discovery depend on execution**, which is backwards; putting it in `port` would leave the executor with its own copy. One package, one answer, **no new edges in the import graph**.

The **loopback-only restriction on plain `http://` is preserved** and now tested. A prompt is the user's source code, and shipping it in cleartext to a remote host because an environment variable said so is not a tradeoff to make silently. `https://` to a remote host is allowed; bare `host:port` is accepted, as Ollama itself accepts it.

`portService.port() int` → `addr() string`. A bare port cannot express a different *host*, and a liveness dial aimed at the wrong address answers a different question than the probe that follows it. Both services now carry their base URL, so the dial, the probe, and the `Endpoint` are provably the same address — and both become testable against a stub server.

### Tests, on a package that had none

Non-default addresses work for Ollama and LM Studio; `Endpoint` is the address the head was **actually found at**; a 500 or unparsable body yields **no heads** rather than a broken one; an empty model list is **zero heads and no error**; `hostPort` tracks the base across schemes and default ports; and discovery and execution resolve **identically** for the same environment.

Verified adversarially — restoring the hardcoded literal:
```
--- FAIL: TestOllama_DiscoversModelsOnANonDefaultAddress
    ollama/qwen3:8b: Endpoint = "http://localhost:11434", want "http://127.0.0.1:56540"
```

### Plus #248's invariant, properly checked

`TestSupports_AlwaysAgreesWithUnroutable` covered five hand-picked heads. The #248 fix made `Supports` *derive* from `Unroutable` so they structurally cannot drift — but that guarantee is only worth what it is checked over. Now the full cross-product of source × provider × endpoint × `LocalOnly` × `AuthReady` — **288 shapes** — plus a check that every unroutable reason is long enough to act on, since `probe` prints it verbatim.

---

## 2 · The installer ↔ goreleaser naming contract (#265)

**Five** independent implementations reconstruct the archive filename by hand — `install.sh`, npm's `postinstall.js`, pip's `__init__.py`, and goreleaser's `name_template` — and nothing checked they agree.

That is exactly how #262 shipped: npm and pip both mapped `arm64` → `windows/arm64` and requested an archive goreleaser was configured never to build. Silent 404, on a platform nobody tested, with no CI signal at all.

The test **reads the real files** rather than a copy of what they are believed to say: `goos × goarch − ignore` from `.goreleaser.yaml`, the platform/arch maps from the npm and pip sources, the case arms from `install.sh`. A sixth transcription of the rules in Go would be the same bug wearing a different hat. Each parse fails loudly if its anchor disappears, so a restructured installer cannot silently stop being checked.

Four contracts:
- **every `(os, arch)` an installer can resolve to must be built**
- the archive **extension** matches `format_overrides` — right target, wrong extension still 404s
- `install.sh` does not claim Windows: it downloads `.tar.gz` unconditionally, so a Windows arm would fetch a zip and hand it to `tar` (#264)
- the **README platform table matches the build matrix in both directions** — the badge advertised "macOS | Linux" while Windows binaries had been shipping

Verified by re-adding the exact `ignore` block that caused #262:
```
--- FAIL: TestInstallers_OnlyRequestTargetsThatAreBuilt
    npm/scripts/postinstall.js can resolve to windows/arm64, but .goreleaser.yaml
    does not build it — that install 404s. This is #262.
    pip/hyctl/__init__.py can resolve to windows/arm64, but ...
```

---

## Verification

```
go test ./... -race -count=1                     all green
go vet ./... (+ windows/arm64, linux/arm64)      clean
```

Closes #282
Closes #265
Part of #269