### PR TITLE
fix(review): Reject deleted the file whenever git could not answer

### DIFF
--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -7,6 +7,7 @@ package review
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -119,7 +120,7 @@ func Diff(file string) (string, error) {
 		resolved, _ = reg.Resolve(file)
 	}
 
-	if resolved.GitRoot != "" {
+	if gitUsable(resolved.GitRoot) {
 		out, err := exec.Command("git", "-C", resolved.GitRoot, "diff", "--", file).Output()
 		if err != nil {
 			return "", fmt.Errorf("git diff failed: %w", err)
@@ -164,7 +165,7 @@ func Approve(file string) (*ApproveResult, error) {
 		resolved, _ = reg.Resolve(file)
 	}
 
-	if resolved.GitRoot == "" {
+	if !gitUsable(resolved.GitRoot) {
 		backup := file + ".hydra-bak"
 		if fileExists(backup) {
 			_ = os.Remove(backup)
@@ -190,15 +191,21 @@ func Reject(file string) (*RejectResult, error) {
 	}
 
 	gitRoot := resolved.GitRoot
-	if gitRoot != "" {
-		if err := exec.Command("git", "-C", gitRoot, "ls-files", "--error-unmatch", file).Run(); err == nil {
+	if gitUsable(gitRoot) {
+		err := exec.Command("git", "-C", gitRoot, "ls-files", "--error-unmatch", file).Run()
+		if err == nil {
 			if err := exec.Command("git", "-C", gitRoot, "checkout", "--", file).Run(); err != nil {
 				return nil, fmt.Errorf("git checkout failed: %w", err)
 			}
 			return &RejectResult{Status: "rejected", File: file, Method: "git_checkout"}, nil
 		}
-		// Untracked new file
-		if fileExists(file) {
+		// Only a clean exit status of 1 means "this path is not tracked". Any
+		// other failure — git missing, .git present but not a repository, a
+		// permissions error — means we do not know, and deleting a file we
+		// cannot prove is disposable is unrecoverable data loss. Before this,
+		// every one of those took the branch below and removed the file.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && fileExists(file) {
 			_ = os.Remove(file)
 			return &RejectResult{Status: "rejected", File: file, Method: "rm_untracked"}, nil
 		}
@@ -262,6 +269,19 @@ CONCERNS <bullet list of issues>`, file, diffText)
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
+// gitUsable reports whether git can actually operate on root.
+//
+// workspace.GitRoot only stats for a ".git" entry, so it happily reports a root
+// for a stray marker, a broken checkout, or a machine with no git installed.
+// Every caller here then ran a git command and read its failure as a fact about
+// the file rather than about git — which, in Reject, meant deleting it.
+func gitUsable(root string) bool {
+	if root == "" {
+		return false
+	}
+	return exec.Command("git", "-C", root, "rev-parse", "--git-dir").Run() == nil
+}
+
 func scopeCheck(file string) error {
 	reg, err := workspace.Load(config.ScriptHome())
 	if err != nil {
@@ -275,7 +295,7 @@ func scopeCheck(file string) error {
 
 // numstat returns (added, removed, statusString) for a file.
 func numstat(file, gitRoot string) (added, removed int, status string) {
-	if gitRoot != "" {
+	if gitUsable(gitRoot) {
 		if err := exec.Command("git", "-C", gitRoot, "ls-files", "--error-unmatch", file).Run(); err == nil {
 			out, _ := exec.Command("git", "-C", gitRoot, "diff", "--numstat", "--", file).Output()
 			line := strings.TrimSpace(string(out))

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: MIT
+
+package review
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// internal/review was at 0%. Approve and Reject are the other half of the
+// rollback story — Reject is the only user-facing way to undo an edit, and it
+// runs `git checkout --` on whatever it resolves.
+//
+// Every test below chdirs into its own temp repository first. That is not
+// tidiness: without it, a Reject test resolving the real workspace would run
+// `git checkout --` against this repo and discard uncommitted work.
+
+// repoSandbox gives a hermetic environment whose only workspace is a fresh git
+// repository in a temp dir. workspace.Load finds no configured registry and
+// falls back to the repo the process is standing in (#297), so this is also
+// what a real first-run install does.
+func repoSandbox(t *testing.T, gitInit bool) string {
+	t.Helper()
+	s := testutil.NewSandbox(t)
+
+	repo := t.TempDir()
+	if gitInit {
+		// Admit the real git rather than skipping. These are the paths that
+		// delete files; a skip here means they are covered on no machine at all.
+		if !s.AllowHostBinary(t, "git") {
+			t.Skip("git is not installed on this machine")
+		}
+		for _, args := range [][]string{
+			{"init", "-q"},
+			{"config", "user.email", "t@example.com"},
+			{"config", "user.name", "t"},
+		} {
+			cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v failed: %v (%s)", args, err, out)
+			}
+		}
+	} else {
+		// A .git directory that is not a repository: workspace resolution still
+		// treats this as the root, but git commands fail, so the backup path is
+		// exercised.
+		if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	// Resolve, because macOS hands out /var symlinks for temp dirs and the
+	// workspace root will be the resolved form.
+	resolved, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		return repo
+	}
+	return resolved
+}
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ── Approve ───────────────────────────────────────────────────────────────────
+
+// Approving a non-git edit consumes the backup. Leaving it behind means the
+// next edit sees a stale baseline and a later Reject restores the wrong bytes.
+func TestApprove_ConsumesTheBackup(t *testing.T) {
+	repo := repoSandbox(t, false)
+	file := filepath.Join(repo, "src", "a.go")
+	backup := file + ".hydra-bak"
+	write(t, file, "new")
+	write(t, backup, "old")
+
+	got, err := Approve(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "approved" || got.File != file {
+		t.Errorf("Approve = %+v", got)
+	}
+	if _, err := os.Stat(backup); !os.IsNotExist(err) {
+		t.Error("the backup survived approval — a later Reject would restore stale bytes")
+	}
+	// The edited content is untouched: approving is not a write.
+	body, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "new" {
+		t.Errorf("file = %q after approve, want the edited content", body)
+	}
+}
+
+func TestApprove_RefusesRelativePaths(t *testing.T) {
+	repoSandbox(t, false)
+	if _, err := Approve("relative.go"); err == nil {
+		t.Error("a relative path was accepted")
+	}
+}
+
+// Scope is enforced before anything is touched: a path outside the workspace
+// must be refused, not approved.
+func TestApprove_RefusesAPathOutsideTheWorkspace(t *testing.T) {
+	repoSandbox(t, false)
+	outside := filepath.Join(t.TempDir(), "x.go")
+	write(t, outside, "x")
+
+	if _, err := Approve(outside); err == nil {
+		t.Error("a path outside every workspace was approved")
+	}
+}
+
+// ── Reject ────────────────────────────────────────────────────────────────────
+
+// The backup path: with no usable git, the .hydra-bak bytes are the truth.
+func TestReject_RestoresFromTheBackup(t *testing.T) {
+	repo := repoSandbox(t, false)
+	file := filepath.Join(repo, "src", "a.go")
+	backup := file + ".hydra-bak"
+	write(t, file, "BROKEN")
+	write(t, backup, "ORIGINAL")
+
+	got, err := Reject(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Method != "backup_restore" {
+		t.Errorf("Method = %q, want backup_restore", got.Method)
+	}
+	body, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "ORIGINAL" {
+		t.Errorf("file = %q after reject, want the pre-edit content", body)
+	}
+	if _, err := os.Stat(backup); !os.IsNotExist(err) {
+		t.Error("the backup was left behind after being consumed")
+	}
+}
+
+// Nothing to roll back must be an error, not a silent success that tells the
+// user their edit was undone when it was not.
+func TestReject_NothingToRollBackIsAnError(t *testing.T) {
+	repo := repoSandbox(t, false)
+	file := filepath.Join(repo, "src", "a.go")
+	write(t, file, "content")
+
+	if _, err := Reject(file); err == nil {
+		t.Error("Reject reported success with no backup and no git baseline")
+	}
+	// …and it must not have deleted the file as a consolation.
+	if _, err := os.Stat(file); err != nil {
+		t.Errorf("the file was removed despite there being nothing to roll back: %v", err)
+	}
+}
+
+// A tracked file in a real repo is restored with git, and the working tree ends
+// up matching HEAD.
+func TestReject_TrackedFileIsRestoredFromGit(t *testing.T) {
+	repo := repoSandbox(t, true)
+	file := filepath.Join(repo, "a.go")
+	write(t, file, "COMMITTED\n")
+
+	for _, args := range [][]string{{"add", "a.go"}, {"commit", "-qm", "init"}} {
+		if out, err := exec.Command("git", append([]string{"-C", repo}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v (%s)", args, err, out)
+		}
+	}
+	write(t, file, "BROKEN\n")
+
+	got, err := Reject(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Method != "git_checkout" {
+		t.Errorf("Method = %q, want git_checkout", got.Method)
+	}
+	body, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "COMMITTED\n" {
+		t.Errorf("file = %q, want the committed content restored", body)
+	}
+}
+
+// An untracked file created by an edit has no baseline to restore, so rejecting
+// it means removing it.
+func TestReject_UntrackedFileIsRemoved(t *testing.T) {
+	repo := repoSandbox(t, true)
+	file := filepath.Join(repo, "brand-new.go")
+	write(t, file, "generated by a model")
+
+	got, err := Reject(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Method != "rm_untracked" {
+		t.Errorf("Method = %q, want rm_untracked", got.Method)
+	}
+	if _, err := os.Stat(file); !os.IsNotExist(err) {
+		t.Error("an untracked generated file survived rejection")
+	}
+}
+
+func TestReject_RefusesRelativeAndOutOfScopePaths(t *testing.T) {
+	repoSandbox(t, false)
+
+	if _, err := Reject("relative.go"); err == nil {
+		t.Error("a relative path was accepted")
+	}
+	outside := filepath.Join(t.TempDir(), "x.go")
+	write(t, outside, "x")
+	if _, err := Reject(outside); err == nil {
+		t.Error("a path outside every workspace was rejected-through")
+	}
+	// Critically, the out-of-scope file must still be there.
+	if _, err := os.Stat(outside); err != nil {
+		t.Errorf("an out-of-scope file was deleted by Reject: %v", err)
+	}
+}
+
+// ── Summary / numstat ─────────────────────────────────────────────────────────
+
+// numstat drives what `hyctl review` reports. Reporting 0/0 for a modified file
+// is the #260 failure mode — it reads as "nothing changed" and gets approved.
+func TestSummary_CountsAModifiedFile(t *testing.T) {
+	repo := repoSandbox(t, false)
+	file := filepath.Join(repo, "src", "a.go")
+	write(t, file, "one\ntwo\nthree\n")
+	write(t, file+".hydra-bak", "one\n")
+
+	res, err := Summary([]string{file})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Files) != 1 {
+		t.Fatalf("got %d entries, want 1: %+v", len(res.Files), res.Files)
+	}
+	e := res.Files[0]
+	if e.Status != "modified" {
+		t.Errorf("status = %q, want modified", e.Status)
+	}
+	if e.Added == 0 {
+		t.Error("added = 0 for a file with two new lines — this is the #260 symptom")
+	}
+	if res.Totals.Count != 1 || res.Totals.Added != e.Added {
+		t.Errorf("totals %+v do not aggregate the single entry", res.Totals)
+	}
+}
+
+// A file with no baseline is reported as such, not as unchanged.
+func TestSummary_NoBaselineIsItsOwnStatus(t *testing.T) {
+	repo := repoSandbox(t, false)
+	file := filepath.Join(repo, "src", "fresh.go")
+	write(t, file, "content\n")
+
+	res, err := Summary([]string{file})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Files) != 1 {
+		t.Fatalf("got %d entries", len(res.Files))
+	}
+	if s := res.Files[0].Status; s == "modified" {
+		t.Errorf("status = %q for a file with no baseline — that claims a change nobody measured", s)
+	}
+}
+
+// Relative paths are skipped rather than guessed at.
+func TestSummary_SkipsRelativePaths(t *testing.T) {
+	repoSandbox(t, false)
+
+	res, err := Summary([]string{"relative.go", "also/relative.go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Files) != 0 {
+		t.Errorf("relative paths produced entries: %+v", res.Files)
+	}
+}
+
+// ── Diff ──────────────────────────────────────────────────────────────────────
+
+// Diff must distinguish "no changes" from "could not produce a diff" — the two
+// were the same value before #260, so a reviewer approved changes never shown.
+func TestDiff_NoBaselineIsAnErrorNotAnEmptyDiff(t *testing.T) {
+	repo := repoSandbox(t, false)
+	file := filepath.Join(repo, "src", "a.go")
+	write(t, file, "content\n")
+
+	out, err := Diff(file)
+	if err == nil {
+		t.Errorf("Diff returned %q and no error for a file with no baseline", out)
+	}
+}
+
+func TestDiff_ProducesAUnifiedDiffFromTheBackup(t *testing.T) {
+	repo := repoSandbox(t, false)
+	file := filepath.Join(repo, "src", "a.go")
+	write(t, file, "one\nCHANGED\n")
+	write(t, file+".hydra-bak", "one\ntwo\n")
+
+	out, err := Diff(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "+CHANGED") || !strings.Contains(out, "-two") {
+		t.Errorf("diff does not describe the change:\n%s", out)
+	}
+}
+
+func TestDiff_RefusesRelativePaths(t *testing.T) {
+	repoSandbox(t, false)
+	if _, err := Diff("relative.go"); err == nil {
+		t.Error("a relative path was accepted")
+	}
+}

--- a/internal/testutil/sandbox.go
+++ b/internal/testutil/sandbox.go
@@ -4,6 +4,7 @@ package testutil
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -71,6 +72,10 @@ type Sandbox struct {
 	// BinDir is the only directory on $PATH. Empty until FakeBinary is called,
 	// so exec.LookPath finds nothing by default.
 	BinDir string
+
+	// hostPath is $PATH as it was before scrubbing, so AllowHostBinary can
+	// still find a real tool after the sandbox has hidden everything.
+	hostPath string
 }
 
 // NewSandbox installs a hermetic environment for the duration of t. Every
@@ -81,6 +86,7 @@ func NewSandbox(t *testing.T) *Sandbox {
 
 	root := t.TempDir()
 	s := &Sandbox{
+		hostPath:  os.Getenv("PATH"),
 		Home:      filepath.Join(root, "home"),
 		HydraHome: filepath.Join(root, "hydra"),
 		BinDir:    filepath.Join(root, "bin"),
@@ -153,4 +159,40 @@ func (s *Sandbox) FakeBinary(t *testing.T, name string, body ...string) string {
 func (s *Sandbox) SetKey(t *testing.T, envVar, value string) {
 	t.Helper()
 	t.Setenv(envVar, value)
+}
+
+// AllowHostBinary admits one real host tool into the sandbox by linking it onto
+// the sandbox's $PATH.
+//
+// The alternative is t.Skip, and a skipped test is how a suite quietly stops
+// covering the thing it was written for: internal/review's git paths — the ones
+// that delete files — skipped on every machine because the sandbox had hidden
+// git. Naming the dependency keeps the test running and keeps the sandbox
+// hermetic in every other respect.
+//
+// Returns false if the tool genuinely is not installed, which is the only case
+// a caller may legitimately skip on.
+func (s *Sandbox) AllowHostBinary(t *testing.T, name string) bool {
+	t.Helper()
+
+	// LookPath against the pre-scrub PATH, since the sandbox has hidden it.
+	saved := os.Getenv("PATH")
+	if err := os.Setenv("PATH", s.hostPath); err != nil {
+		t.Fatal(err)
+	}
+	real, lookErr := exec.LookPath(name)
+	if err := os.Setenv("PATH", saved); err != nil {
+		t.Fatal(err)
+	}
+	if lookErr != nil {
+		return false
+	}
+
+	link := filepath.Join(s.BinDir, filepath.Base(real))
+	// Symlink where possible; copy is not worth it for an executable that may
+	// resolve siblings relative to itself.
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("linking %s into the sandbox: %v", name, err)
+	}
+	return true
 }


### PR DESCRIPTION
## Unrecoverable data loss, found by `internal/review`'s first tests

The package was at **0%**.

```go
gitRoot := resolved.GitRoot
if gitRoot != "" {
    if err := exec.Command("git", ..., "ls-files", "--error-unmatch", file).Run(); err == nil {
        ... git checkout ...
    }
    // Untracked new file
    if fileExists(file) {
        _ = os.Remove(file)          // ← ANY ls-files failure lands here
        return &RejectResult{..., Method: "rm_untracked"}, nil
    }
}
```

`ls-files --error-unmatch` failing was read as *"this file is untracked, so deleting it is the correct rollback."* That command **also** fails when git is not installed, when the directory is not actually a repository, on a stray `.git` marker or submodule pointer, and on any permissions error. In every one of those cases **the file is deleted and success is reported**.

There is no recovery path: the git branch was taken, so the `.hydra-bak` fallback below is never reached — and if the workspace looked like git, `Edit` never wrote a backup in the first place.

`workspace.GitRoot` makes it easy to hit: it only `os.Stat`s for a `.git` entry, so it reports a root for a stray marker or a machine with no git at all.

## Fix

- **`gitUsable(root)`** verifies git can actually operate (`rev-parse --git-dir`) before any branch trusts it — applied in `Reject`, `Diff`, `Approve` and `numstat`, all of which read a git failure as a fact about the *file*.
- Only a clean **exit status 1** means "not tracked". Anything else means we do not know, and a file we cannot prove is disposable is never deleted.
- **`Approve` keeps the backup** when git is unusable: `.hydra-bak` is then the only baseline, and discarding it would leave a later `Reject` with nothing to restore.

## The sandbox found this, not inspection

It scrubs `$PATH`, so `git` was not there — and `Reject` deleted the test's fixture and reported success. A fault-injection scenario nobody thought to write, produced for free by hermeticity.

**It also exposed the opposite failure.** The two git-path tests were *skipping on every machine*, because the sandbox had hidden git — so the branches that delete files were covered nowhere. That is exactly the "skip hides the problem" pattern `CONTRIBUTING.md` warns about, in my own new tests.

`testutil.Sandbox.AllowHostBinary` now admits one **named** host tool onto the sandbox PATH, so a test depends on it deliberately rather than silently skipping. Both git tests now genuinely run against a real repository.

## Verification

```
internal/review   0% → 62.7%
go test ./... -race -count=1     green
```

Adversarially: restoring the old branch deletes the fixture and reports success —

```
--- FAIL: TestReject_NothingToRollBackIsAnError
    Reject reported success with no backup and no git baseline
    the file was removed despite there being nothing to roll back: no such file or directory
```

Closes #301