### PR TITLE
fix(workspace): stop shipping personal paths; fall back to the current repo

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -126,7 +126,70 @@ func Load(hydraHome string) (*Registry, error) {
 		}
 	}
 
+	// Nothing was configured at all — fall back to the repository the user is
+	// standing in, so a fresh install works without hand-writing a registry
+	// (#297).
+	//
+	// The condition is "the file declared no workspaces", not "no workspace
+	// survived". If entries exist but were all skipped, the user configured
+	// something and it could not be used: substituting a different scope for
+	// the one they asked for would be worse than refusing. That case is
+	// reported through Skipped() and Hydra edits nothing.
+	if len(rf.Workspaces) == 0 {
+		if ws, ok := defaultWorkspace(); ok {
+			r.workspaces = append(r.workspaces, ws)
+		}
+	}
+
 	return r, nil
+}
+
+// DefaultWorkspaceName is the name given to the synthesized fallback workspace,
+// so it is identifiable in errors and logs as "not something you configured".
+const DefaultWorkspaceName = "cwd"
+
+// defaultDeniedGlobs is the floor for the synthesized workspace. The fallback
+// exists to make a fresh install usable, not to hand a model the contents of
+// every credential file in the tree, so these are denied even though
+// allowed_globs is "**".
+var defaultDeniedGlobs = []string{
+	"**/.git/**",
+	"**/.env*",
+	"**/node_modules/**",
+	"**/vendor/**",
+	"**/secrets/**",
+	"**/*.pem",
+	"**/*.key",
+	"**/id_rsa*",
+	"**/*-credentials*.json",
+	"**/.aws/**",
+	"**/.ssh/**",
+}
+
+// defaultWorkspace synthesizes a workspace rooted at the current repository.
+//
+// Deliberately the git root, not the working directory. A bare cwd could be
+// "/" or the user's home, and defaulting write scope to either is not a
+// tradeoff to make on a user's behalf. A git repository is a bounded,
+// intentional project, and it is the same boundary every other developer tool
+// assumes. Outside a repository there is no default at all — Hydra says it has
+// no workspace and the user configures one, which is the honest outcome.
+func defaultWorkspace() (Workspace, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return Workspace{}, false
+	}
+	root := GitRoot(cwd)
+	if root == "" {
+		return Workspace{}, false
+	}
+	return Workspace{
+		Name:         DefaultWorkspaceName,
+		Root:         filepath.Clean(root),
+		Git:          "auto",
+		AllowedGlobs: []string{"**"},
+		DeniedGlobs:  defaultDeniedGlobs,
+	}, true
 }
 
 // Check validates that path is inside a workspace and matches its glob rules.

--- a/internal/workspace/workspace_scope_test.go
+++ b/internal/workspace/workspace_scope_test.go
@@ -10,7 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/ankit373/hydra/internal/testutil"
+	"github.com/ankit373/hydra/registry"
 )
 
 // Check is the security boundary: it decides whether Hydra may write to a file
@@ -331,9 +334,14 @@ func TestLoad_FallsBackToTheEmbeddedRegistryOnEveryPlatform(t *testing.T) {
 			t.Errorf("skipped entry %+v does not identify itself or say why", sk)
 		}
 	}
