### PR TITLE
fix(docs): skip intro was buried under the topbar and swallowed every click

### DIFF
--- a/cmd/hydra/docs_anchors_test.go
+++ b/cmd/hydra/docs_anchors_test.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// docs/index.html is hand-maintained and served straight to users, with no
+// build step and no test of any kind. Two classes of bug are both invisible in
+// review and immediately visible to a visitor: an anchor that points at nothing,
+// and a control that is painted over by something with a higher z-index.
+//
+// The second one shipped: "skip intro" sat at top:20px inside a hero whose
+// stacking context is below .topbar (sticky, top:0, height:52px, z-index:60).
+// The link was rendered underneath the bar, which has a background and a
+// backdrop-filter, so every click landed on the bar and the button did nothing.
+
+func indexHTML(t *testing.T) string {
+	t.Helper()
+	return repoFile(t, "docs", "index.html")
+}
+
+// cssPx pulls a pixel value for a property out of a CSS rule, e.g.
+// cssPx(src, ".skip-intro", "top") for `.skip-intro{...top:68px;...}`.
+func cssPx(t *testing.T, src, selector, prop string) (int, bool) {
+	t.Helper()
+	// Match the selector's rule body up to the closing brace.
+	re := regexp.MustCompile(regexp.QuoteMeta(selector) + `\s*\{([^}]*)\}`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		return 0, false
+	}
+	pv := regexp.MustCompile(`(?:^|[;\s])` + regexp.QuoteMeta(prop) + `\s*:\s*(-?\d+)px`)
+	pm := pv.FindStringSubmatch(m[1])
+	if pm == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(pm[1])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func cssInt(t *testing.T, src, selector, prop string) (int, bool) {
+	t.Helper()
+	re := regexp.MustCompile(regexp.QuoteMeta(selector) + `\s*\{([^}]*)\}`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		return 0, false
+	}
+	pv := regexp.MustCompile(`(?:^|[;\s])` + regexp.QuoteMeta(prop) + `\s*:\s*(-?\d+)`)
+	pm := pv.FindStringSubmatch(m[1])
+	if pm == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(pm[1])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// The hero's "skip intro" control must be clickable: either it sits clear of the
+// topbar, or it stacks above it. Sitting inside the bar's band at a lower
+// z-index is the bug.
+func TestSkipIntro_IsNotBuriedUnderTheTopbar(t *testing.T) {
+	src := indexHTML(t)
+
+	barH, ok := cssPx(t, src, ".topbar", "height")
+	if !ok {
+		t.Fatal("could not read .topbar height — the topbar was restructured and this guard " +
+			"is no longer measuring what it thinks it is")
+	}
+	barZ, ok := cssInt(t, src, ".topbar", "z-index")
+	if !ok {
+		t.Fatal("could not read .topbar z-index")
+	}
+	skipTop, ok := cssPx(t, src, ".skip-intro", "top")
+	if !ok {
+		t.Fatal("could not read .skip-intro top")
+	}
+	skipZ, ok := cssInt(t, src, ".skip-intro", "z-index")
+	if !ok {
+		t.Fatal("could not read .skip-intro z-index")
+	}
+
+	// .hero-pin creates no stacking context above the topbar, so a z-index
+	// inside the hero only competes with the bar if it exceeds it outright.
+	if skipZ > barZ {
+		return // deliberately floated above the bar; clickable either way
+	}
+	if skipTop < barH {
+		t.Errorf("skip-intro sits at top:%dpx, inside .topbar's 0–%dpx band, at z-index %d "+
+			"vs the bar's %d — the bar paints over it and swallows the click.\n"+
+			"Move it below the bar (top >= %dpx) or raise it above z-index %d.",
+			skipTop, barH, skipZ, barZ, barH, barZ)
+	}
+}
+
+// The mobile override must clear the bar too: only .topbar nav is hidden under
+// 720px, the bar keeps its height.
+func TestSkipIntro_MobileOverrideAlsoClearsTheTopbar(t *testing.T) {
+	src := indexHTML(t)
+	barH, ok := cssPx(t, src, ".topbar", "height")
+	if !ok {
+		t.Fatal("could not read .topbar height")
+	}
+
+	// The media-block override, e.g. `@media(max-width:720px){ … .skip-intro{top:64px;} }`
+	re := regexp.MustCompile(`@media\(max-width:720px\)\{[^@]*?\.skip-intro\s*\{([^}]*)\}`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		return // no mobile override is fine; the base rule applies
+	}
+	pv := regexp.MustCompile(`top\s*:\s*(-?\d+)px`)
+	pm := pv.FindStringSubmatch(m[1])
+	if pm == nil {
+		return
+	}
+	top, err := strconv.Atoi(pm[1])
+	if err != nil {
+		t.Fatalf("unparsable mobile top %q", pm[1])
+	}
+	if top < barH {
+		t.Errorf("mobile .skip-intro top:%dpx is inside .topbar's 0–%dpx band. Only the bar's "+
+			"nav is hidden under 720px — the bar keeps its height.", top, barH)
+	}
+}
+
+// Every in-page anchor must resolve. A href="#thing" with no id="thing" is a
+// link that silently does nothing, which is exactly how the skip-intro bug
+// presented even though its target did exist.
+func TestDocs_EveryInPageAnchorResolves(t *testing.T) {
+	for _, page := range []string{"index.html"} {
+		src := repoFile(t, "docs", page)
+
+		ids := map[string]bool{}
+		for _, m := range regexp.MustCompile(`\bid="([^"]+)"`).FindAllStringSubmatch(src, -1) {
+			ids[m[1]] = true
+		}
+		if len(ids) == 0 {
+			t.Fatalf("%s: parsed no ids at all", page)
+		}
+
+		seen := map[string]bool{}
+		for _, m := range regexp.MustCompile(`\bhref="#([^"]*)"`).FindAllStringSubmatch(src, -1) {
+			frag := m[1]
+			// href="#" is a deliberate no-op placeholder, not a broken link.
+			if frag == "" || seen[frag] {
+				continue
+			}
+			seen[frag] = true
+			if !ids[frag] {
+				t.Errorf("%s: href=\"#%s\" has no matching id — the link does nothing", page, frag)
+			}
+		}
+		if len(seen) == 0 {
+			t.Errorf("%s: found no in-page anchors; this guard has stopped guarding", page)
+		}
+		t.Logf("%s: %d in-page anchors, all resolve", page, len(seen))
+	}
+}
+
+// The nav's targets are the site's structure. Losing one is a dead link in the
+// most visible place on the page.
+func TestDocs_TopbarNavTargetsExist(t *testing.T) {
+	src := indexHTML(t)
+
+	navRe := regexp.MustCompile(`(?s)<div class="topbar".*?</div>`)
+	nav := navRe.FindString(src)
+	if nav == "" {
+		t.Fatal("could not locate the topbar markup")
+	}
+	ids := map[string]bool{}
+	for _, m := range regexp.MustCompile(`\bid="([^"]+)"`).FindAllStringSubmatch(src, -1) {
+		ids[m[1]] = true
+	}
+	var checked int
+	for _, m := range regexp.MustCompile(`href="#([^"]+)"`).FindAllStringSubmatch(nav, -1) {
+		checked++
+		if !ids[m[1]] {
+			t.Errorf("topbar links to #%s, which does not exist", m[1])
+		}
+	}
+	if checked == 0 {
+		t.Log("topbar has no in-page links")
+	}
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -273,13 +273,21 @@ a{color:inherit;text-decoration:none;}
   background:linear-gradient(90deg,var(--cyan),var(--violet),var(--magenta));-webkit-background-clip:text;background-clip:text;
   color:transparent;margin-bottom:7px;}
 .deep .db{font-size:11px;color:var(--dim);letter-spacing:.5px;line-height:1.6;transition:opacity .15s ease-out;font-family:var(--mono);}
-.skip-intro{position:absolute;top:20px;left:50%;transform:translateX(-50%);z-index:3;pointer-events:auto;
+/* top must clear .topbar (position:sticky, top:0, height:52px, z-index:60).
+   At top:20px this pill sat entirely inside the bar's 0–52px band, and since
+   .hero-pin creates no stacking context above z-index 60, the bar painted over
+   it — background and backdrop-filter and all — so every click landed on the
+   topbar and "skip intro" did nothing. Kept below the bar rather than raised
+   above it: floating a hero control over the nav is the wrong fix. */
+.skip-intro{position:absolute;top:68px;left:50%;transform:translateX(-50%);z-index:3;pointer-events:auto;
   font-family:var(--mono);font-size:10.5px;letter-spacing:2px;text-transform:uppercase;color:var(--faint);
   border:1px solid var(--line);border-radius:20px;padding:6px 14px;transition:.15s;background:rgba(6,7,15,.4);}
 .skip-intro:hover{color:var(--aqua);border-color:var(--aqua);}
 .hero-buffer{height:14vh;}
 @media(max-width:720px){#hudLog,#hudTele,.hud-meta{display:none;}
-  .skip-intro{top:16px;}}
+  /* The topbar keeps its 52px height on mobile — only its nav is hidden — so
+     this still has to clear it. */
+  .skip-intro{top:64px;}}
 .hero-inner{position:relative;z-index:3;padding:0 24px 9vh;max-width:var(--maxw);margin:0 auto;width:100%;
   text-align:center;pointer-events:none;transition:opacity .12s linear;}
 .eyebrow{font-family:var(--mono);font-size:12px;letter-spacing:3.5px;text-transform:uppercase;color:var(--aqua);

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## The link was never broken — it was unreachable

`<a class="skip-intro" href="#universe">` and `<section id="universe">` both exist. The problem is stacking:

| element | position | z-index | occupies |
|---|---|---|---|
| `.topbar` | `sticky; top:0` | **60** | y = 0–52px |
| `.skip-intro` | `absolute; top:20px` | 3 | y ≈ 20–48px |

`.skip-intro` sits inside `.hero-sticky`, and `.hero-pin` creates **no stacking context above z-index 60**. The topbar has a background *and* a `backdrop-filter`, so it is not click-through. It paints over the pill entirely and every click lands on the bar.

The mobile override was worse, not better — `@media(max-width:720px){.skip-intro{top:16px;}}`. Only `.topbar nav` is hidden below 720px; the bar keeps its 52px height.

## Fix

Below the bar: `top:68px` desktop, `top:64px` mobile.

Deliberately **not** raised above `z-index:60` — floating a hero control over the nav would fix the click and break the layout.

## Guards

`docs/index.html` is hand-maintained, served straight to users, has no build step, and had **no test of any kind**. Four guards, in `cmd/hydra` alongside the other repo-level ones:

1. `.skip-intro` clears the topbar **or** outranks its z-index
2. the mobile override clears it too
3. **every in-page `href="#x"` resolves to an `id="x"`** — a dead anchor is a link that silently does nothing, which is exactly how this bug presented *even though its target existed*
4. every topbar nav target exists — the most visible place on the page to have a dead link

Each fails loudly if the markup is restructured underneath it, rather than silently passing over something it can no longer find.

Verified adversarially — restoring `top:20px`:

```
--- FAIL: TestSkipIntro_IsNotBuriedUnderTheTopbar
    skip-intro sits at top:20px, inside .topbar's 0–52px band, at z-index 3 vs
    the bar's 60 — the bar paints over it and swallows the click.
    Move it below the bar (top >= 52px) or raise it above z-index 60.
--- FAIL: TestSkipIntro_MobileOverrideAlsoClearsTheTopbar
    mobile .skip-intro top:20px is inside .topbar's 0–52px band. Only the bar's
    nav is hidden under 720px — the bar keeps its height.
```

`sitemap.xml` lastmod updated per the docs-sync rule.

Closes #292