### PR TITLE
feat(dist): install.ps1 — Windows had no curl-style installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,44 @@ jobs:
         run: |
           shellcheck --severity=error install.sh
 
+  # install.ps1's counterpart to the shellcheck job above. It runs on Windows
+  # because that is where PowerShell's own parser lives — and because nobody
+  # developing this repo on macOS or Linux can otherwise tell whether the
+  # installer even parses, let alone works (#264).
+  powershell:
+    name: PowerShell lint
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # A parse error is the failure that matters most: install.ps1 is piped
+      # straight into `iex`, so a syntax error reaches users as a wall of
+      # PowerShell noise mid-install.
+      - name: Parse install.ps1
+        shell: pwsh
+        run: |
+          $errs = $null
+          $null = [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path ./install.ps1), [ref]$null, [ref]$errs)
+          if ($errs) {
+            $errs | ForEach-Object { Write-Host "::error::$($_.Extent.StartLineNumber): $($_.Message)" }
+            exit 1
+          }
+          Write-Host "install.ps1 parses cleanly"
+
+      - name: PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser -ErrorAction Stop
+          $results = Invoke-ScriptAnalyzer -Path ./install.ps1 -Severity Error,Warning
+          if ($results) {
+            $results | Format-Table -AutoSize | Out-String | Write-Host
+            # Errors block; warnings are surfaced, matching shellcheck's policy
+            # of --severity=error above.
+            if ($results | Where-Object { $_.Severity -eq 'Error' }) { exit 1 }
+          }
+          Write-Host "PSScriptAnalyzer: no errors"
+
   typecheck:
     name: TypeScript typecheck
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -413,10 +413,20 @@ npx hyctl init            # run without installing
 pip install hyctl
 ```
 
-**Standalone installer** (curl):
+**Standalone installer** — macOS/Linux (curl):
 ```bash
 curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install.sh | sh
 ```
+
+**Standalone installer** — Windows (PowerShell):
+```powershell
+irm https://raw.githubusercontent.com/ankit373/hydra/main/install.ps1 | iex
+```
+Installs per-user to `%LOCALAPPDATA%\Programs\hyctl` and extends your user `PATH` —
+no administrator rights needed. Both installers verify the download against the
+release's `checksums.txt` and refuse to install if it is listed and does not match.
+Pin a version with `$env:HYDRA_VERSION` / `HYDRA_VERSION`, or change the directory
+with `$env:HYDRA_BIN` / `HYDRA_BIN`.
 
 **Prebuilt binaries** — download from [github.com/ankit373/hydra/releases](https://github.com/ankit373/hydra/releases).
 
@@ -425,14 +435,13 @@ curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install.sh | sh
 Every release builds `hyctl` for all six targets below. This table is kept in step with
 `.goreleaser.yaml`'s build matrix — if a row is here, an artifact exists for it.
 
-| OS | x86-64 | ARM64 | Homebrew | npm / npx | pip | `install.sh` |
+| OS | x86-64 | ARM64 | Homebrew | npm / npx | pip | script |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|
-| macOS | ✅ | ✅ (Apple Silicon) | ✅ | ✅ | ✅ | ✅ |
-| Linux | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Windows | ✅ | ✅ | — | ✅ | ✅ | — |
+| macOS | ✅ | ✅ (Apple Silicon) | ✅ | ✅ | ✅ | `install.sh` |
+| Linux | ✅ | ✅ | ✅ | ✅ | ✅ | `install.sh` |
+| Windows | ✅ | ✅ | — | ✅ | ✅ | `install.ps1` |
 
-Windows has no Homebrew and no `curl \| sh` path — use npm or pip, or download the archive
-directly. A PowerShell installer is [tracked separately](https://github.com/ankit373/hydra/issues/264).
+Windows has no Homebrew; use npm, pip, `install.ps1`, or download the archive directly.
 
 The **desktop app** ships for macOS (universal), Windows x86-64 and Linux x86-64. ARM64 desktop
 builds are [not yet available](https://github.com/ankit373/hydra/issues/263) — the CLI covers ARM64

--- a/cmd/hydra/dist_naming_test.go
+++ b/cmd/hydra/dist_naming_test.go
@@ -142,6 +142,13 @@ func TestInstallers_OnlyRequestTargetsThatAreBuilt(t *testing.T) {
 			oses:   shellCaseValues(t, repoFile(t, "install.sh"), `OS="`),
 			arches: shellCaseValues(t, repoFile(t, "install.sh"), `ARCH="`),
 		},
