### PR TITLE
test(executor): cover SigV4 signing and the HTTP execution path (8.6% → 26.4%)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,6 +17,25 @@ regexes = [
   # Ahrefs Web Analytics data-key: a public site identifier embedded in the page
   # <head> and served to every visitor (equivalent to a GA measurement ID).
   '''yRz83E87rXgYWlhmro5mIg''',
+
+  # AWS SigV4 known-answer vectors: the *derived signing keys* for AWS's own
+  # published example secret, used by internal/executor/sigv4_test.go. They are
+  # 64 hex chars of high entropy, so gitleaks reads them as generic-api-key —
+  # correct by pattern, wrong by fact. A signing key is the output of a KDF over
+  # a documented sample secret; it authenticates nothing, and the first value is
+  # printed verbatim in AWS's "deriving the signing key" documentation.
+  #
+  # They are hardcoded on purpose. Computing them in the test would only prove
+  # the code agrees with itself, which is the entire thing a known-answer vector
+  # exists to rule out. Splitting them to dodge the entropy rule would be worse
+  # still: defeating the scanner by obfuscation rather than declaring the
+  # exception.
+  #
+  # Allowlisted as exact values rather than by path — tighter than the
+  # pii_test.go entry below, since this cannot hide anything but these two
+  # specific strings, in any file.
+  '''f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d''',
+  '''938127b5336810ddb6a5d6af445fcac9e371f9ed418ed386b022aed82901be75''',
 ]
 
 paths = [

--- a/internal/executor/http_exec_test.go
+++ b/internal/executor/http_exec_test.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// A head with an Endpoint short-circuits provider config resolution, so the
+// whole HTTP execution path can be driven against a stub server instead of a
+// real API. Everything here runs inside a sandbox, so no developer's API key
+// can turn one of these into a live, billable call.
+func stubHead(url string) provider.Head {
+	return provider.Head{ID: "stub-model", Provider: "openai", Source: "env", Endpoint: url, AuthReady: true}
+}
+
+const okChatBody = `{"model":"gpt-test","choices":[{"message":{"content":"hello from the stub"}}],
+  "usage":{"prompt_tokens":11,"completion_tokens":7}}`
+
+func TestExecute_HappyPathParsesOutputAndUsage(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	var gotPath, gotMethod, gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod, gotCT = r.URL.Path, r.Method, r.Header.Get("Content-Type")
+		_, _ = w.Write([]byte(okChatBody))
+	}))
+	defer srv.Close()
+
+	resp, err := (&HTTPExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hi", Head: stubHead(srv.URL), MaxTokens: 64,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Errorf("path = %s, want /v1/chat/completions", gotPath)
+	}
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q", gotCT)
+	}
+	if resp.Output != "hello from the stub" {
+		t.Errorf("Output = %q", resp.Output)
+	}
+	// Token counts must come from the provider, not be estimated — cost
+	// reporting labels these as actual spend.
+	if resp.InputTokens != 11 || resp.OutputTokens != 7 {
+		t.Errorf("tokens = %d/%d, want 11/7", resp.InputTokens, resp.OutputTokens)
+	}
+	if resp.TokensEstimated {
+		t.Error("TokensEstimated = true, but the provider reported real usage — " +
+			"estimated tokens must never be presented as measured spend")
+	}
+	if resp.Model != "gpt-test" {
+		t.Errorf("Model = %q, want the provider's reported model", resp.Model)
+	}
+	if resp.Duration <= 0 {
+		t.Error("Duration was not measured")
+	}
+}
+
+// The system prompt must actually reach the provider. Dropping it silently
+// changes the model's behaviour with no error anywhere.
+func TestExecute_SendsSystemPromptAndUserPrompt(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	var body string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(b)
+		body = string(b)
+		_, _ = w.Write([]byte(okChatBody))
+	}))
+	defer srv.Close()
+
+	_, err := (&HTTPExecutor{}).Execute(context.Background(), Request{
+		Prompt: "USER-MARKER", System: "SYSTEM-MARKER", Head: stubHead(srv.URL),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"USER-MARKER", "SYSTEM-MARKER", `"role":"system"`, `"role":"user"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("request body missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Index(body, "SYSTEM-MARKER") > strings.Index(body, "USER-MARKER") {
+		t.Error("system message is ordered after the user message")
+	}
+}
+
+// Fault injection: every one of these must be an error, never a Response that
+// a caller would treat as a successful (and billable) completion.
+func TestExecute_FaultsAreErrorsNotEmptySuccesses(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		wantIn  string
+	}{
+		{"500", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("upstream exploded"))
+		}, "status 500"},
+		{"401 unauthorized", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"bad key"}`))
+		}, "status 401"},
+		{"429 rate limited", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+		}, "status 429"},
+		{"malformed json", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("{not json"))
+		}, "decode"},
+		{"no choices", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"model":"m","choices":[]}`))
+		}, "empty response"},
+		{"truncated body", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Length", "500")
+			_, _ = w.Write([]byte(`{"choices":[{"messa`))
+		}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.NewSandbox(t)
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			resp, err := (&HTTPExecutor{}).Execute(context.Background(), Request{
+				Prompt: "x", Head: stubHead(srv.URL),
+			})
+			if err == nil {
+				t.Fatalf("got a Response (%+v) instead of an error — a caller would bill this "+
+					"as a successful completion", resp)
+			}
+			if resp != nil {
+				t.Errorf("both a Response and an error were returned: %+v", resp)
+			}
+			if tc.wantIn != "" && !strings.Contains(err.Error(), tc.wantIn) {
+				t.Errorf("error %q does not mention %q", err, tc.wantIn)
+			}
+			// The head ID must be in the error or an operator cannot tell which
+			// head failed in a fallback chain.
+			if !strings.Contains(err.Error(), "stub-model") {
+				t.Errorf("error %q does not name the head", err)
+			}
+		})
+	}
+}
+
+// A cancelled context must abort promptly rather than block until the client
+// timeout — dispatch relies on this to enforce its own deadlines.
+func TestExecute_HonoursContextCancellation(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		_, _ = w.Write([]byte(okChatBody))
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(30 * time.Millisecond); cancel() }()
+
+	start := time.Now()
+	_, err := (&HTTPExecutor{}).Execute(ctx, Request{Prompt: "x", Head: stubHead(srv.URL)})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("a cancelled request returned success")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("took %v to notice cancellation", elapsed)
+	}
+}
+
+// Concurrent execution must be race-free: dispatch fans out across heads and
+// swarm fans out further still.
+func TestExecute_IsSafeUnderConcurrency(t *testing.T) {
+	testutil.NewSandbox(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(okChatBody))
+	}))
+	defer srv.Close()
+
+	e := &HTTPExecutor{}
+	errs := make(chan error, 16)
+	for i := 0; i < 16; i++ {
+		go func() {
+			_, err := e.Execute(context.Background(), Request{Prompt: "x", Head: stubHead(srv.URL)})
+			errs <- err
+		}()
+	}
+	for i := 0; i < 16; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("concurrent execute %d: %v", i, err)
+		}
+	}
+}
+
+// An unknown provider with no endpoint must be refused before any network call.
+func TestExecute_UnsupportedProviderIsRefused(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	_, err := (&HTTPExecutor{}).Execute(context.Background(), Request{
+		Prompt: "x", Head: provider.Head{ID: "who", Provider: "nobody", Source: "env"},
+	})
+	if err == nil {
+		t.Fatal("an unknown provider was accepted")
+	}
+	if !strings.Contains(err.Error(), "not executable") {
+		t.Errorf("error %q does not explain that the provider is unsupported", err)
+	}
+}
+
+// ── pure helpers ──────────────────────────────────────────────────────────────
+
+func TestBuildMessages(t *testing.T) {
+	if got := buildMessages(Request{Prompt: "p"}); len(got) != 1 || got[0].Role != "user" || got[0].Content != "p" {
+		t.Errorf("without a system prompt: %+v", got)
+	}
+	got := buildMessages(Request{Prompt: "p", System: "s"})
+	if len(got) != 2 || got[0].Role != "system" || got[1].Role != "user" {
+		t.Errorf("with a system prompt: %+v", got)
+	}
+	// An empty system prompt must not become an empty system message, which
+	// some providers reject outright.
+	if got := buildMessages(Request{Prompt: "p", System: ""}); len(got) != 1 {
+		t.Errorf("empty system prompt produced %d messages", len(got))
+	}
+}
+
+func TestDefaultMaxTokens(t *testing.T) {
+	for _, tc := range []struct{ v, fallback, want int }{
+		{0, 1024, 1024}, {512, 1024, 512}, {-1, 1024, 1024}, {1, 1024, 1},
+	} {
+		if got := defaultMaxTokens(tc.v, tc.fallback); got != tc.want {
+			t.Errorf("defaultMaxTokens(%d, %d) = %d, want %d", tc.v, tc.fallback, got, tc.want)
+		}
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	if got := firstNonEmpty("", "  ", "x", "y"); got != "x" {
+		t.Errorf("got %q, want x — whitespace-only is not a value", got)
+	}
+	if got := firstNonEmpty("", ""); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+	if got := firstNonEmpty(); got != "" {
+		t.Errorf("no args returned %q", got)
+	}
+}
+
+func TestTrimLocalModelID(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"ollama/qwen3:8b", "qwen3:8b"},
+		{"lmstudio/some-model", "some-model"},
+		{"gpt-4o", "gpt-4o"},
+		{"", ""},
+		// Only the leading prefix is stripped, never an embedded occurrence.
+		{"x/ollama/y", "x/ollama/y"},
+	} {
+		if got := trimLocalModelID(tc.in); got != tc.want {
+			t.Errorf("trimLocalModelID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestJoinTextBlocks_SkipsEmptyAndTrims(t *testing.T) {
+	got := joinTextBlocks([]textBlock{{"  a  "}, {"   "}, {""}, {"b"}})
+	if got != "a\nb" {
+		t.Errorf("got %q, want %q", got, "a\nb")
+	}
+	if got := joinTextBlocks(nil); got != "" {
+		t.Errorf("nil blocks gave %q", got)
+	}
+}
+
+func TestStringifyAny(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"string", "hi", "hi"},
+		{"slice of strings", []any{"a", "b"}, "a\nb"},
+		{"slice with empties", []any{"a", "", "b"}, "a\nb"},
+		{"empty slice", []any{}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stringifyAny(tc.in); got != tc.want {
+				t.Errorf("stringifyAny(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The error must carry the status and a bounded slice of the body — enough to
+// diagnose, not so much that a huge error page floods the log.
+func TestHTTPStatusError_IsInformativeAndBounded(t *testing.T) {
+	huge := strings.Repeat("E", 100_000)
+	resp := &http.Response{StatusCode: 503, Body: http.NoBody}
+	resp.Body = httptest.NewRecorder().Result().Body
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(503)
+		_, _ = w.Write([]byte(huge))
+	}))
+	defer srv.Close()
+
+	r, err := http.Get(srv.URL) //nolint:noctx // test-local
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Body.Close()
+
+	e := httpStatusError("head-x", r)
+	msg := e.Error()
+	if !strings.Contains(msg, "503") || !strings.Contains(msg, "head-x") {
+		t.Errorf("error %q lacks the status or the head ID", msg[:min(200, len(msg))])
+	}
+	if len(msg) > 8192 {
+		t.Errorf("error is %d bytes — an upstream error page should be truncated, not logged whole", len(msg))
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/executor/sigv4_test.go
+++ b/internal/executor/sigv4_test.go
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"bytes"
+	"encoding/hex"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// AWS SigV4 request signing had 0% coverage. It is the highest-consequence code
+// in this package: get it wrong and every Bedrock call fails with a 403 that
+// says nothing useful, and the failure mode of getting it *subtly* wrong is
+// worse — a signature that works today and breaks on a header change.
+//
+// Tested against known-answer vectors rather than by re-deriving the algorithm
+// in the test, which would only prove the code agrees with itself. The vectors
+// below were computed with an independent implementation (Python's hmac +
+// hashlib) and the first matches the value AWS publishes in its own
+// "deriving the signing key" documentation.
+
+// AWS's published example: secret wJalrX…EXAMPLEKEY, 20120215/us-east-1/iam.
+const (
+	awsExampleSecret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+	awsExampleKeyHex = "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"
+	// A second, independent vector so a single lucky match cannot pass.
+	awsSecondKeyHex = "938127b5336810ddb6a5d6af445fcac9e371f9ed418ed386b022aed82901be75"
+	// Well-known: SHA-256 of the empty string.
+	emptySHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+func TestAWSSigningKey_MatchesPublishedVectors(t *testing.T) {
+	cases := []struct {
+		name              string
+		date, region, svc string
+		want              string
+	}{
+		{"AWS documented example", "20120215", "us-east-1", "iam", awsExampleKeyHex},
+		{"second vector", "20150830", "us-east-1", "service", awsSecondKeyHex},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hex.EncodeToString(awsSigningKey(awsExampleSecret, tc.date, tc.region, tc.svc))
+			if got != tc.want {
+				t.Errorf("awsSigningKey(%s/%s/%s)\n got  %s\n want %s",
+					tc.date, tc.region, tc.svc, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSHA256Hex_MatchesKnownAnswer(t *testing.T) {
+	if got := sha256Hex(nil); got != emptySHA256 {
+		t.Errorf("sha256Hex(nil) = %s, want %s", got, emptySHA256)
+	}
+	if got := sha256Hex([]byte{}); got != emptySHA256 {
+		t.Errorf("sha256Hex(empty) = %s, want %s", got, emptySHA256)
+	}
+	// Different input must give a different digest — guards against a stub that
+	// always returns the same thing.
+	if sha256Hex([]byte("a")) == emptySHA256 {
+		t.Error("sha256Hex is not actually hashing its input")
+	}
+}
+
+// The signing key must depend on every input. A derivation that ignores one
+// (say, region) produces signatures that validate in one region and fail in
+// another, which is a nightmare to diagnose from a 403.
+func TestAWSSigningKey_DependsOnEveryInput(t *testing.T) {
+	base := awsSigningKey("secret", "20240101", "us-east-1", "bedrock")
+	variants := map[string][]byte{
+		"secret":  awsSigningKey("other", "20240101", "us-east-1", "bedrock"),
+		"date":    awsSigningKey("secret", "20240102", "us-east-1", "bedrock"),
+		"region":  awsSigningKey("secret", "20240101", "eu-west-1", "bedrock"),
+		"service": awsSigningKey("secret", "20240101", "us-east-1", "s3"),
+	}
+	for what, got := range variants {
+		if bytes.Equal(base, got) {
+			t.Errorf("changing %s did not change the signing key — it is not part of the derivation", what)
+		}
+	}
+}
+
+func signedRequest(t *testing.T, body []byte, withToken bool) *http.Request {
+	t.Helper()
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "AWS_ACCESS_KEY_ID", "AKIDEXAMPLE")
+	s.SetKey(t, "AWS_SECRET_ACCESS_KEY", awsExampleSecret)
+	if withToken {
+		s.SetKey(t, "AWS_SESSION_TOKEN", "session-token-value")
+	}
+
+	req, err := http.NewRequest(http.MethodPost,
+		"https://bedrock-runtime.us-east-1.amazonaws.com/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if err := signAWSRequest(req, body, "us-east-1", "bedrock"); err != nil {
+		t.Fatalf("signAWSRequest: %v", err)
+	}
+	return req
+}
+
+// Every header named in SignedHeaders must actually be sent. AWS recomputes the
+// canonical request from the headers it receives; a header declared but absent
+// (or present but not declared) yields a different canonical request and a 403.
+func TestSignAWSRequest_SignedHeadersMatchWhatIsSent(t *testing.T) {
+	body := []byte(`{"model":"x"}`)
+	req := signedRequest(t, body, false)
+
+	auth := req.Header.Get("Authorization")
+	if auth == "" {
+		t.Fatal("no Authorization header was set")
+	}
+	signed := ""
+	for _, part := range strings.Split(auth, ", ") {
+		if strings.HasPrefix(part, "SignedHeaders=") {
+			signed = strings.TrimPrefix(part, "SignedHeaders=")
+		}
+	}
+	if signed == "" {
+		t.Fatalf("no SignedHeaders in %q", auth)
+	}
+
+	for _, h := range strings.Split(signed, ";") {
+		if h == "host" {
+			continue // host comes from the URL, not the header map
+		}
+		if req.Header.Get(h) == "" {
+			t.Errorf("SignedHeaders declares %q but the request does not send it — "+
+				"AWS will compute a different canonical request and reject this with a 403", h)
+		}
+	}
+}
+
+// SignedHeaders must be lowercase and sorted; SigV4 requires it and AWS will
+// not reorder them for us.
+func TestSignAWSRequest_SignedHeadersAreLowercaseAndSorted(t *testing.T) {
+	for _, withToken := range []bool{false, true} {
+		req := signedRequest(t, []byte(`{}`), withToken)
+		auth := req.Header.Get("Authorization")
+		var signed string
+		for _, part := range strings.Split(auth, ", ") {
+			if strings.HasPrefix(part, "SignedHeaders=") {
+				signed = strings.TrimPrefix(part, "SignedHeaders=")
+			}
+		}
+		hs := strings.Split(signed, ";")
+		for i, h := range hs {
+			if h != strings.ToLower(h) {
+				t.Errorf("token=%v: SignedHeaders entry %q is not lowercase", withToken, h)
+			}
+			if i > 0 && hs[i-1] >= h {
+				t.Errorf("token=%v: SignedHeaders not sorted: %q before %q (full: %s)",
+					withToken, hs[i-1], h, signed)
+			}
+		}
+		// The session token must be signed when present and absent when not —
+		// signing a header you do not send, or sending one you did not sign,
+		// both produce a 403.
+		hasTokenHeader := strings.Contains(signed, "x-amz-security-token")
+		if hasTokenHeader != withToken {
+			t.Errorf("withToken=%v but SignedHeaders %s x-amz-security-token",
+				withToken, map[bool]string{true: "contains", false: "omits"}[hasTokenHeader])
+		}
+	}
+}
+
+// The payload hash must be the hash of the payload actually sent. Signing an
+// empty body while sending a real one is a 403 that looks like a credentials
+// problem.
+func TestSignAWSRequest_PayloadHashCoversTheRealBody(t *testing.T) {
+	body := []byte(`{"model":"claude","messages":[]}`)
+	req := signedRequest(t, body, false)
+
+	if got, want := req.Header.Get("X-Amz-Content-Sha256"), sha256Hex(body); got != want {
+		t.Errorf("X-Amz-Content-Sha256 = %s, want %s (hash of the body being sent)", got, want)
+	}
+	// And a different body must produce a different hash, or the header is
+	// carrying a constant.
+	other := signedRequest(t, []byte(`{"different":true}`), false)
+	if other.Header.Get("X-Amz-Content-Sha256") == req.Header.Get("X-Amz-Content-Sha256") {
+		t.Error("two different bodies produced the same payload hash")
+	}
+}
+
+// The secret must never leave the process. The Authorization header carries the
+// access key ID and a derived signature — never the secret itself.
+func TestSignAWSRequest_NeverLeaksTheSecret(t *testing.T) {
+	req := signedRequest(t, []byte(`{"a":1}`), true)
+
+	for name, values := range req.Header {
+		for _, v := range values {
+			if strings.Contains(v, awsExampleSecret) {
+				t.Errorf("header %s leaks AWS_SECRET_ACCESS_KEY verbatim: %q", name, v)
+			}
+		}
+	}
+	auth := req.Header.Get("Authorization")
+	if !strings.Contains(auth, "AKIDEXAMPLE") {
+		t.Errorf("Authorization does not carry the access key ID: %q", auth)
+	}
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 ") {
+		t.Errorf("Authorization does not use the SigV4 scheme: %q", auth)
+	}
+}
+
+// The credential scope must be date/region/service/aws4_request, in that order.
+// AWS rejects any other shape outright.
+func TestSignAWSRequest_CredentialScopeIsWellFormed(t *testing.T) {
+	req := signedRequest(t, []byte(`{}`), false)
+	auth := req.Header.Get("Authorization")
+
+	var cred string
+	for _, part := range strings.Split(auth, ", ") {
+		if strings.HasPrefix(part, "AWS4-HMAC-SHA256 Credential=") {
+			cred = strings.TrimPrefix(part, "AWS4-HMAC-SHA256 Credential=")
+		}
+	}
+	if cred == "" {
+		t.Fatalf("no Credential= in %q", auth)
+	}
+	parts := strings.Split(cred, "/")
+	if len(parts) != 5 {
+		t.Fatalf("Credential has %d segments, want 5 (keyID/date/region/service/aws4_request): %q",
+			len(parts), cred)
+	}
+	if parts[0] != "AKIDEXAMPLE" {
+		t.Errorf("credential key ID = %q", parts[0])
+	}
+	if parts[2] != "us-east-1" || parts[3] != "bedrock" {
+		t.Errorf("credential region/service = %s/%s, want us-east-1/bedrock", parts[2], parts[3])
+	}
+	if parts[4] != "aws4_request" {
+		t.Errorf("credential terminator = %q, want aws4_request", parts[4])
+	}
+	// The date segment must match X-Amz-Date's date part, or the scope and the
+	// timestamp disagree and AWS rejects it.
+	amzDate := req.Header.Get("X-Amz-Date")
+	if len(amzDate) < 8 || parts[1] != amzDate[:8] {
+		t.Errorf("credential date %q does not match X-Amz-Date %q", parts[1], amzDate)
+	}
+}
+
+// Missing credentials must be an error, not an unsigned request sent anyway.
+func TestSignAWSRequest_RefusesWithoutCredentials(t *testing.T) {
+	cases := []struct {
+		name       string
+		id, secret string
+	}{
+		{"no credentials at all", "", ""},
+		{"access key only", "AKID", ""},
+		{"secret only", "", "shh"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testutil.NewSandbox(t)
+			if tc.id != "" {
+				s.SetKey(t, "AWS_ACCESS_KEY_ID", tc.id)
+			}
+			if tc.secret != "" {
+				s.SetKey(t, "AWS_SECRET_ACCESS_KEY", tc.secret)
+			}
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/x", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := signAWSRequest(req, nil, "us-east-1", "bedrock"); err == nil {
+				t.Error("signed a request with incomplete credentials instead of erroring")
+			}
+			if req.Header.Get("Authorization") != "" {
+				t.Error("an Authorization header was set despite the failure")
+			}
+		})
+	}
+}
+
+// canonicalHeaders builds half of the string-to-sign. Its output must end every
+// line with \n and never contain a stray value — SigV4 is byte-exact.
+func TestCanonicalHeaders_ShapeIsByteExact(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://host.example.com/p", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Amz-Date", "20240101T000000Z")
+	req.Header.Set("X-Amz-Content-Sha256", emptySHA256)
+
+	canonical, signed := canonicalHeaders(req)
+	if !strings.HasSuffix(canonical, "\n") {
+		t.Error("canonical headers block does not end with a newline")
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(canonical, "\n"), "\n") {
+		if !strings.Contains(line, ":") {
+			t.Errorf("canonical header line %q has no colon", line)
+		}
+		if strings.HasSuffix(line, " ") || strings.Contains(line, ": ") {
+			t.Errorf("canonical header line %q has untrimmed whitespace — SigV4 is byte-exact", line)
+		}
+	}
+	// host must come from the URL, not from a Host header that Go does not
+	// populate in Header.
+	if !strings.Contains(canonical, "host:host.example.com\n") {
+		t.Errorf("canonical headers missing host from the URL:\n%s", canonical)
+	}
+	// Every declared header must appear in the block.
+	for _, h := range strings.Split(signed, ";") {
+		if !strings.Contains(canonical, h+":") {
+			t.Errorf("signed header %q is not in the canonical block", h)
+		}
+	}
+}


### PR DESCRIPTION
## Why this package first

`internal/executor` was the **lowest-covered package in the repo at 8.6%**, and the highest consequence: it spends money, handles credentials, and signs AWS requests.

**AWS SigV4 sat at 0%.** The code deciding whether every Bedrock call authenticates had never once been exercised.

## Signing — known-answer vectors, not self-agreement

Tested against KAT vectors rather than by re-deriving the algorithm in the test, which would only prove the code agrees with itself. The vectors were computed with an **independent implementation** (Python `hmac`+`hashlib`), and the first matches the value AWS publishes in its own *"deriving the signing key"* documentation:

```
20120215/us-east-1/iam  → f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d
```

A second vector is included so a single lucky match cannot pass.

Beyond the KAT, the properties that actually cause 403s in production:

- **every header in `SignedHeaders` is really sent**, and vice versa. AWS recomputes the canonical request from what it *receives*; a header declared but absent yields a different string-to-sign and a 403 that reads like a credentials problem.
- `SignedHeaders` is lowercase and sorted, and the session token appears **exactly** when one is set.
- the payload hash covers the body actually sent — verified by confirming two different bodies hash differently, so the header cannot be a constant.
- the credential scope is `keyID/date/region/service/aws4_request` and its date agrees with `X-Amz-Date`.
- **the signing key changes when any of secret, date, region or service changes.** A derivation that silently ignores region produces signatures that work in one region and fail in another — a nightmare to diagnose from a 403.
- the secret never appears in any header, and incomplete credentials are an **error** rather than an unsigned request sent anyway.

## HTTP path — driven against a stub, with fault injection

A head carrying an `Endpoint` short-circuits provider resolution, so the real code runs with no network. Every test is inside a `testutil` sandbox that clears API keys, so **no developer's key can turn one of these into a live billable call**.

Fault injection is the point of this half. `500` / `401` / `429`, malformed JSON, an empty `choices` array, and a truncated body must **each** produce an error and a `nil` Response — never a Response a caller would bill as a successful completion — and each error must name the head, or an operator cannot tell which one failed in a fallback chain.

Plus: context cancellation is honoured promptly, 16 concurrent executions are race-free (dispatch fans out, swarm fans out further), and an unsupported provider is refused before any network call.

## Helpers

Including the ones with real edges: an empty system prompt must not become an empty `system` message (some providers reject that outright), `trimLocalModelID` strips only a *leading* prefix, and an upstream error page is truncated rather than logged whole.

## Result

```
internal/executor   8.6% → 26.4%
go test ./... -race -count=1     full suite green
go vet ./...                     clean
```

Part of #254. Next by risk: `internal/workspace` (19.5%, the scope/security boundary), then `editor`/`review` (atomic write + rollback).