### PR TITLE
test: fuzzing + benchmarks — and the DoS in the scope check they found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,15 +199,32 @@ jobs:
           }
           Write-Host "install.ps1 parses cleanly"
 
+      # Best-effort, unlike the parse step above. PSScriptAnalyzer has to be
+      # fetched from the PowerShell Gallery, and a gallery outage is not a
+      # defect in install.ps1 — blocking every unrelated PR on it is the wrong
+      # trade. The parse check needs no network and is the real gate.
       - name: PSScriptAnalyzer
         shell: pwsh
         run: |
-          Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser -ErrorAction Stop
+          try {
+            # Registering explicitly: the runner image occasionally starts with
+            # no repositories, which surfaces as "No match was found for the
+            # specified search criteria and module name 'PSScriptAnalyzer'".
+            if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+              Register-PSRepository -Default -ErrorAction Stop
+            }
+            Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -ErrorAction SilentlyContinue
+            Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser -ErrorAction Stop
+          } catch {
+            Write-Host "::warning::PSScriptAnalyzer unavailable ($($_.Exception.Message)) — skipping. The parse check above still ran."
+            exit 0
+          }
+
           $results = Invoke-ScriptAnalyzer -Path ./install.ps1 -Severity Error,Warning
           if ($results) {
             $results | Format-Table -AutoSize | Out-String | Write-Host
-            # Errors block; warnings are surfaced, matching shellcheck's policy
-            # of --severity=error above.
+            # Errors block; warnings are surfaced, matching the shellcheck job's
+            # --severity=error policy.
             if ($results | Where-Object { $_.Severity -eq 'Error' }) { exit 1 }
           }
           Write-Host "PSScriptAnalyzer: no errors"

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -84,16 +84,7 @@ func TestStats_AgreesWithUnified(t *testing.T) {
 	added, removed := Stats(old, new)
 	u := Unified("old", "new", old, new)
 
-	var uAdded, uRemoved int
-	for _, l := range strings.Split(u, "\n") {
-		switch {
-		case strings.HasPrefix(l, "+++"), strings.HasPrefix(l, "---"):
-		case strings.HasPrefix(l, "+"):
-			uAdded++
-		case strings.HasPrefix(l, "-"):
-			uRemoved++
-		}
-	}
+	uAdded, uRemoved := countDiffLines(u)
 	if added != uAdded || removed != uRemoved {
 		t.Errorf("Stats = +%d/-%d but the diff body has +%d/-%d", added, removed, uAdded, uRemoved)
 	}
@@ -129,16 +120,7 @@ func TestUnified_MatchesSystemDiffWhereAvailable(t *testing.T) {
 			// diff(1) exits 1 when files differ; that is not an error.
 			out, _ := exec.Command("diff", "-u", oldPath, newPath).CombinedOutput()
 
-			var sysAdded, sysRemoved int
-			for _, l := range strings.Split(string(out), "\n") {
-				switch {
-				case strings.HasPrefix(l, "+++"), strings.HasPrefix(l, "---"):
-				case strings.HasPrefix(l, "+"):
-					sysAdded++
-				case strings.HasPrefix(l, "-"):
-					sysRemoved++
-				}
-			}
+			sysAdded, sysRemoved := countDiffLines(string(out))
 			added, removed := Stats([]byte(tc.old), []byte(tc.new))
 			if added != sysAdded || removed != sysRemoved {
 				t.Errorf("Stats = +%d/-%d, diff(1) = +%d/-%d\nsystem output:\n%s",
@@ -191,10 +173,17 @@ func applyUnified(old []string, u string) ([]string, error) {
 	var out []string
 	oldIdx := 0 // 0-based cursor into old
 
-	for _, l := range strings.Split(strings.TrimRight(u, "\n"), "\n") {
+	// The "--- old" / "+++ new" lines are the file header and appear exactly
+	// once, before the first hunk. They are NOT recognised by prefix: a content
+	// line beginning "++" renders as "+++" and is indistinguishable from the
+	// header. Real diff(1) emits exactly that, and the first version of this
+	// helper dropped such lines as headers and silently lost content — found by
+	// FuzzUnified_RoundTrips with old="0", new="++".
+	for i, l := range strings.Split(strings.TrimRight(u, "\n"), "\n") {
+		if i < 2 {
+			continue // the two header lines
+		}
 		switch {
-		case strings.HasPrefix(l, "---"), strings.HasPrefix(l, "+++"):
-			continue
 		case strings.HasPrefix(l, "@@"):
 			// "@@ -oldStart,oldLines +newStart,newLines @@"
 			var oldStart, oldLines, newStart, newLines int
@@ -237,4 +226,25 @@ func applyUnified(old []string, u string) ([]string, error) {
 		}
 	}
 	return append(out, old[oldIdx:]...), nil
+}
+
+// countDiffLines counts added/removed lines in a unified diff body.
+//
+// Only the first two lines are the file header. Recognising "---"/"+++" by
+// prefix anywhere is wrong: a content line beginning "++" renders as "+++" and
+// would be skipped as a header, undercounting the change. diff(1) emits exactly
+// that shape.
+func countDiffLines(u string) (added, removed int) {
+	for i, l := range strings.Split(u, "\n") {
+		if i < 2 {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(l, "+"):
+			added++
+		case strings.HasPrefix(l, "-"):
+			removed++
+		}
+	}
+	return added, removed
 }

--- a/internal/diff/fuzz_test.go
+++ b/internal/diff/fuzz_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+
+package diff
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Fuzzing, rather than more table cases, because the input here is a model's
+// output and a user's source — neither of which the table author gets to choose.
+// The table tests assert that the diff is *right* for shapes we thought of;
+// these assert it never crashes, hangs, or lies for shapes we did not.
+//
+// Run the search with:
+//	go test ./internal/diff -fuzz=FuzzUnified -fuzztime=60s
+//
+// Without -fuzz these execute the seed corpus as ordinary tests, so they still
+// guard in CI.
+
+func fuzzSeeds(f *testing.F) {
+	pairs := [][2]string{
+		{"", ""},
+		{"a\n", ""},
+		{"", "a\n"},
+		{"a\nb\nc\n", "a\nB\nc\n"},
+		{"a\r\nb\r\n", "a\nb\n"},
+		{"no trailing newline", "no trailing newline!"},
+		{strings.Repeat("x\n", 50), strings.Repeat("y\n", 50)},
+		{"a\na\na\n", "a\na\n"},
+		{"\x00\x01\x02", "\x00\x01\x03"},
+		{"line with \t tab\n", "line with  spaces\n"},
+	}
+	for _, p := range pairs {
+		f.Add(p[0], p[1])
+	}
+}
+
+// The property that matters: applying our own diff to old must reproduce new,
+// for *any* pair of inputs. A diff that is merely well-formed is not enough —
+// it is written over the user's file.
+func FuzzUnified_RoundTrips(f *testing.F) {
+	fuzzSeeds(f)
+
+	f.Fuzz(func(t *testing.T, oldS, newS string) {
+		// Keep the search focused on structure rather than on one enormous
+		// string; the oversized path has its own explicit test.
+		if len(oldS) > 4096 || len(newS) > 4096 {
+			t.Skip()
+		}
+
+		u := Unified("old", "new", []byte(oldS), []byte(newS))
+
+		wantLines := splitLines(newS)
+		if u == "" {
+			// Empty means identical — so it had better be identical.
+			if !sameLines(splitLines(oldS), wantLines) {
+				t.Fatalf("empty diff for differing inputs\n old=%q\n new=%q", oldS, newS)
+			}
+			return
+		}
+
+		got, err := applyUnified(splitLines(oldS), u)
+		if err != nil {
+			t.Fatalf("our own diff does not apply: %v\n old=%q\n new=%q\n diff:\n%s", err, oldS, newS, u)
+		}
+		if !sameLines(got, wantLines) {
+			t.Fatalf("round trip lost information\n old=%q\n new=%q\n got=%q\n diff:\n%s",
+				oldS, newS, strings.Join(got, "\n"), u)
+		}
+	})
+}
+
+// Stats is what `hyctl review` reports. It must agree with the diff body for
+// every input, or the summary and the diff tell the user different stories.
+func FuzzStats_AgreesWithUnified(f *testing.F) {
+	fuzzSeeds(f)
+
+	f.Fuzz(func(t *testing.T, oldS, newS string) {
+		if len(oldS) > 4096 || len(newS) > 4096 {
+			t.Skip()
+		}
+		added, removed := Stats([]byte(oldS), []byte(newS))
+		if added < 0 || removed < 0 {
+			t.Fatalf("negative counts: +%d/-%d", added, removed)
+		}
+
+		u := Unified("old", "new", []byte(oldS), []byte(newS))
+		uAdd, uRem := countDiffLines(u)
+		if added != uAdd || removed != uRem {
+			t.Fatalf("Stats = +%d/-%d but the diff body has +%d/-%d\n old=%q\n new=%q",
+				added, removed, uAdd, uRem, oldS, newS)
+		}
+		// Identical inputs must report no change, and differing inputs must
+		// report some — a silent 0/0 for a modified file is #260's symptom.
+		same := sameLines(splitLines(oldS), splitLines(newS))
+		if same && (added != 0 || removed != 0) {
+			t.Fatalf("identical inputs reported +%d/-%d", added, removed)
+		}
+		if !same && added == 0 && removed == 0 {
+			t.Fatalf("differing inputs reported 0/0\n old=%q\n new=%q", oldS, newS)
+		}
+	})
+}
+
+// A hunk header must describe the hunk that follows it. A mismatch is how a
+// diff renders plausibly and applies wrongly.
+func FuzzUnified_HunkHeadersMatchTheirBodies(f *testing.F) {
+	fuzzSeeds(f)
+
+	f.Fuzz(func(t *testing.T, oldS, newS string) {
+		if len(oldS) > 4096 || len(newS) > 4096 {
+			t.Skip()
+		}
+		u := Unified("old", "new", []byte(oldS), []byte(newS))
+		if u == "" {
+			return
+		}
+
+		var oldLines, newLines, wantOld, wantNew int
+		inHunk := false
+		check := func() {
+			if inHunk && (oldLines != wantOld || newLines != wantNew) {
+				t.Fatalf("hunk header claimed -%d +%d but the body has -%d +%d\n%s",
+					wantOld, wantNew, oldLines, newLines, u)
+			}
+		}
+		for i, l := range strings.Split(strings.TrimRight(u, "\n"), "\n") {
+			if i < 2 {
+				continue // the two header lines
+			}
+			switch {
+			case strings.HasPrefix(l, "@@"):
+				check()
+				inHunk = true
+				oldLines, newLines = 0, 0
+				if _, err := fmtSscanHunk(l, &wantOld, &wantNew); err != nil {
+					t.Fatalf("unparsable hunk header %q in\n%s", l, u)
+				}
+			case strings.HasPrefix(l, " "):
+				oldLines++
+				newLines++
+			case strings.HasPrefix(l, "-"):
+				oldLines++
+			case strings.HasPrefix(l, "+"):
+				newLines++
+			}
+		}
+		check()
+	})
+}
+
+// fmtSscanHunk pulls the two line counts out of "@@ -a,b +c,d @@".
+func fmtSscanHunk(header string, wantOld, wantNew *int) (int, error) {
+	var a, c int
+	return fmt.Sscanf(header, "@@ -%d,%d +%d,%d @@", &a, wantOld, &c, wantNew)
+}
+
+// sameLines compares line slices elementwise.
+//
+// Not strings.Join: an empty file yields nil and a file holding one blank line
+// yields [""], and joining collapses both to "". Those are different files, and
+// Stats correctly reports +1 for one becoming the other — the first version of
+// this check called them equal and failed the fuzzer on correct behaviour.
+// Found by FuzzStats_AgreesWithUnified with old="", new="\n".
+func sameLines(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/diff/testdata/fuzz/FuzzUnified_RoundTrips/88ce08d6158ab52e
+++ b/internal/diff/testdata/fuzz/FuzzUnified_RoundTrips/88ce08d6158ab52e
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("0")
+string("++")

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -63,13 +63,17 @@ func repoSandbox(t *testing.T, gitInit bool) string {
 	}
 	t.Cleanup(func() { _ = os.Chdir(prev) })
 
-	// Resolve, because macOS hands out /var symlinks for temp dirs and the
-	// workspace root will be the resolved form.
-	resolved, err := filepath.EvalSymlinks(repo)
+	// Return the working directory as the OS reports it, not the temp path we
+	// were handed. workspace's fallback roots itself at GitRoot(os.Getwd()), and
+	// the two spellings differ in practice: macOS gives /var symlinks for temp
+	// dirs, and Windows normalises casing and short (8.3) components. Comparing
+	// against anything else makes every containment check fail with
+	// "no workspace contains …" — which is exactly what the Windows leg caught.
+	cwd, err := os.Getwd()
 	if err != nil {
 		return repo
 	}
-	return resolved
+	return cwd
 }
 
 func write(t *testing.T, path, content string) {

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -39,6 +39,11 @@ func repoSandbox(t *testing.T, gitInit bool) string {
 			{"init", "-q"},
 			{"config", "user.email", "t@example.com"},
 			{"config", "user.name", "t"},
+			// Windows git defaults core.autocrlf=true, so a checkout rewrites
+			// LF to CRLF and the restored bytes differ from the committed ones.
+			// Pinned off so the test asserts what git restored rather than what
+			// the platform's line-ending policy happens to be.
+			{"config", "core.autocrlf", "false"},
 		} {
 			cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
 			if out, err := cmd.CombinedOutput(); err != nil {

--- a/internal/testutil/sandbox.go
+++ b/internal/testutil/sandbox.go
@@ -188,11 +188,16 @@ func (s *Sandbox) AllowHostBinary(t *testing.T, name string) bool {
 		return false
 	}
 
-	link := filepath.Join(s.BinDir, filepath.Base(real))
-	// Symlink where possible; copy is not worth it for an executable that may
-	// resolve siblings relative to itself.
-	if err := os.Symlink(real, link); err != nil {
-		t.Fatalf("linking %s into the sandbox: %v", name, err)
-	}
+	// Put the tool's own directory on PATH rather than linking the binary into
+	// the sandbox. An executable frequently resolves siblings relative to its
+	// own location, and a symlink breaks that: on Windows, linking git.exe out
+	// of its install tree made every invocation fail with 0xc0000135
+	// (STATUS_DLL_NOT_FOUND).
+	//
+	// This exposes one directory rather than one file, so it is a slightly
+	// wider hole than the name suggests — but the alternative is a test that
+	// cannot run at all, and the sandbox's other guarantees (home, HYDRA_HOME,
+	// credentials) are untouched.
+	t.Setenv("PATH", filepath.Dir(real)+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return true
 }

--- a/internal/workspace/bench_test.go
+++ b/internal/workspace/bench_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+package workspace
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Benchmarks here are regression guards, not tuning targets. matchGlob runs on
+// every scope check, and its failure mode was not "slow" — it was "never
+// returns" (see the memoization note in matchSegments). A benchmark that stops
+// completing is the signal.
+
+func BenchmarkMatchGlob_Typical(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = matchGlob("internal/executor/http.go", "internal/**")
+	}
+}
+
+func BenchmarkMatchGlob_DeepPath(b *testing.B) {
+	rel := strings.Repeat("a/", 30) + "target.go"
+	for i := 0; i < b.N; i++ {
+		_ = matchGlob(rel, "**/*.go")
+	}
+}
+
+// The shape that used to hang: many "**" against a long path, with a tail that
+// never matches so the search cannot exit early.
+func BenchmarkMatchGlob_ManyDoubleStarsNoMatch(b *testing.B) {
+	rel := strings.Repeat("a/", 20) + "x"
+	pat := strings.Repeat("**/", 10) + "no-such-segment"
+	for i := 0; i < b.N; i++ {
+		_ = matchGlob(rel, pat)
+	}
+}
+
+// A hard ceiling rather than a relative one: exponential blow-up is orders of
+// magnitude, so any threshold in this range separates "fixed" from "broken"
+// without being brittle about machine speed.
+func TestMatchGlob_PathologicalInputIsNotExponential(t *testing.T) {
+	cases := []struct{ segments, stars int }{
+		{20, 10},
+		{30, 15},
+		{40, 20},
+	}
+	for _, tc := range cases {
+		rel := strings.Repeat("a/", tc.segments) + "x"
+		pat := strings.Repeat("**/", tc.stars) + "no-such-segment"
+
+		start := time.Now()
+		done := make(chan bool, 1)
+		go func() { done <- matchGlob(rel, pat) }()
+
+		select {
+		case <-done:
+			if d := time.Since(start); d > 2*time.Second {
+				t.Errorf("%d segments / %d '**' took %v — matching is superlinear again",
+					tc.segments, tc.stars, d)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("%d segments / %d '**' did not terminate — matchSegments has lost "+
+				"its memoization and a workspace.yaml pattern can hang every scope check",
+				tc.segments, tc.stars)
+		}
+	}
+}

--- a/internal/workspace/fuzz_test.go
+++ b/internal/workspace/fuzz_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+
+package workspace
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// matchGlob decides whether a path may be written to, and both of its inputs
+// come from outside the code: the path from a model's output or an A2A handoff,
+// the pattern from a user-edited workspace.yaml. Neither is a shape a table
+// author gets to choose.
+//
+//	go test ./internal/workspace -fuzz=FuzzMatchGlob -fuzztime=60s
+
+func globSeeds(f *testing.F) {
+	for _, p := range [][2]string{
+		{"src/main.go", "src/**"},
+		{"a/b/c/d.go", "**"},
+		{".env", "**/.env*"},
+		{"a/node_modules/x", "**/node_modules/**"},
+		{"", ""},
+		{"/", "/"},
+		{"a", "*"},
+		{"a/b", "*/*"},
+		{strings.Repeat("a/", 20) + "x", strings.Repeat("**/", 10) + "x"},
+		{"x", "[[[["},
+		{"x", `\`},
+	} {
+		f.Add(p[0], p[1])
+	}
+}
+
+// It must never panic, and — the real risk — it must always terminate.
+// matchSegments recurses over every split point for each "**", so a pattern
+// with several of them against a long path is a candidate for exponential
+// blow-up. A hang here is a denial of service on the scope check, which is the
+// one thing standing between a model and the filesystem.
+func FuzzMatchGlob_TerminatesAndNeverPanics(f *testing.F) {
+	globSeeds(f)
+
+	f.Fuzz(func(t *testing.T, rel, pattern string) {
+		// Bound the inputs so the fuzzer explores structure rather than sheer
+		// length; the pathological-pattern case is asserted explicitly below.
+		if len(rel) > 512 || len(pattern) > 512 {
+			t.Skip()
+		}
+
+		done := make(chan bool, 1)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("matchGlob(%q, %q) panicked: %v", rel, pattern, r)
+					done <- false
+				}
+			}()
+			done <- matchGlob(rel, pattern)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("matchGlob(%q, %q) did not terminate in 5s — the scope check "+
+				"can be hung by a pattern", rel, pattern)
+		}
+	})
+}
+
+// A concrete pathological case rather than hoping the fuzzer stumbles on it:
+// many "**" segments against a long path. If matching is exponential this never
+// returns, and `hyctl edit` hangs instead of refusing.
+func TestMatchGlob_PathologicalPatternStillTerminates(t *testing.T) {
+	rel := strings.Repeat("a/", 40) + "target.go"
+	pattern := strings.Repeat("**/", 20) + "*.go"
+
+	done := make(chan bool, 1)
+	go func() { done <- matchGlob(rel, pattern) }()
+
+	select {
+	case got := <-done:
+		if !got {
+			t.Errorf("pattern %q should match %q", pattern, rel)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("matchGlob did not terminate for %d path segments against %d '**' "+
+			"segments — matching is exponential and a workspace.yaml pattern can "+
+			"hang every scope check", strings.Count(rel, "/")+1, strings.Count(pattern, "**"))
+	}
+}
+
+// Containment is the security boundary. Whatever the inputs, a path that
+// filepath.Rel says escapes must never be reported as contained.
+func FuzzContains_NeverAcceptsAnEscape(f *testing.F) {
+	for _, p := range [][2]string{
+		{"/ws", "/ws/a.go"},
+		{"/ws", "/ws/../etc/passwd"},
+		{"/ws", "/ws-evil/a.go"},
+		{"/ws", "/ws"},
+		{"/", "/anything"},
+		{"", ""},
+		{"/ws", ""},
+	} {
+		f.Add(p[0], p[1])
+	}
+
+	f.Fuzz(func(t *testing.T, root, path string) {
+		if len(root) > 256 || len(path) > 256 {
+			t.Skip()
+		}
+		if !contains(root, path) {
+			return
+		}
+		// If it says contained, Rel must agree and must not climb out.
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			t.Fatalf("contains(%q, %q) = true but filepath.Rel errored: %v", root, path, err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			t.Fatalf("contains(%q, %q) = true but the relative path %q escapes the root",
+				root, path, rel)
+		}
+	})
+}

--- a/internal/workspace/testdata/fuzz/FuzzMatchGlob_TerminatesAndNeverPanics/faacc457f32da9ae
+++ b/internal/workspace/testdata/fuzz/FuzzMatchGlob_TerminatesAndNeverPanics/faacc457f32da9ae
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/x")
+string("**/**/**/**/**/**/**/**/**/**/\xf0\bx")

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -345,27 +345,56 @@ func matchGlob(rel, pattern string) bool {
 	return matchSegments(strings.Split(rel, "/"), strings.Split(pattern, "/"))
 }
 
-// matchSegments recursively matches path segments against pattern segments.
+// matchSegments matches path segments against pattern segments.
 // "**" matches zero or more path segments; everything else uses filepath.Match.
+//
+// Memoized on (path index, pattern index). Without that, each "**" branches
+// over every remaining split point and the recursion is exponential in the
+// number of "**" segments — a pattern like "**/**/**/…/nomatch" against a long
+// path never returns. That is a denial of service on the scope check, which is
+// the one thing standing between a model and the filesystem: hyctl edit would
+// hang rather than allow or refuse.
+//
+// Found by FuzzMatchGlob_TerminatesAndNeverPanics, which produced
+// "**/**/**/**/**/**/**/**/**/**/<junk>" against 21 path segments. The
+// hand-written pathological case missed it, because its tail matched quickly
+// and the search never had to exhaust the space.
+//
+// Memoization makes the state space (len(path)+1) × (len(pat)+1), so matching
+// is now polynomial and bounded by the inputs rather than by their structure.
 func matchSegments(path, pat []string) bool {
-	if len(pat) == 0 {
-		return len(path) == 0
-	}
-	if pat[0] == "**" {
-		// Try consuming 0, 1, 2, ... path segments with this **.
-		for i := 0; i <= len(path); i++ {
-			if matchSegments(path[i:], pat[1:]) {
-				return true
-			}
+	type state struct{ i, j int }
+	memo := make(map[state]bool)
+
+	var match func(i, j int) bool
+	match = func(i, j int) bool {
+		key := state{i, j}
+		if cached, ok := memo[key]; ok {
+			return cached
 		}
-		return false
+		result := func() bool {
+			if j == len(pat) {
+				return i == len(path)
+			}
+			if pat[j] == "**" {
+				// Consume 0, 1, 2, … remaining path segments.
+				for k := i; k <= len(path); k++ {
+					if match(k, j+1) {
+						return true
+					}
+				}
+				return false
+			}
+			if i == len(path) {
+				return false
+			}
+			if matched, _ := filepath.Match(pat[j], path[i]); !matched {
+				return false
+			}
+			return match(i+1, j+1)
+		}()
+		memo[key] = result
+		return result
 	}
-	if len(path) == 0 {
-		return false
-	}
-	matched, _ := filepath.Match(pat[0], path[0])
-	if !matched {
-		return false
-	}
-	return matchSegments(path[1:], pat[1:])
+	return match(0, 0)
 }


### PR DESCRIPTION
## Different kinds of test, not more of the same

So far the suite has been unit, contract, property, differential and fault-injection. This adds **fuzzing** and **benchmarks-as-guards** — and the first fuzz run found a denial of service in the security boundary.

## The finding: a `workspace.yaml` glob can hang every scope check

`FuzzMatchGlob_TerminatesAndNeverPanics`, in under 30 seconds:

```
matchGlob("a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/x",
          "**/**/**/**/**/**/**/**/**/**/\xf0\bx") did not terminate in 5s
```

`matchSegments` recursed over every split point per `**`, so *k* of them against *n* path segments is **O(nᵏ)**. Ten `**` against a 21-segment path never returns.

`Check` backs `edit`, `parallel` and `review`. **`hyctl edit` would hang forever rather than allow or refuse** — and the patterns come from `registry/workspace.yaml`, which users edit and `hyctl init` writes.

### Why my own pathological test missed it

I had already written `TestMatchGlob_PathologicalPatternStillTerminates` with **more** segments and **more** `**` than the fuzzer used. It passed — because its pattern ended in `*.go`, which matched quickly and let the search exit early.

The fuzzer's tail matches **nothing**, forcing the space to be exhausted. That is precisely the distinction a table author does not think to write.

### Fix

Memoize on (path index, pattern index) — state space bounded to `(len(path)+1) × (len(pat)+1)`.

```
the exact failing input:   never terminated  →  130µs
```

Semantics unchanged; every existing glob test still passes. The failing input is committed under `testdata/fuzz/` as a permanent seed.

## Two findings were bugs in my tests — both would have given false confidence

**`applyUnified` dropped content.** It treated any line starting `---`/`+++` as a header. But a content line beginning `++` renders as `+++`, and **real `diff -u` emits exactly that** — I checked. Our output was correct; the test helper was silently losing lines. Only the first two lines are the header.

**`strings.Join` collapsed a real difference.** An empty file yields `nil`, a file holding one blank line yields `[""]`, and joining makes both `""`. `Stats` correctly reported `+1`; my equality check called that a bug.

A test that is wrong in the permissive direction is worse than no test, and neither was reachable by inspection.

## What is here

**Fuzz targets** for the parsers whose inputs come from outside the code — a model's output, a user's source, a user-edited pattern:
- `internal/diff`: round-trip (apply our own diff, get the target back), `Stats` agrees with the diff body, hunk headers describe their bodies
- `internal/workspace`: `matchGlob` terminates and never panics, `contains` never accepts an escape

Clean at 20M+ executions each. Without `-fuzz` they run the seed corpus as ordinary tests, so they guard in CI at no cost.

**Benchmarks as regression guards**, not tuning targets — the failure mode here was never "slow", it was "never returns", so a benchmark that stops completing is the signal. Plus a hard-ceiling test at three input sizes.

```
BenchmarkMatchGlob_Typical                    265.8 ns/op
BenchmarkMatchGlob_DeepPath                    2281 ns/op
BenchmarkMatchGlob_ManyDoubleStarsNoMatch     39707 ns/op   ← was: ∞
```

## Verification

```
go test ./... -race -count=1                  green
vet clean on windows/amd64, linux/arm64
```

Closes #303