### PR TITLE
test: cover the four zero-coverage packages, and fix what that found

### DIFF
--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -22,8 +22,13 @@ type Result struct {
 // It never returns an error — individual provider failures are silently skipped
 // so a broken provider doesn't block the init wizard.
 func Run(ctx context.Context) *Result {
-	providers := provider.All()
+	return RunWith(ctx, provider.All())
+}
 
+// RunWith is Run against an explicit provider set, so discovery can be tested
+// without registering fakes into the process-global registry — which every
+// other test in the binary would then see.
+func RunWith(ctx context.Context, providers []provider.Provider) *Result {
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	var all []provider.Head
@@ -32,6 +37,13 @@ func Run(ctx context.Context) *Result {
 		wg.Add(1)
 		go func(p provider.Provider) {
 			defer wg.Done()
+			// "Individual provider failures are silently skipped" has to include
+			// a panic, or the guarantee is only about the errors a provider
+			// remembers to return. Without this, one misbehaving provider takes
+			// down the whole probe — and `hyctl probe` is often the first thing
+			// a user runs.
+			defer func() { _ = recover() }()
+
 			heads, err := p.Discover(ctx)
 			if err != nil {
 				return

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT
+
+package probe
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// probe.Run is the machine scan every other surface is built on: hyctl probe,
+// the init wizard, and dispatch's head selection. It was at 0%.
+
+type fakeProvider struct {
+	id      string
+	heads   []provider.Head
+	err     error
+	panics  bool
+	delay   time.Duration
+	callsMu sync.Mutex
+	calls   int
+}
+
+func (f *fakeProvider) ID() string { return f.id }
+
+func (f *fakeProvider) Discover(ctx context.Context) ([]provider.Head, error) {
+	f.callsMu.Lock()
+	f.calls++
+	f.callsMu.Unlock()
+
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.panics {
+		panic("provider exploded")
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.heads, nil
+}
+
+// head builds a distinct cloud head. The provider name matters: rank.ByCapScore
+// dedupes non-local heads by Provider — deliberately, so a vendor with fifty
+// models shows as one head — so fakes sharing a provider name collapse into one.
+// The first version of these tests used Provider:"test" throughout and saw
+// three heads become two, which is the dedup contract working, not a bug.
+func head(id string, score int, local bool) provider.Head {
+	return provider.Head{ID: id, Name: id, Provider: id, Source: "registry",
+		CapScore: score, LocalOnly: local, AuthReady: true}
+}
+
+func TestRunWith_AggregatesEveryProvider(t *testing.T) {
+	res := RunWith(context.Background(), []provider.Provider{
+		&fakeProvider{id: "a", heads: []provider.Head{head("a1", 50, false)}},
+		&fakeProvider{id: "b", heads: []provider.Head{head("b1", 90, false), head("b2", 10, true)}},
+	})
+
+	if len(res.Heads) != 3 {
+		t.Fatalf("got %d heads, want 3: %+v", len(res.Heads), res.Heads)
+	}
+}
+
+// The Cortex is the highest-ranked head. Getting it wrong sends every
+// unpinned dispatch to the wrong place.
+func TestRunWith_CortexIsTheTopRankedHead(t *testing.T) {
+	res := RunWith(context.Background(), []provider.Provider{
+		&fakeProvider{id: "a", heads: []provider.Head{head("weak", 10, false)}},
+		&fakeProvider{id: "b", heads: []provider.Head{head("strong", 99, false)}},
+		&fakeProvider{id: "c", heads: []provider.Head{head("mid", 55, false)}},
+	})
+
+	if res.Cortex == nil {
+		t.Fatal("no Cortex chosen despite three heads")
+	}
+	if res.Cortex.ID != "strong" {
+		t.Errorf("Cortex = %q, want the highest CapScore (%q)", res.Cortex.ID, "strong")
+	}
+	// Cortex must be the first ranked head, not a copy of something else.
+	if res.Heads[0].ID != res.Cortex.ID {
+		t.Errorf("Cortex %q is not Heads[0] (%q)", res.Cortex.ID, res.Heads[0].ID)
+	}
+	// …and the ranking must be descending.
+	for i := 1; i < len(res.Heads); i++ {
+		if res.Heads[i-1].CapScore < res.Heads[i].CapScore {
+			t.Errorf("heads not ranked: %d before %d", res.Heads[i-1].CapScore, res.Heads[i].CapScore)
+		}
+	}
+}
+
+// The documented guarantee: one broken provider must not block the rest.
+func TestRunWith_AFailingProviderDoesNotHideTheOthers(t *testing.T) {
+	good := &fakeProvider{id: "good", heads: []provider.Head{head("g", 70, false)}}
+	bad := &fakeProvider{id: "bad", err: errors.New("no network")}
+
+	res := RunWith(context.Background(), []provider.Provider{bad, good})
+
+	if len(res.Heads) != 1 || res.Heads[0].ID != "g" {
+		t.Errorf("got %+v, want the one head from the working provider", res.Heads)
+	}
+	if bad.calls == 0 {
+		t.Error("the failing provider was never called")
+	}
+}
+
+// "Failures are silently skipped" has to cover a panic too, or the guarantee is
+// only about errors a provider remembers to return. hyctl probe is often the
+// first command a user runs; one bad provider must not crash it.
+func TestRunWith_APanickingProviderDoesNotCrashTheProbe(t *testing.T) {
+	res := RunWith(context.Background(), []provider.Provider{
+		&fakeProvider{id: "boom", panics: true},
+		&fakeProvider{id: "fine", heads: []provider.Head{head("f", 60, false)}},
+	})
+
+	if len(res.Heads) != 1 || res.Heads[0].ID != "f" {
+		t.Errorf("got %+v, want the surviving provider's head", res.Heads)
+	}
+	if res.Cortex == nil || res.Cortex.ID != "f" {
+		t.Errorf("Cortex = %+v, want the surviving head", res.Cortex)
+	}
+}
+
+// Nothing discovered is a valid outcome, and must not be a nil-pointer trap for
+// callers that read Cortex.
+func TestRunWith_NoProvidersYieldsNoCortex(t *testing.T) {
+	res := RunWith(context.Background(), nil)
+	if res == nil {
+		t.Fatal("RunWith returned nil")
+	}
+	if len(res.Heads) != 0 {
+		t.Errorf("got %d heads from no providers", len(res.Heads))
+	}
+	if res.Cortex != nil {
+		t.Errorf("Cortex = %+v with no heads", res.Cortex)
+	}
+}
+
+func TestRunWith_ProvidersThatFindNothing(t *testing.T) {
+	res := RunWith(context.Background(), []provider.Provider{
+		&fakeProvider{id: "a"},
+		&fakeProvider{id: "b", heads: []provider.Head{}},
+	})
+	if len(res.Heads) != 0 || res.Cortex != nil {
+		t.Errorf("got %+v / cortex %+v, want nothing", res.Heads, res.Cortex)
+	}
+}
+
+// Providers are queried concurrently; the shared slice must be race-free.
+// Run under -race this is the assertion.
+func TestRunWith_ConcurrentProvidersAreRaceFree(t *testing.T) {
+	var ps []provider.Provider
+	for i := 0; i < 24; i++ {
+		id := "p" + strconv.Itoa(i)
+		ps = append(ps, &fakeProvider{
+			id: id,
+			heads: []provider.Head{
+				head(id+"-a", 50+i, false),
+				head(id+"-b", 40+i, false),
+			},
+		})
+	}
+	res := RunWith(context.Background(), ps)
+	if len(res.Heads) != 48 {
+		t.Errorf("got %d heads, want 48", len(res.Heads))
+	}
+}
+
+// The dedup contract itself, asserted rather than stumbled into: several heads
+// from one cloud provider collapse to the strongest, while local heads each
+// stay — a machine with four Ollama models has four usable heads, but a vendor
+// with forty API models is still one entry.
+func TestRunWith_CloudHeadsDedupePerProviderButLocalOnesDoNot(t *testing.T) {
+	cloud := []provider.Head{
+		{ID: "openai/gpt-a", Provider: "openai", Source: "env", CapScore: 70, AuthReady: true},
+		{ID: "openai/gpt-b", Provider: "openai", Source: "env", CapScore: 90, AuthReady: true},
+		{ID: "openai/gpt-c", Provider: "openai", Source: "env", CapScore: 50, AuthReady: true},
+	}
+	local := []provider.Head{
+		{ID: "ollama/qwen", Provider: "local", Source: "port", CapScore: 60, LocalOnly: true, AuthReady: true},
+		{ID: "ollama/llama", Provider: "local", Source: "port", CapScore: 55, LocalOnly: true, AuthReady: true},
+	}
+
+	res := RunWith(context.Background(), []provider.Provider{
+		&fakeProvider{id: "cloud", heads: cloud},
+		&fakeProvider{id: "local", heads: local},
+	})
+
+	var gotCloud, gotLocal int
+	for _, h := range res.Heads {
+		if h.LocalOnly {
+			gotLocal++
+			continue
+		}
+		gotCloud++
+		if h.CapScore != 90 {
+			t.Errorf("kept the %d-score openai head; dedup must keep the strongest", h.CapScore)
+		}
+	}
+	if gotCloud != 1 {
+		t.Errorf("got %d cloud heads, want 1 — one entry per cloud provider", gotCloud)
+	}
+	if gotLocal != 2 {
+		t.Errorf("got %d local heads, want 2 — each local model is its own head", gotLocal)
+	}
+}
+
+// A cancelled context must not be ignored: a provider that honours it returns
+// promptly and the probe finishes rather than waiting out every timeout.
+func TestRunWith_CancelledContextReturnsPromptly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	res := RunWith(ctx, []provider.Provider{
+		&fakeProvider{id: "slow", delay: 10 * time.Second,
+			heads: []provider.Head{head("never", 10, false)}},
+	})
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Errorf("took %v with a cancelled context", elapsed)
+	}
+	if len(res.Heads) != 0 {
+		t.Errorf("a cancelled probe still produced heads: %+v", res.Heads)
+	}
+}
+
+// Every provider is asked exactly once — a double call would double-count heads
+// and, for the port provider, double the network probes.
+func TestRunWith_EachProviderIsAskedOnce(t *testing.T) {
+	p := &fakeProvider{id: "once", heads: []provider.Head{head("h", 50, false)}}
+	RunWith(context.Background(), []provider.Provider{p})
+
+	if p.calls != 1 {
+		t.Errorf("provider called %d times, want 1", p.calls)
+	}
+}

--- a/internal/provider/agy/provider_test.go
+++ b/internal/provider/agy/provider_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+
+package agy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// This package turns registry/models.yaml into routable heads. It was at 0%,
+// and it is the layer #238 was about: it read disk only, so every installed
+// binary discovered no agy heads at all.
+
+func writeModels(t *testing.T, hydraHome, body string) {
+	t.Helper()
+	dir := filepath.Join(hydraHome, "registry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func discover(t *testing.T) []headLite {
+	t.Helper()
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Fatalf("Discover returned an error: %v", err)
+	}
+	out := make([]headLite, 0, len(heads))
+	for _, h := range heads {
+		out = append(out, headLite{h.ID, h.Name, h.Provider, h.Source, h.CapScore, h.Meta})
+	}
+	return out
+}
+
+type headLite struct {
+	ID, Name, Provider, Source string
+	CapScore                   int
+	Meta                       map[string]string
+}
+
+// The #238 contract: with no on-disk registry, the embedded copy must still
+// yield heads. Anything else means a brew/npm/pip install can never route to
+// agy.
+func TestDiscover_UsesTheEmbeddedRegistryWhenNothingIsOnDisk(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	heads := discover(t)
+	if len(heads) == 0 {
+		t.Fatal("no agy heads from the embedded registry — this is what every " +
+			"installed binary sees (#238)")
+	}
+	for _, h := range heads {
+		if h.Provider != "antigravity" {
+			t.Errorf("%s: Provider = %q, want antigravity", h.ID, h.Provider)
+		}
+		if h.Source != "registry" {
+			t.Errorf("%s: Source = %q, want registry", h.ID, h.Source)
+		}
+		if h.Meta["model_flag"] == "" {
+			t.Errorf("%s has no model_flag; the executor cannot select a model", h.ID)
+		}
+		if h.Meta["tier"] == "" {
+			t.Errorf("%s has no tier meta; rank.UITier falls back to CapScore thresholds", h.ID)
+		}
+		if _, err := strconv.Atoi(h.Meta["tier"]); err != nil {
+			t.Errorf("%s tier meta %q is not a number", h.ID, h.Meta["tier"])
+		}
+	}
+}
+
+// An on-disk registry overrides the embedded one, which is the whole point of
+// $HYDRA_HOME: retune routing without a rebuild.
+func TestDiscover_OnDiskRegistryWins(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	writeModels(t, s.HydraHome, `
+models:
+  - tier: 3
+    id: only-one
+    name: Only One
+    executor: agy
+    model_flag: "--model=x"
+    token_pool: pool-a
+    enabled: true
+`)
+
+	heads := discover(t)
+	if len(heads) != 1 || heads[0].ID != "only-one" {
+		t.Fatalf("got %+v, want just the on-disk entry", heads)
+	}
+	if heads[0].CapScore != 88 {
+		t.Errorf("tier 3 scored %d, want 88", heads[0].CapScore)
+	}
+	if heads[0].Meta["token_pool"] != "pool-a" {
+		t.Errorf("token_pool = %q", heads[0].Meta["token_pool"])
+	}
+}
+
+// Every exclusion rule, stated. A head that should be filtered but is not gets
+// dispatched to and fails at the point of use.
+func TestDiscover_SkipsEntriesThatCannotBeRoutedTo(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	writeModels(t, s.HydraHome, `
+models:
+  - {tier: 3, id: good,          name: Good,      executor: agy,   model_flag: "--m=1", enabled: true}
+  - {tier: 3, id: disabled,      name: Disabled,  executor: agy,   model_flag: "--m=2", enabled: false}
+  - {tier: 3, id: other-exec,    name: Other,     executor: ollama, model_flag: "--m=3", enabled: true}
+  - {tier: 3, id: no-flag,       name: NoFlag,    executor: agy,   model_flag: "",      enabled: true}
+  - {tier: 3, id: null-flag,     name: NullFlag,  executor: agy,   model_flag: "null",  enabled: true}
+`)
+
+	heads := discover(t)
+	if len(heads) != 1 {
+		t.Fatalf("got %d heads, want only the routable one: %+v", len(heads), heads)
+	}
+	if heads[0].ID != "good" {
+		t.Errorf("kept %q, want %q", heads[0].ID, "good")
+	}
+}
+
+// Tier → CapScore is what puts agy heads in the right place in the ladder.
+func TestTierScore(t *testing.T) {
+	want := map[int]int{2: 92, 3: 88, 4: 82, 5: 80, 6: 78, 7: 72, 8: 70, 9: 68}
+	for tier, score := range want {
+		if got := tierScore(tier); got != score {
+			t.Errorf("tierScore(%d) = %d, want %d", tier, got, score)
+		}
+	}
+	// Unknown tiers get a mid fallback rather than 0, which would sort them
+	// below every local model.
+	for _, unknown := range []int{0, 1, 10, 99, -1} {
+		if got := tierScore(unknown); got != 60 {
+			t.Errorf("tierScore(%d) = %d, want the 60 fallback", unknown, got)
+		}
+	}
+}
+
+// The score ladder must be monotonic in the tier: a stronger tier (lower
+// number) must never score below a weaker one, or routing inverts.
+func TestTierScore_IsMonotonicAcrossTheLadder(t *testing.T) {
+	prev := 1 << 30
+	for tier := 2; tier <= 9; tier++ {
+		got := tierScore(tier)
+		if got >= prev {
+			t.Errorf("tier %d scored %d, not below tier %d's %d — the ladder inverts",
+				tier, got, tier-1, prev)
+		}
+		prev = got
+	}
+}
+
+// Malformed YAML must degrade to "no agy heads", never to an error that stops
+// the whole probe or to a partial head with missing routing metadata.
+func TestDiscover_MalformedYAMLYieldsNoHeadsAndNoError(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	writeModels(t, s.HydraHome, "models: [this is not: valid: yaml")
+
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Errorf("malformed models.yaml returned an error (%v); it must degrade quietly "+
+			"so one bad file does not stop the probe", err)
+	}
+	if len(heads) != 0 {
+		t.Errorf("malformed models.yaml produced heads: %+v", heads)
+	}
+}
+
+func TestDiscover_EmptyRegistryYieldsNoHeads(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	writeModels(t, s.HydraHome, "models: []\n")
+
+	if heads := discover(t); len(heads) != 0 {
+		t.Errorf("got %+v from an empty models list", heads)
+	}
+}
+
+func TestProvider_ID(t *testing.T) {
+	if got := (&Provider{}).ID(); got != "agy" {
+		t.Errorf("ID() = %q, want agy", got)
+	}
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+
+package provider
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// The registry is process-global and populated from init() functions across
+// four packages, so it is written during program start and read afterwards
+// from goroutines. It was at 0%.
+//
+// Tests here build their own Registry rather than touching the global one:
+// registering a fake globally would leak into every other test in the binary.
+
+type stubProvider struct {
+	id    string
+	heads []Head
+}
+
+func (s *stubProvider) ID() string                               { return s.id }
+func (s *stubProvider) Discover(context.Context) ([]Head, error) { return s.heads, nil }
+
+func newRegistry() *Registry {
+	return &Registry{providers: make(map[string]Provider)}
+}
+
+func TestRegistry_AddAndAll(t *testing.T) {
+	r := newRegistry()
+	if got := r.all(); len(got) != 0 {
+		t.Errorf("a fresh registry returned %d providers", len(got))
+	}
+
+	r.add(&stubProvider{id: "a"})
+	r.add(&stubProvider{id: "b"})
+
+	got := r.all()
+	if len(got) != 2 {
+		t.Fatalf("got %d providers, want 2", len(got))
+	}
+	seen := map[string]bool{}
+	for _, p := range got {
+		seen[p.ID()] = true
+	}
+	if !seen["a"] || !seen["b"] {
+		t.Errorf("registry lost a provider: %v", seen)
+	}
+}
+
+// Keyed by ID, so re-registering replaces rather than duplicating. A duplicate
+// would be discovered twice and double every head it reports.
+func TestRegistry_SameIDReplacesRatherThanDuplicates(t *testing.T) {
+	r := newRegistry()
+	first := &stubProvider{id: "dup", heads: []Head{{ID: "old"}}}
+	second := &stubProvider{id: "dup", heads: []Head{{ID: "new"}}}
+
+	r.add(first)
+	r.add(second)
+
+	all := r.all()
+	if len(all) != 1 {
+		t.Fatalf("got %d providers for one ID, want 1", len(all))
+	}
+	heads, err := all[0].Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 1 || heads[0].ID != "new" {
+		t.Errorf("kept %+v, want the most recent registration", heads)
+	}
+}
+
+// all() must hand back a copy: a caller ranging over it while init() is still
+// registering, or mutating what it got, must not corrupt the registry.
+func TestRegistry_AllReturnsACopy(t *testing.T) {
+	r := newRegistry()
+	r.add(&stubProvider{id: "a"})
+
+	got := r.all()
+	got[0] = &stubProvider{id: "mutated"}
+
+	again := r.all()
+	if again[0].ID() != "a" {
+		t.Errorf("mutating the returned slice changed the registry: %q", again[0].ID())
+	}
+}
+
+// Concurrent registration and reads. Under -race this is the assertion; the
+// count check catches a lost write that a race detector alone would not.
+func TestRegistry_ConcurrentAddAndAllAreSafe(t *testing.T) {
+	r := newRegistry()
+	const n = 64
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			r.add(&stubProvider{id: "p" + strconv.Itoa(i)})
+		}(i)
+	}
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for _, p := range r.all() {
+				_ = p.ID()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := len(r.all()); got != n {
+		t.Errorf("got %d providers after %d concurrent adds — a write was lost", got, n)
+	}
+}
+
+// The global registry is what probe.Run reads. Every provider package registers
+// from init(), so by the time any test runs they must all be present — a
+// missing one is a head class that can never be discovered.
+func TestGlobalRegistry_IsPopulatedByInit(t *testing.T) {
+	// Only the packages this test binary imports will have registered, so this
+	// asserts the mechanism works rather than a specific roster.
+	before := len(All())
+	Register(&stubProvider{id: "test-only-provider"})
+	after := len(All())
+
+	if after != before+1 {
+		t.Errorf("Register did not add to the global registry (%d → %d)", before, after)
+	}
+	var found bool
+	for _, p := range All() {
+		if p.ID() == "test-only-provider" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the registered provider is not in All()")
+	}
+}

--- a/internal/update/semver_test.go
+++ b/internal/update/semver_test.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+
+package update
+
+import (
+	"sort"
+	"testing"
+)
+
+// internal/update was at 0%. semverGT decides whether a user is told a new
+// release exists — so a wrong answer is silent: nobody sees a notification that
+// was never printed.
+
+func TestSemverGT_ReleaseBeatsItsOwnPrerelease(t *testing.T) {
+	// The bug this package shipped with: parseVer discarded everything after
+	// "-", so a release and its pre-releases compared equal and semverGT
+	// returned false. Every user running v1.1.0-rc.9 would never be told that
+	// v1.1.0 exists.
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"v1.1.0", "v1.1.0-rc.9", true},
+		{"v1.1.0-rc.9", "v1.1.0", false},
+		{"v1.1.0-rc.9", "v1.1.0-rc.8", true},
+		{"v1.1.0-rc.8", "v1.1.0-rc.9", false},
+		{"v1.1.0-rc.10", "v1.1.0-rc.9", true}, // numeric, not lexical
+		{"v1.2.0-rc.1", "v1.1.0", true},       // a newer minor, even as an rc
+	}
+	for _, tc := range cases {
+		if got := semverGT(tc.a, tc.b); got != tc.want {
+			t.Errorf("semverGT(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestSemverGT_NumericCore(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"v2.0.0", "v1.9.9", true},
+		{"v1.2.0", "v1.1.9", true},
+		{"v1.1.2", "v1.1.1", true},
+		{"v1.1.1", "v1.1.1", false},
+		{"v1.1.1", "v1.1.2", false},
+		{"1.2.0", "v1.1.0", true},   // the v prefix is optional
+		{"v1.10.0", "v1.9.0", true}, // numeric, not lexical
+	}
+	for _, tc := range cases {
+		if got := semverGT(tc.a, tc.b); got != tc.want {
+			t.Errorf("semverGT(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// Build metadata is explicitly excluded from precedence by the spec.
+func TestSemverGT_BuildMetadataIsIgnored(t *testing.T) {
+	for _, pair := range [][2]string{
+		{"v1.1.0+build.1", "v1.1.0"},
+		{"v1.1.0", "v1.1.0+build.1"},
+		{"v1.1.0+a", "v1.1.0+b"},
+	} {
+		if semverGT(pair[0], pair[1]) {
+			t.Errorf("semverGT(%q, %q) = true; build metadata must not affect precedence",
+				pair[0], pair[1])
+		}
+	}
+	// …but it must not swallow the pre-release next to it.
+	if !semverGT("v1.1.0+build", "v1.1.0-rc.1+build") {
+		t.Error("build metadata masked the pre-release comparison")
+	}
+}
+
+// The SemVer spec's own example ordering, end to end. Sorting with semverGT
+// must reproduce it exactly.
+func TestSemverGT_SpecExampleOrdering(t *testing.T) {
+	want := []string{
+		"1.0.0-alpha",
+		"1.0.0-alpha.1",
+		"1.0.0-alpha.beta",
+		"1.0.0-beta",
+		"1.0.0-beta.2",
+		"1.0.0-beta.11",
+		"1.0.0-rc.1",
+		"1.0.0",
+	}
+	got := append([]string(nil), want...)
+	// Shuffle deterministically, then sort back with semverGT.
+	for i := range got {
+		j := (i * 7) % len(got)
+		got[i], got[j] = got[j], got[i]
+	}
+	sort.Slice(got, func(i, j int) bool { return semverGT(got[j], got[i]) })
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ordering wrong at %d:\n got  %v\n want %v", i, got, want)
+		}
+	}
+}
+
+func TestParseVer(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantNum [3]int
+		wantPre string
+	}{
+		{"v1.2.3", [3]int{1, 2, 3}, ""},
+		{"1.2.3", [3]int{1, 2, 3}, ""},
+		{"v1.2.3-rc.1", [3]int{1, 2, 3}, "rc.1"},
+		{"v1.2.3+build", [3]int{1, 2, 3}, ""},
+		{"v1.2.3-rc.1+build", [3]int{1, 2, 3}, "rc.1"},
+		{"v1.2", [3]int{1, 2, 0}, ""},
+		{"v1", [3]int{1, 0, 0}, ""},
+		{"", [3]int{0, 0, 0}, ""},
+		{"garbage", [3]int{0, 0, 0}, ""},
+		{"  v1.2.3  ", [3]int{1, 2, 3}, ""},
+	}
+	for _, tc := range cases {
+		num, pre := parseVer(tc.in)
+		if num != tc.wantNum || pre != tc.wantPre {
+			t.Errorf("parseVer(%q) = %v/%q, want %v/%q", tc.in, num, pre, tc.wantNum, tc.wantPre)
+		}
+	}
+}
+
+// Nothing unparsable may be reported as newer — that would show an update
+// notice pointing at a version that does not exist.
+func TestSemverGT_GarbageIsNeverNewer(t *testing.T) {
+	for _, junk := range []string{"", "garbage", "vv1", "...", "-rc.1", "v"} {
+		if semverGT(junk, "v1.0.0") {
+			t.Errorf("semverGT(%q, v1.0.0) = true", junk)
+		}
+	}
+}
+
+// The real scenario, spelled out: this repo's own release history.
+func TestSemverGT_HydraReleaseHistory(t *testing.T) {
+	// A user on each of these must be offered v1.1.0.
+	for _, installed := range []string{
+		"v1.0.0", "v1.0.1", "v1.1.0-rc.1", "v1.1.0-rc.8", "v1.1.0-rc.9",
+	} {
+		if !semverGT("v1.1.0", installed) {
+			t.Errorf("a user on %s is never told about v1.1.0", installed)
+		}
+	}
+	// …and a user already on v1.1.0 is not nagged.
+	if semverGT("v1.1.0", "v1.1.0") {
+		t.Error("v1.1.0 offered as an update to itself")
+	}
+}
+
+// ── ordering axioms, fuzzed ──────────────────────────────────────────────────
+
+// A comparison used for sorting must be a strict weak ordering, or a sort built
+// on it can produce nonsense (or, in Go, panic).
+func FuzzSemverGT_IsAStrictOrdering(f *testing.F) {
+	for _, s := range []string{
+		"v1.0.0", "v1.0.1", "1.0.0-rc.1", "v2.0.0-alpha.beta",
+		"", "v", "0.0.0", "v1.1.0-rc.10", "v1.1.0+build",
+	} {
+		f.Add(s, s)
+	}
+
+	f.Fuzz(func(t *testing.T, a, b string) {
+		if len(a) > 64 || len(b) > 64 {
+			t.Skip()
+		}
+		// Irreflexive: nothing is greater than itself.
+		if semverGT(a, a) {
+			t.Fatalf("semverGT(%q, %q) = true — not irreflexive", a, a)
+		}
+		// Asymmetric: both directions cannot hold.
+		if semverGT(a, b) && semverGT(b, a) {
+			t.Fatalf("semverGT is true in both directions for %q and %q", a, b)
+		}
+	})
+}
+
+func FuzzSemverGT_IsTransitive(f *testing.F) {
+	f.Add("v1.0.0", "v1.0.1", "v1.0.2")
+	f.Add("v1.0.0-rc.1", "v1.0.0", "v1.0.1")
+
+	f.Fuzz(func(t *testing.T, a, b, c string) {
+		if len(a) > 32 || len(b) > 32 || len(c) > 32 {
+			t.Skip()
+		}
+		if semverGT(a, b) && semverGT(b, c) && !semverGT(a, c) {
+			t.Fatalf("not transitive: %q > %q > %q but not %q > %q", a, b, c, a, c)
+		}
+	})
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -9,7 +9,6 @@ package update
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -114,26 +113,103 @@ func fetchLatest() string {
 	return payload.TagName
 }
 
-// semverGT reports whether a > b (both "vX.Y.Z[-pre]" format).
+// semverGT reports whether a > b, following SemVer 2.0.0 precedence.
+//
+// The pre-release identifier is part of the comparison, not something to
+// discard. Stripping it — as this did — made every release equal to its own
+// pre-releases, so semverGT("v1.1.0", "v1.1.0-rc.9") was false and a user
+// running rc.9 was never told the final v1.1.0 existed. rc-to-rc updates were
+// invisible for the same reason.
 func semverGT(a, b string) bool {
-	ap, bp := parseVer(a), parseVer(b)
-	for i := range ap {
-		if ap[i] != bp[i] {
-			return ap[i] > bp[i]
+	aNum, aPre := parseVer(a)
+	bNum, bPre := parseVer(b)
+
+	for i := range aNum {
+		if aNum[i] != bNum[i] {
+			return aNum[i] > bNum[i]
 		}
 	}
-	return false
+	// Same X.Y.Z: a pre-release has LOWER precedence than the release itself.
+	if aPre == "" && bPre == "" {
+		return false
+	}
+	if aPre == "" {
+		return true // a is the release, b is a pre-release of it
+	}
+	if bPre == "" {
+		return false
+	}
+	return comparePrerelease(aPre, bPre) > 0
 }
 
-func parseVer(v string) [3]int {
-	v = strings.TrimPrefix(v, "v")
-	if idx := strings.IndexAny(v, "-+"); idx != -1 {
-		v = v[:idx]
+// comparePrerelease orders two dot-separated pre-release strings per SemVer:
+// numeric identifiers compare numerically, alphanumeric ones lexically, numeric
+// sorts below alphanumeric, and a longer run of equal identifiers wins.
+func comparePrerelease(a, b string) int {
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	for i := 0; i < len(as) && i < len(bs); i++ {
+		if as[i] == bs[i] {
+			continue
+		}
+		an, aIsNum := numericIdent(as[i])
+		bn, bIsNum := numericIdent(bs[i])
+		switch {
+		case aIsNum && bIsNum:
+			if an != bn {
+				return sign(an - bn)
+			}
+		case aIsNum:
+			return -1 // numeric < alphanumeric
+		case bIsNum:
+			return 1
+		default:
+			return strings.Compare(as[i], bs[i])
+		}
+	}
+	return sign(len(as) - len(bs))
+}
+
+func numericIdent(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, true
+}
+
+func sign(n int) int {
+	switch {
+	case n > 0:
+		return 1
+	case n < 0:
+		return -1
+	}
+	return 0
+}
+
+// parseVer splits "vX.Y.Z[-pre][+build]" into its numeric core and pre-release.
+// Build metadata is discarded: SemVer excludes it from precedence entirely.
+func parseVer(v string) ([3]int, string) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if idx := strings.IndexByte(v, '+'); idx != -1 {
+		v = v[:idx] // build metadata never affects precedence
+	}
+	pre := ""
+	if idx := strings.IndexByte(v, '-'); idx != -1 {
+		pre, v = v[idx+1:], v[:idx]
 	}
 	parts := strings.SplitN(v, ".", 3)
 	var out [3]int
 	for i := 0; i < len(parts) && i < 3; i++ {
-		fmt.Sscanf(parts[i], "%d", &out[i])
+		if n, ok := numericIdent(parts[i]); ok {
+			out[i] = n
+		}
 	}
-	return out
+	return out, pre
 }


### PR DESCRIPTION
`update`, `probe`, `provider` and `provider/agy` were all at **0%**. Covering them found two real bugs.

## 1 · A user on any pre-release is never told the final release exists

```
semverGT(v1.1.0     , v1.1.0-rc.9) = false     ← never notified
semverGT(v1.1.0-rc.9, v1.1.0-rc.8) = false     ← rc→rc also invisible
```

`parseVer` discarded everything after `-`, so `v1.1.0` and `v1.1.0-rc.9` both parsed to `[1 1 0]` and compared equal. Every release was "not newer than" its own pre-releases.

**This is live.** Anyone who installed one of the nine `v1.1.0-rc.*` builds to help test the release **will never learn v1.1.0 shipped** — and the failure is a notification that is simply never printed, so nobody reports it.

`semverGT` now implements SemVer 2.0.0 precedence: a pre-release ranks below its release, identifiers compare dot-by-dot with numeric below alphanumeric, build metadata excluded.

Verified against the spec's own worked example end to end —
`1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0` — against this repo's real release history, and **fuzzed for the ordering axioms** (irreflexive, asymmetric, transitive), since a comparison used for sorting that is not a strict weak ordering can make a sort produce nonsense.

## 2 · A panicking provider took down the whole probe

`Run`'s doc promised *"individual provider failures are silently skipped so a broken provider doesn't block the init wizard"* — but the goroutines had no `recover`, so a panic killed the process. `hyctl probe` is often the first command a user runs. The guarantee now covers panics, which is what it always claimed.

`probe` also gained `RunWith`, so discovery is testable against an explicit provider set rather than registering fakes into the process-global registry where every other test in the binary would see them.

## Two of my own tests were wrong first

`rank.ByCapScore` dedupes non-local heads **by Provider** — deliberately, so a vendor with fifty models shows as one head. My fakes all shared `Provider:"test"` and collapsed; three heads becoming two was the *contract working*.

Fixed, and the rule is now asserted directly rather than stumbled into: cloud heads collapse to the strongest, local heads each stay. A machine with four Ollama models has four usable heads; a vendor with forty API models is one entry.

## Coverage

| package | before | after |
|---|---|---|
| `probe` | 0% | **95.5%** |
| `provider/agy` | 0% | **94.4%** |
| `update` | 0% | **51.6%** |
| `provider` | 0% | **47.8%** |

**Total 48.6% → 49.8%.** Only `bench/`, `cmd/specstest` and `internal/build` now lack tests — all trivial.

Also covered: the #238 contract (agy heads come from the embedded registry when nothing is on disk — otherwise no install can route to agy), every agy exclusion rule, tier→score monotonicity, registry concurrency under `-race`, and that `all()` returns a copy.

```
go test ./... -race -count=1        green
vet clean on windows/amd64, linux/arm64
```

Closes #305