### PR TITLE
test(coverage): Phase C — routing, spend, config and hardware sizing to 90%+

### DIFF
--- a/internal/config/config_failure_test.go
+++ b/internal/config/config_failure_test.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: MIT
+
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	. "github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// Save's failure paths matter more than its success path: a half-written
+// config.toml costs the user their whole setup, and litter left in ~/.hydra
+// accumulates silently on every collision.
+
+func TestSave_UnwritableConfigDirIsAnErrorNotSilentDataLoss(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	// ~/.hydra is a regular file, so MkdirAll cannot create the directory. This
+	// happens for real when a stray `hydra` file is written by a script.
+	if err := os.WriteFile(filepath.Join(s.Home, ".hydra"), []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Save(&Config{Cortex: "x"}); err == nil {
+		t.Error("Save reported success with an unusable config directory — the " +
+			"wizard would tell the user their setup was saved")
+	}
+	if Exists() {
+		t.Error("Exists() = true when the config could not be written")
+	}
+}
+
+func TestSave_FailedRenameLeavesNoTempFile(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if err := os.MkdirAll(Dir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A directory at config.toml's path: the rename cannot replace it. This
+	// stands in for the real case, which is Windows refusing a rename onto a
+	// file another hyctl process has open.
+	if err := os.MkdirAll(Path(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Save(&Config{Cortex: "x"}); err == nil {
+		t.Fatal("Save succeeded onto a directory")
+	}
+
+	entries, err := os.ReadDir(Dir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".config-") {
+			t.Errorf("temp file %s survived a failed rename; every collision would "+
+				"leave another one in ~/.hydra", e.Name())
+		}
+	}
+}
+
+func TestSave_ReadOnlyConfigDirIsAnError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not enforce a read-only directory mode for the owner")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+	testutil.NewSandbox(t)
+
+	if err := os.MkdirAll(Dir(), 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(Dir(), 0o700) })
+
+	if err := Save(&Config{Cortex: "x"}); err == nil {
+		t.Error("Save succeeded into a read-only ~/.hydra")
+	}
+}
+
+// ScriptHome decides where an on-disk registry override is read from. Getting
+// its precedence wrong means an operator's retuned routing.yaml is ignored, or
+// worse, a stale one next to the binary silently wins over their $HYDRA_HOME.
+
+func TestScriptHome_HydraHomeBeatsEverythingElse(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	// Plant a registry next to the test binary too, so the walk-up branch would
+	// hit if precedence were wrong.
+	planted := plantRegistryBesideBinary(t)
+
+	if got := ScriptHome(); got != s.HydraHome {
+		t.Errorf("ScriptHome() = %q, want $HYDRA_HOME %q (the walk-up found %q "+
+			"and took precedence)", got, s.HydraHome, planted)
+	}
+}
+
+func TestScriptHome_WalksUpToARepoCheckout(t *testing.T) {
+	testutil.NewSandbox(t)
+	t.Setenv("HYDRA_HOME", "")
+
+	planted := plantRegistryBesideBinary(t)
+
+	got := ScriptHome()
+	if got != planted {
+		t.Errorf("ScriptHome() = %q, want the checkout %q found by walking up from "+
+			"the binary — a dev build would read the embedded registry instead of "+
+			"the working tree's", got, planted)
+	}
+}
+
+func TestScriptHome_FallsBackToTheConfigDir(t *testing.T) {
+	testutil.NewSandbox(t)
+	t.Setenv("HYDRA_HOME", "")
+
+	// No $HYDRA_HOME and no registry above the binary: this is every installed
+	// binary. A miss here is normal — the embedded copy is what actually gets
+	// read (#238) — but the path returned must still be somewhere an operator
+	// can drop an override.
+	if got, want := ScriptHome(), Dir(); got != want {
+		t.Errorf("ScriptHome() = %q, want %q", got, want)
+	}
+}
+
+// A relative or untidy $HYDRA_HOME must be cleaned, or the same override
+// resolves to two different strings and the breadcrumb changes with it.
+func TestScriptHome_CleansThePath(t *testing.T) {
+	testutil.NewSandbox(t)
+	t.Setenv("HYDRA_HOME", "/tmp/hydra/../hydra/./registry-root/")
+
+	if got, want := ScriptHome(), filepath.Clean("/tmp/hydra/registry-root"); got != want {
+		t.Errorf("ScriptHome() = %q, want the cleaned %q", got, want)
+	}
+}
+
+// plantRegistryBesideBinary creates registry/routing.yaml next to the running
+// test binary, which is what ScriptHome's walk-up looks for, and removes it
+// afterwards.
+func plantRegistryBesideBinary(t *testing.T) string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("cannot locate the test binary: %v", err)
+	}
+	dir := filepath.Dir(exe)
+	regDir := filepath.Join(dir, "registry")
+	if _, err := os.Stat(filepath.Join(regDir, "routing.yaml")); err == nil {
+		return dir // already there (running from a checkout); nothing to plant
+	}
+	if err := os.MkdirAll(regDir, 0o700); err != nil {
+		t.Skipf("cannot write beside the test binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(regDir, "routing.yaml"), []byte("{}\n"), 0o600); err != nil {
+		t.Skipf("cannot write beside the test binary: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(regDir) })
+	return dir
+}
+
+// Breadcrumb ties a log entry to the routing rules in effect when it was
+// written. An error from it must propagate — a caller that logs an empty
+// fingerprint has recorded that the deployment is unidentifiable, which is
+// indistinguishable from a deployment with no registry.
+func TestBreadcrumb_MissingRegistryFileIsAnError(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	orig := BreadcrumbFiles
+	t.Cleanup(func() { BreadcrumbFiles = orig })
+	BreadcrumbFiles = []string{"routing.yaml", "not-a-registry-file.yaml"}
+
+	got, err := Breadcrumb()
+	if err == nil {
+		t.Errorf("Breadcrumb() = %q with an unreadable registry file, want an error", got)
+	}
+	if got != "" {
+		t.Errorf("Breadcrumb() = %q alongside an error; a partial fingerprint would "+
+			"be logged as if it identified the deployment", got)
+	}
+}

--- a/internal/cost/cost_log_test.go
+++ b/internal/cost/cost_log_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ankit373/hydra/internal/testutil"
 )
@@ -309,5 +310,318 @@ func TestRenderSummary_SubCentSpendIsNotShownAsZero(t *testing.T) {
 	if strings.Contains(out, "$0.00\n") && !strings.Contains(out, "0.0004") {
 		t.Logf("output:\n%s", out)
 		t.Error("a real sub-cent charge renders as $0.00 with no indication it was non-zero")
+	}
+}
+
+// Summary is what `hyctl cost` prints. It must separate today from all-time and
+// report the token-source split, since "estimated" spend must never be shown as
+// measured.
+func TestSummary_SeparatesTodayFromAllTimeAndLabelsTokenSource(t *testing.T) {
+	today := time.Now().UTC().Format(time.RFC3339)
+	old := time.Now().UTC().AddDate(0, 0, -30).Format(time.RFC3339)
+
+	fixture(t,
+		row(t, Row{TS: old, Model: "a", EstCostUSD: 1.00, PromptTokens: 100,
+			ResponseTokens: 50, TokensSource: "actual"}),
+		row(t, Row{TS: today, Model: "b", EstCostUSD: 0.25, PromptTokens: 20,
+			ResponseTokens: 10, TokensSource: "estimated"}),
+	)
+
+	res, err := Summary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AllTime.Calls != 2 {
+		t.Errorf("AllTime.Calls = %d, want 2", res.AllTime.Calls)
+	}
+	if res.Today.Calls != 1 {
+		t.Errorf("Today.Calls = %d, want just the row from today", res.Today.Calls)
+	}
+	if res.Today.EstCostUSD > res.AllTime.EstCostUSD {
+		t.Error("today's spend exceeds all-time spend")
+	}
+	// The split is what stops estimated tokens being presented as measured.
+	if res.ActualTokens == 0 || res.EstimatedTokens == 0 {
+		t.Errorf("token source split = %d actual / %d estimated; both rows should be "+
+			"counted and labelled", res.ActualTokens, res.EstimatedTokens)
+	}
+	if len(res.Recent) == 0 {
+		t.Error("Summary carries no recent rows to show")
+	}
+}
+
+// Today and All are the per-tier breakdown `hyctl cost` prints. Today must be a
+// subset of All, and both are sorted by spend so the expensive tier is first.
+func TestTodayAndAll_GroupByTier(t *testing.T) {
+	today := time.Now().UTC().Format(time.RFC3339)
+	old := time.Now().UTC().AddDate(0, 0, -10).Format(time.RFC3339)
+
+	fixture(t,
+		row(t, Row{TS: today, Tier: 3, Model: "m1", EstCostUSD: 0.10, PromptTokens: 1}),
+		row(t, Row{TS: today, Tier: 3, Model: "m1", EstCostUSD: 0.20, PromptTokens: 1}),
+		row(t, Row{TS: today, Tier: 8, Model: "m3", EstCostUSD: 0.90, PromptTokens: 1}),
+		row(t, Row{TS: old, Tier: 1, Model: "m2", EstCostUSD: 0.30, PromptTokens: 1}),
+	)
+
+	todayRows, err := Today()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(todayRows) != 2 {
+		t.Fatalf("Today() = %+v, want tiers 3 and 8 only (tier 1 is 10 days old)", todayRows)
+	}
+	// Sorted by spend descending — the expensive tier is what the user must see.
+	if todayRows[0].Key != "8" {
+		t.Errorf("Today()[0].Key = %q, want the costliest tier 8 first: %+v",
+			todayRows[0].Key, todayRows)
+	}
+	for _, g := range todayRows {
+		if g.Key == "3" && g.Calls != 2 {
+			t.Errorf("tier 3 has %d calls, want the 2 rows merged", g.Calls)
+		}
+	}
+
+	allRows, err := All()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(allRows) != 3 {
+		t.Errorf("All() = %+v, want all three tiers", allRows)
+	}
+
+	// ByPool labels rows with no pool rather than dropping them; an unlabelled
+	// row that vanished would understate spend.
+	pools, err := ByPool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pools) != 1 || pools[0].Key != "unknown" || pools[0].Calls != 4 {
+		t.Errorf("ByPool() = %+v, want all 4 rows under \"unknown\"", pools)
+	}
+}
+
+// JSON is the scripting surface; `--since` must filter on real timestamps
+// rather than string comparison, so timezone offsets behave.
+func TestJSON_FiltersBySinceUsingRealTimestamps(t *testing.T) {
+	fixture(t,
+		row(t, Row{TS: "2026-08-01T10:00:00Z", Model: "old", PromptTokens: 1}),
+		row(t, Row{TS: "2026-08-03T10:00:00+02:00", Model: "offset", PromptTokens: 1}),
+		row(t, Row{TS: "2026-08-05T10:00:00Z", Model: "new", PromptTokens: 1}),
+	)
+
+	all, err := JSON("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Errorf("JSON(\"\") returned %d rows, want all 3", len(all))
+	}
+
+	since, err := JSON("2026-08-02T00:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(since) != 2 {
+		t.Errorf("JSON(since) returned %d rows, want the 2 at or after it: %+v", len(since), since)
+	}
+
+	if _, err := JSON("not-a-timestamp"); err == nil {
+		t.Error("an unparsable --since was accepted; the user would silently get " +
+			"unfiltered output")
+	}
+}
+
+// FilterDays trims to the last N calendar days. n<=0 means "everything", which
+// is what an unset flag produces.
+func TestFilterDays_Windows(t *testing.T) {
+	now := time.Now().UTC()
+	rows := []Row{
+		{TS: now.Format(time.RFC3339)},
+		{TS: now.AddDate(0, 0, -2).Format(time.RFC3339)},
+		{TS: now.AddDate(0, 0, -40).Format(time.RFC3339)},
+		{TS: "unparsable"},
+	}
+	if got := len(FilterDays(rows, 0)); got != len(rows) {
+		t.Errorf("FilterDays(n=0) returned %d rows, want all %d", got, len(rows))
+	}
+	if got := len(FilterDays(rows, 7)); got > 3 {
+		t.Errorf("FilterDays(n=7) returned %d rows, want at most the recent ones", got)
+	}
+}
+
+// SwarmStats only counts swarm rows, and reports the winner rate as a fraction
+// — a rate above 1 would render as "150%".
+func TestSwarmStats_CountsOnlySwarmRowsAndBoundsTheRate(t *testing.T) {
+	rows := []Row{
+		{SwarmMode: "best", SwarmWinner: true, WallMS: 1000, EstCostUSD: 0.1},
+		{SwarmMode: "best", SwarmWinner: false, WallMS: 3000, EstCostUSD: 0.2},
+		{SwarmMode: "race", SwarmWinner: true, WallMS: 2000, EstCostUSD: 0.3},
+		{Model: "not-a-swarm-row", WallMS: 9999, EstCostUSD: 9.9},
+	}
+	got := SwarmStats(rows)
+
+	if got.Runs != 3 {
+		t.Errorf("Runs = %d, want the 3 swarm rows only", got.Runs)
+	}
+	if got.WinnerRate < 0 || got.WinnerRate > 1 {
+		t.Errorf("WinnerRate = %v, outside [0,1] — it renders as a percentage", got.WinnerRate)
+	}
+	if got.TotalCost > 1.0 {
+		t.Errorf("TotalCost = %v; the non-swarm row was included", got.TotalCost)
+	}
+	if got.ByMode["best"] != 2 || got.ByMode["race"] != 1 {
+		t.Errorf("ByMode = %v", got.ByMode)
+	}
+
+	// No swarm rows at all must be a zero summary, not a divide by zero.
+	empty := SwarmStats([]Row{{Model: "plain"}})
+	if empty.Runs != 0 || empty.WinnerRate != 0 {
+		t.Errorf("SwarmStats with no swarm rows = %+v", empty)
+	}
+}
+
+// ByRun / ByTask are how a caller asks "what did that one run cost me". A
+// missing id must be an error, not silently-zero spend.
+func TestByRunAndByTask_ScopeToOneIDAndErrorWhenAbsent(t *testing.T) {
+	ts := time.Now().UTC().Format(time.RFC3339)
+	fixture(t,
+		row(t, Row{TS: ts, RunID: "run-a", TaskID: "task-1", Tier: 1, EstCostUSD: 0.10, PromptTokens: 5}),
+		row(t, Row{TS: ts, RunID: "run-a", TaskID: "task-2", Tier: 8, EstCostUSD: 0.02, PromptTokens: 5}),
+		row(t, Row{TS: ts, RunID: "run-b", TaskID: "task-3", Tier: 1, EstCostUSD: 9.00, PromptTokens: 5}),
+	)
+
+	res, err := ByRun("run-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Totals.Calls != 2 {
+		t.Errorf("ByRun(run-a).Calls = %d, want 2 — run-b leaked in", res.Totals.Calls)
+	}
+	if res.Totals.EstCostUSD > 1.0 {
+		t.Errorf("ByRun(run-a) cost = %v; run-b's $9 was counted", res.Totals.EstCostUSD)
+	}
+	if len(res.ByTier) != 2 {
+		t.Errorf("ByRun(run-a).ByTier = %+v, want tiers 1 and 8", res.ByTier)
+	}
+
+	tot, err := ByTask("task-3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tot.Calls != 1 {
+		t.Errorf("ByTask(task-3).Calls = %d, want 1", tot.Calls)
+	}
+
+	if _, err := ByRun("nope"); err == nil {
+		t.Error("ByRun on an unknown run returned no error — a typo'd run id would " +
+			"report $0.00 spent")
+	}
+	if _, err := ByTask("nope"); err == nil {
+		t.Error("ByTask on an unknown task returned no error")
+	}
+}
+
+// ByModel and ByDay back `hyctl stats`. ByDay's key must be the calendar day
+// (not the full timestamp), or every call becomes its own "day".
+func TestByModelAndByDay_KeyOnModelAndCalendarDay(t *testing.T) {
+	rows := []Row{
+		{TS: "2026-08-01T01:00:00Z", Model: "sonnet", EstCostUSD: 0.10, PromptTokens: 1},
+		{TS: "2026-08-01T23:59:59Z", Model: "sonnet", EstCostUSD: 0.20, PromptTokens: 1},
+		{TS: "2026-08-02T01:00:00Z", Model: "", EstCostUSD: 0.05, PromptTokens: 1},
+		{TS: "bad", Model: "x"},
+	}
+
+	var sawUnknown bool
+	for _, g := range ByModel(rows) {
+		if g.Key == "sonnet" && g.Calls != 2 {
+			t.Errorf("sonnet grouped into %d calls, want 2", g.Calls)
+		}
+		if g.Key == "unknown" {
+			sawUnknown = true
+		}
+	}
+	if !sawUnknown {
+		t.Errorf("a row with no model was not labelled \"unknown\": %+v", ByModel(rows))
+	}
+
+	days := ByDay(rows)
+	if len(days) != 3 {
+		t.Fatalf("ByDay() = %+v, want two calendar days plus \"unknown\"", days)
+	}
+	// Ascending by date, unlike every other grouping — a chart drawn from this
+	// reads left-to-right in time.
+	for i := 1; i < len(days); i++ {
+		if days[i-1].Key > days[i].Key {
+			t.Errorf("ByDay is not sorted ascending: %+v", days)
+			break
+		}
+	}
+	if days[0].Key != "2026-08-01" {
+		t.Errorf("ByDay()[0].Key = %q, want the earliest day", days[0].Key)
+	}
+}
+
+// Tail is `hyctl cost --tail`: newest first, clamped to what exists.
+func TestTail_NewestFirstAndClamped(t *testing.T) {
+	fixture(t,
+		row(t, Row{TS: "2026-08-01T00:00:00Z", Model: "oldest", PromptTokens: 1}),
+		row(t, Row{TS: "2026-08-02T00:00:00Z", Model: "middle", PromptTokens: 1}),
+		row(t, Row{TS: "2026-08-03T00:00:00Z", Model: "newest", PromptTokens: 1}),
+	)
+
+	two, err := Tail(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(two) != 2 || two[0].Model != "newest" || two[1].Model != "middle" {
+		t.Errorf("Tail(2) = %+v, want newest first", two)
+	}
+
+	for _, n := range []int{0, -1, 999} {
+		all, err := Tail(n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(all) != 3 {
+			t.Errorf("Tail(%d) returned %d rows, want all 3 clamped", n, len(all))
+		}
+	}
+}
+
+// The rendered tables are the actual product surface. They must not panic on
+// empty input, must survive labels longer than the column, and must format
+// large numbers readably rather than as an unreadable digit run.
+func TestRenderers_HandleEmptyLongLabelsAndLargeNumbers(t *testing.T) {
+	// Empty input: a fresh install runs `hyctl stats` before anything dispatched.
+	_ = capture(t, func() { RenderStatsTable("today", nil) })
+	_ = capture(t, func() { RenderTail(nil) })
+
+	long := strings.Repeat("very-long-model-name-", 5)
+	out := capture(t, func() {
+		RenderStatsTable("all time", []GroupRow{
+			{Key: long, Calls: 1234567, PromptTokens: 9876543, ResponseTokens: 12, EstCostUSD: 12.5},
+			{Key: "short", Calls: 1, PromptTokens: 999, ResponseTokens: 0, EstCostUSD: 0.001},
+		})
+	})
+	if strings.Contains(out, long) {
+		t.Error("an over-long key was printed in full, breaking the column alignment")
+	}
+	if !strings.Contains(out, "1,234,567") {
+		t.Errorf("large counts are not comma-grouped:\n%s", out)
+	}
+	if !strings.Contains(out, "999") || strings.Contains(out, ",999") {
+		t.Errorf("a sub-1000 number was given a separator:\n%s", out)
+	}
+	if !strings.Contains(out, "Total") {
+		t.Errorf("no total row:\n%s", out)
+	}
+
+	// A row with no enum must still print something — "?" — rather than a gap
+	// that reads as a missing column.
+	tail := capture(t, func() {
+		RenderTail([]Row{{TS: "2026-08-01T00:00:00Z", Tier: 3, Model: "m", WallMS: 12}})
+	})
+	if !strings.Contains(tail, "?/3") {
+		t.Errorf("a row with no enum did not render a placeholder:\n%s", tail)
 	}
 }

--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -1,0 +1,577 @@
+// SPDX-License-Identifier: MIT
+
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/a2a"
+	"github.com/ankit373/hydra/internal/budget"
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/policy"
+	"github.com/ankit373/hydra/internal/pricing"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// A dispatch that actually succeeds is the path nothing else covers: it is
+// where the handoff, the budget book and state.json are written. A head backed
+// by a real (fake) CLI binary is the only way to reach it without a network or
+// an API key.
+func echoHead(t *testing.T, s *testutil.Sandbox, id string, capScore int) provider.Head {
+	t.Helper()
+	body := "#!/bin/sh\necho 'reviewed: looks fine'\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\necho reviewed: looks fine\r\n"
+	}
+	// Provider "openai" has a CLI template, so executor.For picks CLIExecutor
+	// and Unroutable accepts the head.
+	return provider.Head{
+		ID: id, Name: id, Provider: "openai", Source: "cli",
+		CapScore: capScore, AuthReady: true,
+		Executable: s.FakeBinary(t, "fake-head-"+id, body),
+	}
+}
+
+// liveDispatcher leaves pricing nil: estimateCost already returns 0 for that,
+// and pricing.Load() spawns a background OpenRouter fetch per call that logs a
+// connection failure into every test's output on a sandboxed machine.
+func liveDispatcher(heads ...provider.Head) *Dispatcher {
+	return &Dispatcher{
+		cfg:    &config.Config{},
+		heads:  heads,
+		policy: policy.New(policy.DefaultRules(false)),
+		budget: budget.NewRegistry(nil),
+	}
+}
+
+func readState(t *testing.T) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(config.Dir(), "logs", "state.json"))
+	if err != nil {
+		t.Fatalf("no state.json was written: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("state.json is not valid JSON: %v\n%s", err, raw)
+	}
+	return m
+}
+
+// The full success path: output returned, handoff written, state.json synced.
+// Each of these is read by a different surface (`hyctl status`, the next
+// agent's --a2a, the cockpit), so a silent failure in any one of them is only
+// visible here.
+func TestDispatch_SuccessWritesHandoffAndState(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	d := liveDispatcher(echoHead(t, s, "h1", 90))
+
+	res, err := d.Dispatch(context.Background(), "review this", Options{})
+	if err != nil {
+		t.Fatalf("dispatch failed against a working head: %v", err)
+	}
+	if !strings.Contains(res.Output, "looks fine") {
+		t.Errorf("Output = %q, want the head's output", res.Output)
+	}
+	if res.Head.ID != "h1" || res.Retries != 0 {
+		t.Errorf("Result = head %q after %d retries, want h1 on the first try",
+			res.Head.ID, res.Retries)
+	}
+
+	// last_handoff.json is what --a2a reads; a dispatch that does not write it
+	// breaks the chain silently.
+	h, err := a2a.Load(filepath.Join(config.Dir(), "logs", "last_handoff.json"))
+	if err != nil || h == nil {
+		t.Fatalf("no handoff was written: %v", err)
+	}
+	if h.Task != "review this" {
+		t.Errorf("handoff Task = %q, want the prompt", h.Task)
+	}
+	if !strings.Contains(h.PriorOutput, "looks fine") {
+		t.Errorf("handoff PriorOutput = %q, want the head's output", h.PriorOutput)
+	}
+	if len(h.Clock) == 0 {
+		t.Error("handoff carries no vector clock, so causal ordering is lost")
+	}
+
+	state := readState(t)
+	if state["last_model"] != "h1" {
+		t.Errorf("state.json last_model = %v, want h1", state["last_model"])
+	}
+	if state["last_status"] != "ok" {
+		t.Errorf("state.json last_status = %v, want ok", state["last_status"])
+	}
+}
+
+// The handoff's vector clock must advance across dispatches — that is what
+// makes a chain reconstructable rather than a sequence of unrelated files.
+func TestDispatch_HandoffClockAdvancesAcrossCalls(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	d := liveDispatcher(echoHead(t, s, "h1", 90))
+	path := filepath.Join(config.Dir(), "logs", "last_handoff.json")
+
+	if _, err := d.Dispatch(context.Background(), "first", Options{}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := a2a.Load(path)
+	if err != nil || first == nil {
+		t.Fatal(err)
+	}
+
+	if _, err := d.Dispatch(context.Background(), "second", Options{}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := a2a.Load(path)
+	if err != nil || second == nil {
+		t.Fatal(err)
+	}
+
+	if got := first.Clock.Compare(second.Clock); got != a2a.Before {
+		t.Errorf("clock %v vs %v = %v, want happens-before — the second dispatch did "+
+			"not inherit the first's history", first.Clock, second.Clock, got)
+	}
+}
+
+// A dry run must resolve the chain without executing anything.
+func TestDispatch_DryRunResolvesTheChainWithoutRunningIt(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	d := liveDispatcher(echoHead(t, s, "strong", 95), echoHead(t, s, "weak", 40))
+
+	res, err := d.Dispatch(context.Background(), "anything", Options{DryRun: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Output != "" {
+		t.Errorf("a dry run produced output %q — it executed a head", res.Output)
+	}
+	if res.Head.ID == "" {
+		t.Error("a dry run named no primary head")
+	}
+	if _, err := os.Stat(filepath.Join(config.Dir(), "logs", "last_handoff.json")); err == nil {
+		t.Error("a dry run wrote a handoff")
+	}
+}
+
+// Fallback: the first head fails, the next one answers, and Retries reports how
+// far down the chain the answer came from.
+func TestDispatch_FallsThroughToTheNextHead(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	failing := echoHead(t, s, "broken", 95)
+	failing.Executable = filepath.Join(s.BinDir, "does-not-exist")
+	working := echoHead(t, s, "ok", 90)
+
+	res, err := liveDispatcher(failing, working).Dispatch(context.Background(), "go", Options{})
+	if err != nil {
+		t.Fatalf("dispatch gave up instead of falling back: %v", err)
+	}
+	if res.Head.ID != "ok" {
+		t.Errorf("answered by %q, want the fallback head", res.Head.ID)
+	}
+	if res.Retries != 1 {
+		t.Errorf("Retries = %d, want 1 — the user is told how far the chain fell",
+			res.Retries)
+	}
+}
+
+// Every head failing must report the last error, not a generic one — that
+// error is the only diagnostic the user gets.
+func TestDispatch_AllHeadsFailingReportsWhy(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	broken := echoHead(t, s, "broken", 95)
+	broken.Executable = filepath.Join(s.BinDir, "does-not-exist")
+
+	_, err := liveDispatcher(broken).Dispatch(context.Background(), "go", Options{})
+	if err == nil {
+		t.Fatal("dispatch succeeded with a head that cannot run")
+	}
+	if !strings.Contains(err.Error(), "all heads failed") {
+		t.Errorf("error = %v, want it to say every head failed", err)
+	}
+}
+
+// PII in the prompt forces local-only routing. With no local head that must be
+// a refusal naming the cause, not a quiet escalation to a paid API head — the
+// whole point of the policy.
+func TestDispatch_PIIForcesLocalOnlyAndSaysSoWhenNothingIsLocal(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	dd := &Dispatcher{
+		cfg:    &config.Config{},
+		heads:  []provider.Head{echoHead(t, s, "cloud", 90)},
+		policy: policy.New(policy.DefaultRules(true)), // local-only PII rule armed
+		budget: budget.NewRegistry(nil),
+	}
+
+	_, err := dd.Dispatch(context.Background(), "my SSN is 123-45-6789", Options{})
+	if err == nil {
+		t.Fatal("a PII prompt was dispatched to a non-local head")
+	}
+	if !strings.Contains(err.Error(), "localOnly=true") {
+		t.Errorf("error = %v, want it to name local-only as the cause", err)
+	}
+}
+
+// A2A injection: the handoff's context must reach the prompt, and a missing or
+// corrupt handoff file must leave the prompt untouched rather than failing the
+// dispatch.
+func TestInjectA2A(t *testing.T) {
+	dir := t.TempDir()
+
+	h := a2a.Handoff{From: "agent-1", Task: "earlier task", PriorOutput: "earlier output"}
+	raw, err := json.Marshal(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "handoff.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := injectA2A(path, "new instruction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"agent-1", "earlier output", "new instruction", "ADDITIONAL INSTRUCTION"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("injected prompt is missing %q:\n%s", want, got)
+		}
+	}
+
+	// An absent file is "no handoff", not a failure: a2a.Load reports it as
+	// (nil, nil) and the prompt goes through untouched. That distinction is why
+	// a first dispatch with --a2a pointed at a not-yet-written file still runs.
+	got, err = injectA2A(filepath.Join(dir, "absent.json"), "unchanged")
+	if err != nil {
+		t.Errorf("a missing handoff file was an error: %v", err)
+	}
+	if got != "unchanged" {
+		t.Errorf("prompt = %q with no handoff, want it untouched", got)
+	}
+
+	if err := os.WriteFile(path, []byte("{truncated"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := injectA2A(path, "unchanged"); err == nil || got != "unchanged" {
+		t.Errorf("corrupt handoff = (%q, %v), want the prompt untouched and an error", got, err)
+	}
+}
+
+// A dispatch given --a2a must not be derailed by a broken handoff file.
+func TestDispatch_BrokenA2AFileDoesNotFailTheRun(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	dd := liveDispatcher(echoHead(t, s, "h1", 90))
+
+	res, err := dd.Dispatch(context.Background(), "work", Options{
+		A2AFile: filepath.Join(t.TempDir(), "nope.json"),
+	})
+	if err != nil {
+		t.Fatalf("an unreadable --a2a file failed the whole dispatch: %v", err)
+	}
+	if res.Output == "" {
+		t.Error("no output despite a working head")
+	}
+}
+
+// claudeMode is the token-preservation governor. Its whole purpose is to
+// downgrade before the orchestrator runs out, so each band's downgrade is
+// pinned — this table was inert for every non-numeric hint before #165.
+func TestClaudeMode_DowngradesByBand(t *testing.T) {
+	tests := []struct {
+		name     string
+		pct      int
+		hint     string
+		wantTier string
+		wantMode string
+	}{
+		{"normal leaves the tier alone", 10, "3", "3", "normal"},
+		{"compact band still does not downgrade", 55, "3", "3", "compact"},
+		{"caution band still does not downgrade", 66, "3", "3", "caution"},
+		{"warning downgrades one tier", 72, "3", "4", "warning"},
+		{"critical downgrades two", 77, "3", "5", "critical"},
+		{"emergency pins to the local tier", 85, "3", "10", "emergency"},
+		{"a downgrade cannot exceed tier 10", 77, "9", "10", "critical"},
+		{"a named tier survives the governor untouched", 72, "expert", "expert", "warning"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.NewSandbox(t)
+			writeStatePct(t, tt.pct, nil)
+
+			dd := liveDispatcher()
+			tier, mode, pct := dd.claudeMode(tt.hint)
+			if pct != tt.pct {
+				t.Errorf("pct = %d, want %d", pct, tt.pct)
+			}
+			if mode != tt.wantMode {
+				t.Errorf("mode = %q, want %q", mode, tt.wantMode)
+			}
+			if tier != tt.wantTier {
+				t.Errorf("tier = %q, want %q", tier, tt.wantTier)
+			}
+		})
+	}
+}
+
+// The governor is rate-aware: a fast burn escalates the mode above its static
+// level band, so the downgrade happens before the threshold is crossed rather
+// than after.
+func TestClaudeMode_FastBurnEscalatesAboveTheStaticBand(t *testing.T) {
+	testutil.NewSandbox(t)
+	// A steep trajectory ending at a level that is only "compact" statically.
+	writeStatePct(t, 60, []int{10, 25, 40, 52, 60})
+
+	dd := liveDispatcher()
+	_, fastMode, _ := dd.claudeMode("3")
+
+	testutil.NewSandbox(t)
+	writeStatePct(t, 60, []int{58, 59, 59, 60, 60}) // flat
+	_, slowMode, _ := dd.claudeMode("3")
+
+	if fastMode == slowMode {
+		t.Skipf("both trajectories yield %q; the risk model did not separate them", fastMode)
+	}
+	if slowMode != "compact" {
+		t.Errorf("a flat trajectory at 60%% = %q, want the static band \"compact\"", slowMode)
+	}
+}
+
+func TestReadClaudePct_MissingOrCorruptStateIsZeroNotAPanic(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if got := readClaudePct(); got != 0 {
+		t.Errorf("readClaudePct() = %d with no state.json, want 0", got)
+	}
+	if got := readClaudePctHistory(); got != nil {
+		t.Errorf("readClaudePctHistory() = %v with no state.json, want nil", got)
+	}
+
+	dir := filepath.Join(config.Dir(), "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("{truncated"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readClaudePct(); got != 0 {
+		t.Errorf("readClaudePct() = %d on corrupt state.json, want 0", got)
+	}
+	if got := readClaudePctHistory(); got != nil {
+		t.Errorf("readClaudePctHistory() = %v on corrupt state.json, want nil", got)
+	}
+}
+
+// state.json is read-modify-written by every dispatch. A successful run must
+// extend the claude_pct history rather than replacing the file, or the rate
+// signal the governor depends on is destroyed on every call.
+func TestSyncStateJSON_PreservesForeignKeysAndExtendsHistory(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	writeStatePct(t, 40, []int{20, 30})
+
+	// Add a key Hydra does not own; another writer's data must survive.
+	statePath := filepath.Join(config.Dir(), "logs", "state.json")
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	m["set_by_someone_else"] = "keep me"
+	raw, err = json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dd := liveDispatcher(echoHead(t, s, "h1", 90))
+	if _, err := dd.Dispatch(context.Background(), "work", Options{}); err != nil {
+		t.Fatal(err)
+	}
+
+	state := readState(t)
+	if state["set_by_someone_else"] != "keep me" {
+		t.Error("a foreign key was dropped; state.json was replaced rather than updated")
+	}
+	hist, _ := state["claude_pct_history"].([]any)
+	if len(hist) != 3 {
+		t.Errorf("claude_pct_history = %v, want the existing two plus this run's 40", hist)
+	}
+}
+
+// asInt / asIntSlice bridge JSON's float64 numbers back to ints. A wrong answer
+// here silently zeroes the governor's history.
+func TestAsIntAndAsIntSlice(t *testing.T) {
+	if got := asInt(float64(52)); got != 52 {
+		t.Errorf("asInt(float64) = %d, want 52 — JSON numbers arrive as float64", got)
+	}
+	if got := asInt(52); got != 52 {
+		t.Errorf("asInt(int) = %d, want 52", got)
+	}
+	for _, v := range []any{nil, "52", true, []any{1}} {
+		if got := asInt(v); got != 0 {
+			t.Errorf("asInt(%#v) = %d, want 0", v, got)
+		}
+	}
+
+	got := asIntSlice([]any{float64(1), float64(2), float64(3)})
+	if len(got) != 3 || got[0] != 1 || got[2] != 3 {
+		t.Errorf("asIntSlice = %v, want [1 2 3]", got)
+	}
+	if got := asIntSlice("not an array"); got != nil {
+		t.Errorf("asIntSlice(string) = %v, want nil", got)
+	}
+	// A mixed array must not drop elements — the history's length is its rate
+	// signal, so a silently shortened slice changes the risk estimate.
+	if got := asIntSlice([]any{float64(1), "x", float64(3)}); len(got) != 3 || got[1] != 0 {
+		t.Errorf("asIntSlice with a bad element = %v, want [1 0 3]", got)
+	}
+}
+
+// Heads and EstimateCost are the surface swarm builds on.
+func TestHeadsAndEstimateCost_AreExposedToCallers(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	dd := liveDispatcher(provider.Head{ID: "a", Name: "a", Provider: "agy", Source: "registry", CapScore: 80})
+	dd.pricing = pricing.Load()
+	if heads := dd.Heads(); len(heads) != 1 || heads[0].ID != "a" {
+		t.Errorf("Heads() = %+v, want the one head it was built with", heads)
+	}
+
+	cheap := dd.EstimateCost(10, 1_000_000, 1_000_000)
+	dear := dd.EstimateCost(1, 1_000_000, 1_000_000)
+	if dear <= cheap {
+		t.Errorf("EstimateCost: tier 1 = %v is not dearer than tier 10 = %v — cost "+
+			"routing has nothing to route on", dear, cheap)
+	}
+}
+
+// New refuses without a config rather than probing the machine and routing
+// against defaults the user never chose.
+func TestNew_WithoutAConfigPointsAtInit(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	dd, err := New(context.Background())
+	if err == nil {
+		t.Fatalf("New() succeeded with no config: %+v", dd)
+	}
+	if !strings.Contains(err.Error(), "hyctl init") {
+		t.Errorf("error = %v, want it to name the fix", err)
+	}
+}
+
+func TestNew_LoadsTheConfigAndArmsThePIIPolicy(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if err := config.Save(&config.Config{
+		Cortex:   "x",
+		Policies: map[string]config.Policy{"pii": {Action: "local-only"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	dd, err := New(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dd.policy == nil || dd.pricing == nil || dd.budget == nil {
+		t.Fatalf("New() left a component nil: %+v", dd)
+	}
+	// The PII rule is armed, so a PII prompt is forced local-only.
+	if action := dd.policy.Evaluate(policy.Request{Prompt: "SSN 123-45-6789", TierHint: "1"}); !action.LocalOnly {
+		t.Error("the pii=local-only config policy did not arm the local-only rule")
+	}
+}
+
+// writeStatePct seeds logs/state.json with a claude_pct and optional history.
+func writeStatePct(t *testing.T, pct int, history []int) {
+	t.Helper()
+	dir := filepath.Join(config.Dir(), "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	m := map[string]any{"claude_pct": pct}
+	if history != nil {
+		m["claude_pct_history"] = history
+	}
+	raw, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The budget governor is what enforces the 70/75/80% ceiling on every
+// delegated head. Booking agy's char/4 estimate as measured usage would make
+// that ceiling a fiction, so the source label has to survive the record.
+func TestRecordBudget_LabelsEstimatedTokensAsEstimated(t *testing.T) {
+	testutil.NewSandbox(t)
+	dd := liveDispatcher()
+
+	dd.recordBudget(&Result{
+		Head:     provider.Head{ID: "measured"},
+		Response: &executor.Response{InputTokens: 1000},
+	})
+	dd.recordBudget(&Result{
+		Head:     provider.Head{ID: "guessed"},
+		Response: &executor.Response{InputTokens: 1000, TokensEstimated: true},
+	})
+
+	if got := dd.budget.Get("measured"); got.Used != 1000 || got.Source != "real" {
+		t.Errorf("measured tokens booked as %+v, want 1000 from a real source", got)
+	}
+	if got := dd.budget.Get("guessed"); got.Source != "estimate" {
+		t.Errorf("estimated tokens booked as source %q — the governor would treat a "+
+			"char/4 guess as a measurement", got.Source)
+	}
+
+	// A response with no token count at all must not create a tracker; a
+	// zero-token entry reads as a head that was used and cost nothing.
+	dd.recordBudget(&Result{
+		Head:     provider.Head{ID: "silent"},
+		Response: &executor.Response{},
+	})
+	if got := dd.budget.Get("silent"); got.Used != 0 || got.Source != "" {
+		t.Errorf("a head that reported no tokens was booked as %+v", got)
+	}
+
+	// No registry at all (a Dispatcher built without one) must be a no-op, not
+	// a nil dereference on the success path of every dispatch.
+	(&Dispatcher{}).recordBudget(&Result{
+		Head:     provider.Head{ID: "x"},
+		Response: &executor.Response{InputTokens: 10},
+	})
+}
+
+// truncate bounds what goes into the run log's Detail field. An error longer
+// than the cap must be marked as cut, or a reader cannot tell a truncated
+// message from a complete one.
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 200); got != "short" {
+		t.Errorf("truncate did not pass a short string through: %q", got)
+	}
+	long := strings.Repeat("x", 500)
+	got := truncate(long, 200)
+	if len([]rune(got)) != 201 {
+		t.Errorf("truncate produced %d runes, want 200 plus the ellipsis", len([]rune(got)))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated text is not marked as cut: %q", got[len(got)-10:])
+	}
+	if got := truncate("", 200); got != "" {
+		t.Errorf("truncate(\"\") = %q", got)
+	}
+}

--- a/internal/policy/coverage_test.go
+++ b/internal/policy/coverage_test.go
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// The policy layer decides whether a prompt may leave the machine and how an
+// edit is allowed to proceed. Both fail dangerously in the permissive
+// direction, so the tests assert what must be refused, not just what is allowed.
+
+// The PII rule is the one that keeps a prompt containing secrets off a cloud
+// head. It must fire when enabled and must not exist when disabled — a rule
+// that silently never matches is the same as no rule.
+func TestDefaultRules_PIIRuleIsPresentOnlyWhenEnabled(t *testing.T) {
+	if got := DefaultRules(false); len(got) != 0 {
+		t.Errorf("local-only disabled produced %d rules: %+v", len(got), got)
+	}
+
+	rules := DefaultRules(true)
+	if len(rules) != 1 {
+		t.Fatalf("local-only enabled produced %d rules, want 1", len(rules))
+	}
+	if rules[0].Name != "pii-local-only" {
+		t.Errorf("rule name = %q", rules[0].Name)
+	}
+	if !rules[0].Apply.LocalOnly {
+		t.Error("the PII rule does not set LocalOnly — a prompt with secrets could " +
+			"still be sent to a cloud head")
+	}
+}
+
+// Evaluate returns the FIRST matching rule, and stamps its name as the reason.
+// Order matters: a later permissive rule must not override an earlier deny.
+func TestEngine_EvaluateReturnsTheFirstMatchWithItsReason(t *testing.T) {
+	e := New([]Rule{
+		{Name: "first", Condition: func(Request) bool { return true },
+			Apply: Action{LocalOnly: true}},
+		{Name: "second", Condition: func(Request) bool { return true },
+			Apply: Action{LocalOnly: false}},
+	})
+
+	got := e.Evaluate(Request{Prompt: "anything"})
+	if !got.LocalOnly {
+		t.Error("a later rule overrode the first match")
+	}
+	if got.Reason != "first" {
+		t.Errorf("Reason = %q, want the matching rule's name — without it the user "+
+			"cannot tell why a dispatch was constrained", got.Reason)
+	}
+}
+
+// No match is no restriction, not a deny — Hydra routes normally unless a rule
+// says otherwise.
+func TestEngine_NoMatchIsNoRestriction(t *testing.T) {
+	e := New([]Rule{
+		{Name: "never", Condition: func(Request) bool { return false },
+			Apply: Action{LocalOnly: true}},
+	})
+	got := e.Evaluate(Request{Prompt: "x"})
+	if got.LocalOnly || got.Reason != "" {
+		t.Errorf("a non-matching ruleset produced %+v", got)
+	}
+
+	// An empty engine behaves the same way.
+	if got := New(nil).Evaluate(Request{Prompt: "x"}); got.LocalOnly {
+		t.Errorf("an empty engine restricted the request: %+v", got)
+	}
+}
+
+// End to end: a prompt containing a secret must be constrained to local heads
+// by the default ruleset.
+func TestEngine_PIIPromptIsForcedLocal(t *testing.T) {
+	e := New(DefaultRules(true))
+
+	secret := "here is my key AKIAIOSFODNN7EXAMPLE please use it"
+	if got := e.Evaluate(Request{Prompt: secret}); !got.LocalOnly {
+		t.Error("a prompt containing an AWS-shaped key was not forced local")
+	}
+	if got := e.Evaluate(Request{Prompt: "write a function that adds two numbers"}); got.LocalOnly {
+		t.Error("an ordinary prompt was forced local — over-triggering pushes every " +
+			"task to the weakest head")
+	}
+}
+
+// ── file policy ──────────────────────────────────────────────────────────────
+
+func TestLoadFilePolicy_UsesTheEmbeddedRegistry(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	e, err := LoadFilePolicy("")
+	if err != nil {
+		t.Fatalf("loading with no on-disk policy failed: %v — this is what every "+
+			"installed binary does", err)
+	}
+	fp := e.Decide(Spec{File: "/repo/a.go", FileExtension: "go"})
+	if fp.EditMode == "" {
+		t.Error("the decided policy has no edit mode")
+	}
+	if fp.MaxWallSeconds <= 0 {
+		t.Error("the decided policy has no wall-clock cap; an edit could run forever")
+	}
+}
+
+func TestLoadFilePolicy_MalformedYAMLIsAnError(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	dir := filepath.Join(s.HydraHome, "registry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "policy.yaml"), []byte("rules: [oops"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadFilePolicy(s.HydraHome); err == nil {
+		t.Error("a malformed policy.yaml loaded without error — edits would run " +
+			"under defaults the operator never chose")
+	}
+}
+
+// Defaults must be safe on their own, because they apply whenever no rule
+// matches — which is the common case.
+func TestDecide_DefaultsAreSafe(t *testing.T) {
+	e := &FilePolicyEngine{}
+	fp := e.Decide(Spec{File: "/x/y.go"})
+
+	if fp.EditMode != "rewrite" {
+		t.Errorf("default EditMode = %q, want rewrite", fp.EditMode)
+	}
+	if !fp.EscalateOnFail {
+		t.Error("the default does not escalate on failure; a failed edit would stop silently")
+	}
+	if !fp.TrackTokens {
+		t.Error("the default does not track tokens; spend would go unrecorded")
+	}
+	if fp.DiffSizeCapPct <= 0 || fp.DiffSizeCapPct > 100 {
+		t.Errorf("default DiffSizeCapPct = %d, outside 1–100", fp.DiffSizeCapPct)
+	}
+	if fp.MaxWallSeconds <= 0 {
+		t.Errorf("default MaxWallSeconds = %d — an edit could run forever", fp.MaxWallSeconds)
+	}
+}
+
+// A rule's when-block must match on every documented condition, and a rule that
+// does not match must not apply. Getting this wrong applies someone else's
+// policy to an edit.
+func TestDecide_RuleMatchingByCondition(t *testing.T) {
+	cases := []struct {
+		name string
+		when map[string]interface{}
+		spec Spec
+		want bool
+	}{
+		{"always", map[string]interface{}{"always": true}, Spec{}, true},
+		{"empty when matches", map[string]interface{}{}, Spec{}, true},
+		{"extension match", map[string]interface{}{"file_extension": "go"},
+			Spec{FileExtension: "go"}, true},
+		{"extension mismatch", map[string]interface{}{"file_extension": "go"},
+			Spec{FileExtension: "ts"}, false},
+		{"task type match", map[string]interface{}{"task_type": "edit"},
+			Spec{TaskType: "edit"}, true},
+		{"all conditions must hold", map[string]interface{}{
+			"file_extension": "go", "task_type": "edit"},
+			Spec{FileExtension: "go", TaskType: "review"}, false},
+		{"unknown key never matches", map[string]interface{}{"no_such_field": "x"},
+			Spec{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matchWhen(tc.when, tc.spec); got != tc.want {
+				t.Errorf("matchWhen(%v, %+v) = %v, want %v", tc.when, tc.spec, got, tc.want)
+			}
+		})
+	}
+}
+
+// Later rules layer over earlier ones, so an operator can set a broad default
+// and then tighten it for a specific case.
+func TestDecide_LaterRulesOverrideEarlierOnes(t *testing.T) {
+	e := &FilePolicyEngine{pf: policyFile{
+		Rules: []policyRule{
+			{When: map[string]interface{}{"always": true},
+				Apply: map[string]interface{}{"max_retries": 1}},
+			{When: map[string]interface{}{"file_extension": "go"},
+				Apply: map[string]interface{}{"max_retries": 5}},
+		},
+	}}
+
+	if got := e.Decide(Spec{FileExtension: "go"}).MaxRetries; got != 5 {
+		t.Errorf("MaxRetries = %d for a .go file, want the later rule's 5", got)
+	}
+	if got := e.Decide(Spec{FileExtension: "ts"}).MaxRetries; got != 1 {
+		t.Errorf("MaxRetries = %d for a .ts file, want the broad rule's 1", got)
+	}
+}
+
+// The when-block operators are how an operator writes "only for big files" or
+// "only outside a playbook". Each has to mean what it says: a comparison that
+// silently reads as equality would apply a rule to every file.
+func TestMatchCondition_EveryOperator(t *testing.T) {
+	spec := Spec{
+		File: "/repo/internal/a.go", FileLines: 500, FileCount: 3,
+		FileExtension: "go", TaskType: "edit", EnumTier: 6,
+		Workspace: "hydra", Prompt: "add pagination", PromptLength: 14,
+		ContextPct: 40, HasGit: true, InPlaybook: false, StageName: "",
+	}
+	cases := []struct {
+		key  string
+		val  interface{}
+		want bool
+	}{
+		// implicit eq
+		{"file_extension", "go", true},
+		{"file_extension", "ts", false},
+		{"has_git", true, true},
+		{"in_playbook", false, true},
+
+		// explicit eq / ne
+		{"task_type_eq", "edit", true},
+		{"task_type_ne", "edit", false},
+		{"task_type_ne", "review", true},
+
+		// numeric comparisons
+		{"file_lines_gt", 100, true},
+		{"file_lines_gt", 1000, false},
+		{"file_lines_lt", 1000, true},
+		{"file_lines_lt", 100, false},
+		{"file_lines_gte", 500, true},
+		{"file_lines_lte", 500, true},
+		{"file_lines_gte", 501, false},
+		{"context_pct_gte", 75, false},
+
+		// numeric comparison against a string, which is how YAML often loads it
+		{"file_lines_gt", "100", true},
+		{"file_lines_gt", "1000", false},
+
+		// contains
+		{"prompt_contains", "pagination", true},
+		{"prompt_contains", "authentication", false},
+		{"file_contains", "internal", true},
+
+		// present
+		{"stage_name_present", true, false},
+		{"workspace_present", true, true},
+
+		// in
+		{"file_extension_in", []interface{}{"go", "ts"}, true},
+		{"file_extension_in", []interface{}{"py", "rb"}, false},
+
+		// an unknown field can never match, rather than matching everything
+		{"no_such_field_gt", 1, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			if got := matchCondition(tc.key, tc.val, spec); got != tc.want {
+				t.Errorf("matchCondition(%q, %v) = %v, want %v", tc.key, tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// toFloat turns a YAML scalar into a number for comparisons. A non-numeric
+// value must degrade to 0 with a warning rather than panic — but the warning
+// matters, because 0 silently makes "file_lines_gt: many" match every file.
+func TestToFloat_EveryScalarShape(t *testing.T) {
+	cases := []struct {
+		in   interface{}
+		want float64
+	}{
+		{42, 42},
+		{int64(42), 42},
+		{42.5, 42.5},
+		{float32(2.5), 2.5},
+		{true, 1},
+		{false, 0},
+		{"42", 42},
+		{"2.5", 2.5},
+		{"not-a-number", 0},
+		{nil, 0},
+		{[]string{"x"}, 0},
+	}
+	for _, tc := range cases {
+		if got := toFloat(tc.in); got != tc.want {
+			t.Errorf("toFloat(%#v) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// specField is the only bridge from a YAML key to a Spec field. A typo must
+// yield nothing rather than a zero value that compares equal to something.
+func TestSpecField_KnownAndUnknownFields(t *testing.T) {
+	spec := Spec{File: "/a.go", FileLines: 10, FileExtension: "go", EnumTier: 3}
+
+	if got := specField("file_extension", spec); fmtV(got) != "go" {
+		t.Errorf("specField(file_extension) = %v", got)
+	}
+	if got := specField("enum_tier", spec); fmtV(got) != "3" {
+		t.Errorf("specField(enum_tier) = %v", got)
+	}
+	// An unknown field resolves to "" rather than nil, so it is indistinguishable
+	// from a present-but-empty one. That is fine for every operator except a
+	// literal equality against "": `when: {file_extensionn: ""}` — a typo — would
+	// match every spec. Narrow, but a policy rule that matches everything because
+	// of a misspelling is the wrong direction to fail in, so it is recorded here
+	// rather than left as folklore.
+	if got := specField("not_a_field", spec); fmtV(got) != "" {
+		t.Errorf("specField(not_a_field) = %v, want the empty value", got)
+	}
+	if !matchCondition("not_a_field", "", spec) {
+		t.Error("a typo'd field compared against \"\" no longer matches; if that was " +
+			"fixed deliberately, this test should assert the new behaviour")
+	}
+}
+
+func fmtV(v interface{}) string { return fmt.Sprintf("%v", v) }

--- a/internal/pricing/load_test.go
+++ b/internal/pricing/load_test.go
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: MIT
+
+package pricing
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// Load is what every command calls at startup. Its job is to never block and
+// never return nil, whatever the network and the cache are doing — a nil DB
+// panics the caller, and a blocking one hangs the CLI on a dead network.
+
+// stubOpenRouter points the fetcher at a local server returning the given
+// models, so no test ever reaches the real API.
+func stubOpenRouter(t *testing.T, models map[string]orPricing) *httptest.Server {
+	t.Helper()
+	var resp orResponse
+	for id, p := range models {
+		resp.Data = append(resp.Data, orModel{ID: id, Pricing: p})
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	orig := openRouterModelsURL
+	openRouterModelsURL = srv.URL
+	t.Cleanup(func() { openRouterModelsURL = orig })
+	return srv
+}
+
+// writeCacheFixture puts a cache file in place with a chosen age.
+func writeCacheFixture(t *testing.T, age time.Duration, models map[string]ModelPrice) {
+	t.Helper()
+	c := &priceCache{
+		FetchedAt: time.Now().UTC().Add(-age),
+		Source:    "fixture",
+		Models:    models,
+	}
+	if err := writeCache(c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// drainBackgroundFetch waits for the goroutine Load() spawns to finish writing.
+//
+// Load's refresh is fire-and-forget: nothing can wait for it, and it resolves
+// the cache path when it runs, not when it is started. A test that returns
+// while one is still in flight has it land in the *next* test's sandbox home.
+// That is a property of Load, not of the tests, so every test that starts one
+// drains it before returning.
+func drainBackgroundFetch(t *testing.T, wantModel string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, err := readCache(); err == nil {
+			if _, ok := c.Models[wantModel]; ok {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("the background fetch never wrote %q to the cache", wantModel)
+}
+
+func TestLoad_NoCacheStillPricesEveryTier(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubOpenRouter(t, map[string]orPricing{"bg/model": {Prompt: "0.000001", Completion: "0.000002"}})
+
+	db := Load()
+	if db == nil {
+		t.Fatal("Load() = nil; every caller dereferences this")
+	}
+	// The tier table is the load-bearing part: it is what prices the CLI-agent
+	// heads that never appear in OpenRouter's catalog (#238).
+	if !db.HasTiers() {
+		t.Fatal("Load() produced no tier pricing, so every CLI-agent head costs $0.00")
+	}
+	if got := db.EstimateCost(1, 1_000_000, 0); got <= 0 {
+		t.Errorf("EstimateCost(tier 1) = %v with no cache, want the fallback rate", got)
+	}
+	// Models are absent on this first call — the fetch is in the background —
+	// and arrive on the next one.
+	if len(db.Models()) != 0 {
+		t.Errorf("Models() = %v with no cache, want none until the fetch lands", db.Models())
+	}
+	drainBackgroundFetch(t, "bg/model")
+	if _, ok := Load().ModelPrice("bg/model"); !ok {
+		t.Error("the second Load did not pick up what the first one fetched")
+	}
+}
+
+func TestLoad_FreshCacheIsOverlaidAndNotRefetched(t *testing.T) {
+	testutil.NewSandbox(t)
+	// Any fetch would replace the fixture; make one detectable.
+	stubOpenRouter(t, map[string]orPricing{"refetched/model": {Prompt: "0.000001", Completion: "0.000002"}})
+
+	writeCacheFixture(t, time.Hour, map[string]ModelPrice{
+		"Vendor/Model": {InputPerMillion: 3, OutputPerMillion: 15},
+	})
+
+	db := Load()
+	// Keys are lowercased on the way in, so lookups are case-insensitive.
+	p, ok := db.ModelPrice("vendor/MODEL")
+	if !ok {
+		t.Fatalf("cached model missing from the DB: %v", db.Models())
+	}
+	if p.InputPerMillion != 3 || p.OutputPerMillion != 15 {
+		t.Errorf("ModelPrice = %+v, want the cached rates", p)
+	}
+
+	// A fresh cache must not trigger a background refresh. Give any goroutine
+	// time to land, then confirm the file is untouched.
+	time.Sleep(200 * time.Millisecond)
+	c, err := readCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Source != "fixture" {
+		t.Errorf("cache Source = %q; a fresh cache was refetched anyway", c.Source)
+	}
+}
+
+func TestLoad_StaleCacheIsUsedImmediatelyThenRefreshedInBackground(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubOpenRouter(t, map[string]orPricing{
+		"fresh/model": {Prompt: "0.000002", Completion: "0.000004"},
+	})
+
+	writeCacheFixture(t, 48*time.Hour, map[string]ModelPrice{
+		"stale/model": {InputPerMillion: 1, OutputPerMillion: 1},
+	})
+
+	db := Load()
+	// The stale data is returned immediately — Load must not block on the network.
+	if _, ok := db.ModelPrice("stale/model"); !ok {
+		t.Error("stale cache was discarded instead of used while the refresh runs")
+	}
+
+	// The background refresh should replace the file.
+	drainBackgroundFetch(t, "fresh/model")
+	if c, _ := readCache(); c != nil && c.Source != "openrouter" {
+		t.Errorf("cache Source = %q after a refresh, want openrouter", c.Source)
+	}
+}
+
+func TestLoad_CorruptCacheIsReplacedNotFatal(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubOpenRouter(t, map[string]orPricing{
+		"good/model": {Prompt: "0.000003", Completion: "0.000009"},
+	})
+
+	if err := os.MkdirAll(filepath.Dir(cachePath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachePath(), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db := Load()
+	if !db.HasTiers() {
+		t.Error("a corrupt cache took the tier fallback down with it")
+	}
+
+	drainBackgroundFetch(t, "good/model")
+}
+
+// Refresh is `hyctl pricing refresh` — synchronous, and its count is printed to
+// the user, so it must be the number actually written.
+func TestRefresh_ReportsWhatItWroteAndSurfacesFailures(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubOpenRouter(t, map[string]orPricing{
+		"a/one":   {Prompt: "0.000001", Completion: "0.000002"},
+		"b/two":   {Prompt: "0", Completion: "0"},         // free models are kept
+		"c/three": {Prompt: "", Completion: "0.000002"},   // unpriced: skipped
+		"d/four":  {Prompt: "-1", Completion: "0.000002"}, // negative: skipped
+	})
+
+	n, err := Refresh()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Errorf("Refresh() = %d models, want the 2 priced ones (free kept, "+
+			"unpriced and negative skipped)", n)
+	}
+
+	c, err := readCache()
+	if err != nil {
+		t.Fatalf("Refresh reported %d models but wrote no readable cache: %v", n, err)
+	}
+	if len(c.Models) != n {
+		t.Errorf("Refresh() reported %d models but the cache holds %d", n, len(c.Models))
+	}
+	if c.Source != "openrouter" {
+		t.Errorf("cache Source = %q, want openrouter", c.Source)
+	}
+	if time.Since(c.FetchedAt) > time.Minute {
+		t.Errorf("FetchedAt = %v, not stamped at fetch time — the cache would read "+
+			"as stale immediately", c.FetchedAt)
+	}
+}
+
+func TestRefresh_ServerErrorIsReportedNotSwallowed(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+	orig := openRouterModelsURL
+	openRouterModelsURL = srv.URL
+	defer func() { openRouterModelsURL = orig }()
+
+	n, err := Refresh()
+	if err == nil {
+		t.Fatalf("Refresh() = (%d, nil) against a 503; the user would be told the "+
+			"refresh succeeded", n)
+	}
+	if n != 0 {
+		t.Errorf("Refresh() = %d models alongside an error", n)
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("error %q does not say what went wrong", err)
+	}
+}
+
+// A fetch that succeeds but cannot be persisted must still return the data —
+// pricing is more useful than caching it.
+func TestFetchAndSave_UnwritableCacheStillReturnsThePrices(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubOpenRouter(t, map[string]orPricing{"a/one": {Prompt: "0.000001", Completion: "0.000002"}})
+
+	// ~/.hydra is a regular file, so the cache directory cannot be created.
+	if err := os.WriteFile(filepath.Dir(cachePath()), []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := fetchAndSave()
+	if err != nil {
+		t.Fatalf("fetchAndSave failed because the cache was unwritable: %v", err)
+	}
+	if len(c.Models) != 1 {
+		t.Errorf("Models = %v, want the fetched model returned despite the write failure", c.Models)
+	}
+	if err := writeCache(c); err == nil {
+		t.Error("writeCache reported success into an uncreatable directory")
+	}
+}
+
+// ModelPrice and TierPrice are the lookup surface `hyctl pricing list` renders.
+// A miss must be reported as a miss, not as a zero price — zero is a real rate
+// for local models.
+func TestModelPriceAndTierPrice_ReportMissesAsMisses(t *testing.T) {
+	db := &DB{
+		models: map[string]ModelPrice{"free/local": {InputPerMillion: 0, OutputPerMillion: 0}},
+		tiers:  map[int]TierPrice{10: {InputPerMillion: 0, OutputPerMillion: 0}},
+	}
+
+	if p, ok := db.ModelPrice("free/local"); !ok || p.InputPerMillion != 0 {
+		t.Errorf("ModelPrice(free/local) = (%+v, %v), want a hit at $0", p, ok)
+	}
+	if _, ok := db.ModelPrice("never/heard-of-it"); ok {
+		t.Error("ModelPrice reported a hit for an unknown model")
+	}
+	if _, ok := db.ModelPrice("FREE/LOCAL"); !ok {
+		t.Error("ModelPrice is case-sensitive; model names arrive in both cases")
+	}
+
+	if p, ok := db.TierPrice(10); !ok || p.InputPerMillion != 0 {
+		t.Errorf("TierPrice(10) = (%+v, %v), want a hit at $0", p, ok)
+	}
+	if _, ok := db.TierPrice(3); ok {
+		t.Error("TierPrice reported a hit for a tier that is not in the table")
+	}
+}
+
+// writeCache falls back to a direct write when the rename cannot complete, and
+// must never leave its .tmp behind either way.
+func TestWriteCache_LeavesNoTempFile(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	c := &priceCache{FetchedAt: time.Now().UTC(), Source: "t", Models: map[string]ModelPrice{"m": {1, 2}}}
+	if err := writeCache(c); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(cachePath() + ".tmp"); err == nil {
+		t.Error("the .tmp file survived a successful write")
+	}
+
+	// Overwriting an existing cache must work too — this is the every-refresh path.
+	c.Source = "second"
+	if err := writeCache(c); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != "second" {
+		t.Errorf("Source = %q after overwrite, want second", got.Source)
+	}
+	if _, err := os.Stat(cachePath() + ".tmp"); err == nil {
+		t.Error("the .tmp file survived an overwrite")
+	}
+}
+
+func TestReadCache_MissingFileIsNotExistNotCorruption(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	_, err := readCache()
+	if err == nil {
+		t.Fatal("readCache succeeded with no cache file")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("err = %v, want an os.ErrNotExist — Load distinguishes "+
+			"\"never fetched\" from \"corrupt\"", err)
+	}
+}
+
+// The tier table is read through registry.Read, so an on-disk override wins and
+// an unparsable one must be an error rather than a silently empty table.
+func TestLoadFallbackTiers_OnDiskOverrideWinsAndCorruptIsAnError(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	regDir := filepath.Join(s.HydraHome, "registry")
+	if err := os.MkdirAll(regDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(regDir, "pricing.yaml")
+	if err := os.WriteFile(path, []byte("tiers:\n  4:\n    input_per_million: 42\n    output_per_million: 84\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tiers, err := loadFallbackTiers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := tiers[4].InputPerMillion; got != 42 {
+		t.Errorf("tier 4 input = %v, want the on-disk override's 42 — an operator's "+
+			"retuned pricing.yaml was ignored", got)
+	}
+
+	if err := os.WriteFile(path, []byte("tiers: [this is not a map"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if tiers, err := loadFallbackTiers(); err == nil {
+		t.Errorf("loadFallbackTiers() = %v with unparsable YAML, want an error — "+
+			"an empty table silently prices everything at $0.00", tiers)
+	}
+}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/ankit373/hydra/internal/testutil"
 )
 
 // ── cost math ─────────────────────────────────────────────────────────────────
@@ -208,8 +210,13 @@ func TestFetchFromOpenRouter_Non200(t *testing.T) {
 // ── Cache ─────────────────────────────────────────────────────────────────────
 
 func TestCacheRoundtrip(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HYDRA_CONFIG_DIR", dir)
+	// HYDRA_CONFIG_DIR was read by nothing — config.Dir() resolves from the
+	// home directory — so this test wrote its fixture straight into the
+	// developer's real ~/.hydra/pricing_cache.json and left it there. A plain
+	// `go test ./...` therefore replaced the machine's live pricing data with
+	// an empty models map, after which every model priced off the tier
+	// fallback until the next background refresh.
+	testutil.NewSandbox(t)
 
 	c := &priceCache{
 		FetchedAt: time.Now().UTC(),
@@ -232,8 +239,13 @@ func TestCacheRoundtrip(t *testing.T) {
 }
 
 func TestReadCache_EmptySentinel(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HYDRA_CONFIG_DIR", dir)
+	// HYDRA_CONFIG_DIR was read by nothing — config.Dir() resolves from the
+	// home directory — so this test wrote its fixture straight into the
+	// developer's real ~/.hydra/pricing_cache.json and left it there. A plain
+	// `go test ./...` therefore replaced the machine's live pricing data with
+	// an empty models map, after which every model priced off the tier
+	// fallback until the next background refresh.
+	testutil.NewSandbox(t)
 
 	// Write a valid but empty cache.
 	c := &priceCache{FetchedAt: time.Now(), Models: map[string]ModelPrice{}}

--- a/internal/provider/port/provider_test.go
+++ b/internal/provider/port/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ankit373/hydra/internal/capabilities"
 	"github.com/ankit373/hydra/internal/provider"
@@ -209,5 +210,97 @@ func TestDiscovery_ResolvesTheSameHostTheExecutorWill(t *testing.T) {
 				t.Errorf("service base %q does not match resolved host %q", svc.base, got)
 			}
 		})
+	}
+}
+
+// Discover walks every service. With nothing listening it must find nothing and
+// not hang — a probe that blocks is worse than one that finds nothing, because
+// `hyctl probe` is often the first command a user runs.
+func TestDiscover_NothingListeningFindsNothingQuickly(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	// Point Ollama at a port nothing is on, so the liveness dial fails fast.
+	s.SetKey(t, "OLLAMA_HOST", "http://127.0.0.1:1")
+
+	start := time.Now()
+	heads, err := (&Provider{}).Discover(context.Background())
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Discover errored with nothing listening: %v", err)
+	}
+	if len(heads) != 0 {
+		t.Errorf("found %d heads with nothing listening: %+v", len(heads), heads)
+	}
+	// Two services, each with a 400ms dial timeout, plus slack.
+	if elapsed > 5*time.Second {
+		t.Errorf("Discover took %v with nothing listening", elapsed)
+	}
+}
+
+// isOpen is the cheap liveness check that saves paying the HTTP timeout per
+// service. It must be accurate in both directions or Discover either skips a
+// live server or waits out a dead one.
+func TestIsOpen_DetectsListeningAndNot(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	if !isOpen(addr) {
+		t.Errorf("isOpen(%q) = false for a listening server", addr)
+	}
+	if isOpen("127.0.0.1:1") {
+		t.Error("isOpen reported a closed port as open")
+	}
+	if isOpen("not-a-valid-address") {
+		t.Error("isOpen reported a malformed address as open")
+	}
+}
+
+// Discover finds a real service when one is listening — the positive case that
+// proves the negative ones above are not passing for the wrong reason.
+func TestDiscover_FindsAListeningOllama(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b"}]}`))
+	}))
+	defer srv.Close()
+
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "OLLAMA_HOST", srv.URL)
+
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 1 {
+		t.Fatalf("got %d heads, want the one served model: %+v", len(heads), heads)
+	}
+	if heads[0].ID != "ollama/qwen3:8b" {
+		t.Errorf("ID = %q", heads[0].ID)
+	}
+	if heads[0].Endpoint != srv.URL {
+		t.Errorf("Endpoint = %q, want the address it was found at", heads[0].Endpoint)
+	}
+}
+
+// Each service's dial address is derived from the base it will probe, for both
+// services — checked directly, since computing them independently is what let
+// them disagree before.
+func TestServiceAddrs_DeriveFromTheirBases(t *testing.T) {
+	if got, want := (&ollamaService{base: "http://127.0.0.1:11500"}).addr(), "127.0.0.1:11500"; got != want {
+		t.Errorf("ollama addr = %q, want %q", got, want)
+	}
+	if got, want := (&lmStudioService{base: "http://127.0.0.1:4321"}).addr(), "127.0.0.1:4321"; got != want {
+		t.Errorf("lmstudio addr = %q, want %q", got, want)
+	}
+	// Default ports are supplied when the base carries none.
+	if got := (&ollamaService{base: "http://localhost"}).addr(); got != "localhost:11434" {
+		t.Errorf("ollama addr with no port = %q, want localhost:11434", got)
+	}
+	if got := (&lmStudioService{base: "http://localhost"}).addr(); got != "localhost:1234" {
+		t.Errorf("lmstudio addr with no port = %q, want localhost:1234", got)
 	}
 }

--- a/internal/review/coverage_test.go
+++ b/internal/review/coverage_test.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: MIT
+
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/config"
+)
+
+// Summary with no files named is what `hyctl review` does by default: it reads
+// what Hydra last edited out of logs/. Getting this wrong means the user
+// reviews nothing and is told everything is clean.
+
+func writeLog(t *testing.T, name string, v any) {
+	t.Helper()
+	dir := filepath.Join(config.Dir(), "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSummary_WithNoArgsReadsTheLastParallelRun(t *testing.T) {
+	repo := repoSandbox(t, false)
+	edited := filepath.Join(repo, "edited.go")
+	write(t, edited, "one\ntwo\nthree\n")
+	write(t, edited+".hydra-bak", "one\n")
+
+	writeLog(t, "last_parallel.json", []map[string]string{
+		{"mode": "edit", "file": edited},
+		{"mode": "read", "file": filepath.Join(repo, "ignored.go")}, // not an edit
+		{"mode": "edit", "file": ""},                                // no path
+	})
+
+	res, err := Summary(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Totals.Count != 1 {
+		t.Fatalf("Summary(nil) reported %d files, want only the one edit: %+v",
+			res.Totals.Count, res.Files)
+	}
+	if res.Files[0].File != edited {
+		t.Errorf("File = %q, want %q", res.Files[0].File, edited)
+	}
+	if res.Files[0].Added != 2 || res.Files[0].Status != "modified" {
+		t.Errorf("entry = %+v, want 2 lines added and status modified", res.Files[0])
+	}
+}
+
+// last_edit.json is the single-file fallback. It must only be consulted when
+// the parallel log yielded nothing, or a stale single edit would shadow a
+// fresh batch.
+func TestSummary_FallsBackToTheLastSingleEditOnlyWhenNeeded(t *testing.T) {
+	repo := repoSandbox(t, false)
+	fromBatch := filepath.Join(repo, "batch.go")
+	fromSingle := filepath.Join(repo, "single.go")
+	for _, f := range []string{fromBatch, fromSingle} {
+		write(t, f, "a\nb\n")
+		write(t, f+".hydra-bak", "a\n")
+	}
+
+	// Only last_edit.json exists: it is used.
+	writeLog(t, "last_edit.json", map[string]string{"file": fromSingle})
+	res, err := Summary(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Totals.Count != 1 || res.Files[0].File != fromSingle {
+		t.Fatalf("Summary(nil) = %+v, want the single edit", res.Files)
+	}
+
+	// Now a batch exists too: it wins.
+	writeLog(t, "last_parallel.json", []map[string]string{{"mode": "edit", "file": fromBatch}})
+	res, err = Summary(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Totals.Count != 1 || res.Files[0].File != fromBatch {
+		t.Errorf("Summary(nil) = %+v, want the batch to shadow the stale single edit", res.Files)
+	}
+}
+
+// A corrupt or absent log must produce an empty review, not an error and not a
+// panic — the logs are written by another process and can be truncated.
+func TestSummary_CorruptOrAbsentLogsReviewNothing(t *testing.T) {
+	repoSandbox(t, false)
+
+	res, err := Summary(nil)
+	if err != nil {
+		t.Fatalf("Summary(nil) with no logs at all: %v", err)
+	}
+	if res.Totals.Count != 0 {
+		t.Errorf("Summary(nil) found %d files with no logs", res.Totals.Count)
+	}
+
+	dir := filepath.Join(config.Dir(), "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"last_parallel.json", "last_edit.json"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{truncated"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err = Summary(nil)
+	if err != nil {
+		t.Fatalf("Summary(nil) with corrupt logs: %v", err)
+	}
+	if res.Totals.Count != 0 {
+		t.Errorf("Summary(nil) found %d files in a corrupt log", res.Totals.Count)
+	}
+}
+
+// numstat's git branches: tracked-and-modified, tracked-and-unchanged,
+// untracked, and missing. Each maps to a different status the reviewer reads.
+func TestNumstat_GitStatuses(t *testing.T) {
+	repo := repoSandbox(t, true)
+
+	tracked := filepath.Join(repo, "tracked.go")
+	write(t, tracked, "one\ntwo\n")
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	run("add", "tracked.go")
+	run("commit", "-qm", "initial")
+
+	if added, removed, status := numstat(tracked, repo); status != "unchanged" || added != 0 || removed != 0 {
+		t.Errorf("committed file = (%d, %d, %q), want (0, 0, unchanged)", added, removed, status)
+	}
+
+	write(t, tracked, "one\ntwo\nthree\n")
+	added, removed, status := numstat(tracked, repo)
+	if status != "modified" || added != 1 || removed != 0 {
+		t.Errorf("modified file = (%d, %d, %q), want (1, 0, modified)", added, removed, status)
+	}
+
+	untracked := filepath.Join(repo, "new.go")
+	write(t, untracked, "a\nb\nc\n")
+	added, removed, status = numstat(untracked, repo)
+	if status != "new" || added != 3 {
+		t.Errorf("untracked file = (%d, %d, %q), want (3, 0, new)", added, removed, status)
+	}
+
+	gone := filepath.Join(repo, "never-existed.go")
+	if added, removed, status := numstat(gone, repo); status != "missing" {
+		t.Errorf("absent file = (%d, %d, %q), want missing", added, removed, status)
+	}
+}
+
+// Without a usable git root the backup is the baseline. An unreadable backup
+// must be reported as no_baseline rather than as an unchanged file — the whole
+// point of #260 is that a silent 0/0 reads as "nothing to review".
+func TestNumstat_BackupPathAndUnreadableBaseline(t *testing.T) {
+	repo := repoSandbox(t, false)
+
+	file := filepath.Join(repo, "a.go")
+	write(t, file, "one\ntwo\nthree\n")
+	write(t, file+".hydra-bak", "one\n")
+
+	added, removed, status := numstat(file, "")
+	if status != "modified" || added != 2 || removed != 0 {
+		t.Errorf("backup baseline = (%d, %d, %q), want (2, 0, modified)", added, removed, status)
+	}
+
+	// A file with no backup at all: nothing to compare against.
+	noBaseline := filepath.Join(repo, "b.go")
+	write(t, noBaseline, "x\n")
+	if _, _, status := numstat(noBaseline, ""); status != "no_baseline" {
+		t.Errorf("file with no backup = %q, want no_baseline", status)
+	}
+
+	// A backup that exists but cannot be read is not a clean file.
+	if _, _, status := numstat(filepath.Join(repo, "gone.go"), ""); status != "missing" {
+		t.Errorf("absent file with no git = %q, want missing", status)
+	}
+}
+
+// gitUsable is the guard that stops a git failure being read as a fact about
+// the file — in Reject that meant deleting it.
+//
+// One sandbox per test: NewSandbox empties $PATH, so a second one in the same
+// test can no longer resolve git and AllowHostBinary skips.
+func TestGitUsable_RejectsAMarkerThatIsNotARepository(t *testing.T) {
+	if gitUsable("") {
+		t.Error("gitUsable(\"\") = true; there is no root to run in")
+	}
+	fake := repoSandbox(t, false) // .git exists but is not a repository
+	if gitUsable(fake) {
+		t.Error("gitUsable() accepted a bare .git directory that is not a repository")
+	}
+}
+
+func TestGitUsable_AcceptsARealRepository(t *testing.T) {
+	repo := repoSandbox(t, true)
+	if !gitUsable(repo) {
+		t.Error("gitUsable() rejected a real repository")
+	}
+}
+
+// Diff against a real repository goes through git; the error path must say so
+// rather than returning a blank diff (#260).
+func TestDiff_UsesGitInARepository(t *testing.T) {
+	repo := repoSandbox(t, true)
+
+	file := filepath.Join(repo, "a.go")
+	write(t, file, "one\n")
+	for _, args := range [][]string{{"add", "a.go"}, {"commit", "-qm", "init"}} {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	write(t, file, "one\ntwo\n")
+
+	got, err := Diff(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, "+two") {
+		t.Errorf("git diff did not show the added line:\n%s", got)
+	}
+
+	// An unchanged file has an empty diff — which is correct here, unlike the
+	// backup path where empty meant the diff had failed.
+	write(t, file, "one\n")
+	if got, err := Diff(file); err != nil || strings.TrimSpace(got) != "" {
+		t.Errorf("Diff of an unchanged tracked file = (%q, %v), want empty", got, err)
+	}
+}
+
+// QA refuses before it dispatches: a relative path or a file outside the
+// workspace must never reach a paid head.
+func TestQA_RefusesBeforeDispatching(t *testing.T) {
+	repo := repoSandbox(t, false)
+
+	if _, err := QA(context.Background(), "relative.go", 4); err == nil {
+		t.Error("QA accepted a relative path")
+	} else if !strings.Contains(err.Error(), "absolute") {
+		t.Errorf("error = %v, want it to name the problem", err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "elsewhere.go")
+	write(t, outside, "x\n")
+	if _, err := QA(context.Background(), outside, 4); err == nil {
+		t.Error("QA accepted a file outside every workspace")
+	} else if !strings.Contains(err.Error(), "scope_rejected") {
+		t.Errorf("error = %v, want a scope rejection", err)
+	}
+
+	// In scope, but nothing has changed: there is no diff to pay a head to read.
+	clean := filepath.Join(repo, "clean.go")
+	write(t, clean, "x\n")
+	if _, err := QA(context.Background(), clean, 4); err == nil {
+		t.Error("QA dispatched a review for a file with no diff")
+	} else if !strings.Contains(err.Error(), "no diff") {
+		t.Errorf("error = %v, want it to say there is no diff", err)
+	}
+}
+
+// With a real diff and no head available, QA must fail at the dispatch step
+// rather than returning an empty verdict that reads as an approval.
+func TestQA_NoHeadAvailableIsAnErrorNotAnEmptyVerdict(t *testing.T) {
+	repo := repoSandbox(t, false)
+
+	file := filepath.Join(repo, "a.go")
+	write(t, file, "one\ntwo\n")
+	write(t, file+".hydra-bak", "one\n")
+
+	res, err := QA(context.Background(), file, 4)
+	if err == nil {
+		t.Fatalf("QA succeeded with no heads discoverable: %+v", res)
+	}
+	if res != nil {
+		t.Errorf("QA returned %+v alongside an error", res)
+	}
+}

--- a/internal/sysinfo/coverage_test.go
+++ b/internal/sysinfo/coverage_test.go
@@ -1,0 +1,632 @@
+// SPDX-License-Identifier: MIT
+
+package sysinfo
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These cover the memory-sizing logic that decides which local model a user is
+// told to pull. Getting it wrong either recommends a model that swaps the
+// machine to a halt, or refuses a model that would have run fine.
+
+// sandboxHome points $HOME at a temp dir so the history file under test is not
+// the developer's real one. testutil is not importable here (it would be an
+// import cycle through config), and the surface needed is one env var.
+func sandboxHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
+	return home
+}
+
+// EffectiveVRAMGB has four sources in priority order; each has a different
+// failure mode, so each is pinned separately.
+func TestEffectiveVRAM_PriorityOrder(t *testing.T) {
+	tests := []struct {
+		name  string
+		specs Specs
+		want  float64
+	}{{
+		// A discrete GPU's VRAM is separate from system RAM and is the most
+		// reliable figure available; 10% goes to driver overhead.
+		name:  "discrete gpu wins outright",
+		specs: Specs{TotalRAMGB: 64, FreeRAMGB: 40, GPUVRAMGB: 24},
+		want:  24 * 0.90,
+	}, {
+		// Apple Silicon has unified memory: GPUVRAMGB is not a separate pool,
+		// so treating it as one would double-count the same bytes.
+		name:  "apple silicon ignores the vram field",
+		specs: Specs{TotalRAMGB: 32, FreeRAMGB: 20, GPUVRAMGB: 32, IsAppleSilicon: true},
+		want:  20 - osMinBufferGB,
+	}, {
+		// Historical P75 beats the instantaneous snapshot: a momentary dip
+		// while a build runs must not permanently downgrade the recommendation.
+		name: "reliable history beats the current snapshot",
+		specs: Specs{
+			TotalRAMGB: 32, FreeRAMGB: 4,
+			History: &HistoricalStats{Reliable: true, P75FreeGB: 18},
+		},
+		want: 18 - osMinBufferGB,
+	}, {
+		name: "unreliable history is ignored",
+		specs: Specs{
+			TotalRAMGB: 32, FreeRAMGB: 10,
+			History: &HistoricalStats{Reliable: false, P75FreeGB: 18},
+		},
+		want: 10 - osMinBufferGB,
+	}, {
+		// Nothing known: a conservative fraction, not the full machine.
+		name:  "no free reading falls back to a fraction of total",
+		specs: Specs{TotalRAMGB: 32},
+		want:  32*0.55 - osMinBufferGB,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.specs.EffectiveVRAMGB()
+			if diff := got - tt.want; diff > 0.001 || diff < -0.001 {
+				t.Errorf("EffectiveVRAMGB() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// The OS buffer and the 85%-of-total ceiling are the two guards against
+// recommending a model that pushes the machine into swap.
+func TestEffectiveVRAM_ClampsAtBothEnds(t *testing.T) {
+	// Free memory below the OS buffer must floor at 0, never go negative — a
+	// negative budget compares as "smaller than every model", which happens to
+	// be right, but the number is then printed to the user.
+	tight := Specs{TotalRAMGB: 16, FreeRAMGB: 0.5}
+	if got := tight.EffectiveVRAMGB(); got != 0 {
+		t.Errorf("EffectiveVRAMGB() = %v with %.1fGB free, want 0", got, tight.FreeRAMGB)
+	}
+
+	// A free reading larger than makes sense (a broken /proc, a VM balloon)
+	// must not hand out the whole machine.
+	bogus := Specs{TotalRAMGB: 16, FreeRAMGB: 99}
+	if got, ceiling := bogus.EffectiveVRAMGB(), 16*0.85; got != ceiling {
+		t.Errorf("EffectiveVRAMGB() = %v with a bogus free reading, want the %.1f ceiling",
+			got, ceiling)
+	}
+}
+
+// Summary and MemoryNote are the strings the user actually reads. Each branch
+// must name real numbers and must never render an unknown machine as an empty
+// one (#258).
+func TestSummaryAndMemoryNote_EveryBranch(t *testing.T) {
+	tests := []struct {
+		name        string
+		specs       Specs
+		wantSummary []string
+		wantNote    []string
+	}{{
+		name:        "unknown hardware says so in both",
+		specs:       Specs{},
+		wantSummary: []string{"unknown"},
+		wantNote:    []string{"could not be detected"},
+	}, {
+		name:        "apple silicon",
+		specs:       Specs{TotalRAMGB: 32, FreeRAMGB: 20, IsAppleSilicon: true},
+		wantSummary: []string{"Apple Silicon", "32GB total"},
+		wantNote:    []string{"usable", "OS buffer"},
+	}, {
+		name:        "apple silicon with no headroom left",
+		specs:       Specs{TotalRAMGB: 32, FreeRAMGB: 1.0, IsAppleSilicon: true},
+		wantSummary: []string{"fully occupied"},
+		wantNote:    []string{"close other apps"},
+	}, {
+		name:        "discrete gpu names the card",
+		specs:       Specs{TotalRAMGB: 64, FreeRAMGB: 40, GPUVRAMGB: 24, GPUName: "RTX 4090"},
+		wantSummary: []string{"RTX 4090", "24GB VRAM"},
+		wantNote:    []string{"VRAM usable", "driver overhead"},
+	}, {
+		name:        "cpu only",
+		specs:       Specs{TotalRAMGB: 16, FreeRAMGB: 9},
+		wantSummary: []string{"CPU inference"},
+		wantNote:    []string{"in use by other processes"},
+	}, {
+		name:        "cpu only with memory exhausted",
+		specs:       Specs{TotalRAMGB: 16, FreeRAMGB: 1.2},
+		wantSummary: []string{"fully occupied"},
+		wantNote:    []string{"close other apps"},
+	}, {
+		// Total known but no free reading at all: the note must say the usage
+		// is unknown rather than presenting the estimate as measured.
+		name:        "total known, current usage unknown",
+		specs:       Specs{TotalRAMGB: 16},
+		wantSummary: []string{"16GB RAM"},
+		wantNote:    []string{"current usage unknown"},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := tt.specs.Summary()
+			for _, want := range tt.wantSummary {
+				if !strings.Contains(summary, want) {
+					t.Errorf("Summary() = %q, want it to mention %q", summary, want)
+				}
+			}
+			note := tt.specs.MemoryNote()
+			for _, want := range tt.wantNote {
+				if !strings.Contains(note, want) {
+					t.Errorf("MemoryNote() = %q, want it to mention %q", note, want)
+				}
+			}
+		})
+	}
+}
+
+// PressureWarning gates whether the user is told to close apps. An unknown
+// reading must produce the "cannot size local models" message, not silence —
+// silence reads as "everything is fine".
+func TestPressureWarning_EveryLevel(t *testing.T) {
+	tests := []struct {
+		pressure Pressure
+		want     string
+	}{
+		{PressureUnknown, "could not be detected"},
+		{PressureModerate, "close other apps"},
+		{PressureHigh, "smaller models recommended"},
+		{PressureLow, ""},
+	}
+	for _, tt := range tests {
+		s := Specs{TotalRAMGB: 16, FreeRAMGB: 4, MemPressure: tt.pressure}
+		got := s.PressureWarning()
+		if tt.want == "" {
+			if got != "" {
+				t.Errorf("PressureWarning() at %v = %q, want no warning", tt.pressure, got)
+			}
+			continue
+		}
+		if !strings.Contains(got, tt.want) {
+			t.Errorf("PressureWarning() at %v = %q, want it to mention %q", tt.pressure, got, tt.want)
+		}
+	}
+}
+
+// computePressure's thresholds decide the warning above. They are a function of
+// the ratio, so they are checked at the ratio boundaries.
+func TestComputePressure_Thresholds(t *testing.T) {
+	tests := []struct {
+		name string
+		s    Specs
+		want Pressure
+	}{
+		{"no reading at all is unknown, not low", Specs{}, PressureUnknown},
+		{"half the machine free is low", Specs{TotalRAMGB: 32, FreeRAMGB: 18}, PressureLow},
+		{"a third free is moderate", Specs{TotalRAMGB: 32, FreeRAMGB: 10}, PressureModerate},
+		{"almost nothing free is high", Specs{TotalRAMGB: 32, FreeRAMGB: 3}, PressureHigh},
+	}
+	for _, tt := range tests {
+		if got := tt.s.computePressure(); got != tt.want {
+			t.Errorf("%s: computePressure() = %v, want %v (effective %.1f of %.0f)",
+				tt.name, got, tt.want, tt.s.EffectiveVRAMGB(), tt.s.TotalRAMGB)
+		}
+	}
+}
+
+// The recommendation list is ordered by capability, so the first model that
+// fits is the best one that fits. The reason and cost strings are what the
+// wizard prints next to each entry.
+func TestOllamaRecommendations_RankAndExplain(t *testing.T) {
+	// 12GB free on an Apple Silicon machine: the 10GB models fit, the 20GB
+	// ones do not.
+	s := Specs{TotalRAMGB: 32, FreeRAMGB: 12, IsAppleSilicon: true, MemPressure: PressureModerate}
+	recs := s.OllamaRecommendations()
+	if len(recs) != len(ollamaModels) {
+		t.Fatalf("got %d recommendations, want one per model", len(recs))
+	}
+
+	var firstFit *ModelRecommendation
+	for i := range recs {
+		m := recs[i]
+		if m.Fits && firstFit == nil {
+			firstFit = &recs[i]
+		}
+		if m.Fits && m.RAMNeededGB > s.EffectiveVRAMGB() {
+			t.Errorf("%s is marked Fits but needs %.0fGB of %.1fGB",
+				m.Model, m.RAMNeededGB, s.EffectiveVRAMGB())
+		}
+		if m.Reason == "" || m.MemoryCost == "" {
+			t.Errorf("%s has no reason/cost string to show the user: %+v", m.Model, m)
+		}
+		if !m.Fits && !strings.Contains(m.MemoryCost, "you have") {
+			t.Errorf("%s does not fit but its cost string does not say what is available: %q",
+				m.Model, m.MemoryCost)
+		}
+	}
+	if firstFit == nil {
+		t.Fatal("nothing fits in 10.5GB usable — the 3GB models should")
+	}
+	if !strings.Contains(firstFit.Reason, "unified memory") {
+		t.Errorf("Apple Silicon reason = %q, want it to name unified memory", firstFit.Reason)
+	}
+	if !strings.Contains(firstFit.Reason, "memory moderate") {
+		t.Errorf("reason = %q, want the moderate-pressure note appended", firstFit.Reason)
+	}
+
+	if best := s.BestOllamaModel(); best.Model != firstFit.Model {
+		t.Errorf("BestOllamaModel() = %s, want the first fitting model %s", best.Model, firstFit.Model)
+	}
+	if !s.AnyLocalModelFits() {
+		t.Error("AnyLocalModelFits() = false when models fit")
+	}
+}
+
+func TestOllamaRecommendations_ReasonNamesWhereTheMemoryIs(t *testing.T) {
+	gpu := Specs{TotalRAMGB: 64, FreeRAMGB: 40, GPUVRAMGB: 24, GPUName: "RTX 4090"}
+	if r := gpu.BestOllamaModel().Reason; !strings.Contains(r, "RTX 4090") {
+		t.Errorf("GPU reason = %q, want it to name the card", r)
+	}
+	cpu := Specs{TotalRAMGB: 32, FreeRAMGB: 20}
+	if r := cpu.BestOllamaModel().Reason; !strings.Contains(r, "CPU inference") {
+		t.Errorf("CPU reason = %q, want it to say CPU inference", r)
+	}
+	// Enough for a small model, but flagged high — the reason must still carry
+	// the swap warning rather than reading as a clean fit.
+	tight := Specs{TotalRAMGB: 16, FreeRAMGB: 4.6, MemPressure: PressureHigh}
+	if r := tight.BestOllamaModel().Reason; !strings.Contains(r, "may swap") {
+		t.Errorf("high-pressure reason = %q, want the swap warning", r)
+	}
+}
+
+// Nothing fitting is a normal outcome on a small machine and must be reported
+// as a memory verdict, not as an unknown-hardware one.
+func TestBestOllamaModel_DistinguishesTooSmallFromUnknown(t *testing.T) {
+	small := Specs{TotalRAMGB: 2, FreeRAMGB: 1.6}
+	best := small.BestOllamaModel()
+	if best.Fits {
+		t.Fatalf("a 2GB machine fits %s", best.Model)
+	}
+	if !strings.Contains(best.Reason, "insufficient memory") {
+		t.Errorf("Reason = %q, want it to say memory is insufficient", best.Reason)
+	}
+	if small.AnyLocalModelFits() {
+		t.Error("AnyLocalModelFits() = true on a 2GB machine")
+	}
+
+	unknown := Specs{}
+	if r := unknown.BestOllamaModel().Reason; !strings.Contains(r, "could not be detected") {
+		t.Errorf("unknown hardware Reason = %q, want it to say hardware was unreadable, "+
+			"not that memory is insufficient", r)
+	}
+}
+
+// The history file drives the P75 estimate. It is written by every Detect(),
+// so it must be rate-limited, tolerate a corrupt line, and drop stale samples.
+func TestHistory_RateLimitedAppendAndParse(t *testing.T) {
+	home := sandboxHome(t)
+	path := filepath.Join(home, ".hydra", historyFile)
+
+	recordSample(&Specs{TotalRAMGB: 32, FreeRAMGB: 12, WiredRAMGB: 4})
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("no history was written: %v", err)
+	}
+
+	// A second call inside the sample interval must not append — Detect() runs
+	// on every command, and an unbounded append would grow without limit.
+	recordSample(&Specs{TotalRAMGB: 32, FreeRAMGB: 99})
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != len(first) {
+		t.Errorf("a second sample was written %v after the first; the interval is %v",
+			0, sampleInterval)
+	}
+
+	// Backdate the file past the interval and it must append again.
+	old := time.Now().Add(-2 * sampleInterval)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	recordSample(&Specs{TotalRAMGB: 32, FreeRAMGB: 14})
+	third, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(third) <= len(second) {
+		t.Error("no sample was appended after the interval elapsed")
+	}
+}
+
+func TestLoadHistory_StatsAndReliabilityThreshold(t *testing.T) {
+	home := sandboxHome(t)
+
+	// No file yet: nil, so EffectiveVRAMGB falls through to the snapshot.
+	if got := LoadHistory(); got != nil {
+		t.Errorf("LoadHistory() = %+v with no file, want nil", got)
+	}
+
+	dir := filepath.Join(home, ".hydra")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	lines := []string{
+		`{"ts":"` + now.Add(-72*time.Hour).Format(time.RFC3339Nano) + `","total_gb":32,"free_gb":8}`,
+		`{"ts":"` + now.Add(-48*time.Hour).Format(time.RFC3339Nano) + `","total_gb":32,"free_gb":12}`,
+		`not json at all`,
+		`{"ts":"` + now.Add(-24*time.Hour).Format(time.RFC3339Nano) + `","total_gb":32,"free_gb":16}`,
+		// Older than historyDays — must be dropped, not averaged in.
+		`{"ts":"` + now.AddDate(0, 0, -30).Format(time.RFC3339Nano) + `","total_gb":32,"free_gb":0.1}`,
+	}
+	path := filepath.Join(dir, historyFile)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h := LoadHistory()
+	if h == nil {
+		t.Fatal("LoadHistory() = nil with three valid samples")
+	}
+	if h.Samples != 3 {
+		t.Errorf("Samples = %d, want 3 (corrupt line skipped, 30-day-old sample dropped)", h.Samples)
+	}
+	if h.MinFreeGB != 8 || h.MaxFreeGB != 16 {
+		t.Errorf("range = [%v, %v], want [8, 16] — the stale 0.1 sample leaked in",
+			h.MinFreeGB, h.MaxFreeGB)
+	}
+	if h.AvgFreeGB != 12 {
+		t.Errorf("AvgFreeGB = %v, want 12", h.AvgFreeGB)
+	}
+	if h.P75FreeGB < h.AvgFreeGB || h.P75FreeGB > h.MaxFreeGB {
+		t.Errorf("P75 = %v, outside [avg %v, max %v]", h.P75FreeGB, h.AvgFreeGB, h.MaxFreeGB)
+	}
+	if !h.Reliable {
+		t.Errorf("Reliable = false with %d samples, threshold is %d", h.Samples, minSamples)
+	}
+	if h.Days < 3 {
+		t.Errorf("Days = %d, want the ~3-day span of the samples", h.Days)
+	}
+}
+
+func TestLoadHistory_TooFewSamplesIsNotReliable(t *testing.T) {
+	home := sandboxHome(t)
+	dir := filepath.Join(home, ".hydra")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"ts":"` + time.Now().UTC().Format(time.RFC3339Nano) + `","total_gb":32,"free_gb":9}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, historyFile), []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h := LoadHistory()
+	if h == nil {
+		t.Fatal("LoadHistory() = nil with one sample")
+	}
+	if h.Reliable {
+		t.Errorf("one sample was treated as reliable; %d are required", minSamples)
+	}
+	// And an unreliable history must not be used as the estimate.
+	s := Specs{TotalRAMGB: 32, FreeRAMGB: 20, History: h}
+	if got, want := s.EffectiveVRAMGB(), 20-osMinBufferGB; got != want {
+		t.Errorf("EffectiveVRAMGB() = %v, want the snapshot-based %v — an unreliable "+
+			"history was used", got, want)
+	}
+}
+
+// percentile interpolates; the boundary cases are where an off-by-one shows up.
+func TestPercentile_BoundariesAndInterpolation(t *testing.T) {
+	if got := percentile(nil, 75); got != 0 {
+		t.Errorf("percentile(nil) = %v, want 0", got)
+	}
+	one := []float64{7}
+	if got := percentile(one, 75); got != 7 {
+		t.Errorf("percentile([7], 75) = %v, want 7", got)
+	}
+	sorted := []float64{0, 10}
+	if got := percentile(sorted, 100); got != 10 {
+		t.Errorf("percentile(_, 100) = %v, want the max", got)
+	}
+	if got := percentile(sorted, 0); got != 0 {
+		t.Errorf("percentile(_, 0) = %v, want the min", got)
+	}
+	if got := percentile(sorted, 50); got != 5 {
+		t.Errorf("percentile([0,10], 50) = %v, want the interpolated 5", got)
+	}
+}
+
+// Detect() is called on every command. It must never panic and never return
+// nil, whatever the platform reports.
+func TestDetect_IsAlwaysUsable(t *testing.T) {
+	sandboxHome(t)
+
+	s := Detect()
+	if s == nil {
+		t.Fatal("Detect() = nil")
+	}
+	if s.OS == "" || s.Arch == "" {
+		t.Errorf("Detect() did not record the platform: %+v", s)
+	}
+	if s.MemPressure == PressureLow && !s.HardwareKnown() {
+		t.Error("unknown hardware was reported as low memory pressure (#258)")
+	}
+	// A sample was recorded, so a second Detect() has history to load.
+	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".hydra", historyFile)); err != nil {
+		if _, werr := os.Stat(filepath.Join(os.Getenv("USERPROFILE"), ".hydra", historyFile)); werr != nil {
+			t.Errorf("Detect() recorded no memory sample: %v", err)
+		}
+	}
+}
+
+// system_profiler's output is free-form text; the VRAM line differs between
+// Intel Macs (dedicated card, "VRAM (Total): 8 GB") and older ones reporting
+// MB. A misparse here reports the wrong budget for local models.
+func TestParseSPDisplays(t *testing.T) {
+	tests := []struct {
+		name     string
+		out      string
+		wantVRAM float64
+		wantName string
+	}{{
+		name: "dedicated card in GB",
+		out: `Graphics/Displays:
+    AMD Radeon Pro 5500M:
+      Chipset Model: AMD Radeon Pro 5500M
+      VRAM (Total): 8 GB
+      Vendor: AMD`,
+		wantVRAM: 8,
+		wantName: "AMD Radeon Pro 5500M",
+	}, {
+		name: "older card reporting MB is converted to GB",
+		out: `      Chipset Model: Intel Iris Plus
+      VRAM (Dynamic, Max): 1536 MB`,
+		wantVRAM: 1.5,
+		wantName: "Intel Iris Plus",
+	}, {
+		// Apple Silicon has no VRAM line at all — unified memory. The name is
+		// still worth reporting; the size must be 0, not a guess.
+		name: "apple silicon reports a name but no vram",
+		out: `      Chipset Model: Apple M3 Max
+      Type: GPU
+      Bus: Built-In`,
+		wantVRAM: 0,
+		wantName: "Apple M3 Max",
+	}, {
+		name:     "empty output yields nothing rather than a default",
+		out:      "",
+		wantVRAM: 0,
+		wantName: "",
+	}, {
+		// A VRAM line whose number will not parse must be skipped, not counted
+		// as zero and not panicked on.
+		name:     "unparsable vram value is skipped",
+		out:      "      VRAM (Total): lots GB",
+		wantVRAM: 0,
+		wantName: "",
+	}, {
+		name:     "a unit with nothing before it does not index out of range",
+		out:      "VRAM GB",
+		wantVRAM: 0,
+		wantName: "",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVRAM, gotName := parseSPDisplays([]byte(tt.out))
+			if gotVRAM != tt.wantVRAM {
+				t.Errorf("VRAM = %v, want %v", gotVRAM, tt.wantVRAM)
+			}
+			if gotName != tt.wantName {
+				t.Errorf("name = %q, want %q", gotName, tt.wantName)
+			}
+		})
+	}
+}
+
+// nvidia-smi reports MiB with --nounits. Treating that number as GB would
+// over-report a 24GB card as 24576GB and recommend every model.
+func TestParseNvidiaSMI(t *testing.T) {
+	tests := []struct {
+		name     string
+		out      string
+		wantVRAM float64
+		wantName string
+	}{{
+		name:     "single card, MB converted to GB",
+		out:      "24564, NVIDIA GeForce RTX 4090\n",
+		wantVRAM: 24564.0 / 1024,
+		wantName: "NVIDIA GeForce RTX 4090",
+	}, {
+		name:     "multi-GPU takes the first row only",
+		out:      "8192, NVIDIA A10\n40960, NVIDIA A100\n",
+		wantVRAM: 8,
+		wantName: "NVIDIA A10",
+	}, {
+		name: "no output at all",
+		out:  "",
+	}, {
+		name: "a row with no name is rejected rather than half-read",
+		out:  "24564\n",
+	}, {
+		name: "an unparsable size is rejected",
+		out:  "N/A, NVIDIA GeForce RTX 4090\n",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVRAM, gotName := parseNvidiaSMI([]byte(tt.out))
+			if diff := gotVRAM - tt.wantVRAM; diff > 0.001 || diff < -0.001 {
+				t.Errorf("VRAM = %v, want %v", gotVRAM, tt.wantVRAM)
+			}
+			if gotName != tt.wantName {
+				t.Errorf("name = %q, want %q", gotName, tt.wantName)
+			}
+		})
+	}
+}
+
+// Every hardware probe shells out. With the tool missing they must report 0 —
+// "unreadable" — and never a fabricated default, which is the #258/#261 defect
+// class. An empty PATH is the portable way to make every one of them fail.
+func TestProbes_MissingToolReportsUnreadableNotADefault(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	if got := darwinRAM(); got != 0 {
+		t.Errorf("darwinRAM() = %v with no sysctl on PATH, want 0", got)
+	}
+	if free, wired := darwinMemoryState(); free != 0 || wired != 0 {
+		t.Errorf("darwinMemoryState() = (%v, %v) with no vm_stat, want (0, 0)", free, wired)
+	}
+	if vram, name := darwinGPUVRAM(); vram != 0 || name != "" {
+		t.Errorf("darwinGPUVRAM() = (%v, %q) with no system_profiler, want (0, \"\")", vram, name)
+	}
+	if vram, name := nvidiaVRAM(); vram != 0 || name != "" {
+		t.Errorf("nvidiaVRAM() = (%v, %q) with no nvidia-smi, want (0, \"\")", vram, name)
+	}
+
+	// windowsMemory is a stub off Windows and the real GlobalMemoryStatusEx call
+	// on it. Either way it must not report negative memory, and off Windows it
+	// must report nothing rather than a plausible-looking number.
+	total, avail := windowsMemory()
+	if total < 0 || avail < 0 {
+		t.Errorf("windowsMemory() = (%v, %v), negative memory", total, avail)
+	}
+	if runtime.GOOS != "windows" && (total != 0 || avail != 0) {
+		t.Errorf("windowsMemory() = (%v, %v) off Windows, want (0, 0)", total, avail)
+	}
+}
+
+// Detect must not fabricate hardware when every probe fails — the machine is
+// then reported as unknown, which is what stops a 0GB budget being presented as
+// a measurement (#258).
+func TestDetect_WithNoProbesAvailableReportsUnknown(t *testing.T) {
+	sandboxHome(t)
+	t.Setenv("PATH", "")
+	if runtime.GOOS == "linux" {
+		// The Linux path reads /proc rather than shelling out; point it at a
+		// path that does not exist so it fails the same way.
+		orig := meminfoPath
+		meminfoPath = filepath.Join(t.TempDir(), "absent")
+		t.Cleanup(func() { meminfoPath = orig })
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("windows reads memory through the kernel, not a subprocess — " +
+			"there is no way to make it fail from here")
+	}
+
+	s := Detect()
+	if s.HardwareKnown() {
+		t.Fatalf("hardware was reported as known with every probe failing: %+v", s)
+	}
+	if s.MemPressure != PressureUnknown {
+		t.Errorf("MemPressure = %v with no reading, want Unknown", s.MemPressure)
+	}
+	if !strings.Contains(s.Summary(), "unknown") {
+		t.Errorf("Summary() = %q, want it to say the hardware is unknown", s.Summary())
+	}
+	if s.AnyLocalModelFits() {
+		t.Error("a model was said to fit on a machine whose memory could not be read")
+	}
+}

--- a/internal/sysinfo/sysinfo.go
+++ b/internal/sysinfo/sysinfo.go
@@ -281,6 +281,17 @@ func darwinGPUVRAM() (float64, string) {
 	if err != nil {
 		return 0, ""
 	}
+	return parseSPDisplays(out)
+}
+
+// parseSPDisplays pulls the chipset name and VRAM size out of
+// `system_profiler SPDisplaysDataType`.
+//
+// Split from the exec for the same reason parseMeminfo is: the parser is the
+// part that can be wrong, and running system_profiler for real is neither
+// deterministic nor available off macOS — so as one function it was untestable
+// everywhere, which is how a misparse ships.
+func parseSPDisplays(out []byte) (float64, string) {
 	lines := strings.Split(string(out), "\n")
 	var name string
 	for _, line := range lines {
@@ -376,6 +387,14 @@ func nvidiaVRAM() (float64, string) {
 	if err != nil {
 		return 0, ""
 	}
+	return parseNvidiaSMI(out)
+}
+
+// parseNvidiaSMI reads the first row of
+// `nvidia-smi --query-gpu=memory.total,name --format=csv,noheader,nounits`,
+// which is MiB and a card name. Split from the exec so it is testable without
+// an NVIDIA card present.
+func parseNvidiaSMI(out []byte) (float64, string) {
 	line := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
 	parts := strings.SplitN(line, ", ", 2)
 	if len(parts) < 2 {


### PR DESCRIPTION
## Summary

Phase C of the coverage epic. Eight packages taken to 90%+, and two real
defects found on the way.

| package | before | after |
|---|---|---|
| `internal/policy` | 55.5% | 92.9% |
| `internal/dispatch` | 56.1% | 93.3% |
| `internal/provider/port` | 60.0% | 88.3% |
| `internal/config` | 61.4% | 88.6% |
| `internal/pricing` | 61.9% | 90.7% |
| `internal/review` | 62.7% | 92.3% |
| `internal/sysinfo` | 70.5% | 94.5% |
| `internal/cost` | 69.9% | 95.8% |

## Defects found

**The pricing tests were overwriting the developer's real cache.** Two of
them set `HYDRA_CONFIG_DIR` and assumed that sandboxed them. Nothing reads
that variable — `config.Dir()` resolves from the home directory — so both
wrote their fixtures straight into `~/.hydra/pricing_cache.json` and left
them there. A plain `go test ./...` replaced the machine's live pricing with
an empty models map, after which every model priced off the tier fallback
until the next background refresh. Verified by reading the file back after a
run. They now use `testutil.NewSandbox`, which is what they meant.

**A whole test was skipping silently.** `NewSandbox` empties `$PATH`, so a
second sandbox in the same test can no longer resolve git and
`AllowHostBinary` skips the test out. One sandbox per test now.

## Notable coverage

- **`dispatch`'s success path had none.** Every prior test selected a head
  that could not execute, so the handoff, the budget book and `state.json`
  were never written under test. A head backed by a fake CLI binary reaches
  it with no network and no API key.
- **`pricing.Load`** is called at the start of every command and had zero
  coverage. Now pinned on all four cache states — absent, fresh, stale,
  corrupt.
- **`review` with no files named** — the default `hyctl review` path, which
  reads what Hydra last edited out of `logs/` — had none either.
- **`sysinfo`**: `parseSPDisplays` and `parseNvidiaSMI` split out of their
  exec calls, matching what `parseMeminfo` already does. `nvidia-smi` reports
  MiB under `--nounits`; reading that as GB would size a 24GB card at
  24576GB.

## Changes

- `internal/{policy,cost,sysinfo,config,pricing,review,dispatch}/*_test.go`,
  `internal/provider/port/provider_test.go` — new tests
- `internal/sysinfo/sysinfo.go` — parser/exec split (behaviour unchanged)
- `internal/pricing/pricing_test.go` — real sandbox

`go test -race ./...` green; `go vet ./...` clean.

Part of #308. Does not close it — Phase D (`executor`, `parallel`, `tui`,
`editor`, `provider`, `swarm`, `update`, `cmd/hydra`) is still outstanding.