-	// Every entry is accounted for exactly once.
-	if got, want := len(r.workspaces)+len(r.Skipped()), 2; got != want {
-		t.Errorf("embedded registry yielded %d kept + skipped, want %d", got, want)
+	// The embedded registry declares no workspaces, so anything present here is
+	// the synthesized fallback — never a machine-specific entry compiled into
+	// the binary (#297).
+	for _, ws := range r.workspaces {
+		if ws.Name != DefaultWorkspaceName {
+			t.Errorf("embedded registry produced workspace %q rooted at %q; it must ship none",
+				ws.Name, ws.Root)
+		}
 	}
 	if len(r.validators) == 0 {
 		t.Error("embedded registry defines no validators")
@@ -428,4 +436,198 @@ func timeoutAfterSeconds(n int) <-chan struct{} {
 		close(ch)
 	}()
 	return ch
+}
+
+// ── default workspace fallback (#297) ─────────────────────────────────────────
+
+// A fresh install ships no workspaces, so Hydra falls back to the repository
+// the user is standing in. Without this a new user's first `hyctl edit` fails
+// with "no workspace contains …" and there is nothing in the binary that could
+// ever match.
+func TestLoad_FallsBackToTheCurrentRepository(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, repo)
+
+	r, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.workspaces) != 1 {
+		t.Fatalf("got %d workspaces, want the synthesized fallback: %+v", len(r.workspaces), r.workspaces)
+	}
+	ws := r.workspaces[0]
+	if ws.Name != DefaultWorkspaceName {
+		t.Errorf("fallback name = %q, want %q so it is identifiable as not user-configured",
+			ws.Name, DefaultWorkspaceName)
+	}
+	// It must be the repo root, resolved — macOS hands out /var symlinks for
+	// temp dirs, so compare resolved forms.
+	if !sameDir(t, ws.Root, repo) {
+		t.Errorf("fallback root = %q, want the git root %q", ws.Root, repo)
+	}
+	if _, err := r.Check(filepath.Join(ws.Root, "src", "main.go")); err != nil {
+		t.Errorf("an ordinary file in the repo was refused: %v", err)
+	}
+}
+
+// The fallback is the git root, never a bare working directory. Defaulting
+// write scope to "/" or a home directory is not a decision to make for a user,
+// so outside a repository there is deliberately no workspace at all.
+func TestLoad_NoFallbackOutsideAGitRepository(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	plain := t.TempDir() // no .git anywhere beneath the temp root
+	chdir(t, plain)
+
+	r, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ws := range r.workspaces {
+		if ws.Name == DefaultWorkspaceName {
+			t.Errorf("synthesized a workspace at %q outside any git repository — "+
+				"a bare cwd could be / or $HOME", ws.Root)
+		}
+	}
+}
+
+// The fallback exists to make a fresh install usable, not to expose every
+// secret in the tree. These must be refused even though allowed_globs is "**".
+func TestLoad_FallbackStillDeniesSecrets(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, repo)
+
+	r, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := r.workspaces[0].Root // resolved form; temp dirs are symlinks on macOS
+	for _, rel := range []string{
+		".env",
+		filepath.Join("app", ".env.production"),
+		filepath.Join("config", "secrets", "db.yml"),
+		filepath.Join("certs", "server.pem"),
+		filepath.Join("certs", "server.key"),
+		filepath.Join(".ssh", "id_rsa"),
+		filepath.Join("node_modules", "pkg", "index.js"),
+		filepath.Join(".git", "config"),
+		filepath.Join("infra", "prod-credentials.json"),
+	} {
+		if _, err := r.Check(filepath.Join(root, rel)); err == nil {
+			t.Errorf("%s was writable under the default workspace", rel)
+		}
+	}
+	// …and ordinary source is still writable, or the deny set is just blocking
+	// everything and the fallback is useless.
+	if _, err := r.Check(filepath.Join(root, "src", "app.go")); err != nil {
+		t.Errorf("ordinary source was refused: %v", err)
+	}
+}
+
+// A configured registry is never widened by the fallback. It applies only when
+// the file yields no usable entry.
+func TestLoad_ConfiguredRegistryIsNeverWidened(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, repo)
+
+	// A registry that defines exactly one narrow workspace elsewhere.
+	other := t.TempDir()
+	regDir := filepath.Join(s.HydraHome, "registry")
+	if err := os.MkdirAll(regDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: \"1.0\"\nworkspaces:\n  only:\n    root: " + filepath.ToSlash(other) +
+		"\n    git: \"false\"\n    allowed_globs: [\"src/**\"]\n"
+	if err := os.WriteFile(filepath.Join(regDir, "workspace.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Load(s.HydraHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ws := range r.workspaces {
+		if ws.Name == DefaultWorkspaceName {
+			t.Fatal("the fallback was added alongside a configured workspace — " +
+				"a configured registry must never be widened")
+		}
+	}
+	// The cwd repo must NOT be writable: it is not in the configured registry.
+	if _, err := r.Check(filepath.Join(repo, "src", "main.go")); err == nil {
+		t.Error("the current repo was writable despite not being configured")
+	}
+}
+
+// The embedded registry must not ship anyone's personal paths. It is compiled
+// into every binary, so an absolute root here is one machine's layout published
+// to every user (#297).
+func TestEmbeddedRegistry_ShipsNoMachineSpecificRoots(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	raw, err := registryFileBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range []string{"/Users/", "/home/", "C:\\Users", "/root/"} {
+		if strings.Contains(raw, bad) && !strings.Contains(raw, "#") {
+			t.Errorf("embedded workspace.yaml contains %q", bad)
+		}
+	}
+	// Parse it and assert no configured workspace carries an absolute root.
+	var rf registryFile
+	if err := yaml.Unmarshal([]byte(raw), &rf); err != nil {
+		t.Fatal(err)
+	}
+	for name, e := range rf.Workspaces {
+		t.Errorf("embedded registry defines workspace %q with root %q — this ships to "+
+			"every user of every install", name, e.Root)
+	}
+}
+
+func registryFileBytes() (string, error) {
+	b, err := registry.Read("", "workspace.yaml")
+	return string(b), err
+}
+
+// chdir changes directory for the duration of the test.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+}
+
+// sameDir compares two directories after resolving symlinks — macOS temp dirs
+// are /var/… symlinks to /private/var/….
+func sameDir(t *testing.T, a, b string) bool {
+	t.Helper()
+	ra, err := filepath.EvalSymlinks(a)
+	if err != nil {
+		ra = a
+	}
+	rb, err := filepath.EvalSymlinks(b)
+	if err != nil {
+		rb = b
+	}
+	return filepath.Clean(ra) == filepath.Clean(rb)
 }

--- a/registry/workspace.yaml
+++ b/registry/workspace.yaml
@@ -22,46 +22,34 @@
 
 version: "1.0"
 
-workspaces:
+# Empty by design.
+#
+# This file is compiled into the binary (go:embed), so anything here ships to
+# every user of every install. It used to carry two absolute roots from the
+# maintainer's own machine (/Users/ankitjha/…), which meant a fresh install had
+# no workspace that could ever match, and every published artifact leaked one
+# person's directory layout (#297).
+#
+# With no entries here, Hydra falls back to **the git repository you are
+# standing in** — allowed_globs "**", minus a denied set covering .git, .env,
+# credentials, keys, node_modules and vendor. The fallback is deliberately the
+# git root and not the working directory: a bare cwd could be "/" or your home
+# directory, and defaulting write scope to either is not a decision to make on
+# a user's behalf. Outside a git repository there is no default, and Hydra will
+# say it has no workspace rather than guess.
+#
+# Define workspaces below to override that entirely — the fallback applies only
+# when this map yields no usable entry, so a configured registry is never
+# widened. Roots must be absolute for the platform Hydra is running on; an entry
+# that is not is skipped (and reported), never fatal.
+#
+#   my-project:
+#     root: /absolute/path/to/project
+#     git: auto                 # auto | true | false
+#     allowed_globs: ["src/**", "test/**"]
+#     denied_globs:  ["**/.env*", "**/secrets/**"]
 
-  apphire:
-    root: /Users/ankitjha/apphire
-    git: auto                   # each sub-package is its own git repo
-    allowed_globs:
-      - "core/**"
-      - "cortex/**"
-      - "forge/**"
-      - "prism/**"
-      - "sentinel/**"
-      - "vault/**"
-      - "vector/**"
-      - "scripts/**"
-    denied_globs:
-      - "**/.env*"
-      - "**/node_modules/**"
-      - "**/.next/**"
-      - "**/dist/**"
-      - "**/build/**"
-      - "**/.git/**"
-      - "**/firebase-admin-*.json"
-      - "**/*-credentials*.json"
-      - "**/secrets/**"
-      - "**/.wrangler/**"
-
-  hydra-self:
-    root: /Users/ankitjha/hydra
-    git: false                  # not a git repo; uses .hydra-bak backups
-    allowed_globs:
-      - "dispatch/**"
-      - "registry/**"
-      - "scripts/**"
-      - "skills/**"
-      - "domains/**"
-      - "heads/**"
-      - "context/**"
-    denied_globs:
-      - "**/logs/**"
-      - "**/.git/**"
+workspaces: {}
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Validators — per-extension safety check run after every edit.


### PR DESCRIPTION
## Every shipped binary contained one person's home directory

`registry/workspace.yaml` is compiled in via `go:embed`, so its contents ship to every user of every install. It carried:

```yaml
apphire:     root: /Users/ankitjha/apphire
hydra-self:  root: /Users/ankitjha/hydra
```

For everyone else those are dead entries that can never match — so a fresh `brew`/`npm`/`pip` install had **no usable workspace at all**, and the first `hyctl edit` failed with *"no workspace contains …"*. It also published the maintainer's directory layout in every artifact.

## The fallback, and why it is the git root

The file now declares no workspaces. Hydra falls back to **the git repository you are standing in**.

Deliberately the git root and **not** the working directory. A bare cwd could be `/` or `$HOME`, and defaulting write scope to either is not a tradeoff to make on a user's behalf. A repository is a bounded, intentional project — the same boundary every other developer tool assumes. **Outside a repository there is no default at all**: Hydra says it has no workspace rather than guess.

It is not unrestricted either. `allowed_globs` is `**`, but a denied set covers `.git`, `.env*`, `secrets`, `*.pem`, `*.key`, `id_rsa*`, `*-credentials*.json`, `.aws`, `.ssh`, `node_modules`, `vendor`. The fallback exists to make an install usable, not to hand a model every credential in the tree.

## A test caught me narrowing the wrong condition

My first version triggered the fallback when **no workspace survived** loading. A test failed with:

```
a relative root was kept: [{Name:cwd Root:/Users/ankitjha/IdeaProjects/hydra ...}]
```

A registry whose entries were all skipped got the cwd repo **substituted for the scope the user actually configured**. Silently swapping in a different scope is worse than refusing.

The trigger is now *"the file declared no workspaces"*. If entries exist but are unusable, that is a configuration error: it reports through `Skipped()` and Hydra edits nothing.

## Asserted

The fallback applies · it is the git root · **no fallback outside a repo** · secrets stay denied while ordinary source stays writable · **a configured registry is never widened** · and the embedded file ships no absolute root — that last one fails if anyone ever commits their own paths here again.

```
internal/workspace   93.3%
go test ./... -race -count=1     green
```

Closes #297