### PR TITLE
fix(release): v1.1.0 never shipped — squash merge erased the release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,7 +475,7 @@ commit cannot land there either; squash or rebase only)
         ↓  (each merge → rc.yml publishes v1.2.0-rc.2, rc.3 …)
 Sign-off ✓
         ↓
-PR: release/v1.2.0 → main  (squash merge)
+PR: release/v1.2.0 → main  (squash merge — MUST carry a Release-As footer, see below)
         ↓
 release-please opens Release PR on main (bumps version, updates CHANGELOG)
         ↓
@@ -485,6 +485,49 @@ GoReleaser builds all platforms, publishes stable release, updates Homebrew tap
         ↓
 Cherry-pick any release-branch fixes back to develop
 ```
+
+### ⚠️ The squash-merge trap — `Release-As:` is mandatory
+
+**A squash merge of `release/v*` → `main` destroys the commit history release-please
+needs, and the release silently does not happen.**
+
+This is not hypothetical: it is exactly what happened to v1.1.0. PR #219 merged green,
+`Release Please` ran green, and **no release was produced**. Its log:
+
+```
+✔ Considering: 3 commits
+✔ No user facing commits found since e5e766e — skipping
+```
+
+The reason: squashing collapses every `feat:`/`fix:` commit on the release branch into a
+**single** commit whose type is taken from the PR title — here `chore(release): v1.1.0`.
+`chore` does not bump. release-please saw no user-facing commit and correctly did nothing.
+Nothing failed, nothing was red, and no `v1.1.0` tag was ever created.
+
+**Therefore: the release→main PR body MUST contain a `Release-As:` footer**, which forces
+the version regardless of commit types:
+
+```
+Release-As: 1.2.0
+```
+
+Put it on its own line at the end of the PR body, so the squash commit carries it. Give the
+PR a `fix(release):` or `feat(release):` title as well, so a user-facing commit exists and
+release-please cannot take the "nothing to do" path at all. Belt and braces — this step is
+invisible when it works and completely silent when it is missed.
+
+**Verify after merging**, every time — a green `Release Please` run does not mean a release:
+
+```bash
+gh run list --branch main --workflow "Release Please" --limit 1   # must be success
+gh pr list --state open --search "release"                        # a Release PR MUST appear
+git ls-remote --tags origin | grep "v1.2.0$"                      # after merging that PR
+```
+
+If no Release PR appears, the footer was missing. Fix it by pushing another PR to `main`
+carrying the footer; do **not** create the tag by hand — a manual tag leaves
+`.release-please-manifest.json` behind at the old version, and the next release is then
+computed off the wrong base (#215).
 
 ### Cutting a release branch
 


### PR DESCRIPTION
## v1.1.0 did not ship

PR #219 merged green. `Release Please` ran green. **No release happened** — no `v1.1.0` tag, no GitHub release, no Homebrew/npm/pip publish. Nothing was red at any point.

From the `Release Please` log:

```
✔ Considering: 3 commits
✔ No user facing commits found since e5e766e — skipping
```

The only commits on `main` since the last release are `chore(release): v1.1.0 (#219)`, and two `ci(release):` commits. None of those bump.

**The squash merge destroyed the information.** `release/v1.1.0` carried ~100 `feat:`/`fix:` commits; squashing collapsed them into one commit whose type came from the PR title — `chore(release):`. Everything release-please needed to compute the bump was erased at merge time.

This is baked into the documented flow, so it **recurs on every release**, and it fails **silently** — which is the worst property a release pipeline can have.

## What this PR does

**Ships v1.1.0.** The body of this PR ends with a `Release-As:` footer, which forces the version regardless of commit types. The squash commit inherits it, release-please honours it, and the Release PR for 1.1.0 opens as it should have on Monday. **The tree merged in #219 is unchanged** — this only restores the version signal the squash discarded. Everything here was already validated on rc.9 by downloading and running the artifact.

The title is `fix(release):` deliberately: it guarantees a user-facing commit exists, so release-please cannot take the "nothing to do" path at all. Belt and braces.

**Stops it recurring.** `CLAUDE.md` now documents the trap, marks the footer mandatory on every `release/* → main` PR, and adds the three commands that verify a release *actually happened* — because a green `Release Please` run does not mean one did:

```bash
gh run list --branch main --workflow "Release Please" --limit 1   # success
gh pr list --state open --search "release"                        # a Release PR MUST appear
git ls-remote --tags origin | grep "v1.1.0$"                      # after merging it
```

## What I deliberately did not do

Create the tag by hand. `git tag v1.1.0 && git push` would ship the binaries but leave `.release-please-manifest.json` at `1.0.1`, so the **next** release would be computed off the wrong base — which is #215, a bug this repo has already had once. Fixing one silent release bug by reintroducing another is not a fix.

## After merging — expected sequence

1. `Release Please` opens a Release PR titled `chore(main): release 1.1.0`
2. Merging **that** PR creates tag `v1.1.0` + the GitHub release
3. `publish.yml` fans out to Homebrew, npm and pip
4. `.release-please-manifest.json` reads `1.1.0`

If step 1 does not happen, the footer did not survive the squash — tell me and I will check the merge commit body directly.

## Separately: `Sync develop with main` is failing

The back-merge after #219 hit conflicts in 18 files, so `develop` is now behind `main`. That is expected — `develop` has moved on with the v1.2.0 work — but it needs a manual resolution. Tracked apart from this PR so the release is not held up by it.

Closes #288

Release-As: 1.1.0