### PR TITLE
test: Phase A — the six near-miss packages to 90%+

### DIFF
--- a/internal/a2a/coverage_test.go
+++ b/internal/a2a/coverage_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+
+package a2a
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Ordering.String labels causal relationships in handoff output. "concurrent"
+// is the one that matters — it is what tells a reader two agents may have
+// raced, so an unlabelled value hides the exact case worth noticing.
+func TestOrdering_StringCoversEveryValue(t *testing.T) {
+	want := map[Ordering]string{
+		Equal:      "equal",
+		Before:     "before",
+		After:      "after",
+		Concurrent: "concurrent",
+	}
+	seen := map[string]bool{}
+	for o, s := range want {
+		got := o.String()
+		if got != s {
+			t.Errorf("Ordering(%d).String() = %q, want %q", int(o), got, s)
+		}
+		if seen[got] {
+			t.Errorf("two orderings share the label %q", got)
+		}
+		seen[got] = true
+	}
+	if got := Ordering(99).String(); got != "concurrent" {
+		t.Errorf("an unknown ordering rendered %q; it must fall back to the "+
+			"conservative reading, not an empty string", got)
+	}
+}
+
+// A missing handoff is "no handoff yet", not an error — the first dispatch of a
+// session has none, and treating that as a failure would break every cold start.
+func TestLoad_MissingFileIsNilNilNotAnError(t *testing.T) {
+	h, err := Load(filepath.Join(t.TempDir(), "never-written.json"))
+	if err != nil {
+		t.Fatalf("a missing handoff errored: %v", err)
+	}
+	if h != nil {
+		t.Errorf("a missing handoff returned %+v", h)
+	}
+}
+
+func TestLoad_MalformedJSONIsAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Error("malformed handoff JSON loaded without error")
+	}
+}
+
+// A handoff carries the prior agent's context and file list. An unwritable
+// destination must surface, not be swallowed — the next agent would otherwise
+// run with no context and no indication why.
+func TestSave_UnwritableDestinationIsAnError(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nope", "deeper")
+	// Parent does not exist and is not creatable as a file path component.
+	path := filepath.Join(dir, "x", "handoff.json")
+	if err := os.WriteFile(filepath.Dir(dir), []byte("i am a file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Handoff{From: "a", Task: "t"}).Save(path); err == nil {
+		t.Error("saving under a path blocked by a regular file reported success")
+	}
+}
+
+func TestSaveLoad_RoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "handoff.json")
+	want := &Handoff{
+		From:    "agent-a",
+		Task:    "add pagination",
+		Files:   []string{"/a/b.go", "/a/c.go"},
+		Context: "the repo uses cobra",
+		Clock:   Clock{"agent-a": 3},
+	}
+	if err := want.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("round trip lost the handoff entirely")
+	}
+	if got.From != want.From || got.Task != want.Task {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+	if len(got.Files) != 2 || got.Clock["agent-a"] != 3 {
+		t.Errorf("files/clock lost in the round trip: %+v", got)
+	}
+}
+
+// ConflictsWith is the whole point of the vector clock: two agents that ran
+// concurrently AND touched the same file may have clobbered each other.
+func TestConflictsWith_RequiresBothConcurrencyAndFileOverlap(t *testing.T) {
+	base := &Handoff{From: "a", Files: []string{"/x.go"}, Clock: Clock{"a": 1}}
+
+	cases := []struct {
+		name string
+		//nolint:govet // field order is for readability here
+		other *Handoff
+		want  bool
+	}{
+		{
+			name:  "concurrent and overlapping",
+			other: &Handoff{From: "b", Files: []string{"/x.go"}, Clock: Clock{"b": 1}},
+			want:  true,
+		},
+		{
+			name:  "concurrent but disjoint files",
+			other: &Handoff{From: "b", Files: []string{"/y.go"}, Clock: Clock{"b": 1}},
+			want:  false,
+		},
+		{
+			name:  "causally after, same file",
+			other: &Handoff{From: "b", Files: []string{"/x.go"}, Clock: Clock{"a": 1, "b": 1}},
+			want:  false,
+		},
+		{
+			name:  "no files at all",
+			other: &Handoff{From: "b", Clock: Clock{"b": 1}},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := base.ConflictsWith(tc.other); got != tc.want {
+				t.Errorf("ConflictsWith = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A nil counterpart must not panic — Load returns nil for a first run, and
+// callers pass that straight through.
+func TestConflictsWith_NilIsNotAConflict(t *testing.T) {
+	h := &Handoff{From: "a", Files: []string{"/x.go"}, Clock: Clock{"a": 1}}
+	if h.ConflictsWith(nil) {
+		t.Error("a nil counterpart was reported as a conflict")
+	}
+}

--- a/internal/budget/coverage_test.go
+++ b/internal/budget/coverage_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+
+package budget
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Mode.String labels the governor band shown in `hyctl status`. An unlabelled
+// or mislabelled band tells the user the wrong thing about whether to compact.
+func TestMode_StringCoversEveryBand(t *testing.T) {
+	want := map[Mode]string{
+		ModeNormal:    "normal",
+		ModeCompact:   "compact",
+		ModeCaution:   "caution",
+		ModeWarning:   "warning",
+		ModeCritical:  "critical",
+		ModeEmergency: "emergency",
+	}
+	seen := map[string]bool{}
+	for m, s := range want {
+		got := m.String()
+		if got != s {
+			t.Errorf("Mode(%d).String() = %q, want %q", int(m), got, s)
+		}
+		if seen[got] {
+			t.Errorf("two bands share the label %q — the user cannot tell them apart", got)
+		}
+		seen[got] = true
+	}
+	// An out-of-range mode must degrade to "normal" rather than print an empty
+	// string, which would render as a blank governor state.
+	if got := Mode(99).String(); got != "normal" {
+		t.Errorf("Mode(99).String() = %q, want normal", got)
+	}
+}
+
+// LoadWindows resolves each model's context window; a missing or unusable
+// registry must yield an empty map, never a nil map a caller would panic on.
+func TestLoadWindows_DegradesToAnEmptyMap(t *testing.T) {
+	dir := t.TempDir()
+
+	// No registry on disk at all → the embedded copy is used, which must parse.
+	if got := LoadWindows(dir); got == nil {
+		t.Fatal("LoadWindows returned a nil map")
+	}
+
+	// A malformed on-disk registry must not panic or return nil.
+	reg := filepath.Join(dir, "registry")
+	if err := os.MkdirAll(reg, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(reg, "models.yaml"), []byte("models: [oops"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := LoadWindows(dir)
+	if got == nil {
+		t.Fatal("malformed models.yaml returned a nil map")
+	}
+	if len(got) != 0 {
+		t.Errorf("malformed models.yaml produced %d windows", len(got))
+	}
+}
+
+func TestLoadWindows_EmbeddedRegistryHasUsableWindows(t *testing.T) {
+	got := LoadWindows("")
+	if len(got) == 0 {
+		t.Fatal("no context windows from the embedded registry — the governor " +
+			"cannot compute a percentage without them")
+	}
+	for id, w := range got {
+		if w <= 0 {
+			t.Errorf("%s has a context window of %d; a zero window makes claude_pct "+
+				"divide by zero or report 0%% forever", id, w)
+		}
+	}
+}
+
+// LoadWindows skips entries with no id, and supplies a fallback window for
+// ollama models that declare none.
+func TestLoadWindows_SkipsUnusableEntriesAndFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	reg := filepath.Join(dir, "registry")
+	if err := os.MkdirAll(reg, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := `
+models:
+  - {id: "",        provider: openai, context_window: 100}
+  - {id: has-win,   provider: openai, context_window: 4096}
+  - {id: ollama-no-win, provider: ollama}
+`
+	if err := os.WriteFile(filepath.Join(reg, "models.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := LoadWindows(dir)
+	if _, ok := got[""]; ok {
+		t.Error("an entry with no id produced a window keyed on the empty string")
+	}
+	if got["has-win"] != 4096 {
+		t.Errorf("has-win = %d, want 4096", got["has-win"])
+	}
+	if got["ollama-no-win"] <= 0 {
+		t.Errorf("an ollama model with no declared window got %d; it needs a fallback "+
+			"or the governor divides by zero", got["ollama-no-win"])
+	}
+}
+
+// logNormCDF returns the LOG of the standard normal CDF, not the CDF — the
+// name says so and I read it as the latter first. It is computed in log space
+// precisely so the deep tail stays finite instead of underflowing to zero,
+// which is what would make the governor's risk estimate collapse to "no risk"
+// exactly when the estimate matters least and the arithmetic is hardest.
+//
+// The contract, then: monotonically increasing, never positive (a log of a
+// probability), and finite even a billion sigma out.
+func TestLogNormCDF_IsAWellFormedLogCDF(t *testing.T) {
+	prev := math.Inf(-1)
+	for _, x := range []float64{-1e9, -100, -3, -1, 0, 1, 3, 100, 1e9} {
+		got := logNormCDF(x)
+		if math.IsNaN(got) || math.IsInf(got, 0) {
+			t.Fatalf("logNormCDF(%v) = %v — the log-space form exists to keep this finite", x, got)
+		}
+		if got > 0 {
+			t.Errorf("logNormCDF(%v) = %v; a log-probability cannot be positive", x, got)
+		}
+		if got < prev {
+			t.Errorf("not monotonic: logNormCDF returned %v after %v", got, prev)
+		}
+		prev = got
+	}
+	// exp(logNormCDF(0)) must be Φ(0) = 0.5.
+	if mid := math.Exp(logNormCDF(0)); mid < 0.49 || mid > 0.51 {
+		t.Errorf("exp(logNormCDF(0)) = %v, want ~0.5", mid)
+	}
+	// …and the far tail must be a very small probability, not zero.
+	if tail := math.Exp(logNormCDF(-10)); tail <= 0 || tail > 1e-20 {
+		t.Errorf("exp(logNormCDF(-10)) = %v, want a tiny positive probability", tail)
+	}
+}
+
+// FirstPassageProb estimates the chance of crossing the ceiling. Degenerate
+// inputs must produce a usable probability rather than NaN, which would render
+// as "NaN%" in hyctl status.
+func TestFirstPassageProb_DegenerateInputsStayFinite(t *testing.T) {
+	cases := []struct{ cur, rate, ceil, horizon float64 }{
+		{0, 0, 80, 60},
+		{80, 0, 80, 60},
+		{90, 5, 80, 60},  // already past the ceiling
+		{10, -5, 80, 60}, // shrinking
+		{50, 1, 50, 0},   // no horizon
+		{50, 1, 0, 60},   // zero ceiling
+	}
+	for _, c := range cases {
+		got := FirstPassageProb(c.cur, c.rate, c.ceil, c.horizon)
+		if math.IsNaN(got) || math.IsInf(got, 0) {
+			t.Errorf("FirstPassageProb(%v, %v, %v, %v) = %v", c.cur, c.rate, c.ceil, c.horizon, got)
+		}
+		if got < 0 || got > 1 {
+			t.Errorf("FirstPassageProb(%v, %v, %v, %v) = %v, outside [0,1]",
+				c.cur, c.rate, c.ceil, c.horizon, got)
+		}
+	}
+}

--- a/internal/entropy/coverage_test.go
+++ b/internal/entropy/coverage_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+
+package entropy
+
+import (
+	"strings"
+	"testing"
+)
+
+// SignalDensity is a gzip-ratio proxy for how much of a context window is
+// actually information. The compaction governor divides by it, so a zero or a
+// value outside (0,1] would either divide by zero or claim a window holds more
+// useful tokens than it has characters.
+func TestSignalDensity_StaysInRangeForEveryShape(t *testing.T) {
+	cases := []struct{ name, in string }{
+		{"empty", ""},
+		{"single char", "x"},
+		{"shorter than the gzip header", "ab"},
+		{"highly repetitive", strings.Repeat("a", 10000)},
+		{"random-ish prose", "The quick brown fox jumps over the lazy dog, repeatedly and with feeling."},
+		{"source code", "func main() {\n\tfmt.Println(\"hi\")\n}\n"},
+		{"binary-ish", string([]byte{0, 1, 2, 3, 255, 254, 253})},
+		{"unicode", "日本語のテキストです。これは圧縮のテストです。"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SignalDensity(tc.in)
+			if tc.in == "" {
+				if got != 0 {
+					t.Errorf("SignalDensity(\"\") = %v, want 0", got)
+				}
+				return
+			}
+			if got <= 0 {
+				t.Errorf("SignalDensity = %v; the governor divides by this", got)
+			}
+			if got > 1 {
+				t.Errorf("SignalDensity = %v > 1 — that claims more useful tokens "+
+					"than there are characters", got)
+			}
+		})
+	}
+}
+
+// The whole premise: repetitive text is low-signal, varied text is high-signal.
+// If that ordering does not hold the metric measures nothing.
+func TestSignalDensity_RepetitiveTextScoresBelowVariedText(t *testing.T) {
+	repetitive := strings.Repeat("the same line over and over\n", 200)
+	varied := ""
+	for i := 0; i < 200; i++ {
+		varied += "line " + strings.Repeat("x", i%37) + " unique-ish content here\n"
+	}
+
+	lo, hi := SignalDensity(repetitive), SignalDensity(varied)
+	if lo >= hi {
+		t.Errorf("repetitive text scored %v and varied text %v — the metric does not "+
+			"distinguish signal from repetition", lo, hi)
+	}
+}
+
+// Tiny inputs are the edge the gzip header overhead exists for: without the
+// subtraction they compress "larger" than the input and score above 1.
+func TestSignalDensity_TinyInputsAreNotScoredAboveOne(t *testing.T) {
+	for _, s := range []string{"a", "ab", "abc", "abcd", "hello"} {
+		if got := SignalDensity(s); got > 1 {
+			t.Errorf("SignalDensity(%q) = %v > 1 — the gzip header overhead is not "+
+				"being subtracted", s, got)
+		}
+	}
+}

--- a/internal/graph/coverage_test.go
+++ b/internal/graph/coverage_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+
+package graph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultPath_IsGraphJSONAtTheRepoRoot(t *testing.T) {
+	root := filepath.Join("a", "b")
+	if got, want := DefaultPath(root), filepath.Join(root, "graph.json"); got != want {
+		t.Errorf("DefaultPath(%q) = %q, want %q", root, got, want)
+	}
+}
+
+// Load's degradation is deliberate and load-bearing: a missing graph must yield
+// an empty graph and no error, so blast-radius queries fall back to 1.0 rather
+// than failing a dispatch. Callers tell the default from a measurement with
+// Empty/Knows (#251).
+func TestLoad_MissingFileIsAnEmptyGraphNotAnError(t *testing.T) {
+	g, err := Load(filepath.Join(t.TempDir(), "absent.json"))
+	if err != nil {
+		t.Fatalf("a missing graph errored: %v", err)
+	}
+	if g == nil {
+		t.Fatal("Load returned a nil graph")
+	}
+	if !g.Empty() {
+		t.Error("a missing graph did not report Empty()")
+	}
+	if g.BlastRadiusForFile("anything.go") != 1.0 {
+		t.Error("a missing graph did not degrade to a blast radius of 1.0")
+	}
+}
+
+// Malformed JSON is different: the file exists and says something we cannot
+// read, which is a problem the operator needs told about rather than silently
+// treated as "no dependencies".
+func TestLoad_MalformedJSONIsAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Error("malformed graph.json loaded without error — it would be " +
+			"indistinguishable from a codebase with no dependencies")
+	}
+}
+
+func TestLoad_ReadsNodesAndEdges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.json")
+	body := `{"nodes":[{"id":"a","file":"a.go"},{"id":"b","file":"b.go"}],
+	          "edges":[{"from":"b","to":"a"}]}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.Empty() {
+		t.Fatal("a graph with two nodes reported Empty()")
+	}
+	if !g.Knows("a.go") {
+		t.Error("Knows(a.go) = false for a file the graph declares")
+	}
+	if g.Knows("nowhere.go") {
+		t.Error("Knows returned true for a file the graph does not contain")
+	}
+	// b depends on a, so changing a breaks b.
+	if got := g.DependentCount("a"); got != 1 {
+		t.Errorf("DependentCount(a) = %d, want 1", got)
+	}
+	if got := g.DependentCount("b"); got != 0 {
+		t.Errorf("DependentCount(b) = %d, want 0 — nothing depends on a leaf", got)
+	}
+}
+
+// Kappa and the percolation factor must be well-defined on the degenerate
+// graphs, since those are what a fresh repo and a missing file produce.
+func TestKappaAndPercolation_OnDegenerateGraphs(t *testing.T) {
+	var nilGraph *Graph
+	if got := nilGraph.Kappa(); got != 0 {
+		t.Errorf("nil graph Kappa = %v, want 0", got)
+	}
+	if nilGraph.Percolates() {
+		t.Error("a nil graph reported as cascade-capable")
+	}
+	if got := nilGraph.PercolationFactor("x.go"); got != 1.0 {
+		t.Errorf("nil graph PercolationFactor = %v, want 1.0", got)
+	}
+
+	empty := &Graph{}
+	if got := empty.Kappa(); got != 0 {
+		t.Errorf("empty graph Kappa = %v, want 0", got)
+	}
+	if got := empty.PercolationFactor("x.go"); got != 1.0 {
+		t.Errorf("empty graph PercolationFactor = %v, want 1.0", got)
+	}
+	if !empty.Empty() {
+		t.Error("the zero-value Graph did not report Empty()")
+	}
+}
+
+// A subcritical graph must never lift a file's blast radius: the factor exists
+// to weight hubs inside a cascade-capable core, and there is no such core when
+// κ < 2.
+func TestPercolationFactor_SubcriticalGraphNeverLifts(t *testing.T) {
+	// A path: a → b → c. Sparse, so κ stays below 2.
+	g := fromDoc(Doc{
+		Nodes: []Node{{ID: "a", File: "a.go"}, {ID: "b", File: "b.go"}, {ID: "c", File: "c.go"}},
+		Edges: []Edge{{From: "b", To: "a"}, {From: "c", To: "b"}},
+	})
+	if g.Percolates() {
+		t.Skip("this fixture percolates; the subcritical branch needs a sparser graph")
+	}
+	for _, f := range []string{"a.go", "b.go", "c.go"} {
+		if got := g.PercolationFactor(f); got != 1.0 {
+			t.Errorf("PercolationFactor(%s) = %v in a subcritical graph, want 1.0", f, got)
+		}
+	}
+}
+
+// Nodes and edges may name things the other does not. Neither may panic, and
+// an edge endpoint with no node declaration must still count toward degree —
+// otherwise κ is computed over a graph that is not the one on disk.
+func TestFromDoc_HandlesUndeclaredEndpointsAndIsolatedNodes(t *testing.T) {
+	g := fromDoc(Doc{
+		Nodes: []Node{{ID: "isolated", File: "iso.go"}},
+		Edges: []Edge{{From: "ghost-a", To: "ghost-b"}},
+	})
+	if g.Empty() {
+		t.Fatal("a graph with a node and an edge reported Empty()")
+	}
+	// The isolated node drags the mean degree down, as it should.
+	if got := g.DependentCount("isolated"); got != 0 {
+		t.Errorf("an isolated node has %d dependents", got)
+	}
+	if got := g.DependentCount("ghost-b"); got != 1 {
+		t.Errorf("an undeclared edge endpoint has %d dependents, want 1", got)
+	}
+}
+
+// Coupling drives the optimal parallel-agent count. Disjoint files must yield
+// the low bound and identical files the high one, or `graph parallel` advises
+// the wrong fan-out.
+func TestCoupling_BoundsAndDegenerateInputs(t *testing.T) {
+	g := fromDoc(Doc{
+		Nodes: []Node{{ID: "a", File: "a.go"}, {ID: "b", File: "b.go"}, {ID: "shared", File: "shared.go"}},
+		Edges: []Edge{{From: "a", To: "shared"}, {From: "b", To: "shared"}},
+	})
+
+	if got := g.Coupling(nil); got != kMin {
+		t.Errorf("Coupling(nil) = %v, want kMin", got)
+	}
+	if got := g.Coupling([]string{"a.go"}); got != kMin {
+		t.Errorf("Coupling of one file = %v, want kMin", got)
+	}
+
+	var nilGraph *Graph
+	if got := nilGraph.Coupling([]string{"a.go", "b.go"}); got != kMin {
+		t.Errorf("nil graph Coupling = %v, want kMin", got)
+	}
+
+	same := g.Coupling([]string{"shared.go", "shared.go"})
+	disjoint := g.Coupling([]string{"a.go", "b.go"})
+	if same < disjoint {
+		t.Errorf("identical files coupled %v, less than disjoint files at %v — "+
+			"parallelism advice would be inverted", same, disjoint)
+	}
+	for _, c := range []float64{same, disjoint} {
+		if c < kMin || c > kMax {
+			t.Errorf("coupling %v outside [%v, %v]", c, kMin, kMax)
+		}
+	}
+}
+
+// A file the graph does not know yields the neutral blast radius — and the
+// caller can tell that apart with Knows, which is the #251 distinction.
+func TestBlastRadiusForFile_UnknownFileIsNeutralButKnowable(t *testing.T) {
+	g := fromDoc(Doc{Nodes: []Node{{ID: "a", File: "a.go"}}})
+
+	if got := g.BlastRadiusForFile("unknown.go"); got != 1.0 {
+		t.Errorf("unknown file blast radius = %v, want 1.0", got)
+	}
+	if g.Knows("unknown.go") {
+		t.Error("Knows returned true for an unknown file — a caller could not tell " +
+			"the 1.0 default from a measured leaf")
+	}
+	if !g.Knows("a.go") {
+		t.Error("Knows returned false for a declared file")
+	}
+}
+
+func TestNodesInFileAndDependents_NilSafe(t *testing.T) {
+	var g *Graph
+	if got := g.NodesInFile("x.go"); got != nil {
+		t.Errorf("nil graph NodesInFile = %v", got)
+	}
+	if got := g.Dependents("x"); got != nil {
+		t.Errorf("nil graph Dependents = %v", got)
+	}
+	if !g.Empty() {
+		t.Error("nil graph did not report Empty()")
+	}
+	if g.Knows("x.go") {
+		t.Error("nil graph claimed to know a file")
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -280,7 +280,18 @@ func (g *Graph) Coupling(files []string) float64 {
 	if pairs > 0 {
 		overlap = sum / float64(pairs)
 	}
-	return kMin + overlap*(kMax-kMin)
+	// Clamped because the interpolation overshoots on exact overlap:
+	// 0.02 + 1×0.28 evaluates to 0.30000000000000004, four ulps above kMax. The
+	// excess is numerically irrelevant to n*, but the documented range is either
+	// true or it is not, and a caller is entitled to rely on it.
+	k := kMin + overlap*(kMax-kMin)
+	if k > kMax {
+		return kMax
+	}
+	if k < kMin {
+		return kMin
+	}
+	return k
 }
 
 // affectedSet is a file's own nodes plus everything that transitively depends on

--- a/internal/runlog/coverage_test.go
+++ b/internal/runlog/coverage_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+
+package runlog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunID_IsTheLogsOwnIdentity(t *testing.T) {
+	tempHome(t)
+	l := New("20260804T120000Z-abc")
+	if got := l.RunID(); got != "20260804T120000Z-abc" {
+		t.Errorf("RunID() = %q, want the id the log was created with", got)
+	}
+}
+
+// A log under an unwritable directory must surface, not vanish. Appends are
+// best-effort at the call sites, but the function itself has to report failure
+// or nobody can ever discover the run log is not being written.
+func TestAppend_UnwritablePathIsAnError(t *testing.T) {
+	home := tempHome(t)
+	// Put a regular file where the runs directory needs to be.
+	logsDir := filepath.Join(home, ".hydra", "logs")
+	if err := os.MkdirAll(logsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logsDir, "runs"), []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := New("blocked").Append(Event{Kind: KindRunStarted}); err == nil {
+		t.Error("appending under a blocked path reported success")
+	}
+}
+
+// A run with no log is "nothing happened yet", not a failure — the tree view
+// asks for runs that may never have emitted.
+func TestLoad_MissingRunIsEmptyNotAnError(t *testing.T) {
+	tempHome(t)
+	events, err := Load("never-ran")
+	if err != nil {
+		t.Fatalf("loading an absent run errored: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("got %d events for a run that never emitted", len(events))
+	}
+}
+
+// A truncated final line is what a crash mid-append leaves. It must not
+// discard the events before it.
+func TestLoad_SkipsMalformedLinesAndKeepsTheRest(t *testing.T) {
+	home := tempHome(t)
+	l := New("partial")
+	if err := l.Append(Event{Kind: KindRunStarted, Agent: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Append(Event{Kind: KindTaskStarted, Agent: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a crash mid-write.
+	path := filepath.Join(home, ".hydra", "logs", "runs", "partial.jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"kind":"trunc`); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	events, err := Load(l.RunID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want the 2 complete ones", len(events))
+	}
+	if events[0].Agent != "a" || events[1].Agent != "b" {
+		t.Errorf("events out of order: %+v", events)
+	}
+}
+
+// Sequence numbers are the total order — wall-clock ties and out-of-order
+// timestamps are expected from concurrent goroutines, so position is what
+// orders a run.
+func TestAppend_AssignsMonotonicSequenceNumbers(t *testing.T) {
+	tempHome(t)
+	l := New("seq")
+	for i := 0; i < 5; i++ {
+		if err := l.Append(Event{Kind: KindTaskStarted}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	events, err := Load(l.RunID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i < len(events); i++ {
+		if events[i].Seq <= events[i-1].Seq {
+			t.Errorf("event %d has seq %d, not above the previous %d",
+				i, events[i].Seq, events[i-1].Seq)
+		}
+	}
+}
+
+// SaveEdit refuses a ref that could address a file outside the run directory.
+// The ref comes from event data, which anything sharing the run id can write.
+func TestSaveEdit_RejectsEveryTraversalShape(t *testing.T) {
+	tempHome(t)
+	for _, ref := range []string{
+		"../escape", "a/b", `a\b`, "..", "", "sub/../../x", "./x", "/abs",
+	} {
+		if err := SaveEdit("r", ref, []byte("x"), []byte("y")); err == nil {
+			t.Errorf("SaveEdit accepted ref %q", ref)
+		}
+	}
+}
+
+func TestLoadEdit_UnreadableSnapshotIsAnError(t *testing.T) {
+	home := tempHome(t)
+	if err := SaveEdit("r", "001", []byte("before"), []byte("after")); err != nil {
+		t.Fatal(err)
+	}
+	// Replace the .before file with a directory so the read fails.
+	p := filepath.Join(home, ".hydra", "logs", "runs", "r.edits", "001.before")
+	if err := os.Remove(p); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(p, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadEdit("r", "001"); err == nil {
+		t.Error("an unreadable snapshot loaded without error")
+	}
+}
+
+// LiveRuns lists runs with a fresh heartbeat. A directory that is not a run
+// log, or a marker for a run with no events, must not crash it.
+func TestLiveRuns_IgnoresUnrelatedEntries(t *testing.T) {
+	home := tempHome(t)
+	dir := filepath.Join(home, ".hydra", "logs", "runs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Junk that is not a run log.
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hi"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "a-directory"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	live, err := LiveRuns()
+	if err != nil {
+		t.Fatalf("LiveRuns errored on unrelated entries: %v", err)
+	}
+	for _, id := range live {
+		if strings.Contains(id, "notes") || strings.Contains(id, "a-directory") {
+			t.Errorf("LiveRuns returned a non-run entry: %q", id)
+		}
+	}
+}
+
+// touch must create the marker when it does not exist and refresh it when it
+// does — both halves, since the create path only runs once per run.
+func TestHeartbeatTouch_CreatesThenRefreshes(t *testing.T) {
+	tempHome(t)
+	h := &Heartbeat{path: HeartbeatPath("touch-test"), interval: time.Millisecond}
+
+	if _, err := os.Stat(h.path); !os.IsNotExist(err) {
+		t.Fatal("marker existed before the first touch")
+	}
+	h.touch()
+	if _, err := os.Stat(h.path); err != nil {
+		t.Fatalf("first touch did not create the marker: %v", err)
+	}
+	// Second touch takes the Chtimes path rather than the create path.
+	h.touch()
+	if _, err := os.Stat(h.path); err != nil {
+		t.Fatalf("second touch removed the marker: %v", err)
+	}
+}

--- a/internal/trust/coverage_test.go
+++ b/internal/trust/coverage_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT
+
+package trust
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultPaths_LiveUnderTheUsersHydraDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	for name, got := range map[string]string{
+		"calibration.jsonl": DefaultPath(),
+		"trust.jsonl":       DefaultLogPath(),
+	} {
+		want := filepath.Join(home, ".hydra", name)
+		if got != want {
+			t.Errorf("path for %s = %q, want %q", name, got, want)
+		}
+	}
+	// The two must not collide — one is the training record, the other the run
+	// ledger, and merging them would corrupt both.
+	if DefaultPath() == DefaultLogPath() {
+		t.Error("calibration and run-log paths are the same file")
+	}
+}
+
+func TestDecision_StringCoversBothOutcomes(t *testing.T) {
+	if got := DecisionAccept.String(); got != "accept" {
+		t.Errorf("DecisionAccept.String() = %q", got)
+	}
+	// Anything else is the budget-exhausted outcome, which must be labelled
+	// distinctly — "we ran out of samples" is not "we are confident".
+	other := Decision(99)
+	if got := other.String(); got != "stopped_on_budget" {
+		t.Errorf("Decision(99).String() = %q, want stopped_on_budget", got)
+	}
+	if DecisionAccept.String() == other.String() {
+		t.Error("accept and budget-exhausted render identically")
+	}
+}
+
+// clamp01 keeps probabilities off 0 and 1 so the log-odds stay finite. Without
+// it a perfectly-calibrated source produces ±Inf and the whole LLR ledger
+// becomes NaN.
+func TestClamp01_KeepsLogOddsFinite(t *testing.T) {
+	for _, p := range []float64{-1, 0, 1e-12, 0.5, 1 - 1e-12, 1, 2} {
+		got := clamp01(p)
+		if got <= 0 || got >= 1 {
+			t.Errorf("clamp01(%v) = %v, not strictly inside (0,1)", p, got)
+		}
+		odds := math.Log(got / (1 - got))
+		if math.IsInf(odds, 0) || math.IsNaN(odds) {
+			t.Errorf("clamp01(%v) = %v gives a non-finite log-odds %v", p, got, odds)
+		}
+	}
+	// Values already inside the range pass through unchanged.
+	if got := clamp01(0.42); got != 0.42 {
+		t.Errorf("clamp01(0.42) = %v, want it untouched", got)
+	}
+}
+
+// A calibration store with no file is a first run, not a failure.
+func TestNew_MissingCalibrationFileIsAFreshStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.jsonl")
+
+	c, err := New(path)
+	if err != nil {
+		t.Fatalf("a missing calibration file errored: %v", err)
+	}
+	if c == nil {
+		t.Fatal("New returned nil for a missing file")
+	}
+	// An unseen source falls back to the prior rather than claiming knowledge.
+	llr := c.LLR("never-seen-source", "go", true)
+	if math.IsNaN(llr) || math.IsInf(llr, 0) {
+		t.Errorf("an unseen source produced a non-finite LLR: %v", llr)
+	}
+}
+
+// Malformed lines must be skipped, not abort the load — the file is appended to
+// by concurrent runs and a crash can truncate the last record.
+func TestNew_SkipsMalformedRecords(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cal.jsonl")
+	// outcome is an int on the wire, not a label — writing "correct" there makes
+	// the whole line fail to unmarshal and be skipped as malformed, which is how
+	// the first version of this fixture silently tested nothing.
+	good := `{"ts":"2026-08-01T00:00:00Z","source":"model:a","domain":"go","said_correct":true,"outcome":1}`
+	body := strings.Join([]string{
+		good,
+		`{not json`,
+		``,
+		good,
+		`{"ts":"trunc`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := New(path)
+	if err != nil {
+		t.Fatalf("malformed records aborted the load: %v", err)
+	}
+	// The two good records must have registered.
+	if llr := c.LLR("model:a", "go", true); llr == 0 {
+		t.Error("the well-formed records did not contribute any evidence")
+	}
+}
+
+// Record appends to the store and to disk; the next load must see it, or
+// calibration silently never accumulates.
+func TestRecord_PersistsAcrossReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cal.jsonl")
+
+	c, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := c.Update("model:x", "go", true, OutcomeCorrect); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before := c.LLR("model:x", "go", true)
+
+	reloaded, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := reloaded.LLR("model:x", "go", true)
+
+	if math.Abs(before-after) > 1e-9 {
+		t.Errorf("LLR was %v in memory and %v after reload — records are not "+
+			"surviving the round trip", before, after)
+	}
+}
+
+func TestRecord_UnwritablePathIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocked, []byte("i am a file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := New(filepath.Join(blocked, "cal.jsonl"))
+	if err != nil {
+		// Constructing may already fail, which is also acceptable.
+		return
+	}
+	if err := c.Update("model:x", "go", true, OutcomeCorrect); err == nil {
+		t.Error("recording under a blocked path reported success — calibration " +
+			"would silently never accumulate")
+	}
+}
+
+// The run ledger is what `hyctl trust explain` reads. A missing file is an
+// empty history, not an error.
+func TestLoadRuns_MissingLedgerIsEmpty(t *testing.T) {
+	runs, err := LoadRuns(filepath.Join(t.TempDir(), "absent.jsonl"))
+	if err != nil {
+		t.Fatalf("a missing ledger errored: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("got %d runs from a missing ledger", len(runs))
+	}
+}
+
+func TestLogRunAndLoadRuns_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trust.jsonl")
+
+	want := RunLog{
+		TaskHash:   TaskHash("is this migration safe?"),
+		Domain:     "go",
+		TargetConf: 0.95,
+		FinalConf:  0.97,
+		Samples:    3,
+		Decision:   DecisionAccept.String(),
+	}
+	if err := LogRun(path, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadRuns(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d runs, want 1", len(got))
+	}
+	if got[0].TaskHash != want.TaskHash || got[0].Decision != want.Decision {
+		t.Errorf("round trip changed the record: %+v", got[0])
+	}
+}
+
+// TaskHash correlates a run with `hyctl trust explain <hash>`. It must be
+// stable for the same prompt and differ for different ones, or the correlation
+// is useless.
+func TestTaskHash_StableAndDiscriminating(t *testing.T) {
+	a := TaskHash("some prompt")
+	if a != TaskHash("some prompt") {
+		t.Error("TaskHash is not stable for the same prompt")
+	}
+	if a == TaskHash("a different prompt") {
+		t.Error("two different prompts hash the same")
+	}
+	if a == "" {
+		t.Error("TaskHash returned an empty string")
+	}
+}


### PR DESCRIPTION
First phase of #308 (90% everywhere).

| package | before | after |
|---|---|---|
| `a2a` | 85.9% | **97.2%** |
| `budget` | 89.9% | **96.9%** |
| `entropy` | 89.3% | **92.9%** |
| `graph` | 87.8% | **92.6%** |
| `trust` | 88.0% | **92.0%** |
| `runlog` | 87.2% | **90.4%** |

## What was uncovered

Almost entirely error paths, `String()` methods and degenerate inputs — which is exactly where a package quietly stops behaving. The tests state a contract rather than execute a line:

- every `Mode` and `Ordering` label is **distinct**, and an out-of-range value degrades to the conservative reading — a governor band or a causal relationship must never render blank
- `LoadWindows` returns an **empty map, not nil**, on a malformed registry (nil panics the caller that ranges it), and every embedded window is positive because a zero divides `claude_pct` by zero
- `logNormCDF` is finite a **billion sigma out** — which is the entire reason it works in log space
- `SignalDensity` stays in (0,1] for repetitive, binary and unicode input, and orders repetitive *below* varied, or the compaction governor divides by nothing meaningful
- `graph.Load` degrades to an empty graph for a **missing** file but **errors** on malformed JSON — "no graph" and "unreadable graph" must not look the same (#251)
- traversal refs, truncated final lines and blocked paths in `runlog`; `clamp01` keeps the LLR ledger off ±Inf

## One production fix

`Coupling` could return `0.30000000000000004` — four ulps above its documented `kMax`, because `0.02 + 1×0.28` does not land exactly. Numerically irrelevant to `n*`, but a documented range is either true or it is not. Clamped.

## Three of my own fixtures were wrong first

Each would have passed while testing nothing:

- **`logNormCDF` returns the log of the CDF**, not the CDF. Asserting `[0,1]` failed on correct behaviour — the name told me and I read past it.
- **trust's `outcome` is an int on the wire.** Writing `"correct"` made every line fail to unmarshal and be skipped as malformed, so the fixture exercised the skip path and nothing else — while passing.
- `a2a`'s `Clock` is a named type, not `map[string]int`.

```
go test ./... -race -count=1        green
vet clean on windows/amd64, linux/arm64
```

Part of #308.