+		{
+			// install.ps1 is Windows-only by construction, so its OS is fixed
+			// rather than parsed; only the arch switch can vary (#264).
+			name:   "install.ps1",
+			oses:   []string{"windows"},
+			arches: psArchValues(t, repoFile(t, "install.ps1")),
+		},
 	}
 
 	for _, inst := range installers {
@@ -171,6 +178,63 @@ func shellCaseValues(t *testing.T, src, prefix string) []string {
 		out = append(out, g[1])
 	}
 	return out
+}
+
+// psArchValues pulls the architectures out of install.ps1's switch, e.g.
+// `'ARM64' { $Arch = 'arm64' }`.
+func psArchValues(t *testing.T, src string) []string {
+	t.Helper()
+	re := regexp.MustCompile(`\$Arch\s*=\s*'([a-z0-9_]+)'`)
+	m := re.FindAllStringSubmatch(src, -1)
+	if len(m) == 0 {
+		t.Fatal("no $Arch assignments found in install.ps1 — restructured, and this " +
+			"guard is no longer reading what it thinks it is")
+	}
+	var out []string
+	for _, g := range m {
+		out = append(out, g[1])
+	}
+	return out
+}
+
+// install.ps1 is the Windows counterpart to install.sh. It must verify
+// checksums and fail closed on a checksums.txt that omits the archive — the
+// #241 hole, and the one behaviour every other installer already shares.
+func TestInstallPs1_VerifiesChecksumsAndFailsClosed(t *testing.T) {
+	src := repoFile(t, "install.ps1")
+
+	if !strings.Contains(src, "Get-FileHash") || !strings.Contains(src, "SHA256") {
+		t.Error("install.ps1 does not compute a SHA256 of what it downloaded")
+	}
+	if !strings.Contains(src, "is not listed in checksums.txt") {
+		t.Error("install.ps1 does not fail closed when checksums.txt omits the archive — " +
+			"that is #241, and every other installer already refuses this case")
+	}
+	if !strings.Contains(src, "checksum mismatch") {
+		t.Error("install.ps1 does not fail on a checksum mismatch")
+	}
+	// Per-user install: an installer that demands elevation for a CLI is a
+	// worse default than one that asks the user to extend PATH.
+	//
+	// Matched on the environment variable rather than the prose "Program
+	// Files", which appears in the script's own comment explaining why it is
+	// not used — the first version of this check failed on that comment, which
+	// is a fair reminder that a substring is not a usage.
+	if regexp.MustCompile(`\$env:ProgramFiles|\$env:ProgramW6432`).MatchString(src) {
+		t.Error("install.ps1 installs under Program Files, which needs elevation")
+	}
+	// PATH must be written at User scope only; Machine needs admin and changes
+	// the environment for everyone on the box.
+	if strings.Contains(src, "'Machine'") {
+		t.Error("install.ps1 writes an environment variable at Machine scope")
+	}
+	if !strings.Contains(src, "LOCALAPPDATA") {
+		t.Error("install.ps1 does not default to a per-user location")
+	}
+	// It must request the zip; Windows archives are not tar.gz.
+	if !strings.Contains(src, ".zip") {
+		t.Error("install.ps1 does not request a .zip")
+	}
 }
 
 // The archive extension must match goreleaser's format_overrides, or the

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -52,10 +52,11 @@ brew install ankit373/hydra/hyctl                                               
 npm install -g hyctl                                                              # npm
 npx hyctl                                                                         # npx (no install)
 pip install hyctl                                                                 # pip
-curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install.sh | sh  # standalone
+curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install.sh | sh  # standalone (macOS/Linux)
+irm https://raw.githubusercontent.com/ankit373/hydra/main/install.ps1 | iex        # standalone (Windows)
 ```
 
-Platform support: `hyctl` is built for macOS, Linux and Windows on both x86-64 and ARM64 — six targets, every release. Homebrew covers macOS and Linux; npm/npx and pip cover all three OSes; `install.sh` covers macOS and Linux (there is no PowerShell installer yet, so on Windows use npm, pip, or the archive directly). The desktop app ships for macOS (universal), Windows x86-64 and Linux x86-64; ARM64 desktop builds are not yet available.
+Platform support: `hyctl` is built for macOS, Linux and Windows on both x86-64 and ARM64 — six targets, every release. Homebrew covers macOS and Linux; npm/npx and pip cover all three OSes; `install.sh` covers macOS and Linux and `install.ps1` covers Windows (per-user, no admin rights; both verify the release checksum). The desktop app ships for macOS (universal), Windows x86-64 and Linux x86-64; ARM64 desktop builds are not yet available.
 
 Or build from source (requires Go 1.22+):
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,200 @@
+<#
+.SYNOPSIS
+  Hydra (hyctl) — standalone binary installer for Windows.
+
+.DESCRIPTION
+  Downloads the prebuilt hyctl.exe for your architecture from the latest GitHub
+  release, verifies it against the published checksums, and installs it.
+  No Go toolchain required, and no administrator rights.
+
+  The PowerShell sibling of install.sh, which handles macOS and Linux only:
+  it downloads a .tar.gz unconditionally, while Windows archives are .zip, so
+  it refuses to run here rather than handing a zip to tar (#264).
+
+.PARAMETER Version
+  Pin a specific release, e.g. v1.2.0. Defaults to the latest.
+  Also settable as $env:HYDRA_VERSION.
+
+.PARAMETER BinDir
+  Install directory. Defaults to $env:LOCALAPPDATA\Programs\hyctl — a
+  per-user location, so no elevation is needed.
+  Also settable as $env:HYDRA_BIN.
+
+.EXAMPLE
+  irm https://raw.githubusercontent.com/ankit373/hydra/main/install.ps1 | iex
+
+.EXAMPLE
+  $env:HYDRA_VERSION = 'v1.2.0'
+  irm https://raw.githubusercontent.com/ankit373/hydra/main/install.ps1 | iex
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Version = $env:HYDRA_VERSION,
+    [string]$BinDir  = $env:HYDRA_BIN
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Repo    = 'ankit373/hydra'
+$Project = 'hydra'      # goreleaser project_name → archive filename prefix
+$Binary  = 'hyctl.exe'  # binary name inside the archive
+$Base    = "https://github.com/$Repo/releases"
+
+function Write-Info { param([string]$Message) Write-Host "  $Message" }
+function Write-Warn { param([string]$Message) Write-Warning $Message }
+function Stop-WithError {
+    param([string]$Message)
+    Write-Host "  x $Message" -ForegroundColor Red
+    exit 1
+}
+
+# Windows PowerShell 5.1 still negotiates TLS 1.0 by default, which GitHub
+# refuses. Without this the very first request fails with an unhelpful
+# "underlying connection was closed".
+try {
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {
+    # PowerShell 7+ manages this itself and may not expose the setter.
+    Write-Verbose "could not set TLS 1.2 explicitly: $($_.Exception.Message)"
+}
+
+Write-Host 'Hydra installer (hyctl)'
+
+# ── Detect architecture ───────────────────────────────────────────────────────
+# PROCESSOR_ARCHITECTURE reports the *process* architecture. A 32-bit
+# PowerShell on 64-bit Windows reports x86 and sets PROCESSOR_ARCHITEW6432 to
+# the real one, so that takes precedence — otherwise a perfectly capable
+# machine would be told it is unsupported.
+$rawArch = $env:PROCESSOR_ARCHITEW6432
+if ([string]::IsNullOrEmpty($rawArch)) { $rawArch = $env:PROCESSOR_ARCHITECTURE }
+
+switch ($rawArch) {
+    'AMD64' { $Arch = 'amd64' }
+    'x86_64' { $Arch = 'amd64' }
+    'ARM64' { $Arch = 'arm64' }
+    default {
+        Stop-WithError "unsupported architecture: $rawArch (hyctl ships windows/amd64 and windows/arm64)"
+    }
+}
+
+# ── Resolve version ───────────────────────────────────────────────────────────
+if ([string]::IsNullOrEmpty($Version)) {
+    try {
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" `
+            -Headers @{ 'User-Agent' = 'hyctl-installer' }
+        $Tag = $release.tag_name
+    } catch {
+        Stop-WithError "could not determine latest release — set `$env:HYDRA_VERSION=vX.Y.Z ($($_.Exception.Message))"
+    }
+} else {
+    $Tag = $Version
+}
+if ([string]::IsNullOrEmpty($Tag)) {
+    Stop-WithError 'could not determine a release tag'
+}
+
+# Archive version = tag without a leading 'v', matching goreleaser's
+# name_template. Kept identical to install.sh, npm and pip; the contract test
+# in cmd/hydra/dist_naming_test.go is what keeps all five in step.
+$Ver     = $Tag -replace '^v', ''
+$Archive = "${Project}_${Ver}_windows_${Arch}.zip"
+$Url     = "$Base/download/$Tag/$Archive"
+$SumsUrl = "$Base/download/$Tag/checksums.txt"
+
+Write-Info "Target  : windows/$Arch"
+Write-Info "Archive : $Archive"
+Write-Info "Release : $Tag"
+
+# ── Download ──────────────────────────────────────────────────────────────────
+$Tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("hyctl-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $Tmp -Force | Out-Null
+
+try {
+    $ArchivePath = Join-Path $Tmp $Archive
+    try {
+        # A progress bar makes Invoke-WebRequest an order of magnitude slower.
+        $prevProgress = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri $Url -OutFile $ArchivePath -UseBasicParsing
+        $ProgressPreference = $prevProgress
+    } catch {
+        Stop-WithError "download failed: $Url ($($_.Exception.Message))"
+    }
+
+    # ── Verify ────────────────────────────────────────────────────────────────
+    # Same three-way policy as install.sh, npm and pip, and for the same reason:
+    #   unreachable checksums.txt  → warn and continue; a network blip should
+    #                                not brick an install
+    #   present but not listing us → FAIL CLOSED; the realistic cause is naming
+    #                                drift, and silently skipping verification
+    #                                for every user is #241
+    #   listed and mismatched      → FAIL
+    $sums = $null
+    try {
+        $sums = (Invoke-WebRequest -Uri $SumsUrl -UseBasicParsing).Content
+    } catch {
+        Write-Warn "checksums.txt not published for $Tag — skipping verification"
+    }
+
+    if ($null -ne $sums) {
+        $line = $sums -split "`n" | Where-Object { $_.Trim().EndsWith($Archive) } | Select-Object -First 1
+        if (-not $line) {
+            Stop-WithError "$Archive is not listed in checksums.txt — refusing to install unverified"
+        }
+        $expected = ($line.Trim() -split '\s+')[0]
+        $actual = (Get-FileHash -Path $ArchivePath -Algorithm SHA256).Hash.ToLower()
+        if ($expected.ToLower() -ne $actual) {
+            Stop-WithError "checksum mismatch — refusing to install (expected $expected, got $actual)"
+        }
+        Write-Info 'Checksum: verified'
+    }
+
+    # ── Extract ───────────────────────────────────────────────────────────────
+    $ExtractDir = Join-Path $Tmp 'x'
+    Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+    $Extracted = Join-Path $ExtractDir $Binary
+    if (-not (Test-Path $Extracted)) {
+        Stop-WithError "archive did not contain '$Binary'"
+    }
+
+    # ── Choose install dir ────────────────────────────────────────────────────
+    # Per-user by default so no elevation is required. Program Files would need
+    # admin, and an installer that demands it for a CLI is a worse default than
+    # one that asks the user to extend PATH.
+    if ([string]::IsNullOrEmpty($BinDir)) {
+        $BinDir = Join-Path $env:LOCALAPPDATA 'Programs\hyctl'
+    }
+    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+
+    $Dest = Join-Path $BinDir $Binary
+    Copy-Item -Path $Extracted -Destination $Dest -Force
+    Write-Info "Installed: $Dest"
+
+    # ── PATH ──────────────────────────────────────────────────────────────────
+    # The user's PATH is persistent state, so it is only extended when hyctl's
+    # directory is genuinely absent, and only at User scope — never Machine,
+    # which would need elevation and affect everyone on the box.
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($null -eq $userPath) { $userPath = '' }
+    $onPath = ($userPath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $BinDir.TrimEnd('\') }).Count -gt 0
+
+    if (-not $onPath) {
+        try {
+            $newPath = if ([string]::IsNullOrEmpty($userPath)) { $BinDir } else { "$userPath;$BinDir" }
+            [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+            $env:Path = "$env:Path;$BinDir"
+            Write-Info "Added to your user PATH: $BinDir"
+            Write-Warn 'Open a new terminal for the PATH change to take effect.'
+        } catch {
+            Write-Warn "could not update PATH automatically — add it yourself: $BinDir"
+        }
+    }
+
+    Write-Host ''
+    Write-Host "Done — hyctl $Tag installed. Run:  hyctl init"
+} finally {
+    Remove-Item -Path $Tmp -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Problem

`install.sh` handles Darwin and Linux and dies on anything else:

```sh
case "$os" in
  Darwin) OS="darwin" ;;
  Linux)  OS="linux" ;;
  *)      die "unsupported OS: $os" ;;
esac
```

…and downloads a `.tar.gz` unconditionally, while Windows archives are `.zip`. So the documented one-line install simply **refused** on Windows. Combined with no Homebrew there, Windows users had npm and pip and nothing else.

## Fix

`install.ps1` **mirrors** `install.sh` rather than inventing its own behaviour.

**Same three-way checksum policy, for the same reasons** — all four installers now agree:

| case | behaviour | why |
|---|---|---|
| `checksums.txt` unreachable | warn, continue | a network blip should not brick an install |
| present, archive **not listed** | **fail closed** | realistic cause is naming drift; silently skipping verification for every user is #241 |
| listed, hash differs | fail | — |

Same env overrides (`HYDRA_VERSION`, `HYDRA_BIN`), same archive name, derived the same way.

## Windows-specific care

- **`PROCESSOR_ARCHITEW6432` takes precedence** over `PROCESSOR_ARCHITECTURE`. The latter reports the *process* architecture, so a 32-bit PowerShell on 64-bit Windows reports `x86` — and a perfectly capable machine would be told it is unsupported.
- **TLS 1.2 is forced.** Windows PowerShell 5.1 still negotiates TLS 1.0 by default, which GitHub refuses; the failure surfaces as an unhelpful *"underlying connection was closed"* on the very first request.
- **Per-user install** to `%LOCALAPPDATA%\Programs\hyctl`, PATH written at **User scope only**. An installer that demands elevation for a CLI is a worse default than one that asks the user to extend PATH, and Machine scope would change the environment for everyone on the box.

## I cannot run PowerShell here — so CI establishes it

There is no `pwsh` on this machine, so **I am not asserting the script works**; the new job is what will.

A `windows-latest` job parses `install.ps1` with **PowerShell's own parser** and runs **PSScriptAnalyzer**, mirroring the existing shellcheck job. The parse check matters most: the script is piped straight into `iex`, so a syntax error reaches users as a wall of PowerShell noise mid-install.

## Covered by the #265 naming contract

Its arch switch is parsed from source (so it cannot drift from the build matrix), and it is asserted to verify checksums, fail closed, request a `.zip`, and stay out of Program Files and Machine scope.

That last check **first failed on the script's own comment** explaining why Program Files is avoided — a fair reminder that a substring is not a usage. It now matches `$env:ProgramFiles`.

## Docs shipped with it

README install section and platform table, and `docs/llms.txt`. The *"no curl installer on Windows"* caveat is gone, because it is no longer true.

Closes #264