### PR TITLE
test(coverage): Phase D+E — executors, edit paths, swarm and the TUI to 90%; three real fixes

### DIFF
--- a/cmd/hydra/cli_contract_test.go
+++ b/cmd/hydra/cli_contract_test.go
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// The CLI surface is the product. A subcommand that panics, exits 0 on failure,
+// or prints something a script cannot parse is a defect the library tests
+// cannot see, because none of them run the command the user actually types.
+//
+// Everything here drives the real rootCmd inside a sandbox, so no test can
+// reach the network, read the developer's config, or spend money (#267).
+
+// run executes hyctl with the given args and captures stdout, stderr and the
+// error Execute returned. Cobra writes its own diagnostics to the command's
+// output writer; os.Stdout is captured for everything the handlers print.
+func run(t *testing.T, args ...string) (stdout, cobraOut string, err error) {
+	t.Helper()
+
+	root := rootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(args)
+	// Cobra's default is to print usage on every error, which buries the actual
+	// message. Silenced here so the assertion sees what the handler returned.
+	root.SilenceUsage = true
+	root.SilenceErrors = true
+
+	stdout = captureStdout(t, func() { err = root.Execute() })
+	return stdout, buf.String(), err
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, perr := os.Pipe()
+	if perr != nil {
+		t.Fatal(perr)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var b bytes.Buffer
+		_, _ = b.ReadFrom(r)
+		done <- b.String()
+	}()
+
+	func() {
+		defer func() {
+			os.Stdout = orig
+			_ = w.Close()
+		}()
+		fn()
+	}()
+	return <-done
+}
+
+// cliSandbox is a hermetic environment with a usable config, so commands that
+// need one get past their first check.
+func cliSandbox(t *testing.T) *testutil.Sandbox {
+	t.Helper()
+	s := testutil.NewSandbox(t)
+	if err := config.Save(&config.Config{Cortex: "none"}); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// Every subcommand must have help text, and none may panic when asked for it.
+// A command with no Short is invisible in `hyctl --help`.
+func TestCLI_EverySubcommandHasHelp(t *testing.T) {
+	cliSandbox(t)
+
+	var walk func(c *cobra.Command, path string)
+	walk = func(c *cobra.Command, path string) {
+		name := strings.TrimSpace(path + " " + c.Name())
+		if c.Short == "" {
+			t.Errorf("%q has no Short description, so it is invisible in help", name)
+		}
+		if c.Use == "" {
+			t.Errorf("%q has no Use line", name)
+		}
+		for _, sub := range c.Commands() {
+			if sub.Name() == "help" || sub.Name() == "completion" {
+				continue // cobra's own
+			}
+			walk(sub, name)
+		}
+	}
+	walk(rootCmd(), "")
+}
+
+// --help must succeed and name the command, for every subcommand. This is what
+// catches a flag whose definition panics at construction.
+func TestCLI_HelpWorksForEverySubcommand(t *testing.T) {
+	cliSandbox(t)
+
+	for _, c := range rootCmd().Commands() {
+		name := c.Name()
+		if name == "help" || name == "completion" {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			_, out, err := run(t, name, "--help")
+			if err != nil {
+				t.Fatalf("`hyctl %s --help` failed: %v", name, err)
+			}
+			if !strings.Contains(out, name) {
+				t.Errorf("help for %q does not name it:\n%s", name, out)
+			}
+		})
+	}
+}
+
+// `hyctl --version` and `hyctl version` must agree. They used to be separate
+// strings; the root flag answered "unknown flag" while the subcommand worked.
+func TestCLI_VersionFlagAndSubcommandAgree(t *testing.T) {
+	cliSandbox(t)
+
+	sub, _, err := run(t, "version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, flagOut, err := run(t, "--version")
+	if err != nil {
+		t.Fatalf("`hyctl --version` failed: %v", err)
+	}
+	if strings.TrimSpace(sub) != strings.TrimSpace(flagOut) {
+		t.Errorf("`hyctl version` and `hyctl --version` disagree:\n%q\nvs\n%q", sub, flagOut)
+	}
+	if !strings.Contains(sub, "commit") || !strings.Contains(sub, "built") {
+		t.Errorf("version output does not carry build provenance:\n%s", sub)
+	}
+}
+
+// An unknown subcommand and an unknown flag must both fail. Exiting 0 on a
+// typo makes a script think the command ran.
+func TestCLI_UnknownCommandsAndFlagsFail(t *testing.T) {
+	cliSandbox(t)
+
+	if _, _, err := run(t, "definitely-not-a-command"); err == nil {
+		t.Error("an unknown subcommand exited successfully")
+	}
+	if _, _, err := run(t, "status", "--definitely-not-a-flag"); err == nil {
+		t.Error("an unknown flag exited successfully")
+	}
+	if _, _, err := run(t, "cost", "--since"); err == nil {
+		t.Error("a flag missing its value exited successfully")
+	}
+}
+
+// Commands that read logs must handle there being none. A fresh install runs
+// these before anything has dispatched.
+func TestCLI_ReadCommandsSurviveAFreshInstall(t *testing.T) {
+	for _, args := range [][]string{
+		{"status"},
+		{"cost"},
+		{"stats"},
+		{"probe"},
+		{"models", "list"},
+		{"trust", "calibration"},
+		{"trust", "stats"},
+		{"context", "entropy", "--help"},
+		{"mcp", "log"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			cliSandbox(t)
+			out, cobraOut, err := run(t, args...)
+			// Some of these legitimately fail with "nothing recorded yet". What
+			// must never happen is a panic or an empty, silent success.
+			if err == nil && strings.TrimSpace(out+cobraOut) == "" {
+				t.Errorf("`hyctl %s` succeeded and printed nothing; the user cannot "+
+					"tell it ran", strings.Join(args, " "))
+			}
+			if err != nil && strings.TrimSpace(err.Error()) == "" {
+				t.Errorf("`hyctl %s` failed with an empty message", strings.Join(args, " "))
+			}
+		})
+	}
+}
+
+// --json is the scripting surface. Whatever it prints must parse, on a fresh
+// install as much as a populated one — a jq pipeline that breaks when there is
+// no data yet is a broken contract.
+func TestCLI_JSONOutputParses(t *testing.T) {
+	for _, args := range [][]string{
+		{"cost", "--json"},
+		{"models", "list", "--json"},
+		{"probe", "--json"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			cliSandbox(t)
+			out, _, err := run(t, args...)
+			if err != nil {
+				t.Skipf("`hyctl %s` is not available in this environment: %v",
+					strings.Join(args, " "), err)
+			}
+			trimmed := strings.TrimSpace(out)
+			if trimmed == "" {
+				t.Fatalf("`hyctl %s` printed nothing; a jq pipeline gets an empty "+
+					"stream rather than an empty array", strings.Join(args, " "))
+			}
+			var v any
+			if err := json.Unmarshal([]byte(trimmed), &v); err != nil {
+				t.Errorf("`hyctl %s` did not emit valid JSON: %v\n%s",
+					strings.Join(args, " "), err, trimmed)
+			}
+		})
+	}
+}
+
+// A dry run must never execute or spend. This is the flag a user reaches for
+// precisely because they are unsure.
+func TestCLI_DryRunExecutesNothing(t *testing.T) {
+	cliSandbox(t)
+
+	_, _, _ = run(t, "dispatch", "--dry-run", "--enum", "SIMPLE", "write a DTO")
+
+	if _, err := os.Stat(filepath.Join(config.Dir(), "logs", "cost.jsonl")); err == nil {
+		t.Error("a dry run wrote cost rows")
+	}
+	if _, err := os.Stat(filepath.Join(config.Dir(), "logs", "last_handoff.json")); err == nil {
+		t.Error("a dry run wrote a handoff")
+	}
+}
+
+// Commands that write to files must refuse a relative path before doing
+// anything, and say which it was.
+//
+// Only the ones that return an error are driven in-process: `hyctl edit` calls
+// os.Exit(2) on a failed edit — deliberately, so callers can gate on it — which
+// would take the test binary down with it. Exit codes are asserted against a
+// real subprocess below.
+func TestCLI_FileCommandsRefuseUnsafePaths(t *testing.T) {
+	cliSandbox(t)
+
+	for _, args := range [][]string{
+		{"review", "diff", "relative.go"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			_, cobraOut, err := run(t, args...)
+			if err == nil {
+				t.Fatalf("`hyctl %s` accepted a relative path", strings.Join(args, " "))
+			}
+			msg := strings.ToLower(err.Error() + cobraOut)
+			if !strings.Contains(msg, "absolute") && !strings.Contains(msg, "path") {
+				t.Errorf("the error does not say what was wrong with the path: %v", err)
+			}
+		})
+	}
+}
+
+// A command that needs a config must say so rather than proceeding against
+// defaults the user never chose.
+func TestCLI_CommandsNeedingAConfigSaySo(t *testing.T) {
+	testutil.NewSandbox(t) // deliberately no config
+
+	_, cobraOut, err := run(t, "dispatch", "--enum", "SIMPLE", "hello")
+	if err == nil {
+		t.Fatal("dispatch ran with no config")
+	}
+	if !strings.Contains(err.Error()+cobraOut, "init") {
+		t.Errorf("the error does not point at `hyctl init`: %v", err)
+	}
+}
+
+// ── display helpers ───────────────────────────────────────────────────────────
+
+// The status bar is the governor's readout. A bar that overflows its width, or
+// a label that truncates a token count to zero, is a wrong number on screen.
+func TestBudgetBar_StaysWithinItsWidth(t *testing.T) {
+	// -10 is not hypothetical: state.json is hand-edited per the orchestrator
+	// protocol, and a negative value used to panic strings.Repeat.
+	for _, pct := range []int{-100, -10, 0, 1, 50, 99, 100, 150, 1000} {
+		bar := stripANSICodes(budgetBar(pct))
+		if n := len([]rune(bar)); n != 10 {
+			t.Errorf("budgetBar(%d) is %d cells wide, want 10: %q", pct, n, bar)
+		}
+	}
+	// The bar must actually fill as the percentage rises.
+	empty := strings.Count(stripANSICodes(budgetBar(0)), "█")
+	full := strings.Count(stripANSICodes(budgetBar(100)), "█")
+	if empty != 0 || full != 10 {
+		t.Errorf("bar fill = %d at 0%% and %d at 100%%, want 0 and 10", empty, full)
+	}
+}
+
+func TestTokenLabel_DoesNotTruncateToZero(t *testing.T) {
+	tests := map[[2]int]string{
+		{0, 1000}:            "0/1k",
+		{999, 200_000}:       "999/200k",
+		{1500, 200_000}:      "1k/200k",
+		{1_500_000, 2 << 20}: "1.5M/2.1M",
+	}
+	for in, want := range tests {
+		if got := tokenLabel(in[0], in[1]); got != want {
+			t.Errorf("tokenLabel(%d, %d) = %q, want %q", in[0], in[1], got, want)
+		}
+	}
+	// A sub-1000 count must never render as "0k" — that reads as no usage at all.
+	if got := tokenLabel(999, 1000); strings.HasPrefix(got, "0k") {
+		t.Errorf("tokenLabel(999, …) = %q, which reads as zero usage", got)
+	}
+}
+
+// Each governor mode must be visually distinct, or an emergency looks like a
+// normal run.
+func TestBudgetModeStyle_DistinguishesTheModes(t *testing.T) {
+	modes := []string{"emergency", "critical", "warning", "caution", "compact", "normal", ""}
+	seen := map[string]bool{}
+	for _, m := range modes {
+		fg := budgetModeStyle(m).GetForeground()
+		if fg == nil {
+			t.Errorf("mode %q has no colour", m)
+			continue
+		}
+		seen[strings.TrimSpace(stripANSICodes(budgetModeStyle(m).Render("x")))+string(rune(len(seen)))] = true
+	}
+	if budgetModeStyle("emergency").GetForeground() == budgetModeStyle("normal").GetForeground() {
+		t.Error("emergency and normal are coloured identically")
+	}
+	// An unknown mode must fall back to the safe colour rather than panicking.
+	if budgetModeStyle("not-a-mode").GetForeground() == nil {
+		t.Error("an unknown mode has no colour")
+	}
+}
+
+func TestTruncLabel_CountsRunes(t *testing.T) {
+	if got := truncLabel("short", 20); got != "short" {
+		t.Errorf("truncLabel = %q", got)
+	}
+	long := strings.Repeat("a", 40)
+	if n := len([]rune(truncLabel(long, 20))); n != 20 {
+		t.Errorf("truncLabel produced %d runes, want 20", n)
+	}
+	// Multi-byte input must be cut on a rune boundary, not a byte one — a split
+	// rune renders as a replacement character in the table.
+	cjk := strings.Repeat("日", 40)
+	got := truncLabel(cjk, 10)
+	if n := len([]rune(got)); n != 10 {
+		t.Errorf("truncLabel of CJK produced %d runes, want 10", n)
+	}
+	for _, r := range got {
+		if r == '�' {
+			t.Fatalf("truncLabel split a rune: %q", got)
+		}
+	}
+}
+
+func TestToFloat(t *testing.T) {
+	// JSON numbers arrive as float64; a wrong answer here silently zeroes the
+	// budget table.
+	if got := toFloat(float64(52)); got != 52 {
+		t.Errorf("toFloat(float64) = %v", got)
+	}
+	if got := toFloat(52); got != 52 {
+		t.Errorf("toFloat(int) = %v", got)
+	}
+	for _, v := range []any{nil, "52", true, []any{1}} {
+		if got := toFloat(v); got != 0 {
+			t.Errorf("toFloat(%#v) = %v, want 0", v, got)
+		}
+	}
+}
+
+// printBudgetStatus reads state.json written by another process. It must
+// survive every shape that file can be in.
+func TestPrintBudgetStatus_SurvivesEveryStateShape(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state string
+	}{
+		{"absent", ""},
+		{"corrupt", "{truncated"},
+		{"empty object", "{}"},
+		{"pct only", `{"claude_pct":52}`},
+		{"pct with history", `{"claude_pct":60,"claude_pct_history":[10,25,40,52,60]}`},
+		{"budget table", `{"claude_pct":30,"budget":{"m":{"pct":40,"used":1000,"window":200000,"mode":"compact"}}}`},
+		{"wrong types", `{"claude_pct":"fifty","budget":{"m":{"pct":"x","used":null}}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.NewSandbox(t)
+			if tc.state != "" {
+				dir := filepath.Join(config.Dir(), "logs")
+				if err := os.MkdirAll(dir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(tc.state), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			// The assertion is that this returns at all.
+			_ = captureStdout(t, printBudgetStatus)
+		})
+	}
+}
+
+func stripANSICodes(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}

--- a/cmd/hydra/exit_code_test.go
+++ b/cmd/hydra/exit_code_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// Exit codes are a contract: `hyctl edit` returns 2 on a failed edit and the
+// MCP gate returns 3 on a denial, specifically so a shell script can branch on
+// them. They cannot be asserted in-process — os.Exit takes the test binary with
+// it — so these drive a real binary.
+
+var hyctlBin string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "hyctl-cli-contract")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	hyctlBin = filepath.Join(dir, "hyctl")
+	if runtime.GOOS == "windows" {
+		hyctlBin += ".exe"
+	}
+	build := exec.Command("go", "build", "-o", hyctlBin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		// Leave hyctlBin empty; the exit-code tests skip and say why rather
+		// than failing the whole package for a build-environment problem.
+		hyctlBin = ""
+		_, _ = os.Stderr.WriteString("cli contract: could not build hyctl: " +
+			err.Error() + "\n" + string(out) + "\n")
+	}
+	os.Exit(m.Run())
+}
+
+// exitCode runs the built binary in a sandboxed HOME and returns its exit code.
+func exitCode(t *testing.T, args ...string) (code int, output string) {
+	t.Helper()
+	if hyctlBin == "" {
+		t.Skip("hyctl could not be built in this environment")
+	}
+	s := testutil.NewSandbox(t)
+
+	cmd := exec.Command(hyctlBin, args...)
+	cmd.Env = append(os.Environ(),
+		"HOME="+s.Home,
+		"USERPROFILE="+s.Home,
+		"HYDRA_HOME="+s.HydraHome,
+		"HYDRA_NO_UPDATE_CHECK=1",
+		"PATH="+s.BinDir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return 0, string(out)
+	}
+	var exitErr *exec.ExitError
+	if ok := asExitError(err, &exitErr); ok {
+		return exitErr.ExitCode(), string(out)
+	}
+	t.Fatalf("could not run hyctl: %v", err)
+	return -1, ""
+}
+
+func asExitError(err error, target **exec.ExitError) bool {
+	if e, ok := err.(*exec.ExitError); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+// Success is 0 and a typo is not.
+func TestExitCodes_SuccessAndFailureAreDistinguishable(t *testing.T) {
+	if code, out := exitCode(t, "version"); code != 0 {
+		t.Errorf("`hyctl version` exited %d, want 0:\n%s", code, out)
+	}
+	if code, _ := exitCode(t, "--help"); code != 0 {
+		t.Errorf("`hyctl --help` exited %d, want 0", code)
+	}
+	if code, _ := exitCode(t, "definitely-not-a-command"); code == 0 {
+		t.Error("an unknown subcommand exited 0; a script would treat the typo as success")
+	}
+	if code, _ := exitCode(t, "edit", "--file", "relative.go", "--enum", "SIMPLE", "--prompt", "x"); code == 0 {
+		t.Error("`hyctl edit` with a relative path exited 0")
+	}
+}
+
+// A command with no config must fail rather than proceeding against defaults
+// the user never chose.
+func TestExitCodes_MissingConfigFails(t *testing.T) {
+	code, out := exitCode(t, "dispatch", "--enum", "SIMPLE", "hello")
+	if code == 0 {
+		t.Errorf("dispatch exited 0 with no config:\n%s", out)
+	}
+	if !strings.Contains(out, "init") {
+		t.Errorf("the failure does not point at `hyctl init`:\n%s", out)
+	}
+}
+
+// The MCP gate's denial code is what a caller branches on to stop an agent
+// touching a file. A denial that exits 0 is a gate that does not gate.
+func TestExitCodes_MCPDenialIsNonZero(t *testing.T) {
+	code, out := exitCode(t, "mcp", "check", "--action", "read",
+		"--resource", "/etc/shadow", "--agent", "test")
+	if code == 0 {
+		t.Errorf("an MCP check exited 0; callers gate on the code:\n%s", out)
+	}
+}
+
+// stdout must stay parseable: a banner or a warning belongs on stderr, or it
+// lands in whatever is consuming the JSON.
+func TestExitCodes_JSONGoesToStdoutAlone(t *testing.T) {
+	if hyctlBin == "" {
+		t.Skip("hyctl could not be built in this environment")
+	}
+	s := testutil.NewSandbox(t)
+
+	cmd := exec.Command(hyctlBin, "models", "list", "--json")
+	cmd.Env = append(os.Environ(),
+		"HOME="+s.Home, "USERPROFILE="+s.Home, "HYDRA_HOME="+s.HydraHome,
+		"HYDRA_NO_UPDATE_CHECK=1", "PATH="+s.BinDir,
+	)
+	stdout, err := cmd.Output() // stderr deliberately not merged
+	if err != nil {
+		t.Skipf("`hyctl models list --json` is unavailable here: %v", err)
+	}
+	trimmed := strings.TrimSpace(string(stdout))
+	if trimmed == "" {
+		t.Fatal("nothing on stdout")
+	}
+	if trimmed[0] != '{' && trimmed[0] != '[' {
+		t.Errorf("stdout does not start with JSON — something else was printed to "+
+			"it:\n%s", trimmed)
+	}
+}

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -350,6 +350,13 @@ func budgetBar(pct int) string {
 	if filled > width {
 		filled = width
 	}
+	// state.json is written by another process — and by hand, per the
+	// orchestrator protocol's `jq '.claude_pct = 52'`. A negative value there
+	// reached strings.Repeat with a negative count, which panics: `hyctl status`
+	// crashed on a malformed field it only meant to display.
+	if filled < 0 {
+		filled = 0
+	}
 	bar := strings.Repeat("█", filled) + strings.Repeat("░", width-filled)
 	return budgetModeStyle(budget.ModeFor(pct).String()).Render(bar)
 }

--- a/cmd/hydra/render_test.go
+++ b/cmd/hydra/render_test.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/swarm"
+	"github.com/ankit373/hydra/internal/testutil"
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+// The result printers are the only place a swarm or SPRT run becomes visible.
+// A printer that omits a failed head, or renders a cost of $0 for a paid run,
+// is a report the user makes decisions from.
+
+func TestPrintSwarmResult_ShowsEveryAttemptAndMarksTheWinner(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	winner := swarm.Attempt{
+		Head:   provider.Head{ID: "strong", Name: "strong"},
+		Status: swarm.StatusOK, Output: "the winning answer",
+		InputTokens: 100, OutputTokens: 50, EstCostUSD: 0.02,
+		Duration: 2 * time.Second, Rank: 1,
+	}
+	res := &swarm.SwarmResult{
+		Mode:   swarm.ModeBest,
+		Prompt: "the question",
+		Attempts: []swarm.Attempt{
+			winner,
+			{Head: provider.Head{ID: "weak", Name: "weak"}, Status: swarm.StatusOK,
+				Output: "a worse answer", EstCostUSD: 0.01},
+			{Head: provider.Head{ID: "broken", Name: "broken"}, Status: swarm.StatusFailed},
+			{Head: provider.Head{ID: "slow", Name: "slow"}, Status: swarm.StatusTimeout},
+		},
+		Winner:       &winner,
+		TotalCostUSD: 0.03,
+		WallDuration: 3 * time.Second,
+	}
+
+	out := captureStdout(t, func() { printSwarmResult(res) })
+
+	for _, want := range []string{"strong", "weak", "broken", "slow"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the report omits head %q — the user paid for it:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "the winning answer") {
+		t.Errorf("the winning answer is not shown:\n%s", out)
+	}
+	if !strings.Contains(out, "0.03") {
+		t.Errorf("the total cost is not reported:\n%s", out)
+	}
+
+	// A run where everything failed must still render, and must not claim a
+	// winner it does not have.
+	empty := &swarm.SwarmResult{
+		Mode:     swarm.ModeAll,
+		Attempts: []swarm.Attempt{{Head: provider.Head{ID: "a"}, Status: swarm.StatusFailed}},
+	}
+	if got := captureStdout(t, func() { printSwarmResult(empty) }); strings.TrimSpace(got) == "" {
+		t.Error("a fully-failed swarm printed nothing")
+	}
+}
+
+// The SPRT report is the evidence ledger behind a confidence number. Every
+// source that was sampled must appear, or the number is unauditable.
+func TestPrintSPRTResult_ShowsTheWholeLedger(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	res := &swarm.SPRTResult{
+		Domain: "go",
+		Target: 0.95,
+		Trust: &trust.Result{
+			Confidence: 0.96,
+			Samples:    3,
+			SpentUSD:   0.0412,
+			Candidate:  "yes, the migration is safe",
+			Ledger: []trust.Evidence{
+				{Source: "model:a", Agreed: true, LLR: 1.2, LambdaAfter: 1.2},
+				{Source: "model:b", Agreed: false, LLR: -0.4, LambdaAfter: 0.8},
+				{Source: "verifier:go-test", Agreed: true, LLR: 2.5, LambdaAfter: 3.3},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() { printSPRTResult(res) })
+
+	for _, want := range []string{"model:a", "model:b", "verifier:go-test", "go"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the ledger omits %q, so the confidence is unauditable:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "agree") || !strings.Contains(out, "disagree") {
+		t.Errorf("verdicts are not labelled:\n%s", out)
+	}
+	if !strings.Contains(out, "96.0%") {
+		t.Errorf("the confidence reached is not reported:\n%s", out)
+	}
+	if !strings.Contains(out, "yes, the migration is safe") {
+		t.Errorf("the answer itself is not printed:\n%s", out)
+	}
+	if !strings.Contains(out, "0.0412") {
+		t.Errorf("the spend is not reported:\n%s", out)
+	}
+}
+
+// An SPRT run is logged so `hyctl trust stats` and `hyctl trust explain` can
+// read it back. A run that is not logged is a paid ensemble with no record.
+func TestLogTrustRun_WritesAReadableRecord(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	res := &swarm.SPRTResult{
+		Domain: "",
+		Target: 0.9,
+		Attempts: []swarm.Attempt{
+			{Head: provider.Head{ID: "a"}, TokensEstimated: true},
+			{Head: provider.Head{ID: "a"}}, // same head twice
+			{Head: provider.Head{ID: "b"}},
+		},
+		Trust: &trust.Result{Confidence: 0.93, Samples: 3, SpentUSD: 0.01,
+			Decision: trust.DecisionAccept},
+	}
+
+	logTrustRun(res, "is this safe?", "")
+
+	raw, err := os.ReadFile(trust.DefaultLogPath())
+	if err != nil {
+		t.Fatalf("no trust run was logged: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(strings.Split(string(raw), "\n")[0])), &got); err != nil {
+		t.Fatalf("the logged run is not valid JSON: %v\n%s", err, raw)
+	}
+	if got["domain"] != "default" {
+		t.Errorf("domain = %v, want it defaulted rather than logged empty", got["domain"])
+	}
+	models, _ := got["models"].([]any)
+	if len(models) != 2 {
+		t.Errorf("models = %v, want each head once", models)
+	}
+	// An estimated-token run must be labelled, so the spend is not read as
+	// measured.
+	if got["cost_source"] == "actual" {
+		t.Error("a run with estimated tokens was logged as actual spend")
+	}
+	if got["task_hash"] == "" {
+		t.Error("no task hash, so `hyctl trust explain` cannot find this run")
+	}
+}
+
+func TestAnyEstimated(t *testing.T) {
+	if anyEstimated(nil) {
+		t.Error("anyEstimated(nil) = true")
+	}
+	measured := []swarm.Attempt{{}, {}}
+	if anyEstimated(measured) {
+		t.Error("anyEstimated = true with no estimated attempts")
+	}
+	// One estimate taints the whole run: the total cannot be presented as
+	// measured when part of it was guessed.
+	mixed := []swarm.Attempt{{}, {TokensEstimated: true}, {}}
+	if !anyEstimated(mixed) {
+		t.Error("anyEstimated = false with one estimated attempt; the total would " +
+			"be reported as measured spend")
+	}
+}
+
+func TestStatusIcon_CoversEveryStatus(t *testing.T) {
+	seen := map[string]bool{}
+	for _, s := range []swarm.HeadStatus{
+		swarm.StatusOK, swarm.StatusFailed, swarm.StatusTimeout,
+		swarm.StatusCanceled, swarm.StatusAuthRequired, swarm.HeadStatus("unknown"),
+	} {
+		icon := statusIcon(s)
+		if icon == "" {
+			t.Errorf("status %q has no icon", s)
+		}
+		seen[icon] = true
+	}
+	if len(seen) < 2 {
+		t.Error("every status renders the same icon; a failure looks like a success")
+	}
+	if statusIcon(swarm.StatusOK) == statusIcon(swarm.StatusFailed) {
+		t.Error("a failed head shows the same icon as a successful one")
+	}
+}
+
+// The ensemble plan is what --dry-run prints for a confidence run. It must name
+// the heads and the estimated spend, since that is the decision the flag exists
+// to inform.
+func TestPrintEnsemblePlan_NamesTheHeadsAndTheCost(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	heads := []provider.Head{
+		{ID: "a", Name: "vendor · model-a", CapScore: 90},
+		{ID: "b", Name: "vendor · model-b", CapScore: 80},
+	}
+	out := captureStdout(t, func() { printEnsemblePlan(heads, 0.0825, 0.95, swarm.ModeBest, 0) })
+
+	for _, want := range []string{"model-a", "model-b"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the plan omits %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "0.08") {
+		t.Errorf("the plan does not state the estimated cost:\n%s", out)
+	}
+	if !strings.Contains(out, "95") {
+		t.Errorf("the plan does not state the target confidence:\n%s", out)
+	}
+
+	// Without a confidence target the same plan describes a swarm, and must
+	// name the mode rather than an SPRT target it does not have.
+	swarmOut := captureStdout(t, func() {
+		printEnsemblePlan(heads, 0.02, 0, swarm.ModeRace, 0.10)
+	})
+	if !strings.Contains(swarmOut, string(swarm.ModeRace)) {
+		t.Errorf("the swarm plan does not name its mode:\n%s", swarmOut)
+	}
+	if strings.Contains(swarmOut, "SPRT") {
+		t.Errorf("a swarm dry run was labelled as an SPRT run:\n%s", swarmOut)
+	}
+}
+
+// `hyctl cost` and `hyctl stats` against real rows: the read path nothing else
+// exercises end to end.
+func TestCLI_CostAndStatsAgainstRealRows(t *testing.T) {
+	cliSandbox(t)
+
+	dir := filepath.Join(config.Dir(), "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	rows := []string{
+		`{"ts":"` + now + `","model":"claude","tier":1,"enum":"CORE","prompt_tokens":1000,` +
+			`"response_tokens":500,"est_cost_usd":0.05,"wall_ms":1200,"tokens_source":"actual"}`,
+		`{"ts":"` + now + `","model":"qwen","tier":10,"enum":"GRUNT","prompt_tokens":200,` +
+			`"response_tokens":100,"est_cost_usd":0,"wall_ms":300,"tokens_source":"estimated"}`,
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cost.jsonl"),
+		[]byte(strings.Join(rows, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{{"cost"}, {"stats"}, {"cost", "--json"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			out, cobraOut, err := run(t, args...)
+			if err != nil {
+				t.Fatalf("`hyctl %s` failed with real rows: %v", strings.Join(args, " "), err)
+			}
+			combined := out + cobraOut
+			if strings.TrimSpace(combined) == "" {
+				t.Fatalf("`hyctl %s` printed nothing", strings.Join(args, " "))
+			}
+			if args[len(args)-1] == "--json" {
+				var v any
+				if jerr := json.Unmarshal([]byte(strings.TrimSpace(out)), &v); jerr != nil {
+					t.Errorf("--json did not emit valid JSON: %v\n%s", jerr, out)
+				}
+				return
+			}
+			if !strings.Contains(combined, "claude") {
+				t.Errorf("the report does not name the model that was billed:\n%s", combined)
+			}
+		})
+	}
+}

--- a/internal/editor/edit_test.go
+++ b/internal/editor/edit_test.go
@@ -41,19 +41,7 @@ func editSandbox(t *testing.T, reply string) string {
 	// enum MODERATE routes to it. A tier-1 head is stronger than any enum an
 	// edit may ask for, and selection would find nothing.
 	//
-	// /bin/cat by absolute path — the sandbox empties $PATH.
-	body := "#!/bin/sh\n/bin/cat <<'HYDRA_EOF'\n" + reply + "\nHYDRA_EOF\n"
-	if runtime.GOOS == "windows" {
-		body = "@echo off\r\n"
-		for _, line := range strings.Split(reply, "\n") {
-			if line == "" {
-				body += "echo.\r\n"
-				continue
-			}
-			body += "echo " + line + "\r\n"
-		}
-	}
-	s.FakeBinary(t, "cody", body)
+	s.FakeBinary(t, "cody", testutil.EchoScript(reply))
 
 	repo := t.TempDir()
 	// A .git directory that is not a repository: workspace resolution roots

--- a/internal/editor/edit_test.go
+++ b/internal/editor/edit_test.go
@@ -1,0 +1,699 @@
+// SPDX-License-Identifier: MIT
+
+package editor
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/testutil"
+
+	// Providers register themselves in init(), and this package does not import
+	// them — without these blanks provider.All() is empty in the test binary and
+	// every dispatch finds no heads. cmd/hydra imports the same set.
+	_ "github.com/ankit373/hydra/internal/provider/cli"
+)
+
+// Edit is `hyctl edit`: one scoped, validated, rollback-safe file edit driven
+// by a model's output. Nothing about it was covered, and every guard on it is
+// the difference between an edit and a lost file.
+
+// editSandbox gives a hermetic environment with a config, a workspace rooted at
+// a temp repo, and a fake head on PATH that replies with the given body — so a
+// real end-to-end edit runs with no network and no API key.
+func editSandbox(t *testing.T, reply string) string {
+	t.Helper()
+	s := testutil.NewSandbox(t)
+
+	if err := config.Save(&config.Config{Cortex: "cody"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// `cody` rather than `claude`: its capability score puts it at UITier 6, so
+	// enum MODERATE routes to it. A tier-1 head is stronger than any enum an
+	// edit may ask for, and selection would find nothing.
+	//
+	// /bin/cat by absolute path — the sandbox empties $PATH.
+	body := "#!/bin/sh\n/bin/cat <<'HYDRA_EOF'\n" + reply + "\nHYDRA_EOF\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\n"
+		for _, line := range strings.Split(reply, "\n") {
+			if line == "" {
+				body += "echo.\r\n"
+				continue
+			}
+			body += "echo " + line + "\r\n"
+		}
+	}
+	s.FakeBinary(t, "cody", body)
+
+	repo := t.TempDir()
+	// A .git directory that is not a repository: workspace resolution roots
+	// here, but git commands fail, so the .hydra-bak backup is what protects
+	// the file — the path a non-git user is on.
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return repo
+	}
+	return cwd
+}
+
+func marked(content string) string {
+	return "<<<HYDRA_FILE_START>>>\n" + content + "\n<<<HYDRA_FILE_END>>>"
+}
+
+func TestEdit_WritesTheContentAndRecordsTheEdit(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}"))
+	file := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "add an empty main", RunID: "run-edit",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "ok" {
+		t.Fatalf("status = %q, error %q", res.Status, res.Error)
+	}
+
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "func main() {}") {
+		t.Errorf("file = %q, want the model's content", raw)
+	}
+	if strings.Contains(string(raw), "HYDRA_FILE") {
+		t.Errorf("the markers leaked into the file: %q", raw)
+	}
+	if res.LinesAdded == 0 {
+		t.Errorf("LinesAdded = 0 for a file that grew: %+v", res)
+	}
+
+	// last_edit.json is what `hyctl review` with no arguments reads.
+	lastEdit, err := os.ReadFile(filepath.Join(config.Dir(), "logs", "last_edit.json"))
+	if err != nil {
+		t.Fatalf("no last_edit.json was written, so `hyctl review` sees nothing: %v", err)
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(lastEdit, &entry); err != nil {
+		t.Fatal(err)
+	}
+	if entry["file"] != file || entry["enum"] != "MODERATE" {
+		t.Errorf("last_edit.json = %v", entry)
+	}
+
+	// The run log records that the file changed, with the before/after held
+	// beside the log rather than inlined in the event.
+	events, err := runlog.Load("run-edit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawEdit bool
+	for _, e := range events {
+		if e.Kind == runlog.KindEdit {
+			sawEdit = true
+			if e.Ref == "" {
+				t.Error("the edit event carries no snapshot ref, so the diff cannot be rendered")
+			}
+			if !strings.Contains(e.Detail, "+") {
+				t.Errorf("edit event Detail = %q, want the line counts", e.Detail)
+			}
+		}
+	}
+	if !sawEdit {
+		t.Errorf("no edit event in the run log: %+v", events)
+	}
+}
+
+func TestEdit_CreatesAFileThatDoesNotExistYet(t *testing.T) {
+	repo := editSandbox(t, marked("brand new"))
+	file := filepath.Join(repo, "sub", "new.txt")
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "create it",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "ok" {
+		t.Fatalf("status = %q, error %q", res.Status, res.Error)
+	}
+	if raw, err := os.ReadFile(file); err != nil || !strings.Contains(string(raw), "brand new") {
+		t.Errorf("file = %q, err %v", raw, err)
+	}
+	// Nothing to back up for a file that did not exist, so no stray .hydra-bak.
+	if _, err := os.Stat(file + ".hydra-bak"); err == nil {
+		t.Error("a backup was created for a file that did not exist")
+	}
+}
+
+// An empty replacement must leave the file byte-identical. This is the worst
+// outcome the edit path can produce.
+func TestEdit_EmptyReplacementLeavesTheFileUntouched(t *testing.T) {
+	repo := editSandbox(t, marked(""))
+	file := filepath.Join(repo, "keep.go")
+	original := "package main\n\n// do not lose me\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "empty it",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" {
+		t.Fatalf("status = %q, want fail", res.Status)
+	}
+	if raw, _ := os.ReadFile(file); string(raw) != original {
+		t.Errorf("the file was modified despite the refusal: %q", raw)
+	}
+	// The backup this edit created must not be left behind — a stale one is a
+	// wrong baseline for the next edit and for `hyctl review`.
+	if _, err := os.Stat(file + ".hydra-bak"); err == nil {
+		t.Error("a backup survived a refused edit")
+	}
+}
+
+func TestEdit_RefusesBeforeDispatching(t *testing.T) {
+	repo := editSandbox(t, marked("x"))
+
+	tests := []struct {
+		name    string
+		req     Request
+		wantErr string
+	}{
+		{"relative path", Request{File: "relative.go", Enum: "MODERATE", Prompt: "x"}, "absolute"},
+		{"CORE is the orchestrator's own job",
+			Request{File: filepath.Join(repo, "a.go"), Enum: "CORE", Prompt: "x"}, "CORE"},
+		{"outside every workspace",
+			Request{File: filepath.Join(t.TempDir(), "elsewhere.go"), Enum: "MODERATE", Prompt: "x"},
+			"scope_rejected"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := Edit(context.Background(), tt.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.Status != "fail" {
+				t.Fatalf("status = %q, want fail", res.Status)
+			}
+			if !strings.Contains(res.Error, tt.wantErr) {
+				t.Errorf("Error = %q, want it to mention %q", res.Error, tt.wantErr)
+			}
+		})
+	}
+}
+
+// A validator that rejects the edit rolls the file back. An edit that fails
+// validation and stays on disk is worse than no edit at all.
+func TestEdit_FailedValidationRollsBack(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the workspace validator template is a POSIX command line here")
+	}
+	repo := editSandbox(t, marked("will not validate"))
+	writeWorkspaceYAML(t, repo, "/usr/bin/false {file}")
+
+	file := filepath.Join(repo, "a.go")
+	original := "package main\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "x", Validate: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" || !res.RolledBack {
+		t.Fatalf("result = %+v, want a rolled-back failure", res)
+	}
+	if raw, _ := os.ReadFile(file); string(raw) != original {
+		t.Errorf("the file was left in its failed state: %q", raw)
+	}
+	if _, err := os.Stat(file + ".hydra-bak"); err == nil {
+		t.Error("the backup survived the rollback")
+	}
+}
+
+func TestEdit_PassingValidationKeepsTheEdit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the workspace validator template is a POSIX command line here")
+	}
+	repo := editSandbox(t, marked("validated"))
+	writeWorkspaceYAML(t, repo, "/usr/bin/true {file}")
+
+	file := filepath.Join(repo, "a.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "x", Validate: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "ok" || !res.ValidatorPassed {
+		t.Fatalf("result = %+v", res)
+	}
+	if raw, _ := os.ReadFile(file); !strings.Contains(string(raw), "validated") {
+		t.Errorf("the edit was rolled back despite passing: %q", raw)
+	}
+}
+
+// The backup is a verbatim copy of the user's source sitting beside it until
+// the edit is approved. It must not be world-readable — the same defect #273
+// fixed for the run log's edit snapshots.
+//
+// It is only created for a non-git workspace: with a git root, git itself holds
+// the baseline. So the workspace is declared git:"false" here, which is the
+// path a user outside a repository is on.
+func TestEdit_BackupIsCreatedForNonGitWorkspacesAndIsNotWorldReadable(t *testing.T) {
+	repo := editSandbox(t, marked("new content"))
+	writeWorkspaceYAML(t, repo, "")
+
+	file := filepath.Join(repo, "secretish.go")
+	if err := os.WriteFile(file, []byte("const apiKey = \"sk-live\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{File: file, Enum: "MODERATE", Prompt: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "ok" {
+		t.Fatalf("result = %+v", res)
+	}
+	if res.GitRoot != "" {
+		t.Fatalf("GitRoot = %q; the workspace declares git:false, so the backup "+
+			"path is what should have run", res.GitRoot)
+	}
+
+	info, err := os.Stat(file + ".hydra-bak")
+	if err != nil {
+		t.Fatalf("no backup was kept after a successful edit, so `hyctl review "+
+			"reject` has no baseline to restore: %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		return // mode bits carry no access information here
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("backup mode %v is group/other readable; it is a verbatim copy of "+
+			"the user's source", info.Mode().Perm())
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// atomicWrite must preserve the file's existing mode. An edit that silently
+// re-permissions a script to 0644 breaks it, and one that leaves a temp file
+// behind litters the user's tree on every failure.
+func TestAtomicWrite_PreservesModeAndLeavesNoTempFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not carry the executable bit this way")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "run.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicWrite(script, "#!/bin/sh\necho hi\n"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("mode = %v after the edit, want 0755 — the script is no longer "+
+			"executable", info.Mode().Perm())
+	}
+
+	// A new file gets the usual default rather than the temp file's 0600.
+	fresh := filepath.Join(dir, "new.txt")
+	if err := atomicWrite(fresh, "hello"); err != nil {
+		t.Fatal(err)
+	}
+	info, err = os.Stat(fresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("new file mode = %v, want 0644", info.Mode().Perm())
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".hydra-tmp") {
+			t.Errorf("%s survived a successful write", e.Name())
+		}
+	}
+}
+
+func TestReadFile_DistinguishesEmptyFromMissing(t *testing.T) {
+	dir := t.TempDir()
+
+	if content, existed := readFile(filepath.Join(dir, "absent")); existed || content != "" {
+		t.Errorf("readFile of a missing file = (%q, %v)", content, existed)
+	}
+	// An empty file exists. That distinction decides "create" versus "modify"
+	// in the prompt the model is given.
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if content, existed := readFile(empty); !existed || content != "" {
+		t.Errorf("readFile of an empty file = (%q, %v), want (\"\", true)", content, existed)
+	}
+}
+
+func TestRollback_RestoresFromEachSource(t *testing.T) {
+	t.Run("from the backup", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "a.txt")
+		backup := file + ".hydra-bak"
+		if err := os.WriteFile(backup, []byte("original\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(file, []byte("bad\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		rollback(file, "original\n", true, "", backup)
+
+		if raw, _ := os.ReadFile(file); string(raw) != "original\n" {
+			t.Errorf("file = %q after rollback", raw)
+		}
+		if _, err := os.Stat(backup); err == nil {
+			t.Error("the backup survived, so the next edit sees a stale baseline")
+		}
+	})
+
+	t.Run("a created file is removed", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "created.txt")
+		if err := os.WriteFile(file, []byte("bad\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rollback(file, "", false, "", file+".hydra-bak")
+		if _, err := os.Stat(file); err == nil {
+			t.Error("a file the edit created was left behind")
+		}
+	})
+
+	t.Run("from the in-memory snapshot", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "a.txt")
+		if err := os.WriteFile(file, []byte("bad\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		rollback(file, "original\n", true, "", file+".hydra-bak")
+		if raw, _ := os.ReadFile(file); string(raw) != "original\n" {
+			t.Errorf("file = %q, want the snapshot restored", raw)
+		}
+	})
+}
+
+func TestTSCTemplate_OnlyWhenTSCIsInstalled(t *testing.T) {
+	root := t.TempDir()
+	if got := tscTemplate(root); got != "" {
+		t.Errorf("tscTemplate = %q with no node_modules, want empty — naming a "+
+			"binary that is not there fails every TypeScript edit at validation "+
+			"and rolls back a correct change", got)
+	}
+
+	bin := filepath.Join(root, "node_modules", ".bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "tsc"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := tscTemplate(root); !strings.Contains(got, "--noEmit") {
+		t.Errorf("tscTemplate = %q, want a type-check", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "tsconfig.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := tscTemplate(root); !strings.Contains(got, "-p ") {
+		t.Errorf("tscTemplate = %q, want it to use the project's tsconfig.json", got)
+	}
+}
+
+func TestDiffStats_CountsFromTheBackupWhenGitIsUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	backup := file + ".hydra-bak"
+	if err := os.WriteFile(backup, []byte("one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("one\ntwo\nthree\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	added, removed := diffStats(file, "one\n", "", backup, true)
+	if added != 2 || removed != 0 {
+		t.Errorf("diffStats = (%d, %d), want (2, 0) — counted from the edit script, "+
+			"not by re-parsing diff(1) (#260)", added, removed)
+	}
+}
+
+func TestWriteLastEdit_IsReadableByReview(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if err := writeLastEdit("/abs/file.go", "SIMPLE", "ws", 3, 1); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(config.Dir(), "logs", "last_edit.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	// `hyctl review` with no arguments reads the "file" key out of this.
+	if got["file"] != "/abs/file.go" {
+		t.Errorf("last_edit.json file = %v", got["file"])
+	}
+	if got["lines_added"] != float64(3) || got["lines_removed"] != float64(1) {
+		t.Errorf("line counts = %v/%v", got["lines_added"], got["lines_removed"])
+	}
+}
+
+// writeWorkspaceYAML points $HYDRA_HOME's registry at a workspace rooted here
+// with a validator for .go files. allowed_globs is required: a workspace
+// without it matches no file at all.
+func writeWorkspaceYAML(t *testing.T, root, goValidator string) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HYDRA_HOME"), "registry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: \"1.0\"\nworkspaces:\n  test:\n    root: " + root +
+		"\n    git: \"false\"\n    allowed_globs: [\"**\"]\n"
+	if goValidator != "" {
+		body += "validators:\n  go: \"" + goValidator + "\"\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, "workspace.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// atomicWrite's remaining paths: an unreadable source mode falls back to the
+// default rather than erroring, and a write that cannot rename leaves nothing
+// behind.
+func TestAtomicWrite_OverwritesAndPreservesContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+
+	if err := atomicWrite(path, "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWrite(path, "second"); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != "second" {
+		t.Errorf("content = %q after overwrite, want second", raw)
+	}
+
+	// Content with no trailing newline, embedded NULs and CRLF must round-trip
+	// byte for byte — atomicWrite is not a text transform.
+	tricky := "no newline at end\r\nwith crlf\x00and a nul"
+	if err := atomicWrite(path, tricky); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != tricky {
+		t.Errorf("content = %q, want it byte-identical", raw)
+	}
+}
+
+// diffStats' last resort is a line-count delta, used when there is neither a
+// git root nor a backup. It must still report a change rather than 0/0, which
+// reads as "nothing happened".
+func TestDiffStats_LineCountFallback(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(file, []byte("a\nb\nc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	added, removed := diffStats(file, "a\n", "", filepath.Join(dir, "absent.bak"), true)
+	if added == 0 && removed == 0 {
+		t.Error("diffStats reported no change for a file that grew by two lines")
+	}
+
+	// Shrinking is counted as removals, not as negative additions.
+	if err := os.WriteFile(file, []byte("a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	added, removed = diffStats(file, "a\nb\nc\n", "", filepath.Join(dir, "absent.bak"), true)
+	if removed == 0 {
+		t.Errorf("diffStats = (%d, %d) for a file that shrank", added, removed)
+	}
+	if added < 0 || removed < 0 {
+		t.Errorf("diffStats = (%d, %d); a negative count renders as a bogus number",
+			added, removed)
+	}
+}
+
+// stripOuterFence must not eat a fence that belongs to the file's own content.
+func TestStripOuterFence_InnerFencesSurvive(t *testing.T) {
+	in := "```md\n# Title\n\n```sh\nrun me\n```\n```"
+	want := "# Title\n\n```sh\nrun me\n```"
+	if got := stripOuterFence(in); got != want {
+		t.Errorf("stripOuterFence = %q, want %q", got, want)
+	}
+	if got := stripOuterFence(""); got != "" {
+		t.Errorf("stripOuterFence(\"\") = %q", got)
+	}
+	if got := stripOuterFence("```go\nunterminated"); got != "unterminated" {
+		t.Errorf("stripOuterFence with no closing fence = %q", got)
+	}
+}
+
+// A rename that cannot complete must leave no temp file. Windows refuses a
+// rename onto a file another process has open, so this is a real collision
+// path, not a hypothetical one — and every collision leaving a .hydra-tmp.*
+// behind litters the user's source tree.
+func TestAtomicWrite_FailedRenameLeavesNoTempFile(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "adirectory")
+	if err := os.MkdirAll(filepath.Join(target, "child"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := atomicWrite(target, "content"); err == nil {
+		t.Fatal("atomicWrite reported success onto a non-empty directory")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".hydra-tmp") {
+			t.Errorf("%s survived a failed rename", e.Name())
+		}
+	}
+}
+
+// In a real repository git holds the baseline, so a rollback restores from the
+// index rather than from a .hydra-bak that was never written.
+func TestRollback_UsesGitInARepository(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if !s.AllowHostBinary(t, "git") {
+		t.Skip("git is not installed on this machine")
+	}
+
+	repo := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "t"},
+		// Windows git defaults core.autocrlf=true, so a checkout rewrites LF to
+		// CRLF and the restored bytes differ from the committed ones.
+		{"config", "core.autocrlf", "false"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	file := filepath.Join(repo, "a.go")
+	original := "package main\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "a.go"}, {"commit", "-qm", "init"}} {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	if err := os.WriteFile(file, []byte("a bad edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rollback(file, original, true, repo, file+".hydra-bak")
+
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != original {
+		t.Errorf("file = %q after rollback, want the committed content", raw)
+	}
+
+	// An untracked file has nothing in the index to restore, so it is removed.
+	untracked := filepath.Join(repo, "new.go")
+	if err := os.WriteFile(untracked, []byte("created by the edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rollback(untracked, "", false, repo, untracked+".hydra-bak")
+	if _, err := os.Stat(untracked); err == nil {
+		t.Error("an untracked file the edit created survived the rollback")
+	}
+}

--- a/internal/executor/agy_test.go
+++ b/internal/executor/agy_test.go
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// The agy executor is the only one that mutates a file the user owns: it swaps
+// the model into agy's own settings.json, runs, and swaps it back. If it does
+// not swap back, the user's editor is left pointing at whatever model Hydra
+// last routed to — a visible, confusing change they did not make.
+
+// fakeAgy plants an `agy` on the sandbox's PATH with the given behaviour.
+func fakeAgy(t *testing.T, s *testutil.Sandbox, stdout, stderr string, exitCode int) {
+	t.Helper()
+	var body string
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\n"
+		if stdout != "" {
+			for _, line := range strings.Split(stdout, "\n") {
+				body += "echo " + line + "\r\n"
+			}
+		}
+		if stderr != "" {
+			for _, line := range strings.Split(stderr, "\n") {
+				body += "echo " + line + " 1>&2\r\n"
+			}
+		}
+		body += "exit /b " + itoa(exitCode) + "\r\n"
+	} else {
+		body = "#!/bin/sh\n"
+		if stdout != "" {
+			body += "printf '%s\\n' " + shellQuote(stdout) + "\n"
+		}
+		if stderr != "" {
+			body += "printf '%s\\n' " + shellQuote(stderr) + " >&2\n"
+		}
+		body += "exit " + itoa(exitCode) + "\n"
+	}
+	s.FakeBinary(t, "agy", body)
+}
+
+func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'" }
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	return string(rune('0' + n))
+}
+
+// writeAgySettings plants agy's settings.json under the sandbox home.
+func writeAgySettings(t *testing.T, contents map[string]any) string {
+	t.Helper()
+	path := agySitesPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.MarshalIndent(contents, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func readAgySettings(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("settings.json is not valid JSON after the run: %v\n%s", err, raw)
+	}
+	return m
+}
+
+func agyHead(modelFlag string) provider.Head {
+	return provider.Head{
+		ID: "agy-tier-3", Name: "agy-tier-3", Provider: "antigravity", Source: "registry",
+		Meta: map[string]string{"model_flag": modelFlag, "token_pool": "gemini"},
+	}
+}
+
+func TestAgyExecute_SwapsTheModelInAndBackOut(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	fakeAgy(t, s, "the answer", "", 0)
+
+	path := writeAgySettings(t, map[string]any{
+		"model":     "gemini-3-pro",
+		"theme":     "dark", // a setting Hydra does not own
+		"telemetry": false,
+	})
+
+	resp, err := (&AgyExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hello", Head: agyHead("claude-sonnet-4.5"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Output != "the answer" {
+		t.Errorf("Output = %q", resp.Output)
+	}
+
+	after := readAgySettings(t, path)
+	if after["model"] != "gemini-3-pro" {
+		t.Errorf("model = %v after the run, want the user's own %q restored",
+			after["model"], "gemini-3-pro")
+	}
+	// Everything else must survive the round trip untouched.
+	if after["theme"] != "dark" || after["telemetry"] != false {
+		t.Errorf("settings.json lost the user's other keys: %+v", after)
+	}
+	// The sentinel backup must not be left behind — a stale one makes the next
+	// run "recover" to an older state.
+	if _, err := os.Stat(path + agyOrigSuffix); err == nil {
+		t.Error("the sentinel backup survived a clean run")
+	}
+	if _, err := os.Stat(path + ".hydra-tmp"); err == nil {
+		t.Error("a temp file survived a clean run")
+	}
+}
+
+// agy does not report token usage, so Hydra estimates from character count.
+// That estimate must be labelled, or the budget governor and the cost report
+// present a guess as measured spend.
+func TestAgyExecute_TokensAreLabelledAsEstimates(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	fakeAgy(t, s, "0123456789012345678901234567890123456789", "", 0)
+	writeAgySettings(t, map[string]any{"model": "x"})
+
+	resp, err := (&AgyExecutor{}).Execute(context.Background(), Request{
+		Prompt: strings.Repeat("a", 400), Head: agyHead("m"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.TokensEstimated {
+		t.Error("TokensEstimated = false; agy reports no usage, so these are char/4 " +
+			"guesses and must never be booked as measured spend")
+	}
+	if resp.InputTokens != 100 {
+		t.Errorf("InputTokens = %d, want 400/4", resp.InputTokens)
+	}
+	if resp.OutputTokens != 10 {
+		t.Errorf("OutputTokens = %d, want 40/4", resp.OutputTokens)
+	}
+}
+
+// The auth check reads stderr and the first three lines of stdout only. It must
+// not scan the whole answer: a model asked about authentication will happily
+// write "please log in" in its response, and treating that as an auth failure
+// would discard a paid answer and send the user to a login page.
+func TestAgyExecute_AuthPhraseInTheAnswerIsNotAnAuthFailure(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	answer := "Here is the code:\nline two\nline three\nTo fix it, tell the user: please log in"
+	fakeAgy(t, s, answer, "", 0)
+	writeAgySettings(t, map[string]any{"model": "x"})
+
+	resp, err := (&AgyExecutor{}).Execute(context.Background(), Request{
+		Prompt: "how do I prompt for login?", Head: agyHead("m"),
+	})
+	if err != nil {
+		t.Fatalf("an answer that mentions logging in was treated as an auth failure: %v", err)
+	}
+	if !strings.Contains(resp.Output, "please log in") {
+		t.Errorf("Output = %q, want the full answer", resp.Output)
+	}
+	if _, err := os.Stat(filepath.Join(config.Dir(), "logs", "auth_required.json")); err == nil {
+		t.Error("auth_required.json was written for a successful answer")
+	}
+}
+
+// A real auth failure must be typed, carry the pool and the URL, and be
+// recorded for the TUI to surface.
+func TestAgyExecute_RealAuthFailureIsTypedAndRecorded(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	fakeAgy(t, s, "", "Not authenticated. Please sign in at https://antigravity.google/auth to continue.", 1)
+	writeAgySettings(t, map[string]any{"model": "gemini-3-pro"})
+
+	_, err := (&AgyExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hi", Head: agyHead("claude-sonnet-4.5"),
+	})
+	if err == nil {
+		t.Fatal("an auth failure was reported as success")
+	}
+	authErr, ok := err.(*AuthRequiredError)
+	if !ok {
+		t.Fatalf("error is %T, want *AuthRequiredError — dispatch keys its fallback "+
+			"on the type, not on the message", err)
+	}
+	if authErr.Pool != "gemini" || authErr.ModelFlag != "claude-sonnet-4.5" {
+		t.Errorf("AuthRequiredError = %+v, want the pool and model that failed", authErr)
+	}
+	if !strings.Contains(authErr.AuthURL, "antigravity.google/auth") {
+		t.Errorf("AuthURL = %q, want the URL from agy's own message", authErr.AuthURL)
+	}
+	if msg := authErr.Error(); !strings.Contains(msg, "gemini") || !strings.Contains(msg, authErr.AuthURL) {
+		t.Errorf("Error() = %q, want it to name the pool and where to authenticate", msg)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(config.Dir(), "logs", "auth_required.json"))
+	if err != nil {
+		t.Fatalf("no auth_required.json was written for the TUI to surface: %v", err)
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		t.Fatal(err)
+	}
+	if entry["pool"] != "gemini" || entry["model"] != "claude-sonnet-4.5" {
+		t.Errorf("auth_required.json = %v", entry)
+	}
+	if entry["detected_at"] == "" {
+		t.Error("auth_required.json carries no timestamp, so a stale one cannot be aged out")
+	}
+}
+
+// An error with no auth signal must stay an ordinary failure carrying stderr,
+// so dispatch falls through to the next head rather than stopping to ask the
+// user to log in.
+func TestAgyExecute_OrdinaryFailureIsNotAnAuthError(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	fakeAgy(t, s, "", "model overloaded, try again", 1)
+	writeAgySettings(t, map[string]any{"model": "x"})
+
+	_, err := (&AgyExecutor{}).Execute(context.Background(), Request{Prompt: "hi", Head: agyHead("m")})
+	if err == nil {
+		t.Fatal("a failing agy was reported as success")
+	}
+	if _, ok := err.(*AuthRequiredError); ok {
+		t.Fatalf("an ordinary failure was classified as an auth failure: %v", err)
+	}
+	if !strings.Contains(err.Error(), "model overloaded") {
+		t.Errorf("error = %v, want agy's own stderr", err)
+	}
+}
+
+// A head with no model_flag cannot be routed to agy at all — swapping in an
+// empty model would run whatever agy happened to be set to.
+func TestAgyExecute_MissingModelFlagIsRefused(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	_, err := (&AgyExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hi",
+		Head:   provider.Head{ID: "agy-tier-1", Provider: "antigravity", Source: "registry"},
+	})
+	if err == nil {
+		t.Fatal("a head with no model_flag was executed")
+	}
+	if !strings.Contains(err.Error(), "model_flag") {
+		t.Errorf("error = %v, want it to name the missing field", err)
+	}
+}
+
+// With no settings.json at all, agy still runs — it just cannot be pinned to a
+// model. A user who has never opened agy must not get a hard failure.
+func TestAgyExecute_NoSettingsFileStillRuns(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	fakeAgy(t, s, "ran anyway", "", 0)
+
+	resp, err := (&AgyExecutor{}).Execute(context.Background(), Request{Prompt: "hi", Head: agyHead("m")})
+	if err != nil {
+		t.Fatalf("agy refused to run without a settings.json: %v", err)
+	}
+	if resp.Output != "ran anyway" {
+		t.Errorf("Output = %q", resp.Output)
+	}
+}
+
+// swapAgyModel writes a sentinel before it mutates anything, so a SIGKILL
+// between the swap and the restore is recoverable. Without it the user's agy is
+// left pinned to Hydra's last model with nothing recording what it was.
+func TestRecoverAgySwap_UndoesAKilledSwap(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	path := writeAgySettings(t, map[string]any{"model": "the-users-model", "theme": "dark"})
+
+	original, err := swapAgyModel(path, "hydras-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if original != "the-users-model" {
+		t.Errorf("swapAgyModel returned %q as the original", original)
+	}
+	if got := readAgySettings(t, path)["model"]; got != "hydras-model" {
+		t.Fatalf("model = %v after the swap, want Hydra's", got)
+	}
+	// Simulate SIGKILL: the deferred restore never runs.
+	if _, err := os.Stat(path + agyOrigSuffix); err != nil {
+		t.Fatalf("no sentinel was written before the mutation: %v", err)
+	}
+
+	recoverAgySwap(path)
+
+	after := readAgySettings(t, path)
+	if after["model"] != "the-users-model" {
+		t.Errorf("model = %v after recovery, want the user's own restored", after["model"])
+	}
+	if after["theme"] != "dark" {
+		t.Errorf("recovery lost the user's other settings: %+v", after)
+	}
+	if _, err := os.Stat(path + agyOrigSuffix); err == nil {
+		t.Error("the sentinel survived recovery, so the next run would recover again")
+	}
+
+	// With no sentinel, recovery is a no-op rather than a truncation.
+	before := readAgySettings(t, path)
+	recoverAgySwap(path)
+	if got := readAgySettings(t, path); got["model"] != before["model"] {
+		t.Error("recoverAgySwap changed settings.json with no sentinel present")
+	}
+}
+
+// A settings.json with no model key means the user never pinned one. Restoring
+// must remove the key again rather than writing an empty string, which agy
+// would read as a model named "".
+func TestRestoreAgyModel_RemovesTheKeyWhenThereWasNone(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	path := writeAgySettings(t, map[string]any{"theme": "dark"})
+
+	original, err := swapAgyModel(path, "hydras-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if original != "" {
+		t.Errorf("original = %q, want empty — there was no model key", original)
+	}
+
+	restoreAgyModel(path, original)
+
+	after := readAgySettings(t, path)
+	if _, present := after["model"]; present {
+		t.Errorf("model key = %v after restore, want it absent as it was before",
+			after["model"])
+	}
+}
+
+// A settings.json that is not JSON must not be overwritten. Hydra cannot know
+// what it meant, and replacing it destroys the user's config.
+func TestSwapAgyModel_RefusesToTouchUnparsableSettings(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	path := agySitesPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := []byte("{ this was hand-edited and is broken")
+	if err := os.WriteFile(path, corrupt, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := swapAgyModel(path, "m"); err == nil {
+		t.Fatal("an unparsable settings.json was swapped anyway")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != string(corrupt) {
+		t.Errorf("settings.json was modified: %q", raw)
+	}
+	// No sentinel may be left pointing at a file that was never swapped.
+	if _, err := os.Stat(path + agyOrigSuffix); err == nil {
+		t.Error("a sentinel was left behind after a refused swap; the next run would " +
+			"\"recover\" a file that was never changed")
+	}
+}
+
+func TestSwapAgyModel_MissingFileIsAnErrorNotASilentNoOp(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if _, err := swapAgyModel(filepath.Join(t.TempDir(), "absent.json"), "m"); err == nil {
+		t.Error("swapping a settings.json that does not exist reported success")
+	}
+}
+
+// agy shares one settings.json, so concurrent executions must be serialized.
+// Without the mutex a swarm run corrupts it and every head runs the wrong model.
+func TestAgyExecute_ConcurrentRunsLeaveSettingsIntact(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	fakeAgy(t, s, "ok", "", 0)
+	path := writeAgySettings(t, map[string]any{"model": "the-users-model", "theme": "dark"})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = (&AgyExecutor{}).Execute(context.Background(), Request{
+				Prompt: "hi", Head: agyHead("model-" + itoa(i)),
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	after := readAgySettings(t, path)
+	if after["model"] != "the-users-model" {
+		t.Errorf("model = %v after 8 concurrent runs, want the user's own restored",
+			after["model"])
+	}
+	if after["theme"] != "dark" {
+		t.Errorf("concurrent runs corrupted settings.json: %+v", after)
+	}
+	if _, err := os.Stat(path + agyOrigSuffix); err == nil {
+		t.Error("a sentinel survived concurrent runs")
+	}
+}
+
+// AGY_TIMEOUT accepts a Go duration or a bare integer meaning seconds; the
+// second form is what a user types.
+func TestAgyExecute_HonoursTheTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no portable sleeping .bat")
+	}
+	s := testutil.NewSandbox(t)
+	s.FakeBinary(t, "agy", "#!/bin/sh\nexec /bin/sleep 30\n")
+	writeAgySettings(t, map[string]any{"model": "x"})
+
+	for _, timeout := range []string{"1s", "1"} {
+		t.Run("AGY_TIMEOUT="+timeout, func(t *testing.T) {
+			t.Setenv("AGY_TIMEOUT", timeout)
+
+			start := time.Now()
+			_, err := (&AgyExecutor{}).Execute(context.Background(), Request{
+				Prompt: "hi", Head: agyHead("m"),
+			})
+			elapsed := time.Since(start)
+
+			if err == nil {
+				t.Fatal("a timed-out run reported success")
+			}
+			if elapsed > 10*time.Second {
+				t.Errorf("took %v with AGY_TIMEOUT=%s — the timeout was not applied "+
+					"(a bare integer means seconds)", elapsed, timeout)
+			}
+		})
+	}
+}
+
+// An unparsable AGY_TIMEOUT must fall back to the default rather than to zero,
+// which would cancel every run immediately.
+func TestAgyExecute_UnparsableTimeoutFallsBackToTheDefault(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	fakeAgy(t, s, "ok", "", 0)
+	writeAgySettings(t, map[string]any{"model": "x"})
+	t.Setenv("AGY_TIMEOUT", "not-a-duration")
+
+	if _, err := (&AgyExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hi", Head: agyHead("m"),
+	}); err != nil {
+		t.Fatalf("a garbage AGY_TIMEOUT cancelled the run: %v", err)
+	}
+}

--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -862,6 +862,12 @@ func stringifyAny(v any) string {
 	case string:
 		return x
 	case []any:
+		// Joined with nothing between them. Replicate's predictions API streams a
+		// text answer as an array of *token fragments* — ["Hel", "lo", ", wor",
+		// "ld"] — and its own clients concatenate them. Joining with "\n" put a
+		// line break between every token, so every Replicate answer arrived as
+		// one fragment per line. Its own tests asserted that, which is how the
+		// shape survived: they pinned the implementation rather than the format.
 		parts := make([]string, 0, len(x))
 		for _, item := range x {
 			s := stringifyAny(item)
@@ -869,7 +875,7 @@ func stringifyAny(v any) string {
 				parts = append(parts, s)
 			}
 		}
-		return strings.Join(parts, "\n")
+		return strings.Join(parts, "")
 	default:
 		raw, err := json.Marshal(x)
 		if err != nil {

--- a/internal/executor/http_exec_test.go
+++ b/internal/executor/http_exec_test.go
@@ -298,8 +298,8 @@ func TestStringifyAny(t *testing.T) {
 	}{
 		{"nil", nil, ""},
 		{"string", "hi", "hi"},
-		{"slice of strings", []any{"a", "b"}, "a\nb"},
-		{"slice with empties", []any{"a", "", "b"}, "a\nb"},
+		{"slice of strings", []any{"a", "b"}, "ab"},
+		{"slice with empties", []any{"a", "", "b"}, "ab"},
 		{"empty slice", []any{}, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/executor/local_test.go
+++ b/internal/executor/local_test.go
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// ── Ollama ────────────────────────────────────────────────────────────────────
+
+// The local head is the terminal fallback: when everything paid is exhausted or
+// a PII policy forces local-only, this is what answers. A silent failure here
+// is a dispatch chain with nothing at the end of it.
+
+func ollamaExecutorFor(srv *httptest.Server) *OllamaExecutor {
+	return &OllamaExecutor{client: srv.Client()}
+}
+
+func TestOllamaExecute_HappyPathParsesOutputAndUsage(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	var gotPath string
+	var gotBody ollamaGenerateRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" { // the health check
+			return
+		}
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"response":"local answer","model":"qwen2.5-coder:7b",
+			"done":true,"prompt_eval_count":21,"eval_count":9}`))
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	resp, err := ollamaExecutorFor(srv).Execute(context.Background(), Request{
+		Prompt: "hello",
+		Head: provider.Head{
+			ID: "qwen2.5-coder:7b", Provider: "ollama", Source: "port", LocalOnly: true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotPath != "/api/generate" {
+		t.Errorf("path = %q, want /api/generate", gotPath)
+	}
+	if gotBody.Stream {
+		t.Error("stream = true; the executor parses a single JSON object, not a stream")
+	}
+	if gotBody.Prompt != "hello" || gotBody.Model != "qwen2.5-coder:7b" {
+		t.Errorf("body = %+v, want the prompt and the head's model", gotBody)
+	}
+	if resp.Output != "local answer" {
+		t.Errorf("Output = %q", resp.Output)
+	}
+	// Ollama reports real counts, so they must not be labelled as estimated —
+	// local heads are free, but the budget governor still books their usage.
+	if resp.InputTokens != 21 || resp.OutputTokens != 9 {
+		t.Errorf("tokens = %d/%d, want 21/9", resp.InputTokens, resp.OutputTokens)
+	}
+	if resp.TokensEstimated {
+		t.Error("TokensEstimated = true though Ollama reported real counts")
+	}
+}
+
+// A head discovered by the port provider carries the server's own model name in
+// Meta, which can differ from the head ID. Sending the ID instead is a 404 from
+// Ollama that reads as "the model is not installed".
+func TestOllamaExecute_PrefersTheModelFlagFromMeta(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	var gotModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			return
+		}
+		var body ollamaGenerateRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotModel = body.Model
+		_, _ = w.Write([]byte(`{"response":"ok","done":true}`))
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	if _, err := ollamaExecutorFor(srv).Execute(context.Background(), Request{
+		Prompt: "hi",
+		Head: provider.Head{
+			ID: "ollama-qwen", Provider: "ollama", Source: "port",
+			Meta: map[string]string{"model_flag": "qwen2.5-coder:7b"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if gotModel != "qwen2.5-coder:7b" {
+		t.Errorf("model = %q, want the model_flag from Meta, not the head ID", gotModel)
+	}
+}
+
+// An empty response with done:true is Ollama saying it produced nothing. That
+// is not a successful answer.
+func TestOllamaExecute_EmptyResponseIsAnError(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			return
+		}
+		_, _ = w.Write([]byte(`{"response":"","done":true}`))
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	if resp, err := ollamaExecutorFor(srv).Execute(context.Background(), Request{
+		Prompt: "hi", Head: provider.Head{ID: "m", Provider: "ollama", Source: "port"},
+	}); err == nil {
+		t.Errorf("an empty generation was reported as success: %+v", resp)
+	}
+}
+
+func TestOllamaExecute_ServerErrorsAndGarbageAreErrors(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	t.Run("http error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/" {
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"model 'nope' not found"}`))
+		}))
+		defer srv.Close()
+		t.Setenv("OLLAMA_HOST", srv.URL)
+
+		_, err := ollamaExecutorFor(srv).Execute(context.Background(), Request{
+			Prompt: "hi", Head: provider.Head{ID: "nope", Provider: "ollama", Source: "port"},
+		})
+		if err == nil {
+			t.Fatal("a 404 was reported as success")
+		}
+		if !strings.Contains(err.Error(), "404") {
+			t.Errorf("error = %v, want the status code", err)
+		}
+	})
+
+	t.Run("unparsable body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/" {
+				return
+			}
+			_, _ = w.Write([]byte(`{"response": truncated`))
+		}))
+		defer srv.Close()
+		t.Setenv("OLLAMA_HOST", srv.URL)
+
+		if _, err := ollamaExecutorFor(srv).Execute(context.Background(), Request{
+			Prompt: "hi", Head: provider.Head{ID: "m", Provider: "ollama", Source: "port"},
+		}); err == nil {
+			t.Fatal("an unparsable body was reported as success")
+		}
+	})
+}
+
+// isHealthy is the gate that decides whether to try starting a server. It must
+// distinguish "answering" from "the port is open but erroring".
+func TestOllamaIsHealthy(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("Ollama is running"))
+	}))
+	defer ok.Close()
+	if !(&OllamaExecutor{client: ok.Client()}).isHealthy(ok.URL) {
+		t.Error("a responding server was reported unhealthy")
+	}
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	if (&OllamaExecutor{client: bad.Client()}).isHealthy(bad.URL) {
+		t.Error("a 500 was reported as healthy")
+	}
+
+	// Nothing listening, and a host that is not a URL at all — both must be
+	// "not healthy" rather than a panic.
+	if (&OllamaExecutor{}).isHealthy("http://127.0.0.1:1") {
+		t.Error("a dead port was reported as healthy")
+	}
+	if (&OllamaExecutor{}).isHealthy("://not a url") {
+		t.Error("an unparsable host was reported as healthy")
+	}
+}
+
+// ensureRunning must not be reached when the server is already up — the
+// auto-start path spawns a subprocess and waits three seconds.
+func TestOllamaEnsureRunning_NoOpWhenAlreadyHealthy(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+
+	start := time.Now()
+	if err := (&OllamaExecutor{client: srv.Client()}).ensureRunning(srv.URL); err != nil {
+		t.Fatalf("a healthy server was reported as needing a start: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("took %v against a healthy server — it tried to start one", elapsed)
+	}
+}
+
+// ollamaHost must resolve through the provider so discovery and execution can
+// never disagree about the address (#282).
+func TestOllamaHost_MatchesDiscovery(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if got, want := ollamaHost(), provider.OllamaHost(); got != want {
+		t.Errorf("ollamaHost() = %q but discovery uses %q — a dispatch would go to a "+
+			"different server than the one probe reported", got, want)
+	}
+	t.Setenv("OLLAMA_HOST", "http://192.0.2.10:11434")
+	if got, want := ollamaHost(), provider.OllamaHost(); got != want {
+		t.Errorf("with OLLAMA_HOST set, ollamaHost() = %q but discovery uses %q", got, want)
+	}
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+// The CLI executor drives installed agent binaries. Its whole job is building
+// an argv, and a wrong one is a subprocess that either does nothing or does
+// something else.
+
+func TestCLIBuildArgs_SubstitutesThePromptPlaceholder(t *testing.T) {
+	tests := []struct {
+		name string
+		tmpl cliTemplate
+		want []string
+	}{
+		{"prompt only", cliTemplate{args: []string{""}}, []string{"the prompt"}},
+		{"flag then prompt", cliTemplate{args: []string{"--print", ""}}, []string{"--print", "the prompt"}},
+		{"prompt in the middle", cliTemplate{args: []string{"ask", "", "--json"}},
+			[]string{"ask", "the prompt", "--json"}},
+		{"stdin templates pass no prompt argument", cliTemplate{stdinPrompt: true}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.tmpl.buildArgs("the prompt")
+			if len(got) != len(tt.want) {
+				t.Fatalf("buildArgs = %q, want %q", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("buildArgs = %q, want %q", got, tt.want)
+					break
+				}
+			}
+		})
+	}
+
+	// A prompt containing spaces, quotes or newlines must stay one argument.
+	// Splitting it would silently send the tool a different instruction.
+	tricky := "write a func; echo \"hi\" && rm -rf /\nsecond line"
+	got := cliTemplate{args: []string{"--print", ""}}.buildArgs(tricky)
+	if len(got) != 2 || got[1] != tricky {
+		t.Errorf("buildArgs fragmented a prompt with shell metacharacters: %q", got)
+	}
+}
+
+func TestCLIExecute_RunsTheBinaryAndReturnsItsOutput(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	body := "#!/bin/sh\necho \"got: $2\"\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\necho got: %2\r\n"
+	}
+	bin := s.FakeBinary(t, "fake-claude", body)
+
+	resp, err := (&CLIExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hello",
+		Head: provider.Head{
+			ID: "claude", Provider: "anthropic", Source: "cli", Executable: bin,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resp.Output, "hello") {
+		t.Errorf("Output = %q, want the prompt echoed back through the argv", resp.Output)
+	}
+	if resp.Model != "claude" {
+		t.Errorf("Model = %q, want the head ID", resp.Model)
+	}
+	if resp.Duration <= 0 {
+		t.Error("Duration was not measured")
+	}
+}
+
+// A template can send the prompt on stdin instead of argv (cursor, continue).
+func TestCLIExecute_StdinTemplatesSendThePromptOnStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the .bat stdin plumbing differs enough that it proves nothing here")
+	}
+	s := testutil.NewSandbox(t)
+	bin := s.FakeBinary(t, "fake-cursor", "#!/bin/sh\nexec /bin/cat\n")
+
+	resp, err := (&CLIExecutor{}).Execute(context.Background(), Request{
+		Prompt: "from stdin",
+		Head: provider.Head{
+			ID: "cursor-agent", Provider: "cursor", Source: "cli", Executable: bin,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Output != "from stdin" {
+		t.Errorf("Output = %q, want the prompt read from stdin", resp.Output)
+	}
+}
+
+// A tool that exits non-zero must be an error carrying its stderr — that text
+// is the only diagnostic the user gets, and dropping it turns a login prompt
+// into a blank failure.
+func TestCLIExecute_NonZeroExitCarriesStderr(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	body := "#!/bin/sh\necho 'not logged in — run: claude login' >&2\nexit 1\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\necho not logged in 1>&2\r\nexit /b 1\r\n"
+	}
+	bin := s.FakeBinary(t, "fake-failing", body)
+
+	_, err := (&CLIExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hi",
+		Head:   provider.Head{ID: "claude", Provider: "anthropic", Source: "cli", Executable: bin},
+	})
+	if err == nil {
+		t.Fatal("a non-zero exit was reported as success")
+	}
+	if !strings.Contains(err.Error(), "not logged in") {
+		t.Errorf("error = %v, want the tool's stderr — it is the only diagnostic "+
+			"the user gets", err)
+	}
+}
+
+func TestCLIExecute_UnknownProviderIsRefusedBeforeSpawning(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	_, err := (&CLIExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hi",
+		Head: provider.Head{
+			ID: "mystery", Provider: "some-vendor", Source: "cli",
+			Executable: "/definitely/not/here",
+		},
+	})
+	if err == nil {
+		t.Fatal("a head with no CLI template was executed anyway")
+	}
+	if !strings.Contains(err.Error(), "no CLI template") {
+		t.Errorf("error = %v, want it to name the missing template", err)
+	}
+}
+
+// The template can be keyed by head ID as well as provider, which is how a
+// single vendor with several tools is driven.
+func TestCLIExecute_TemplateMayBeKeyedByHeadID(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	var id string
+	for k := range cliTemplates {
+		if _, isProvider := cliTemplates[k]; isProvider && k == "cursor" {
+			id = k
+		}
+	}
+	if id == "" {
+		t.Skip("no head-ID-keyed template to exercise")
+	}
+	body := "#!/bin/sh\necho ok\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\necho ok\r\n"
+	}
+	bin := s.FakeBinary(t, "fake-byid", body)
+
+	if _, err := (&CLIExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hi",
+		Head:   provider.Head{ID: id, Provider: "unregistered-vendor", Source: "cli", Executable: bin},
+	}); err != nil {
+		t.Fatalf("a template keyed by head ID was not found: %v", err)
+	}
+}
+
+// A context deadline must kill the subprocess rather than leaving it running.
+func TestCLIExecute_ContextCancellationKillsTheSubprocess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no portable sleeping .bat")
+	}
+	s := testutil.NewSandbox(t)
+	bin := s.FakeBinary(t, "fake-slow", "#!/bin/sh\nexec /bin/sleep 30\n")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := (&CLIExecutor{}).Execute(ctx, Request{
+		Prompt: "hi",
+		Head:   provider.Head{ID: "claude", Provider: "anthropic", Source: "cli", Executable: bin},
+	})
+	if err == nil {
+		t.Fatal("a cancelled subprocess returned success")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("took %v to kill the subprocess", elapsed)
+	}
+}
+
+// ── token sidecar ─────────────────────────────────────────────────────────────
+
+// The sidecar path comes from the environment and is written to. It is
+// deliberately confined to the temp directory: an executor must never be
+// steerable into writing over an arbitrary file.
+
+func TestWriteTokenSidecar_WritesInsideTempDir(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	path := filepath.Join(os.TempDir(), "hydra-sidecar-test.json")
+	t.Cleanup(func() { _ = os.Remove(path) })
+	t.Setenv("HYDRA_TOKEN_SIDECAR", path)
+
+	writeTokenSidecar("qwen:7b", "ollama", "real", 100, 50)
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("no sidecar was written: %v", err)
+	}
+	var got tokenSidecar
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "qwen:7b" || got.PromptTokens != 100 || got.ResponseTokens != 50 {
+		t.Errorf("sidecar = %+v", got)
+	}
+	// The source label is what stops an estimate being read as a measurement.
+	if got.Source != "real" {
+		t.Errorf("Source = %q, want real", got.Source)
+	}
+
+	if info, err := os.Stat(path); err == nil && runtime.GOOS != "windows" {
+		if info.Mode().Perm()&0o077 != 0 {
+			t.Errorf("sidecar mode %v is group/other readable", info.Mode().Perm())
+		}
+	}
+}
+
+func TestWriteTokenSidecar_RefusesToWriteOutsideTempDir(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	tmp := filepath.Clean(os.TempDir())
+	cases := []struct {
+		name   string
+		target string
+	}{
+		{
+			// Cleans to the parent of the temp directory.
+			name:   "traversal out of the temp directory",
+			target: filepath.Join(tmp, "..", "hydra-escaped-sidecar.json"),
+		},
+		{
+			// A sibling whose path merely starts with the temp directory's. A
+			// plain HasPrefix without the separator would accept this.
+			name:   "sibling directory sharing the prefix",
+			target: tmp + "-evil" + string(filepath.Separator) + "sidecar.json",
+		},
+		{
+			name:   "relative path",
+			target: filepath.Join("relative", "sidecar.json"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clean := filepath.Clean(tc.target)
+			t.Setenv("HYDRA_TOKEN_SIDECAR", tc.target)
+			writeTokenSidecar("m", "e", "real", 1, 1)
+
+			if _, err := os.Stat(clean); err == nil {
+				_ = os.Remove(clean)
+				t.Errorf("a sidecar was written to %q, outside the temp directory — "+
+					"the executor is steerable into writing arbitrary files", clean)
+			}
+		})
+	}
+
+	// Unset is a no-op, not a write to "".
+	t.Setenv("HYDRA_TOKEN_SIDECAR", "")
+	writeTokenSidecar("m", "e", "real", 1, 1)
+}
+
+// With no server answering, ensureRunning tries to start one. On a machine with
+// no ollama installed that must be a clear error naming the cause, not a silent
+// three-second stall followed by a generic failure.
+//
+// The auto-start attempt is guarded by a package-level sync.Once, so it happens
+// at most once per process and every later caller falls through to the
+// three-second wait loop instead. Resetting it here is what makes this test
+// independent of which other test ran first — without that it passes alone and
+// fails under -count=2.
+func TestOllamaEnsureRunning_ReportsWhyItCouldNotStart(t *testing.T) {
+	testutil.NewSandbox(t) // empty PATH: there is no ollama to start
+
+	ollamaServeOnce = sync.Once{}
+	t.Cleanup(func() { ollamaServeOnce = sync.Once{} })
+
+	start := time.Now()
+	err := (&OllamaExecutor{}).ensureRunning("http://127.0.0.1:1")
+	if err == nil {
+		t.Fatal("ensureRunning reported success with nothing listening and no binary")
+	}
+	if !strings.Contains(err.Error(), "could not start") {
+		t.Errorf("error = %v, want it to say the server could not be started", err)
+	}
+	// It must not sit through the three-second readiness wait when the start
+	// itself failed — there is nothing to wait for.
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("took %v to report a failed start", elapsed)
+	}
+}

--- a/internal/executor/providers_test.go
+++ b/internal/executor/providers_test.go
@@ -1,0 +1,656 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// Each provider adapter builds a request in that vendor's wire format and picks
+// the answer back out of that vendor's response shape. Both halves are pure
+// convention — a wrong header name is a 401 the user reads as "my key is bad",
+// and a wrong response field is an empty string that Hydra reports as a
+// successful, empty answer. Nothing but a test catches the second one.
+//
+// The adapters address their vendors by hardcoded URL, so tests redirect them
+// with a transport rather than by making the URLs configurable for tests alone.
+
+// redirect returns an executor whose requests all land on srv, keeping the
+// original host/path visible to the handler through r.Host and r.URL.Path.
+func redirect(srv *httptest.Server) *HTTPExecutor {
+	target, _ := url.Parse(srv.URL)
+	return &HTTPExecutor{client: &http.Client{
+		Transport: rewriteTransport{host: target.Host, base: http.DefaultTransport},
+	}}
+}
+
+type rewriteTransport struct {
+	host string
+	base http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	clone := r.Clone(r.Context())
+	clone.URL.Scheme = "http"
+	clone.URL.Host = t.host
+	return t.base.RoundTrip(clone)
+}
+
+// capture records what the adapter actually put on the wire.
+type capture struct {
+	path    string // decoded
+	rawPath string // as it went over the wire
+	query   string
+	host    string
+	headers http.Header
+	body    map[string]any
+}
+
+func serve(t *testing.T, status int, response string) (*httptest.Server, *capture) {
+	t.Helper()
+	got := &capture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.path, got.query, got.host = r.URL.Path, r.URL.RawQuery, r.Host
+		got.rawPath = r.URL.EscapedPath()
+		got.headers = r.Header.Clone()
+		_ = json.NewDecoder(r.Body).Decode(&got.body)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(response))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, got
+}
+
+func head(providerID string) provider.Head {
+	return provider.Head{ID: providerID + "-head", Provider: providerID, Source: "env", AuthReady: true}
+}
+
+func TestExecuteAnthropic_WireFormatAndParsing(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "ANTHROPIC_API_KEY", "sk-ant-test")
+	t.Setenv("ANTHROPIC_MODEL", "claude-test-1")
+
+	srv, got := serve(t, 200, `{"model":"claude-test-1","content":[
+		{"type":"text","text":"first block"},{"type":"text","text":"second block"}],
+		"usage":{"input_tokens":31,"output_tokens":12}}`)
+
+	resp, err := redirect(srv).Execute(context.Background(), Request{
+		Prompt: "hello", System: "be terse", MaxTokens: 256, Head: head("anthropic"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.host != "api.anthropic.com" || got.path != "/v1/messages" {
+		t.Errorf("addressed %s%s, want api.anthropic.com/v1/messages", got.host, got.path)
+	}
+	// Anthropic authenticates on x-api-key, not Authorization; the version
+	// header is mandatory and the API rejects the call without it.
+	if k := got.headers.Get("x-api-key"); k != "sk-ant-test" {
+		t.Errorf("x-api-key = %q, want the configured key", k)
+	}
+	if v := got.headers.Get("anthropic-version"); v == "" {
+		t.Error("no anthropic-version header; the API rejects the request without one")
+	}
+	if got.body["system"] != "be terse" {
+		t.Errorf("system = %v, want the system prompt as a top-level field, not a message",
+			got.body["system"])
+	}
+	if got.body["max_tokens"] != float64(256) {
+		t.Errorf("max_tokens = %v, want 256 — Anthropic requires it", got.body["max_tokens"])
+	}
+	if got.body["model"] != "claude-test-1" {
+		t.Errorf("model = %v, want the env override", got.body["model"])
+	}
+
+	// Multiple content blocks must be joined, not silently truncated to the first.
+	if !strings.Contains(resp.Output, "first block") || !strings.Contains(resp.Output, "second block") {
+		t.Errorf("Output = %q, want both content blocks", resp.Output)
+	}
+	if resp.InputTokens != 31 || resp.OutputTokens != 12 {
+		t.Errorf("tokens = %d/%d, want 31/12 from the provider's own usage block",
+			resp.InputTokens, resp.OutputTokens)
+	}
+	if resp.TokensEstimated {
+		t.Error("TokensEstimated = true though the provider reported real usage")
+	}
+}
+
+func TestExecuteAnthropic_MaxTokensDefaultsRatherThanSendingZero(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "ANTHROPIC_API_KEY", "k")
+
+	srv, got := serve(t, 200, `{"content":[{"type":"text","text":"ok"}]}`)
+	if _, err := redirect(srv).Execute(context.Background(), Request{
+		Prompt: "hi", Head: head("anthropic"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got.body["max_tokens"] == float64(0) || got.body["max_tokens"] == nil {
+		t.Errorf("max_tokens = %v with none requested; Anthropic rejects a request "+
+			"without a positive value", got.body["max_tokens"])
+	}
+}
+
+func TestExecuteGemini_WireFormatAndParsing(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "GEMINI_API_KEY", "goog-test")
+	t.Setenv("GEMINI_MODEL", "gemini-test-pro")
+
+	srv, got := serve(t, 200, `{"candidates":[{"content":{"parts":[
+		{"text":"part one"},{"text":"part two"}]}}],
+		"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":4},
+		"modelVersion":"gemini-test-pro-002"}`)
+
+	resp, err := redirect(srv).Execute(context.Background(), Request{
+		Prompt: "hello", System: "be terse", MaxTokens: 128, Head: head("google"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Gemini names the model in the path, so a model with a slash or colon must
+	// be escaped rather than splitting the route.
+	if !strings.Contains(got.path, "gemini-test-pro") || !strings.HasSuffix(got.path, ":generateContent") {
+		t.Errorf("path = %q, want the model and :generateContent", got.path)
+	}
+	if k := got.headers.Get("x-goog-api-key"); k != "goog-test" {
+		t.Errorf("x-goog-api-key = %q", k)
+	}
+	if _, ok := got.body["system_instruction"]; !ok {
+		t.Error("the system prompt was dropped; Gemini takes it as system_instruction, " +
+			"not as a message")
+	}
+	if _, ok := got.body["generationConfig"]; !ok {
+		t.Error("max tokens were dropped; Gemini takes them under generationConfig")
+	}
+
+	if !strings.Contains(resp.Output, "part one") || !strings.Contains(resp.Output, "part two") {
+		t.Errorf("Output = %q, want both parts joined", resp.Output)
+	}
+	if resp.InputTokens != 9 || resp.OutputTokens != 4 {
+		t.Errorf("tokens = %d/%d, want 9/4", resp.InputTokens, resp.OutputTokens)
+	}
+	if resp.Model != "gemini-test-pro-002" {
+		t.Errorf("Model = %q, want the modelVersion the API actually served", resp.Model)
+	}
+}
+
+// Gemini returns 200 with no candidates when the prompt is filtered. That is
+// not a successful empty answer — reporting it as one would log a paid call
+// that produced nothing and hand the caller "".
+func TestExecuteGemini_NoCandidatesIsAnError(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "GEMINI_API_KEY", "k")
+
+	srv, _ := serve(t, 200, `{"candidates":[],"promptFeedback":{"blockReason":"SAFETY"}}`)
+	if resp, err := redirect(srv).Execute(context.Background(), Request{
+		Prompt: "hi", Head: head("google"),
+	}); err == nil {
+		t.Errorf("a filtered response was reported as success: %+v", resp)
+	}
+}
+
+func TestExecuteCohere_WireFormatAndParsing(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "COHERE_API_KEY", "co-test")
+	t.Setenv("COHERE_MODEL", "command-test")
+
+	srv, got := serve(t, 200, `{"id":"x","message":{"content":[
+		{"type":"text","text":"cohere says hi"}]},
+		"usage":{"tokens":{"input_tokens":5,"output_tokens":3}}}`)
+
+	resp, err := redirect(srv).Execute(context.Background(), Request{
+		Prompt: "hello", MaxTokens: 64, Head: head("cohere"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.host != "api.cohere.ai" || got.path != "/v2/chat" {
+		t.Errorf("addressed %s%s, want api.cohere.ai/v2/chat", got.host, got.path)
+	}
+	if a := got.headers.Get("Authorization"); a != "Bearer co-test" {
+		t.Errorf("Authorization = %q", a)
+	}
+	if resp.Output != "cohere says hi" {
+		t.Errorf("Output = %q", resp.Output)
+	}
+	// Cohere nests usage one level deeper than everyone else; reading it at the
+	// top level yields a silent 0/0 and free-looking spend.
+	if resp.InputTokens != 5 || resp.OutputTokens != 3 {
+		t.Errorf("tokens = %d/%d, want 5/3 from usage.tokens", resp.InputTokens, resp.OutputTokens)
+	}
+}
+
+func TestExecuteAzure_BuildsTheDeploymentURL(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "AZURE_OPENAI_API_KEY", "az-test")
+	// A trailing slash on the endpoint is what a user copies out of the portal.
+	t.Setenv("AZURE_OPENAI_ENDPOINT", "https://my-resource.openai.azure.com/")
+	t.Setenv("AZURE_OPENAI_DEPLOYMENT", "my deployment")
+
+	srv, got := serve(t, 200, okChatBody)
+
+	resp, err := redirect(srv).Execute(context.Background(), Request{
+		Prompt: "hello", Head: head("azure"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(got.path, "//") {
+		t.Errorf("path = %q — the endpoint's trailing slash was not trimmed", got.path)
+	}
+	if !strings.Contains(got.rawPath, "my%20deployment") {
+		t.Errorf("wire path = %q, want the deployment name escaped; a space would "+
+			"otherwise break the route", got.rawPath)
+	}
+	if !strings.Contains(got.query, "api-version=") {
+		t.Errorf("query = %q, want an api-version — Azure rejects the call without one", got.query)
+	}
+	if k := got.headers.Get("api-key"); k != "az-test" {
+		t.Errorf("api-key = %q; Azure does not use Authorization", k)
+	}
+	if resp.Output != "hello from the stub" {
+		t.Errorf("Output = %q", resp.Output)
+	}
+}
+
+func TestExecuteAzure_EmptyChoicesIsAnError(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "AZURE_OPENAI_API_KEY", "k")
+	t.Setenv("AZURE_OPENAI_ENDPOINT", "https://r.openai.azure.com")
+	t.Setenv("AZURE_OPENAI_DEPLOYMENT", "d")
+
+	srv, _ := serve(t, 200, `{"choices":[]}`)
+	if resp, err := redirect(srv).Execute(context.Background(), Request{
+		Prompt: "hi", Head: head("azure"),
+	}); err == nil {
+		t.Errorf("an empty choices array was reported as success: %+v", resp)
+	}
+}
+
+// Bedrock is the only provider that signs rather than sending a bearer token.
+// An unsigned request is a 403 the user cannot diagnose from Hydra's output.
+func TestExecuteBedrock_SignsTheRequest(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "AWS_ACCESS_KEY_ID", "AKIDEXAMPLE")
+	s.SetKey(t, "AWS_SECRET_ACCESS_KEY", "secret")
+	t.Setenv("AWS_REGION", "eu-west-1")
+
+	srv, got := serve(t, 200, okChatBody)
+
+	resp, err := redirect(srv).Execute(context.Background(), Request{
+		Prompt: "hello", Head: head("bedrock"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(got.host, "eu-west-1") {
+		t.Errorf("host = %q, want the configured region", got.host)
+	}
+	auth := got.headers.Get("Authorization")
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 ") {
+		t.Fatalf("Authorization = %q, want a SigV4 signature", auth)
+	}
+	for _, want := range []string{"AKIDEXAMPLE", "eu-west-1/bedrock/aws4_request", "Signature="} {
+		if !strings.Contains(auth, want) {
+			t.Errorf("signature is missing %q: %s", want, auth)
+		}
+	}
+	// SigV4 signs the payload hash, so it must be sent as a header for the
+	// service to verify what it received.
+	if got.headers.Get("X-Amz-Content-Sha256") == "" {
+		t.Error("no X-Amz-Content-Sha256; the service cannot verify the payload")
+	}
+	if resp.Output != "hello from the stub" {
+		t.Errorf("Output = %q", resp.Output)
+	}
+}
+
+// Replicate is asynchronous: the first response is usually "starting", and the
+// answer only exists after polling. Returning that first response as the answer
+// would hand the caller a status object.
+func TestExecuteReplicate_PollsUntilTheAnswerExists(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "REPLICATE_API_TOKEN", "r8-test")
+	t.Setenv("REPLICATE_MODEL", "meta/llama-test")
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Method == http.MethodPost {
+			// The poll URL must be on Replicate's own host — the executor
+			// refuses anything else, which is what stops a hostile response
+			// redirecting the authenticated poll somewhere arbitrary.
+			_, _ = w.Write([]byte(`{"status":"processing","urls":{"get":"https://api.replicate.com/v1/predictions/abc"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"succeeded","output":["chunk one ","chunk two"]}`))
+	}))
+	defer srv.Close()
+
+	resp, err := redirect(srv).Execute(context.Background(), Request{
+		Prompt: "hello", System: "be terse", Head: head("replicate"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls < 2 {
+		t.Errorf("made %d calls; a processing prediction was returned without polling", calls)
+	}
+	// Replicate streams output as an array of fragments that must be joined,
+	// not rendered as a Go slice.
+	if resp.Output != "chunk one chunk two" {
+		t.Errorf("Output = %q, want the fragments joined", resp.Output)
+	}
+}
+
+// A poll URL pointing anywhere but Replicate must be refused. This is the guard
+// against a response steering an authenticated request at another host.
+func TestGetReplicatePrediction_RefusesAForeignPollURL(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	_, err := (&HTTPExecutor{}).getReplicatePrediction(
+		context.Background(), "h", "https://attacker.example/v1/predictions/abc")
+	if err == nil {
+		t.Fatal("a poll URL on another host was accepted")
+	}
+	if !strings.Contains(err.Error(), "unexpected Replicate poll URL") {
+		t.Errorf("error = %v, want it to name the rejected URL", err)
+	}
+}
+
+// A prediction that ends in failure must surface Replicate's own message.
+func TestExecuteReplicate_FailedPredictionReportsItsError(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "REPLICATE_API_TOKEN", "r8")
+
+	srv, _ := serve(t, 200, `{"status":"failed","error":"model out of memory"}`)
+	_, err := redirect(srv).Execute(context.Background(), Request{Prompt: "hi", Head: head("replicate")})
+	if err == nil {
+		t.Fatal("a failed prediction was reported as success")
+	}
+	if !strings.Contains(err.Error(), "model out of memory") {
+		t.Errorf("error = %v, want Replicate's own message", err)
+	}
+
+	srv2, _ := serve(t, 200, `{"status":"canceled"}`)
+	_, err = redirect(srv2).Execute(context.Background(), Request{Prompt: "hi", Head: head("replicate")})
+	if err == nil || !strings.Contains(err.Error(), "canceled") {
+		t.Errorf("a canceled prediction gave %v, want the status named", err)
+	}
+}
+
+// Every adapter must turn an HTTP error into an error, not into an empty
+// successful response. This is the same defect class as #260 and #310: a
+// silent empty answer reads as a real one.
+func TestEveryProvider_HTTPErrorIsAnError(t *testing.T) {
+	providers := []string{"anthropic", "google", "cohere", "azure", "bedrock", "replicate", "openai"}
+
+	for _, p := range providers {
+		t.Run(p, func(t *testing.T) {
+			s := testutil.NewSandbox(t)
+			for _, kv := range [][2]string{
+				{"ANTHROPIC_API_KEY", "k"}, {"GEMINI_API_KEY", "k"}, {"COHERE_API_KEY", "k"},
+				{"AZURE_OPENAI_API_KEY", "k"}, {"REPLICATE_API_TOKEN", "k"}, {"OPENAI_API_KEY", "k"},
+				{"AWS_ACCESS_KEY_ID", "k"}, {"AWS_SECRET_ACCESS_KEY", "k"},
+			} {
+				s.SetKey(t, kv[0], kv[1])
+			}
+			t.Setenv("AWS_REGION", "us-east-1")
+			t.Setenv("AZURE_OPENAI_ENDPOINT", "https://r.openai.azure.com")
+			t.Setenv("AZURE_OPENAI_DEPLOYMENT", "d")
+
+			srv, _ := serve(t, http.StatusTooManyRequests, `{"error":{"message":"rate limited"}}`)
+			resp, err := redirect(srv).Execute(context.Background(), Request{Prompt: "hi", Head: head(p)})
+			if err == nil {
+				t.Fatalf("HTTP 429 was reported as success: %+v", resp)
+			}
+			if !strings.Contains(err.Error(), "429") {
+				t.Errorf("error = %v, want the status code so the user can act on it", err)
+			}
+		})
+	}
+}
+
+// SupportsHTTP is what stops dispatch routing to a head it cannot drive. Each
+// provider has its own set of required settings, and a head that reports as
+// supported without them fails at execution time instead of at selection time.
+func TestSupportsHTTP_RequiresEveryProvidersOwnSettings(t *testing.T) {
+	tests := []struct {
+		provider string
+		env      map[string]string
+	}{
+		{"anthropic", map[string]string{"ANTHROPIC_API_KEY": "k"}},
+		{"google", map[string]string{"GEMINI_API_KEY": "k"}},
+		{"cohere", map[string]string{"COHERE_API_KEY": "k"}},
+		{"azure", map[string]string{
+			"AZURE_OPENAI_API_KEY": "k", "AZURE_OPENAI_ENDPOINT": "https://r.openai.azure.com",
+			"AZURE_OPENAI_DEPLOYMENT": "d",
+		}},
+		{"bedrock", map[string]string{
+			"AWS_ACCESS_KEY_ID": "k", "AWS_SECRET_ACCESS_KEY": "s", "AWS_REGION": "us-east-1",
+		}},
+		{"replicate", map[string]string{"REPLICATE_API_TOKEN": "k", "REPLICATE_MODEL": "m/n"}},
+		{"openai", map[string]string{"OPENAI_API_KEY": "k"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+" unconfigured", func(t *testing.T) {
+			testutil.NewSandbox(t)
+			if SupportsHTTP(head(tt.provider)) {
+				t.Errorf("%s reports as supported with nothing configured; dispatch "+
+					"would route to it and fail at execution", tt.provider)
+			}
+		})
+		t.Run(tt.provider+" configured", func(t *testing.T) {
+			testutil.NewSandbox(t)
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			if !SupportsHTTP(head(tt.provider)) {
+				t.Errorf("%s reports as unsupported with %v set", tt.provider, tt.env)
+			}
+		})
+	}
+
+	// Azure needs three settings, so any one missing must disqualify it — this
+	// is where a partial config silently produces a broken URL.
+	for _, missing := range []string{"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOYMENT"} {
+		t.Run("azure without "+missing, func(t *testing.T) {
+			testutil.NewSandbox(t)
+			for _, k := range []string{"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOYMENT"} {
+				if k != missing {
+					t.Setenv(k, "set")
+				}
+			}
+			if SupportsHTTP(head("azure")) {
+				t.Errorf("azure reports as supported without %s", missing)
+			}
+		})
+	}
+
+	testutil.NewSandbox(t)
+	if SupportsHTTP(provider.Head{ID: "x", Provider: "some-vendor-we-do-not-speak"}) {
+		t.Error("an unknown provider reports as supported")
+	}
+}
+
+// The Azure API version has a default because the service requires one, but an
+// operator pinning an older one must win.
+func TestAzureAPIVersion_DefaultsButIsOverridable(t *testing.T) {
+	testutil.NewSandbox(t)
+	if got := azureAPIVersion(); got == "" {
+		t.Error("azureAPIVersion() is empty; Azure rejects a request without it")
+	}
+	t.Setenv("AZURE_OPENAI_API_VERSION", "2023-05-15")
+	if got := azureAPIVersion(); got != "2023-05-15" {
+		t.Errorf("azureAPIVersion() = %q, want the operator's pin", got)
+	}
+}
+
+// Region and credential lookups accept the standard AWS variable names, in the
+// order the AWS SDKs themselves resolve them.
+func TestAWSEnvLookups(t *testing.T) {
+	testutil.NewSandbox(t)
+	if bedrockRegion() != "" || awsAccessKeyID() != "" || awsSecretAccessKey() != "" || awsSessionToken() != "" {
+		t.Fatal("the sandbox did not clear the AWS environment")
+	}
+
+	t.Setenv("AWS_DEFAULT_REGION", "ap-south-1")
+	if got := bedrockRegion(); got != "ap-south-1" {
+		t.Errorf("bedrockRegion() = %q, want the AWS_DEFAULT_REGION fallback", got)
+	}
+	t.Setenv("AWS_REGION", "us-west-2")
+	if got := bedrockRegion(); got != "us-west-2" {
+		t.Errorf("bedrockRegion() = %q, want AWS_REGION to win", got)
+	}
+
+	t.Setenv("AWS_SESSION_TOKEN", "tok")
+	if got := awsSessionToken(); got != "tok" {
+		t.Errorf("awsSessionToken() = %q", got)
+	}
+}
+
+// defaultModelFor resolves a model without a rebuild. A provider with no
+// fallback (Replicate, where the model is the identity of what runs) must
+// return empty rather than a guess.
+func TestDefaultModelFor_EnvOverridesAndReplicateHasNoDefault(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if got := defaultModelFor("anthropic"); got == "" {
+		t.Error("anthropic has no default model")
+	}
+	if got := defaultModelFor("replicate"); got != "" {
+		t.Errorf("defaultModelFor(replicate) = %q; there is no sensible default — "+
+			"the model is what the user is paying to run", got)
+	}
+	if got := defaultModelFor("not-a-provider"); got != "" {
+		t.Errorf("defaultModelFor(unknown) = %q", got)
+	}
+
+	// The vendor-specific variable and Hydra's own both work, vendor first.
+	t.Setenv("HYDRA_MODEL_ANTHROPIC", "hydra-pinned")
+	if got := defaultModelFor("anthropic"); got != "hydra-pinned" {
+		t.Errorf("defaultModelFor(anthropic) = %q, want the HYDRA_ override", got)
+	}
+	t.Setenv("ANTHROPIC_MODEL", "vendor-pinned")
+	if got := defaultModelFor("anthropic"); got != "vendor-pinned" {
+		t.Errorf("defaultModelFor(anthropic) = %q, want the vendor variable to win", got)
+	}
+}
+
+// Replicate's output is untyped JSON: a string, an array of fragments, or a
+// number. All three must render as text a human can read.
+func TestStringifyAny_HandlesEveryReplicateOutputShape(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"plain string", "hello", "hello"},
+		{"streamed token fragments concatenate", []any{"a ", "b"}, "a b"},
+		{"number", float64(42), "42"},
+		{"nil is empty, not \"<nil>\"", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stringifyAny(tt.in); got != tt.want {
+				t.Errorf("stringifyAny(%#v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+	// An object falls back to JSON rather than Go's %v, which would emit
+	// map[k:v] — not something a user or a downstream parser can use.
+	if got := stringifyAny(map[string]any{"k": "v"}); !strings.Contains(got, `"k"`) {
+		t.Errorf("stringifyAny(map) = %q, want JSON", got)
+	}
+}
+
+// A context deadline must abort a poll rather than running to the five-minute
+// ceiling.
+func TestExecuteReplicate_HonoursContextCancellation(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.SetKey(t, "REPLICATE_API_TOKEN", "k")
+
+	srv, _ := serve(t, 200, `{"status":"processing","urls":{"get":"https://api.replicate.com/v1/predictions/abc"}}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if _, err := redirect(srv).Execute(ctx, Request{Prompt: "hi", Head: head("replicate")}); err == nil {
+		t.Fatal("a cancelled poll returned success")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("took %v to notice cancellation", elapsed)
+	}
+}
+
+// The sandbox can only hide a variable it knows about. This keeps
+// testutil.ModelPinVars in step with the table defaultModelFor actually reads,
+// so adding a provider cannot quietly reintroduce the leak: a developer with
+// the new variable exported would otherwise have every model-resolution test
+// read their shell.
+//
+// Mirrors TestAPIKeyVars_CoversEnvProvider, which does the same for credentials.
+func TestModelPinVars_CoversDefaultModelFor(t *testing.T) {
+	scrubbed := map[string]bool{}
+	for _, v := range testutil.ModelPinVars {
+		scrubbed[v] = true
+	}
+
+	// Every provider defaultModelFor knows about, and the variables it consults
+	// for each. Derived by asking it: set each candidate and see if it wins.
+	providers := []string{
+		"anthropic", "openai", "openrouter", "google", "xai", "groq", "together",
+		"fireworks", "mistral", "deepseek", "bedrock", "perplexity", "cohere", "replicate",
+	}
+
+	for _, p := range providers {
+		t.Run(p, func(t *testing.T) {
+			testutil.NewSandbox(t)
+			base := defaultModelFor(p)
+
+			// Any variable that can change this provider's answer must be
+			// scrubbed. Probe the two naming conventions the table uses.
+			candidates := []string{
+				strings.ToUpper(p) + "_MODEL",
+				"HYDRA_MODEL_" + strings.ToUpper(p),
+			}
+			for _, env := range candidates {
+				t.Setenv(env, "probe-value")
+				changed := defaultModelFor(p) != base
+				t.Setenv(env, "")
+				if changed && !scrubbed[env] {
+					t.Errorf("%s changes defaultModelFor(%s) but testutil.ModelPinVars "+
+						"does not clear it — a developer with it exported gets different "+
+						"test results", env, p)
+				}
+			}
+		})
+	}
+
+	// The sandbox must actually leave them empty, whatever the developer has set.
+	t.Setenv("ANTHROPIC_MODEL", "leaked-from-the-shell")
+	t.Setenv("AWS_REGION", "leaked-region")
+	testutil.NewSandbox(t)
+	if got := defaultModelFor("anthropic"); got == "leaked-from-the-shell" {
+		t.Error("the sandbox did not clear ANTHROPIC_MODEL")
+	}
+	if got := bedrockRegion(); got != "" {
+		t.Errorf("bedrockRegion() = %q inside a sandbox, want empty", got)
+	}
+}

--- a/internal/parallel/edit_test.go
+++ b/internal/parallel/edit_test.go
@@ -41,20 +41,7 @@ func editSandbox(t *testing.T, reply string) (repo string) {
 	// rather than `claude` because its capability score puts it at UITier 6, so
 	// enum MODERATE routes to it — a tier-1 head is *stronger* than any enum an
 	// edit task is allowed to ask for, and selection would find nothing.
-	// /bin/cat by absolute path: the sandbox empties $PATH, so a bare `cat`
-	// resolves to nothing and the script exits 127.
-	body := "#!/bin/sh\n/bin/cat <<'HYDRA_EOF'\n" + reply + "\nHYDRA_EOF\n"
-	if runtime.GOOS == "windows" {
-		body = "@echo off\r\n"
-		for _, line := range strings.Split(reply, "\n") {
-			if line == "" {
-				body += "echo.\r\n"
-				continue
-			}
-			body += "echo " + line + "\r\n"
-		}
-	}
-	s.FakeBinary(t, "cody", body)
+	s.FakeBinary(t, "cody", testutil.EchoScript(reply))
 
 	repo = t.TempDir()
 	// A .git directory that is not a repository: workspace resolution roots

--- a/internal/parallel/edit_test.go
+++ b/internal/parallel/edit_test.go
@@ -1,0 +1,760 @@
+// SPDX-License-Identifier: MIT
+
+package parallel
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/testutil"
+
+	// Providers register themselves in init(), and this package does not import
+	// them — so without these blanks provider.All() is empty in the test binary
+	// and every dispatch finds no heads at all. cmd/hydra imports the same set.
+	_ "github.com/ankit373/hydra/internal/provider/cli"
+)
+
+// The edit path is the only thing in Hydra that writes to the user's source
+// files from a model's output. Every guard on it — scope, marker parsing,
+// atomic write, validation, rollback — is the difference between an edit and a
+// corrupted file, and none of them was covered.
+
+// editSandbox gives a hermetic environment with a config, a workspace rooted at
+// a temp repo, and a fake `claude` on PATH that replies with whatever body is
+// given. That makes a real end-to-end edit run with no network and no API key.
+func editSandbox(t *testing.T, reply string) (repo string) {
+	t.Helper()
+	s := testutil.NewSandbox(t)
+
+	if err := config.Save(&config.Config{Cortex: "cody"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The head is discovered from $PATH by the cli provider. `cody` is used
+	// rather than `claude` because its capability score puts it at UITier 6, so
+	// enum MODERATE routes to it — a tier-1 head is *stronger* than any enum an
+	// edit task is allowed to ask for, and selection would find nothing.
+	// /bin/cat by absolute path: the sandbox empties $PATH, so a bare `cat`
+	// resolves to nothing and the script exits 127.
+	body := "#!/bin/sh\n/bin/cat <<'HYDRA_EOF'\n" + reply + "\nHYDRA_EOF\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\n"
+		for _, line := range strings.Split(reply, "\n") {
+			if line == "" {
+				body += "echo.\r\n"
+				continue
+			}
+			body += "echo " + line + "\r\n"
+		}
+	}
+	s.FakeBinary(t, "cody", body)
+
+	repo = t.TempDir()
+	// A .git directory that is not a repository: workspace resolution roots
+	// here, but git commands fail, so the backup path is what protects the file.
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	// As the OS reports it: macOS gives /var symlinks for temp dirs and Windows
+	// normalises casing, and workspace containment compares the resolved form.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return repo
+	}
+	return cwd
+}
+
+func marked(content string) string {
+	return "<<<HYDRA_FILE_START>>>\n" + content + "\n<<<HYDRA_FILE_END>>>"
+}
+
+func runEdit(t *testing.T, task Task) EditResult {
+	t.Helper()
+	results, err := Run(context.Background(), []Task{task}, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	var got EditResult
+	if err := json.Unmarshal(results[0].raw, &got); err != nil {
+		t.Fatalf("result is not an EditResult: %v\n%s", err, results[0].raw)
+	}
+	return got
+}
+
+func TestEdit_WritesTheModelsContentAndReportsTheDiff(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}"))
+	file := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{
+		Label: "edit main", Enum: "MODERATE", File: file,
+		Prompt: "add an empty main", Validate: boolPtr(false),
+	})
+
+	if got.Status != "ok" {
+		t.Fatalf("status = %q, error %q", got.Status, got.Error)
+	}
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "func main() {}") {
+		t.Errorf("file = %q, want the model's content", raw)
+	}
+	// The markers must never reach the file.
+	if strings.Contains(string(raw), "HYDRA_FILE") {
+		t.Errorf("the markers leaked into the file: %q", raw)
+	}
+	if got.LinesAdded == 0 {
+		t.Errorf("LinesAdded = 0 for a file that grew: %+v", got)
+	}
+	// No temp file and no stale backup left in the user's tree.
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".hydra-tmp") || strings.HasSuffix(e.Name(), ".hydra-bak") {
+			t.Errorf("%s was left behind after a successful edit", e.Name())
+		}
+	}
+}
+
+func TestEdit_CreatesAFileThatDoesNotExistYet(t *testing.T) {
+	repo := editSandbox(t, marked("brand new"))
+	file := filepath.Join(repo, "sub", "dir", "new.txt")
+
+	got := runEdit(t, Task{
+		Label: "create", Enum: "MODERATE", File: file,
+		Prompt: "create it", Validate: boolPtr(false),
+	})
+	if got.Status != "ok" {
+		t.Fatalf("status = %q, error %q", got.Status, got.Error)
+	}
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("the file was not created: %v", err)
+	}
+	if !strings.Contains(string(raw), "brand new") {
+		t.Errorf("file = %q", raw)
+	}
+}
+
+// A model that answers with nothing between the markers must not truncate the
+// user's file to empty. This is the worst outcome the edit path can produce.
+func TestEdit_EmptyReplacementIsRefusedAndTheFileIsUntouched(t *testing.T) {
+	repo := editSandbox(t, marked(""))
+	file := filepath.Join(repo, "keep.go")
+	original := "package main\n\n// do not lose me\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{
+		Label: "empty", Enum: "MODERATE", File: file,
+		Prompt: "empty it", Validate: boolPtr(false),
+	})
+
+	if got.Status != "fail" {
+		t.Fatalf("status = %q, want fail — an empty replacement was accepted", got.Status)
+	}
+	if got.Error != "empty_replacement" {
+		t.Errorf("Error = %q, want empty_replacement", got.Error)
+	}
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != original {
+		t.Errorf("the file was modified despite the refusal:\n%q", raw)
+	}
+}
+
+// A model that echoes a marker back inside its content would write it into the
+// file, and the next edit would then parse against it.
+//
+// The shape that reaches this guard is a repeated start marker with no
+// terminator: with both markers present the extractor stops at the first end
+// marker and swallows any repeated start, so the only way a marker survives
+// extraction is the unterminated branch.
+func TestEdit_MarkerLeakageIsRefused(t *testing.T) {
+	repo := editSandbox(t, "<<<HYDRA_FILE_START>>>\nline one\n<<<HYDRA_FILE_START>>>\nline two")
+	file := filepath.Join(repo, "a.go")
+	original := "original\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{
+		Label: "leak", Enum: "MODERATE", File: file,
+		Prompt: "x", Validate: boolPtr(false),
+	})
+	if got.Status != "fail" || got.Error != "marker_leakage" {
+		t.Fatalf("result = %+v, want a marker_leakage failure", got)
+	}
+	if raw, _ := os.ReadFile(file); string(raw) != original {
+		t.Errorf("the file was modified: %q", raw)
+	}
+}
+
+// No markers at all means the model ignored the instruction. Writing its prose
+// into the file would replace source with an explanation.
+func TestEdit_NoMarkersIsRefused(t *testing.T) {
+	repo := editSandbox(t, "Sure! Here is what I would change: ...")
+	file := filepath.Join(repo, "a.go")
+	original := "original\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{
+		Label: "prose", Enum: "MODERATE", File: file,
+		Prompt: "x", Validate: boolPtr(false),
+	})
+	if got.Status != "fail" {
+		t.Fatalf("status = %q, want fail: %+v", got.Status, got)
+	}
+	if raw, _ := os.ReadFile(file); string(raw) != original {
+		t.Errorf("prose was written into the file: %q", raw)
+	}
+}
+
+// A relative path, a CORE task, and a file outside every workspace must all be
+// refused before anything is dispatched.
+func TestEdit_RefusesBeforeDispatching(t *testing.T) {
+	repo := editSandbox(t, marked("x"))
+
+	tests := []struct {
+		name    string
+		task    Task
+		wantErr string
+	}{{
+		name:    "relative path",
+		task:    Task{Label: "rel", Enum: "MODERATE", File: "relative.go", Prompt: "x"},
+		wantErr: "absolute",
+	}, {
+		name: "CORE is the orchestrator's own job",
+		task: Task{Label: "core", Enum: "CORE",
+			File: filepath.Join(repo, "a.go"), Prompt: "x"},
+		wantErr: "CORE",
+	}, {
+		name: "outside every workspace",
+		task: Task{Label: "outside", Enum: "MODERATE",
+			File: filepath.Join(t.TempDir(), "elsewhere.go"), Prompt: "x"},
+		wantErr: "scope_rejected",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runEdit(t, tt.task)
+			if got.Status != "fail" {
+				t.Fatalf("status = %q, want fail", got.Status)
+			}
+			if !strings.Contains(got.Error, tt.wantErr) {
+				t.Errorf("Error = %q, want it to mention %q", got.Error, tt.wantErr)
+			}
+		})
+	}
+}
+
+// A validator that rejects the edit must roll the file back. An edit that fails
+// validation and stays on disk is worse than no edit at all.
+func TestEdit_FailedValidationRollsTheFileBack(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the workspace validator template is a POSIX command line here")
+	}
+	repo := editSandbox(t, marked("this will not validate"))
+
+	// A workspace registry whose validator for .go always fails.
+	writeWorkspaceYAML(t, repo, "/usr/bin/false {file}")
+
+	file := filepath.Join(repo, "a.go")
+	original := "package main\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{
+		Label: "validate", Enum: "MODERATE", File: file, Prompt: "x",
+	})
+
+	if got.Status != "fail" || got.Error != "validation_failed" {
+		t.Fatalf("result = %+v, want a validation_failed failure", got)
+	}
+	if !got.RolledBack {
+		t.Error("RolledBack = false; the caller cannot tell whether the file changed")
+	}
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != original {
+		t.Errorf("the file was left in its failed state:\n%q", raw)
+	}
+	if _, err := os.Stat(file + ".hydra-bak"); err == nil {
+		t.Error("the backup survived the rollback, so the next edit sees a stale baseline")
+	}
+}
+
+// A validator that passes leaves the edit in place.
+func TestEdit_PassingValidationKeepsTheEdit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the workspace validator template is a POSIX command line here")
+	}
+	repo := editSandbox(t, marked("validated content"))
+	writeWorkspaceYAML(t, repo, "/usr/bin/true {file}")
+
+	file := filepath.Join(repo, "a.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{Label: "ok", Enum: "MODERATE", File: file, Prompt: "x"})
+	if got.Status != "ok" {
+		t.Fatalf("result = %+v", got)
+	}
+	if !got.ValidatorPassed {
+		t.Error("ValidatorPassed = false on a passing validator")
+	}
+	if raw, _ := os.ReadFile(file); !strings.Contains(string(raw), "validated content") {
+		t.Errorf("the edit was rolled back despite passing: %q", raw)
+	}
+}
+
+// Results are persisted for `hyctl review` to read. A batch that writes nothing
+// leaves the user with no way to see what was changed.
+func TestEdit_ResultsArePersistedForReview(t *testing.T) {
+	repo := editSandbox(t, marked("content"))
+	file := filepath.Join(repo, "a.txt")
+
+	if _, err := Run(context.Background(), []Task{{
+		Label: "persisted", Enum: "MODERATE", File: file,
+		Prompt: "x", Validate: boolPtr(false),
+	}}, Options{}); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(config.Dir(), "logs", "last_parallel.json"))
+	if err != nil {
+		t.Fatalf("no last_parallel.json was written: %v", err)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		t.Fatalf("last_parallel.json is not a JSON array: %v\n%s", err, raw)
+	}
+	if len(rows) != 1 || rows[0]["file"] != file || rows[0]["mode"] != "edit" {
+		t.Errorf("last_parallel.json = %v, want the one edit `hyctl review` reads", rows)
+	}
+}
+
+// A text task carries the head's answer through unchanged, and reads its
+// --context file into the prompt.
+func TestTextTask_ReturnsTheAnswerAndReadsItsContextFile(t *testing.T) {
+	repo := editSandbox(t, "the model's answer")
+
+	ctxFile := filepath.Join(repo, "context.md")
+	if err := os.WriteFile(ctxFile, []byte("CONTEXT LINE"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := Run(context.Background(), []Task{{
+		Label: "ask", Enum: "MODERATE", Prompt: "question", Context: ctxFile,
+	}}, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got TextResult
+	if err := json.Unmarshal(results[0].raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "ok" {
+		t.Fatalf("status = %q, error %q", got.Status, got.Error)
+	}
+	if !strings.Contains(got.Output, "the model's answer") {
+		t.Errorf("Output = %q", got.Output)
+	}
+
+	// A context file that does not exist must not fail the task — the prompt
+	// simply goes without it.
+	results, err = Run(context.Background(), []Task{{
+		Label: "ask", Enum: "MODERATE", Prompt: "question",
+		Context: filepath.Join(repo, "absent.md"),
+	}}, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(results[0].raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "ok" {
+		t.Errorf("a missing context file failed the task: %+v", got)
+	}
+}
+
+// A task whose dispatch fails must be reported as a failed task, not as a
+// failed batch — the other tasks in the fan-out still ran.
+func TestRun_OneFailingTaskDoesNotFailTheBatch(t *testing.T) {
+	repo := editSandbox(t, marked("fine"))
+
+	results, err := Run(context.Background(), []Task{
+		{Label: "good", Enum: "MODERATE", File: filepath.Join(repo, "a.txt"),
+			Prompt: "x", Validate: boolPtr(false)},
+		{Label: "bad", Enum: "MODERATE", File: "not-absolute.txt", Prompt: "x"},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("one bad task failed the whole batch: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want one per task", len(results))
+	}
+
+	statuses := map[string]string{}
+	for _, r := range results {
+		var e EditResult
+		if err := json.Unmarshal(r.raw, &e); err != nil {
+			t.Fatal(err)
+		}
+		statuses[e.Label] = e.Status
+	}
+	if statuses["good"] != "ok" || statuses["bad"] != "fail" {
+		t.Errorf("statuses = %v, want good ok and bad fail", statuses)
+	}
+}
+
+// ── unit-level helpers ────────────────────────────────────────────────────────
+
+func TestStatusOf(t *testing.T) {
+	if got := statusOf(json.RawMessage(`{"status":"ok"}`)); got != "ok" {
+		t.Errorf("statusOf = %q, want ok", got)
+	}
+	// Neither garbage nor a missing field may read as a success.
+	for _, raw := range []string{`not json`, `{}`, `{"status":""}`} {
+		if got := statusOf(json.RawMessage(raw)); got != "unknown" {
+			t.Errorf("statusOf(%s) = %q, want unknown", raw, got)
+		}
+	}
+}
+
+func TestRunValidate_DoesNotFragmentPathsWithSpaces(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX command lines")
+	}
+	// /usr/bin/test -f <path> succeeds only if the path reached it as one
+	// argument. strings.Fields would have split it at the space.
+	dir := t.TempDir()
+	spaced := filepath.Join(dir, "a file with spaces.go")
+	if err := os.WriteFile(spaced, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if rc := runValidate("/bin/test -f {file}", spaced); rc != 0 {
+		t.Errorf("exit %d — the path was fragmented at its spaces", rc)
+	}
+
+	if rc := runValidate("/usr/bin/false", "ignored"); rc == 0 {
+		t.Error("a failing validator reported success")
+	}
+	// A template naming a binary that does not exist is a failure, not a pass:
+	// treating "could not run the check" as "the check passed" is how an
+	// unvalidated edit ships.
+	if rc := runValidate("definitely-not-installed-anywhere", "x"); rc == 0 {
+		t.Error("a missing validator binary was treated as a pass")
+	}
+	// An empty template means no validator is configured, which is a pass.
+	if rc := runValidate("", "x"); rc != 0 {
+		t.Errorf("an empty template returned %d, want 0 (no validator configured)", rc)
+	}
+}
+
+func TestReadFileAndFileExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.txt")
+
+	if content, existed := readFile(path); existed || content != "" {
+		t.Errorf("readFile of a missing file = (%q, %v)", content, existed)
+	}
+	if fileExists(path) {
+		t.Error("fileExists = true for a missing file")
+	}
+
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if content, existed := readFile(path); !existed || content != "hello" {
+		t.Errorf("readFile = (%q, %v), want (hello, true)", content, existed)
+	}
+	if !fileExists(path) {
+		t.Error("fileExists = false for a file that exists")
+	}
+	// An empty file exists — distinguishing it from a missing one is what
+	// decides "create" versus "modify" in the edit prompt.
+	empty := filepath.Join(dir, "empty.txt")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if content, existed := readFile(empty); !existed || content != "" {
+		t.Errorf("readFile of an empty file = (%q, %v), want (\"\", true)", content, existed)
+	}
+}
+
+func TestEnumToTier_MatchesTheRouter(t *testing.T) {
+	// Same mapping the router applies, or a fan-out routes differently from a
+	// single dispatch of the same enum.
+	for _, enum := range []string{"SIMPLE", "STANDARD", "COMPLEX", "GRUNT", ""} {
+		if got, want := enumToTier(enum), dispatch.EnumToTier(enum); got != want {
+			t.Errorf("enumToTier(%q) = %q but the router says %q", enum, got, want)
+		}
+	}
+}
+
+func TestDiffStats_CountsFromTheBackupWhenGitIsUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	backup := file + ".hydra-bak"
+
+	if err := os.WriteFile(backup, []byte("one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("one\ntwo\nthree\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	added, removed := diffStats(file, "one\n", "", backup, true)
+	if added != 2 || removed != 0 {
+		t.Errorf("diffStats = (%d, %d), want (2, 0) — counted from the backup, not "+
+			"by re-parsing diff(1) (#260)", added, removed)
+	}
+
+	// With no backup at all it falls back to a line-count delta, which must
+	// still report growth rather than zero.
+	noBackup := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(noBackup, []byte("a\nb\nc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	added, removed = diffStats(noBackup, "a\n", "", noBackup+".hydra-bak", true)
+	if added == 0 && removed == 0 {
+		t.Error("diffStats reported no change for a file that grew by two lines")
+	}
+}
+
+func TestRollback_RestoresFromEachSource(t *testing.T) {
+	t.Run("from the backup", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "a.txt")
+		backup := file + ".hydra-bak"
+		if err := os.WriteFile(backup, []byte("original\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(file, []byte("bad edit\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		rollback(file, "original\n", true, "", backup)
+
+		if raw, _ := os.ReadFile(file); string(raw) != "original\n" {
+			t.Errorf("file = %q after rollback", raw)
+		}
+		if _, err := os.Stat(backup); err == nil {
+			t.Error("the backup survived; the next edit would see a stale baseline")
+		}
+	})
+
+	t.Run("a file that did not exist is removed", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "created.txt")
+		if err := os.WriteFile(file, []byte("bad edit\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		rollback(file, "", false, "", file+".hydra-bak")
+
+		if _, err := os.Stat(file); err == nil {
+			t.Error("a file the edit created was left behind after rollback")
+		}
+	})
+
+	t.Run("from the in-memory snapshot", func(t *testing.T) {
+		dir := t.TempDir()
+		file := filepath.Join(dir, "a.txt")
+		if err := os.WriteFile(file, []byte("bad edit\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		rollback(file, "original\n", true, "", file+".hydra-bak")
+
+		if raw, _ := os.ReadFile(file); string(raw) != "original\n" {
+			t.Errorf("file = %q, want the snapshot restored", raw)
+		}
+	})
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// writeWorkspaceYAML points $HYDRA_HOME's registry at a workspace rooted here,
+// with a top-level validator for .go files. allowed_globs is required: a
+// workspace without it matches no file at all.
+func writeWorkspaceYAML(t *testing.T, root, goValidator string) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HYDRA_HOME"), "registry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: \"1.0\"\nworkspaces:\n  test:\n    root: " + root +
+		"\n    git: \"false\"\n    allowed_globs: [\"**\"]\nvalidators:\n  go: \"" +
+		goValidator + "\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "workspace.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Replaces the two single-case tests that were in parallel_test.go: these are
+// strict supersets of them, and two partial tests of one function is how a
+// shape goes uncovered while looking covered.
+//
+// extractContent handles three shapes the model can produce: both markers, a
+// terminator with no opener (the model started writing straight away), and an
+// opener with no terminator (it ran out of budget mid-answer).
+func TestExtractContent_EveryMarkerShape(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{{
+		name: "both markers",
+		raw:  "preamble\n<<<HYDRA_FILE_START>>>\nline one\nline two\n<<<HYDRA_FILE_END>>>\ntrailing prose",
+		want: "line one\nline two",
+	}, {
+		// The model skipped the opener and wrote the file directly. Everything
+		// up to the terminator is the content.
+		name: "terminator only",
+		raw:  "line one\nline two\n<<<HYDRA_FILE_END>>>",
+		want: "line one\nline two",
+	}, {
+		// Truncated mid-answer. Everything after the opener is what there is.
+		name: "opener only",
+		raw:  "<<<HYDRA_FILE_START>>>\nline one\nline two",
+		want: "line one\nline two",
+	}, {
+		// Neither marker: the model answered in prose. Returning "" is what
+		// makes runEditTask refuse rather than write the prose to the file.
+		name: "no markers at all",
+		raw:  "Sure, here is what I would do...",
+		want: "",
+	}, {
+		name: "empty input",
+		raw:  "",
+		want: "",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractContent(tt.raw); got != tt.want {
+				t.Errorf("extractContent = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Models wrap output in a code fence even when told not to. The fence must come
+// off, but a fence *inside* the file (a markdown file, a README) must not.
+func TestStripOuterFence(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain fence", "```\ncode\n```", "code"},
+		{"language-tagged fence", "```go\ncode\n```", "code"},
+		{"no fence", "code", "code"},
+		{"opening fence only", "```go\ncode", "code"},
+		{
+			// An inner fence belongs to the file's own content.
+			name: "inner fences survive",
+			in:   "```md\n# Title\n\n```sh\nrun me\n```\n```",
+			want: "# Title\n\n```sh\nrun me\n```",
+		},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripOuterFence(tt.in); got != tt.want {
+				t.Errorf("stripOuterFence(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// tscTemplate is only offered when the workspace actually has tsc installed —
+// naming a binary that is not there would fail every TypeScript edit at the
+// validation step and roll back a correct change.
+func TestTSCTemplate_OnlyWhenTSCIsInstalled(t *testing.T) {
+	root := t.TempDir()
+
+	if got := tscTemplate(root); got != "" {
+		t.Errorf("tscTemplate = %q with no node_modules, want empty", got)
+	}
+
+	bin := filepath.Join(root, "node_modules", ".bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bin, "tsc"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// No tsconfig.json: check the single file with explicit flags.
+	got := tscTemplate(root)
+	if !strings.Contains(got, "--noEmit") || !strings.Contains(got, "{file}") {
+		t.Errorf("tscTemplate = %q, want a single-file check naming {file}", got)
+	}
+
+	// With a tsconfig.json the project's own settings win, and the template
+	// checks the project rather than one file.
+	if err := os.WriteFile(filepath.Join(root, "tsconfig.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got = tscTemplate(root)
+	if !strings.Contains(got, "-p ") {
+		t.Errorf("tscTemplate = %q, want it to use the project's tsconfig.json", got)
+	}
+	if strings.Contains(got, "{file}") {
+		t.Errorf("tscTemplate = %q — a project-wide check takes no file argument", got)
+	}
+}
+
+// persistResults must survive a logs directory it cannot write to, since it
+// runs after the edits have already landed on disk. Failing here must not be
+// mistaken for the batch failing.
+func TestPersistResults_UnwritableLogDirIsReportedNotFatal(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	// ~/.hydra is a regular file, so logs/ cannot be created.
+	if err := os.WriteFile(config.Dir(), []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := persistResults([]Result{{raw: json.RawMessage(`{"status":"ok"}`)}})
+	if err == nil {
+		t.Error("persistResults reported success with an uncreatable logs directory")
+	}
+}

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -35,22 +35,6 @@ func TestRun_DuplicateFileConflict(t *testing.T) {
 	}
 }
 
-func TestExtractContent(t *testing.T) {
-	body := markerStart + "\nhello\nworld\n" + markerEnd
-	if got := extractContent("prose\n" + body + "\ntrailing"); got != "hello\nworld" {
-		t.Errorf("extractContent(both) = %q, want %q", got, "hello\nworld")
-	}
-	if got := extractContent("no markers here"); got != "" {
-		t.Errorf("extractContent(none) = %q, want empty", got)
-	}
-}
-
-func TestStripOuterFence(t *testing.T) {
-	if got := stripOuterFence("```ts\nconst x = 1\n```"); got != "const x = 1" {
-		t.Errorf("stripOuterFence() = %q, want %q", got, "const x = 1")
-	}
-}
-
 func TestFileExt(t *testing.T) {
 	if got := fileExt("main.go"); got != "go" {
 		t.Errorf("fileExt = %q, want go", got)

--- a/internal/provider/ollama_host.go
+++ b/internal/provider/ollama_host.go
@@ -3,6 +3,7 @@
 package provider
 
 import (
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -48,6 +49,19 @@ func OllamaHost() string {
 	return strings.TrimRight(u.Scheme+"://"+u.Host, "/")
 }
 
+// isLoopback decides whether cleartext is acceptable for this host.
+//
+// It parses the address rather than matching a "127." prefix, because a prefix
+// match is not an address check: "127.0.0.1.evil.com" is a perfectly valid
+// hostname that someone else controls and that resolves wherever they point it,
+// and it passed. The guard exists to keep the user's source code off the
+// network in cleartext, so it has to test what the string actually is.
 func isLoopback(host string) bool {
-	return host == "localhost" || host == "::1" || strings.HasPrefix(host, "127.")
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }

--- a/internal/provider/ollama_host_test.go
+++ b/internal/provider/ollama_host_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+
+package provider
+
+import (
+	"testing"
+)
+
+// OllamaHost is the single answer both discovery and execution use. They used
+// to disagree — the executor honoured $OLLAMA_HOST while the port provider
+// hardcoded localhost, so a user running Ollama anywhere else had a working
+// server discovery could not see, no tier-10 head, and a silent degrade to a
+// paid one (#282).
+func TestOllamaHost_Resolution(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{{
+		name: "unset uses the default",
+		env:  "",
+		want: DefaultOllamaHost,
+	}, {
+		// Ollama's own OLLAMA_HOST is a bare host:port; url.Parse would read
+		// "192.168.1.5" as a scheme without the normalisation.
+		name: "bare host:port is accepted the way ollama accepts it",
+		env:  "127.0.0.1:11500",
+		want: "http://127.0.0.1:11500",
+	}, {
+		name: "explicit http to loopback",
+		env:  "http://localhost:9999",
+		want: "http://localhost:9999",
+	}, {
+		name: "trailing slash is trimmed",
+		env:  "http://localhost:11434/",
+		want: "http://localhost:11434",
+	}, {
+		name: "a path is dropped, not appended to",
+		env:  "http://localhost:11434/api/",
+		want: "http://localhost:11434",
+	}, {
+		// A prompt is the user's source code. Sending it in cleartext to a
+		// remote host because an environment variable said so is not a tradeoff
+		// to make silently.
+		name: "plain http to a remote host is refused",
+		env:  "http://192.168.1.50:11434",
+		want: DefaultOllamaHost,
+	}, {
+		name: "https to a remote host is allowed",
+		env:  "https://ollama.example.com",
+		want: "https://ollama.example.com",
+	}, {
+		name: "ipv6 loopback over http is allowed",
+		env:  "http://[::1]:11434",
+		want: "http://[::1]:11434",
+	}, {
+		name: "a non-http scheme falls back rather than erroring",
+		env:  "ftp://localhost:11434",
+		want: DefaultOllamaHost,
+	}, {
+		// A stray export must not make Ollama undiscoverable.
+		name: "unparsable value falls back to the default",
+		env:  "http://[::1",
+		want: DefaultOllamaHost,
+	}, {
+		name: "a scheme with no host falls back",
+		env:  "http://",
+		want: DefaultOllamaHost,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_HOST", tt.env)
+			if got := OllamaHost(); got != tt.want {
+				t.Errorf("OllamaHost() with OLLAMA_HOST=%q = %q, want %q", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+// isLoopback decides whether cleartext is acceptable, so a host that merely
+// looks local must not qualify.
+func TestIsLoopback(t *testing.T) {
+	local := []string{"localhost", "::1", "127.0.0.1", "127.1.2.3"}
+	for _, h := range local {
+		if !isLoopback(h) {
+			t.Errorf("isLoopback(%q) = false", h)
+		}
+	}
+	remote := []string{
+		"example.com",
+		"192.168.1.5",
+		"10.0.0.1",
+		// Looks local, is not: a hostname someone else controls.
+		"localhost.evil.com",
+		"127.0.0.1.evil.com",
+		"",
+	}
+	for _, h := range remote {
+		if isLoopback(h) {
+			t.Errorf("isLoopback(%q) = true — cleartext prompts would be sent there", h)
+		}
+	}
+}

--- a/internal/swarm/judge_test.go
+++ b/internal/swarm/judge_test.go
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// The judge decides which of N paid answers the user actually gets. Its parser
+// reads free-form model output, so every malformed shape it accepts is a wrong
+// answer presented as the best one.
+
+func okAttempt(id string, capScore int, output string) Attempt {
+	return Attempt{
+		Head:   provider.Head{ID: id, Name: id, CapScore: capScore},
+		Status: StatusOK,
+		Output: output,
+	}
+}
+
+func failedAttempt(id string) Attempt {
+	return Attempt{
+		Head:   provider.Head{ID: id, Name: id, CapScore: 90},
+		Status: StatusFailed,
+		Err:    errors.New("boom"),
+	}
+}
+
+func TestParseJudgeResponse_AcceptsNoisyOutput(t *testing.T) {
+	successIdx := []int{0, 1}
+
+	tests := []struct {
+		name       string
+		raw        string
+		wantWinner int
+	}{{
+		name:       "bare json",
+		raw:        `{"winner":1,"scores":[70,85],"reason":"clearer"}`,
+		wantWinner: 1,
+	}, {
+		// Models wrap JSON in a fence even when told not to.
+		name:       "fenced json",
+		raw:        "```json\n{\"winner\":0,\"scores\":[90,60],\"reason\":\"correct\"}\n```",
+		wantWinner: 0,
+	}, {
+		name:       "prose either side",
+		raw:        "Here is my evaluation:\n{\"winner\":1,\"scores\":[10,20],\"reason\":\"x\"}\nHope that helps!",
+		wantWinner: 1,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := parseJudgeResponse(tt.raw, 2, successIdx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v.WinnerIndex != tt.wantWinner {
+				t.Errorf("WinnerIndex = %d, want %d", v.WinnerIndex, tt.wantWinner)
+			}
+			if v.Reason == "" {
+				t.Error("Reason is empty; it is what the user is shown to justify the pick")
+			}
+		})
+	}
+}
+
+// Every malformed verdict must be an error. A judge that "succeeds" on garbage
+// hands the user an arbitrary answer and calls it the best one.
+func TestParseJudgeResponse_RejectsMalformedVerdicts(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           string
+		totalAttempts int
+		successIdx    []int
+	}{{
+		name: "not json at all", raw: "I prefer the second one.",
+		totalAttempts: 2, successIdx: []int{0, 1},
+	}, {
+		name: "truncated json", raw: `{"winner":0,"scores":[1,2]`,
+		totalAttempts: 2, successIdx: []int{0, 1},
+	}, {
+		// A score per response is what makes the verdict auditable; a short
+		// array means the judge did not evaluate them all.
+		name: "too few scores", raw: `{"winner":0,"scores":[90],"reason":"x"}`,
+		totalAttempts: 2, successIdx: []int{0, 1},
+	}, {
+		name: "too many scores", raw: `{"winner":0,"scores":[90,80,70],"reason":"x"}`,
+		totalAttempts: 2, successIdx: []int{0, 1},
+	}, {
+		// The judge picked a response that does not exist. Indexing on it would
+		// panic in Run, which dereferences attempts[verdict.WinnerIndex].
+		name: "winner out of range", raw: `{"winner":7,"scores":[90,80],"reason":"x"}`,
+		totalAttempts: 2, successIdx: []int{0, 1},
+	}, {
+		// It picked an attempt that failed — there is no output to return.
+		name: "winner is a failed attempt", raw: `{"winner":1,"scores":[90],"reason":"x"}`,
+		totalAttempts: 2, successIdx: []int{0},
+	}, {
+		name: "negative winner", raw: `{"winner":-1,"scores":[90,80],"reason":"x"}`,
+		totalAttempts: 2, successIdx: []int{0, 1},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := parseJudgeResponse(tt.raw, tt.totalAttempts, tt.successIdx)
+			if err == nil {
+				t.Fatalf("parseJudgeResponse accepted %s: %+v", tt.name, v)
+			}
+		})
+	}
+}
+
+// Scores are reported against the full attempt list, so a failed attempt scores
+// zero rather than shifting every later score up by one.
+func TestParseJudgeResponse_MapsScoresBackOntoFailedAttempts(t *testing.T) {
+	// Attempt 1 failed; only 0 and 2 were judged.
+	v, err := parseJudgeResponse(`{"winner":2,"scores":[60,95],"reason":"x"}`, 3, []int{0, 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v.Scores) != 3 {
+		t.Fatalf("Scores = %v, want one per attempt", v.Scores)
+	}
+	if v.Scores[0] != 60 || v.Scores[1] != 0 || v.Scores[2] != 95 {
+		t.Errorf("Scores = %v, want [60 0 95] — the failed attempt must score 0 "+
+			"rather than shifting the others", v.Scores)
+	}
+}
+
+// buildJudgePrompt must carry every successful candidate and its index, or the
+// judge is scoring something other than what it is shown.
+func TestBuildJudgePrompt_CarriesEveryCandidate(t *testing.T) {
+	attempts := []Attempt{
+		okAttempt("alpha", 90, "answer from alpha"),
+		failedAttempt("beta"),
+		okAttempt("gamma", 80, "answer from gamma"),
+	}
+	got := buildJudgePrompt("the original question", attempts, []int{0, 2})
+
+	for _, want := range []string{
+		"the original question",
+		"answer from alpha", "answer from gamma",
+		"alpha", "gamma",
+		"Response 0", "Response 2",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("judge prompt is missing %q", want)
+		}
+	}
+	// The failed attempt has no output to score and must not appear as a
+	// candidate — the judge would otherwise be asked to rank an empty answer.
+	if strings.Contains(got, "Response 1 ") {
+		t.Errorf("the failed attempt was offered as a candidate:\n%s", got)
+	}
+	if !strings.Contains(got, `{"winner"`) {
+		t.Error("the prompt does not state the response format it will be parsed against")
+	}
+}
+
+// One successful attempt needs no LLM call: there is nothing to compare.
+// Spending a tier-1 dispatch to pick the only candidate is pure waste.
+func TestLLMJudge_SingleSuccessSkipsTheDispatch(t *testing.T) {
+	j := newLLMJudge(nil, "1", 0) // a nil dispatcher would panic if used
+
+	attempts := []Attempt{failedAttempt("a"), okAttempt("b", 88, "the only answer")}
+	v, err := j.Judge(context.Background(), "q", attempts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.WinnerIndex != 1 {
+		t.Errorf("WinnerIndex = %d, want the only successful attempt", v.WinnerIndex)
+	}
+	if v.Scores[1] != 88 {
+		t.Errorf("Scores = %v, want the head's CapScore for the sole candidate", v.Scores)
+	}
+	if v.Reason == "" {
+		t.Error("no reason given")
+	}
+}
+
+func TestLLMJudge_NoSuccessfulAttemptsIsAnError(t *testing.T) {
+	j := newLLMJudge(nil, "1", 0)
+	if v, err := j.Judge(context.Background(), "q", []Attempt{failedAttempt("a")}); err == nil {
+		t.Errorf("Judge returned %+v with nothing to judge", v)
+	}
+}
+
+func TestNewLLMJudge_DefaultsTheTimeout(t *testing.T) {
+	if got := newLLMJudge(nil, "1", 0); got.timeout != defaultJudgeTimeout {
+		t.Errorf("timeout = %v with none set, want the default %v — zero would "+
+			"cancel the judge immediately", got.timeout, defaultJudgeTimeout)
+	}
+	if got := newLLMJudge(nil, "1", 5*time.Second); got.timeout != 5*time.Second {
+		t.Errorf("timeout = %v, want the caller's 5s", got.timeout)
+	}
+}
+
+// The CapScore judge is the deterministic fallback used when the LLM judge
+// fails. It must never pick a failed attempt.
+func TestCapScoreJudge_PicksTheStrongestSuccess(t *testing.T) {
+	attempts := []Attempt{
+		okAttempt("weak", 60, "a"),
+		failedAttempt("strongest-but-failed"), // CapScore 90
+		okAttempt("strong", 85, "b"),
+	}
+
+	v, err := (&CapScoreJudge{}).Judge(context.Background(), "q", attempts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.WinnerIndex != 2 {
+		t.Errorf("WinnerIndex = %d, want the strongest *successful* attempt", v.WinnerIndex)
+	}
+
+	if _, err := (&CapScoreJudge{}).Judge(context.Background(), "q", []Attempt{failedAttempt("a")}); err == nil {
+		t.Error("CapScoreJudge returned a winner with no successful attempts")
+	}
+}
+
+// ── winner selection ──────────────────────────────────────────────────────────
+
+func TestRaceWinner_FallsBackToTheFirstSuccess(t *testing.T) {
+	ranked := []Attempt{okAttempt("a", 90, "x"), okAttempt("b", 80, "y")}
+	ranked[1].Rank = 1
+	if got := raceWinner(ranked); got == nil || got.Head.ID != "b" {
+		t.Errorf("raceWinner = %+v, want the rank-1 attempt", got)
+	}
+
+	// Nothing ranked: the first success stands in rather than nil, which would
+	// report a successful race with no answer.
+	unranked := []Attempt{failedAttempt("a"), okAttempt("b", 80, "y")}
+	if got := raceWinner(unranked); got == nil || got.Head.ID != "b" {
+		t.Errorf("raceWinner with nothing ranked = %+v, want the first success", got)
+	}
+
+	if got := raceWinner([]Attempt{failedAttempt("a")}); got != nil {
+		t.Errorf("raceWinner = %+v with no successes, want nil", got)
+	}
+}
+
+func TestCapScoreWinner_MarksTheWinnerAndIgnoresFailures(t *testing.T) {
+	attempts := []Attempt{
+		failedAttempt("failed-but-strong"), // 90
+		okAttempt("mid", 70, "x"),
+		okAttempt("best", 85, "y"),
+	}
+	got := capScoreWinner(attempts)
+	if got == nil || got.Head.ID != "best" {
+		t.Fatalf("capScoreWinner = %+v, want the strongest success", got)
+	}
+	if attempts[2].Rank != 1 {
+		t.Error("the winner was not marked rank 1 in the attempt list the caller keeps")
+	}
+	if capScoreWinner([]Attempt{failedAttempt("a")}) != nil {
+		t.Error("capScoreWinner returned a winner with no successes")
+	}
+}
+
+// `--swarm-mode all` ranks everything so the user can compare. Failed attempts
+// must stay unranked rather than being given a place in the ordering.
+func TestRankByCapScore(t *testing.T) {
+	attempts := []Attempt{
+		okAttempt("mid", 70, "x"),
+		failedAttempt("failed"),
+		okAttempt("best", 95, "y"),
+		okAttempt("worst", 50, "z"),
+	}
+	rankByCapScore(attempts)
+
+	if attempts[2].Rank != 1 || attempts[0].Rank != 2 || attempts[3].Rank != 3 {
+		t.Errorf("ranks = %d/%d/%d/%d, want best=1 mid=2 worst=3",
+			attempts[0].Rank, attempts[1].Rank, attempts[2].Rank, attempts[3].Rank)
+	}
+	if attempts[1].Rank != 0 {
+		t.Errorf("the failed attempt was ranked %d; it has no output to rank",
+			attempts[1].Rank)
+	}
+}
+
+func TestFirstSuccessful(t *testing.T) {
+	if got := firstSuccessful([]Attempt{failedAttempt("a"), okAttempt("b", 1, "x")}); got == nil || got.Head.ID != "b" {
+		t.Errorf("firstSuccessful = %+v", got)
+	}
+	if got := firstSuccessful(nil); got != nil {
+		t.Errorf("firstSuccessful(nil) = %+v, want nil", got)
+	}
+}
+
+// truncate bounds the prompt preview written to cost.jsonl. It counts runes,
+// not bytes — cutting a multi-byte character in half produces invalid UTF-8 in
+// a JSON log.
+func TestTruncate_CountsRunesNotBytes(t *testing.T) {
+	if got := truncate("short", 80); got != "short" {
+		t.Errorf("truncate = %q", got)
+	}
+
+	long := strings.Repeat("é", 100) // two bytes each
+	got := truncate(long, 80)
+	if n := len([]rune(got)); n != 81 {
+		t.Errorf("truncate produced %d runes, want 80 plus the ellipsis", n)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Error("truncated text is not marked as cut")
+	}
+	for _, r := range got {
+		if r == '�' {
+			t.Fatalf("truncate split a multi-byte rune: %q", got)
+		}
+	}
+}
+
+// classifyError decides how a head's failure is reported and, for auth, whether
+// the user is told to log in. Reading them all as generic failures hides the
+// one the user can act on.
+func TestClassifyError_EveryStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want HeadStatus
+	}{
+		{"nil is ok", nil, StatusOK},
+		{"auth required", &executor.AuthRequiredError{ModelFlag: "m", Pool: "p"}, StatusAuthRequired},
+		{"wrapped auth required",
+			errors.New("outer: " + (&executor.AuthRequiredError{}).Error()), StatusFailed},
+		{"deadline", context.DeadlineExceeded, StatusTimeout},
+		{"canceled", context.Canceled, StatusCanceled},
+		{"anything else", errors.New("boom"), StatusFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyError(tt.err); got != tt.want {
+				t.Errorf("classifyError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+
+	// Wrapping must not hide the type — errors.As unwraps, and that is what
+	// keeps "run: claude login" reaching the user through a fallback chain.
+	wrapped := fmt.Errorf("dispatch failed: %w", &executor.AuthRequiredError{ModelFlag: "m"})
+	if got := classifyError(wrapped); got != StatusAuthRequired {
+		t.Errorf("a wrapped AuthRequiredError classified as %v, want AuthRequired", got)
+	}
+	deadline := fmt.Errorf("head timed out: %w", context.DeadlineExceeded)
+	if got := classifyError(deadline); got != StatusTimeout {
+		t.Errorf("a wrapped deadline classified as %v, want Timeout", got)
+	}
+}

--- a/internal/swarm/run_test.go
+++ b/internal/swarm/run_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -24,14 +23,10 @@ import (
 // swarmHead builds a head backed by a fake CLI binary that prints reply.
 func swarmHead(t *testing.T, s *testutil.Sandbox, id string, capScore int, reply string) provider.Head {
 	t.Helper()
-	body := "#!/bin/sh\n/bin/cat <<'HYDRA_EOF'\n" + reply + "\nHYDRA_EOF\n"
-	if runtime.GOOS == "windows" {
-		body = "@echo off\r\necho " + strings.ReplaceAll(reply, "\n", " ") + "\r\n"
-	}
 	return provider.Head{
 		ID: id, Name: id, Provider: "openai", Source: "cli",
 		CapScore: capScore, AuthReady: true,
-		Executable: s.FakeBinary(t, "fake-"+id, body),
+		Executable: s.FakeBinary(t, "fake-"+id, testutil.EchoScript(reply)),
 	}
 }
 

--- a/internal/swarm/run_test.go
+++ b/internal/swarm/run_test.go
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/cost"
+	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// Run fans one prompt out to N heads and charges the user for all of them. Its
+// contract is that every head's answer is accounted for, exactly one winner is
+// reported, and the spend is logged — none of which was covered.
+
+// swarmHead builds a head backed by a fake CLI binary that prints reply.
+func swarmHead(t *testing.T, s *testutil.Sandbox, id string, capScore int, reply string) provider.Head {
+	t.Helper()
+	body := "#!/bin/sh\n/bin/cat <<'HYDRA_EOF'\n" + reply + "\nHYDRA_EOF\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\necho " + strings.ReplaceAll(reply, "\n", " ") + "\r\n"
+	}
+	return provider.Head{
+		ID: id, Name: id, Provider: "openai", Source: "cli",
+		CapScore: capScore, AuthReady: true,
+		Executable: s.FakeBinary(t, "fake-"+id, body),
+	}
+}
+
+// brokenHead points at a binary that is not there, so its attempt fails.
+func brokenHead(s *testutil.Sandbox, id string, capScore int) provider.Head {
+	return provider.Head{
+		ID: id, Name: id, Provider: "openai", Source: "cli",
+		CapScore: capScore, AuthReady: true,
+		Executable: filepath.Join(s.BinDir, "does-not-exist-"+id),
+	}
+}
+
+func newSwarm(t *testing.T, heads ...provider.Head) *Swarm {
+	t.Helper()
+	d, err := dispatch.New(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// pricing nil: EstimateCost is exercised separately, and a live pricing DB
+	// spawns a background OpenRouter fetch per construction.
+	return New(d, heads, nil)
+}
+
+func swarmSandbox(t *testing.T) *testutil.Sandbox {
+	t.Helper()
+	s := testutil.NewSandbox(t)
+	if err := config.Save(&config.Config{Cortex: "strong"}); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// `--swarm-mode all` runs every head and ranks them, so the user can compare.
+func TestRun_ModeAllRunsEveryHeadAndRanksThem(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t,
+		swarmHead(t, s, "strong", 95, "answer from strong"),
+		swarmHead(t, s, "weak", 60, "answer from weak"),
+	)
+
+	res, err := sw.Run(context.Background(), "the question", Options{Mode: ModeAll})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Attempts) != 2 {
+		t.Fatalf("got %d attempts, want one per head", len(res.Attempts))
+	}
+	for _, a := range res.Attempts {
+		if a.Status != StatusOK {
+			t.Errorf("%s failed: %v", a.Head.ID, a.Err)
+		}
+		if a.Output == "" {
+			t.Errorf("%s produced no output", a.Head.ID)
+		}
+		if a.Duration <= 0 {
+			t.Errorf("%s has no measured duration", a.Head.ID)
+		}
+	}
+	if res.Winner == nil || res.Winner.Head.ID != "strong" {
+		t.Errorf("Winner = %+v, want the highest-CapScore success", res.Winner)
+	}
+	if res.WallDuration <= 0 {
+		t.Error("WallDuration was not measured; the swarm's own cost is its wall time")
+	}
+	if res.Mode != ModeAll || res.Prompt != "the question" {
+		t.Errorf("result did not carry the request back: %+v", res)
+	}
+}
+
+// Race returns the first answer and marks it. The losers still ran and still
+// cost money, so they must still appear in the attempt list.
+func TestRun_ModeRaceReportsOneWinnerAndKeepsTheLosers(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t,
+		swarmHead(t, s, "a", 90, "answer a"),
+		swarmHead(t, s, "b", 80, "answer b"),
+	)
+
+	res, err := sw.Run(context.Background(), "q", Options{Mode: ModeRace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Winner == nil {
+		t.Fatal("race produced no winner")
+	}
+	if res.Winner.Rank != 1 {
+		t.Errorf("the winner is rank %d, want 1", res.Winner.Rank)
+	}
+	winners := 0
+	for _, a := range res.Attempts {
+		if a.Rank == 1 {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Errorf("%d attempts are marked rank 1; a race has exactly one winner", winners)
+	}
+}
+
+// Best mode judges. With no judge head reachable the LLM judge fails, and the
+// deterministic CapScore fallback must still produce a winner rather than
+// leaving the user with nothing after paying for N answers.
+func TestRun_ModeBestFallsBackToCapScoreWhenTheJudgeFails(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t,
+		swarmHead(t, s, "mid", 70, "answer from mid"),
+		swarmHead(t, s, "best", 88, "answer from best"),
+	)
+
+	res, err := sw.Run(context.Background(), "q", Options{Mode: ModeBest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Winner == nil {
+		t.Fatal("best mode produced no winner; the user paid for two answers and got none")
+	}
+	if res.Winner.Head.ID != "best" {
+		t.Errorf("Winner = %s, want the strongest success from the CapScore fallback",
+			res.Winner.Head.ID)
+	}
+}
+
+// A head that fails must not take the swarm down with it: the others answered.
+func TestRun_OneFailingHeadDoesNotFailTheSwarm(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t,
+		brokenHead(s, "broken", 95),
+		swarmHead(t, s, "working", 70, "the answer"),
+	)
+
+	res, err := sw.Run(context.Background(), "q", Options{Mode: ModeAll})
+	if err != nil {
+		t.Fatalf("one failing head failed the whole swarm: %v", err)
+	}
+	if len(res.Attempts) != 2 {
+		t.Fatalf("got %d attempts, want both recorded — a failed head is part of "+
+			"what the run did", len(res.Attempts))
+	}
+	if res.Winner == nil || res.Winner.Head.ID != "working" {
+		t.Errorf("Winner = %+v, want the head that answered", res.Winner)
+	}
+	var sawFailure bool
+	for _, a := range res.Attempts {
+		if a.Head.ID == "broken" {
+			sawFailure = a.Status != StatusOK
+			if a.Err == nil {
+				t.Error("the failed attempt carries no error to show the user")
+			}
+		}
+	}
+	if !sawFailure {
+		t.Error("the broken head was recorded as successful")
+	}
+}
+
+// Every head failing is an answer of "none", not a crash.
+func TestRun_AllHeadsFailingLeavesNoWinner(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t, brokenHead(s, "a", 90), brokenHead(s, "b", 80))
+
+	res, err := sw.Run(context.Background(), "q", Options{Mode: ModeAll})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Winner != nil {
+		t.Errorf("Winner = %+v with every head failed", res.Winner)
+	}
+}
+
+// Spend is logged to cost.jsonl, which is what `hyctl cost` and `hyctl stats`
+// read. A swarm that does not log is spend the user cannot see.
+func TestRun_LogsEveryAttemptToTheCostLog(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t,
+		swarmHead(t, s, "a", 90, "answer a"),
+		swarmHead(t, s, "b", 80, "answer b"),
+	)
+
+	if _, err := sw.Run(context.Background(), "the prompt", Options{Mode: ModeAll}); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := cost.LoadAll()
+	if err != nil {
+		t.Fatalf("no cost log after a swarm run: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("cost.jsonl has %d rows, want one per attempt: %+v", len(rows), rows)
+	}
+	var winners int
+	for _, r := range rows {
+		if r.SwarmMode != string(ModeAll) {
+			t.Errorf("row mode = %q, want %q — `hyctl stats` groups on this",
+				r.SwarmMode, ModeAll)
+		}
+		if r.SwarmWinner {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Errorf("%d rows are flagged as the winner, want exactly 1", winners)
+	}
+}
+
+// Unknown modes must be refused before any head is fired, not after.
+func TestRun_UnknownModeIsRefused(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t, swarmHead(t, s, "a", 90, "x"))
+
+	if _, err := sw.Run(context.Background(), "q", Options{Mode: SwarmMode("sideways")}); err == nil {
+		t.Error("an unknown swarm mode fired the heads anyway")
+	}
+}
+
+func TestRun_NoHeadsIsAnErrorNotAnEmptyResult(t *testing.T) {
+	swarmSandbox(t)
+	sw := newSwarm(t)
+
+	if res, err := sw.Run(context.Background(), "q", Options{Mode: ModeAll}); err == nil {
+		t.Errorf("Run succeeded with no heads: %+v", res)
+	}
+}
+
+// The pre-flight cost guard exists so a wide fan-out cannot be fired by
+// accident. It must refuse *before* spending, not report the overage after.
+func TestRun_CostGuardRefusesBeforeFiring(t *testing.T) {
+	s := swarmSandbox(t)
+	d, err := dispatch.New(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	heads := []provider.Head{
+		swarmHead(t, s, "a", 90, "x"),
+		swarmHead(t, s, "b", 80, "y"),
+	}
+	sw := New(d, heads, fixedPricing{perCall: 1.0})
+
+	_, err = sw.Run(context.Background(), "q", Options{Mode: ModeAll, MaxEstCostUSD: 0.50})
+	if err == nil {
+		t.Fatal("the cost guard did not fire")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Errorf("error = %v, want it to name the limit", err)
+	}
+	// Nothing ran, so nothing was logged.
+	if rows, lerr := cost.LoadAll(); lerr == nil && len(rows) != 0 {
+		t.Errorf("%d cost rows were written despite the guard refusing", len(rows))
+	}
+
+	// Under the limit it proceeds.
+	if _, err := sw.Run(context.Background(), "q", Options{Mode: ModeAll, MaxEstCostUSD: 10}); err != nil {
+		t.Errorf("the guard refused a run inside its limit: %v", err)
+	}
+}
+
+// Plan is what --dry-run reports. It must name the same heads Run would fire —
+// a plan that describes a different run than the one it precedes is worse than
+// no plan (#167).
+func TestPlan_MatchesWhatRunWouldFire(t *testing.T) {
+	s := swarmSandbox(t)
+	heads := []provider.Head{
+		swarmHead(t, s, "a", 90, "x"),
+		swarmHead(t, s, "b", 80, "y"),
+	}
+	d, err := dispatch.New(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sw := New(d, heads, fixedPricing{perCall: 0.25})
+
+	planned, estUSD, err := sw.Plan("q", Options{Mode: ModeAll})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(planned) != 2 {
+		t.Fatalf("Plan named %d heads, want 2", len(planned))
+	}
+	if estUSD <= 0 {
+		t.Error("Plan reported no estimated cost, so --dry-run says a paid fan-out is free")
+	}
+
+	// A dry run must not have executed anything.
+	if _, err := os.Stat(filepath.Join(config.Dir(), "logs", "cost.jsonl")); err == nil {
+		t.Error("Plan wrote cost rows; it is supposed to execute nothing")
+	}
+
+	res, err := sw.Run(context.Background(), "q", Options{Mode: ModeAll})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Attempts) != len(planned) {
+		t.Errorf("Plan named %d heads but Run fired %d", len(planned), len(res.Attempts))
+	}
+	for i := range planned {
+		if planned[i].ID != res.Attempts[i].Head.ID {
+			t.Errorf("Plan named %q at position %d but Run fired %q",
+				planned[i].ID, i, res.Attempts[i].Head.ID)
+		}
+	}
+}
+
+func TestPlan_NoHeadsIsAnError(t *testing.T) {
+	swarmSandbox(t)
+	sw := newSwarm(t)
+	if heads, est, err := sw.Plan("q", Options{}); err == nil {
+		t.Errorf("Plan succeeded with no heads: %v, $%v", heads, est)
+	}
+}
+
+// fixedPricing charges the same for every call, so a cost assertion does not
+// depend on the live pricing DB.
+type fixedPricing struct{ perCall float64 }
+
+func (f fixedPricing) EstimateCost(_, _, _ int) float64 { return f.perCall }
+
+// ── SPRT ──────────────────────────────────────────────────────────────────────
+
+// RunSPRT is `hyctl dispatch --confidence`: it samples heads adaptively and
+// stops as soon as the calibrated confidence reaches the target. It is the
+// production caller of trust.Run, and nothing exercised it.
+
+func TestRunSPRT_RejectsATargetOutsideZeroToOne(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t, swarmHead(t, s, "a", 90, "x"))
+
+	// A confidence of 0 or 1 has no stopping rule: 1 is unreachable and 0 is
+	// already met, so both would either never stop or never sample.
+	for _, target := range []float64{0, 1, -0.5, 1.5} {
+		if res, err := sw.RunSPRT(context.Background(), "q", Options{Confidence: target}); err == nil {
+			t.Errorf("RunSPRT accepted confidence %v: %+v", target, res)
+		}
+	}
+}
+
+func TestRunSPRT_NoHeadsIsAnError(t *testing.T) {
+	swarmSandbox(t)
+	sw := newSwarm(t)
+
+	if res, err := sw.RunSPRT(context.Background(), "q", Options{Confidence: 0.9}); err == nil {
+		t.Errorf("RunSPRT succeeded with no heads: %+v", res)
+	}
+}
+
+// Heads that agree should reach the target and stop; the result must carry the
+// attempts actually made, so the user can see what they paid for.
+func TestRunSPRT_AgreeingHeadsReachTheTargetAndRecordTheirAttempts(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t,
+		swarmHead(t, s, "a", 90, "the same answer"),
+		swarmHead(t, s, "b", 85, "the same answer"),
+		swarmHead(t, s, "c", 80, "the same answer"),
+	)
+
+	res, err := sw.RunSPRT(context.Background(), "q", Options{Confidence: 0.75, Domain: "go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Trust == nil {
+		t.Fatal("no trust result; the confidence the user asked for is unreported")
+	}
+	if len(res.Attempts) == 0 {
+		t.Fatal("no attempts recorded; the run's spend is invisible")
+	}
+	if len(res.Attempts) > 3 {
+		t.Errorf("made %d attempts against 3 heads", len(res.Attempts))
+	}
+	if res.Target != 0.75 {
+		t.Errorf("Target = %v, want the requested 0.75", res.Target)
+	}
+	if res.Domain != "go" {
+		t.Errorf("Domain = %q, want the requested one — calibration is per-domain", res.Domain)
+	}
+	if res.Prompt != "q" {
+		t.Errorf("Prompt = %q", res.Prompt)
+	}
+	for _, a := range res.Attempts {
+		if a.Status == StatusOK && a.Output == "" {
+			t.Errorf("%s succeeded with no output", a.Head.ID)
+		}
+		if a.FinishedAt.IsZero() {
+			t.Errorf("%s has no finish time", a.Head.ID)
+		}
+	}
+}
+
+// A domain is required for calibration lookup; an empty one must default rather
+// than being written to the ledger as the empty-string domain.
+func TestRunSPRT_EmptyDomainDefaults(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t, swarmHead(t, s, "a", 90, "answer"))
+
+	res, err := sw.RunSPRT(context.Background(), "q", Options{Confidence: 0.6})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Domain == "" {
+		t.Error("Domain is empty; calibration would be recorded against no domain at all")
+	}
+}
+
+// Every head failing must be an error rather than a confident verdict drawn
+// from no evidence.
+func TestRunSPRT_AllHeadsFailingDoesNotProduceAConfidentAnswer(t *testing.T) {
+	s := swarmSandbox(t)
+	sw := newSwarm(t, brokenHead(s, "a", 90), brokenHead(s, "b", 80))
+
+	res, err := sw.RunSPRT(context.Background(), "q", Options{Confidence: 0.9})
+	if err == nil && res != nil && res.Trust != nil && res.Trust.Confidence >= 0.9 {
+		t.Errorf("reported %.2f confidence with every head failed", res.Trust.Confidence)
+	}
+}

--- a/internal/testutil/golden_test.go
+++ b/internal/testutil/golden_test.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT
+
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Normalise is what makes a golden file comparable across a maintainer's
+// laptop, a Linux runner and a Windows one. Every substitution it misses is a
+// golden test that passes on one machine and fails on another — and every one
+// it over-applies hides a real change.
+
+func TestNormalise_ReplacesWhatDiffersByMachine(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{{
+		name: "timestamps",
+		in:   "ran at 2026-08-05T12:34:56Z\n",
+		want: "ran at <ts>\n",
+	}, {
+		name: "timestamps with an offset",
+		in:   "ran at 2026-08-05T12:34:56.789+05:30\n",
+		want: "ran at <ts>\n",
+	}, {
+		name: "dollar amounts",
+		in:   "cost $0.0412\n",
+		want: "cost <usd>\n",
+	}, {
+		name: "windows line endings",
+		in:   "one\r\ntwo\r\n",
+		want: "one\ntwo\n",
+	}, {
+		name: "trailing whitespace, which varies by terminal-width assumptions",
+		in:   "padded   \nalso\t\n",
+		want: "padded\nalso\n",
+	}, {
+		name: "backslashes become forward slashes",
+		in:   `a\b\c` + "\n",
+		want: "a/b/c\n",
+	}, {
+		// Output is compared line by line, so a missing or extra trailing
+		// newline must not be the difference.
+		name: "trailing newlines are collapsed to exactly one",
+		in:   "text\n\n\n",
+		want: "text\n",
+	}, {
+		name: "no trailing newline gains one",
+		in:   "text",
+		want: "text\n",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Normalise(tt.in); got != tt.want {
+				t.Errorf("Normalise(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// Temp paths are substituted longest-first. A sandbox's HydraHome sits inside
+// the same root as its Home, so shortest-first would half-substitute the
+// nested one and leave a machine-specific fragment in the golden file.
+func TestNormalise_SubstitutesNestedTempPathsLongestFirst(t *testing.T) {
+	root := "/tmp/TestSomething123"
+	nested := root + "/hydra"
+
+	in := "home=" + root + " hydra=" + nested + "\n"
+	got := Normalise(in, root, nested) // deliberately shortest first
+
+	if strings.Contains(got, "TestSomething123") {
+		t.Errorf("a machine-specific path survived: %q", got)
+	}
+	if strings.Contains(got, "<tmp>/hydra") {
+		t.Errorf("the nested path was half-substituted by its parent: %q", got)
+	}
+	if got != "home=<tmp> hydra=<tmp>\n" {
+		t.Errorf("Normalise = %q", got)
+	}
+
+	// An empty path in the list must be ignored, not replace everything.
+	if got := Normalise("abc\n", ""); got != "abc\n" {
+		t.Errorf("an empty temp path matched everything: %q", got)
+	}
+}
+
+// Windows hands back both separators for the same path depending on who built
+// the string, so the alternate spelling must normalise too.
+func TestNormalise_SubstitutesEitherSeparatorSpelling(t *testing.T) {
+	winPath := `C:\Users\RUNNER~1\AppData\Local\Temp\TestX`
+	forward := strings.ReplaceAll(winPath, `\`, `/`)
+
+	for _, spelling := range []string{winPath, forward} {
+		got := Normalise("path="+spelling+"\n", winPath)
+		if got != "path=<tmp>\n" {
+			t.Errorf("Normalise with %q spelling = %q, want the temp path replaced",
+				spelling, got)
+		}
+	}
+}
+
+// Golden's whole point is a comparison that can fail. These drive both
+// outcomes through a real testdata file.
+func TestGolden_MatchesAndReportsADifference(t *testing.T) {
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	if err := os.MkdirAll("testdata", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join("testdata", "sample.golden"),
+		[]byte("hello\nworld\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A match must not fail. The critical part is that `got` and `want` are
+	// both normalised: comparing a normalised got against a raw want made every
+	// golden fail on Windows, where git's autocrlf rewrote the fixture.
+	if goldenFails(t, "sample", "hello\r\nworld\r\n") {
+		t.Error("Golden failed on output that differs only by line ending")
+	}
+
+	// A real difference must fail.
+	if !goldenFails(t, "sample", "hello\nEARTH\n") {
+		t.Error("Golden passed on genuinely different output")
+	}
+
+	// A missing golden file must fail rather than silently passing — a contract
+	// with no fixture is not a contract.
+	if !goldenFails(t, "never-blessed", "anything") {
+		t.Error("Golden passed with no fixture on disk")
+	}
+}
+
+// goldenFails reports whether Golden failed for this input.
+//
+// The call runs on its own goroutine because Golden reports a missing fixture
+// with t.Fatalf, and FailNow calls runtime.Goexit, which unwinds whichever
+// goroutine it runs on: on the test's own goroutine that would abort this test,
+// and on a synthetic *testing.T never started by the framework it panics.
+// Golden's failure *text* is not asserted here — testing.T does not expose what
+// a throwaway T recorded, and an assertion that cannot fail is worse than none.
+func goldenFails(t *testing.T, name, got string) bool {
+	t.Helper()
+
+	fake := &testing.T{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() { _ = recover() }()
+		Golden(fake, name, got)
+	}()
+	<-done
+	return fake.Failed()
+}
+
+// ── sandbox helpers ───────────────────────────────────────────────────────────
+
+func TestSetKey_IsScopedToTheTest(t *testing.T) {
+	s := NewSandbox(t)
+	if os.Getenv("ANTHROPIC_API_KEY") != "" {
+		t.Fatal("the sandbox did not clear the key")
+	}
+	s.SetKey(t, "ANTHROPIC_API_KEY", "sk-test")
+	if os.Getenv("ANTHROPIC_API_KEY") != "sk-test" {
+		t.Error("SetKey did not set the variable")
+	}
+}
+
+func TestFakeBinary_IsExecutableAndOnPath(t *testing.T) {
+	s := NewSandbox(t)
+
+	path := s.FakeBinary(t, "some-tool")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("FakeBinary wrote nothing: %v", err)
+	}
+	// The point of the helper is that exec.LookPath finds it — a discovery test
+	// asserting "this CLI is installed" depends on that and nothing else.
+	if !strings.HasPrefix(path, s.BinDir) {
+		t.Errorf("the binary is at %q, outside the sandbox's PATH dir %q", path, s.BinDir)
+	}
+	if runtime.GOOS == "windows" && !strings.HasSuffix(path, ".bat") {
+		t.Errorf("path = %q; exec.LookPath on Windows needs an executable extension", path)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o100 == 0 {
+			t.Errorf("mode %v is not executable", info.Mode().Perm())
+		}
+	}
+}
+
+func TestWriteRegistry_WritesEveryBreadcrumbFile(t *testing.T) {
+	dir := t.TempDir()
+	WriteRegistry(t, dir)
+
+	entries, err := os.ReadDir(filepath.Join(dir, "registry"))
+	if err != nil {
+		t.Fatalf("no registry was written: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("the registry directory is empty")
+	}
+
+	// With explicit contents, each file gets its own — which is what lets a
+	// breadcrumb test show that changing one file changes the fingerprint.
+	dir2 := t.TempDir()
+	WriteRegistry(t, dir2, "a", "b", "c", "d")
+	raw, err := os.ReadFile(filepath.Join(dir2, "registry", "routing.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != "a" {
+		t.Errorf("routing.yaml = %q, want the first content argument", raw)
+	}
+}

--- a/internal/testutil/sandbox.go
+++ b/internal/testutil/sandbox.go
@@ -38,6 +38,56 @@ var APIKeyVars = []string{
 	"XAI_API_KEY",
 }
 
+// ModelPinVars is every environment variable that names *which model* a
+// provider should use, or how to reach it (executor.defaultModelFor's table,
+// plus Azure's endpoint/deployment/version and the AWS region).
+//
+// These are not credentials, so APIKeyVars did not cover them — and a
+// developer with ANTHROPIC_MODEL exported for day-to-day use had every test
+// that touches model resolution silently read their shell instead of the
+// default under test. The failure mode is the one the sandbox exists to
+// prevent: a test that passes on one machine and not another, for a reason
+// nothing in the test names.
+//
+// Kept in sync with defaultModelFor by TestModelPinVars_CoversDefaultModelFor.
+var ModelPinVars = []string{
+	"ANTHROPIC_MODEL",
+	"AWS_BEDROCK_MODEL_ID",
+	"AWS_DEFAULT_REGION",
+	"AWS_REGION",
+	"AWS_SESSION_TOKEN",
+	"AZURE_OPENAI_API_VERSION",
+	"AZURE_OPENAI_DEPLOYMENT",
+	"BEDROCK_MODEL_ID",
+	"COHERE_MODEL",
+	"DEEPSEEK_MODEL",
+	"FIREWORKS_MODEL",
+	"GEMINI_MODEL",
+	"GOOGLE_MODEL",
+	"GROQ_MODEL",
+	"HYDRA_MODEL_ANTHROPIC",
+	"HYDRA_MODEL_BEDROCK",
+	"HYDRA_MODEL_COHERE",
+	"HYDRA_MODEL_DEEPSEEK",
+	"HYDRA_MODEL_FIREWORKS",
+	"HYDRA_MODEL_GOOGLE",
+	"HYDRA_MODEL_GROQ",
+	"HYDRA_MODEL_MISTRAL",
+	"HYDRA_MODEL_OPENAI",
+	"HYDRA_MODEL_OPENROUTER",
+	"HYDRA_MODEL_PERPLEXITY",
+	"HYDRA_MODEL_REPLICATE",
+	"HYDRA_MODEL_TOGETHER",
+	"HYDRA_MODEL_XAI",
+	"MISTRAL_MODEL",
+	"OPENAI_MODEL",
+	"OPENROUTER_MODEL",
+	"PERPLEXITY_MODEL",
+	"REPLICATE_MODEL",
+	"TOGETHER_MODEL",
+	"XAI_MODEL",
+}
+
 // tuningVars are Hydra's own knobs. A developer with HYDRA_HOME exported for
 // day-to-day use would otherwise have every test read their real registry.
 var tuningVars = []string{
@@ -108,6 +158,9 @@ func NewSandbox(t *testing.T) *Sandbox {
 	t.Setenv("PATH", s.BinDir)
 
 	for _, v := range APIKeyVars {
+		t.Setenv(v, "")
+	}
+	for _, v := range ModelPinVars {
 		t.Setenv(v, "")
 	}
 	for _, v := range tuningVars {

--- a/internal/testutil/sandbox.go
+++ b/internal/testutil/sandbox.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -253,4 +254,48 @@ func (s *Sandbox) AllowHostBinary(t *testing.T, name string) bool {
 	// credentials) are untouched.
 	t.Setenv("PATH", filepath.Dir(real)+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return true
+}
+
+// EchoScript returns a script body for FakeBinary that prints reply verbatim on
+// stdout, on whichever platform the test is running.
+//
+// It exists because the obvious Windows form is wrong in a way that only shows
+// up for the payloads these tests actually use. `echo <<<HYDRA_FILE_START>>>`
+// in a .bat is not an echo of that text: `<` and `>` are cmd.exe's redirection
+// operators, so the interpreter fails with "<< was unexpected at this time"
+// and the fake head exits 255. Every marker-based edit test therefore passed on
+// Unix and failed on Windows for a reason that had nothing to do with the code
+// under test.
+//
+// On Unix the reply goes through a quoted heredoc, which needs no escaping at
+// all. /bin/cat is named by absolute path because NewSandbox empties $PATH.
+func EchoScript(reply string) string {
+	if runtime.GOOS != "windows" {
+		return "#!/bin/sh\n/bin/cat <<'HYDRA_TESTUTIL_EOF'\n" + reply + "\nHYDRA_TESTUTIL_EOF\n"
+	}
+
+	var b strings.Builder
+	b.WriteString("@echo off\r\n")
+	for _, line := range strings.Split(reply, "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if line == "" {
+			b.WriteString("echo.\r\n")
+			continue
+		}
+		b.WriteString("echo " + escapeBatch(line) + "\r\n")
+	}
+	return b.String()
+}
+
+// escapeBatch quotes the characters cmd.exe interprets before echo sees them.
+// The caret must be escaped first, or it would double-escape everything after.
+func escapeBatch(s string) string {
+	return strings.NewReplacer(
+		"^", "^^",
+		"<", "^<",
+		">", "^>",
+		"&", "^&",
+		"|", "^|",
+		"%", "%%",
+	).Replace(s)
 }

--- a/internal/testutil/sandbox_test.go
+++ b/internal/testutil/sandbox_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -166,5 +167,76 @@ func TestFakeBinary_IsExecutableOnThisOS(t *testing.T) {
 	}
 	if err := exec.Command(resolved).Run(); err != nil {
 		t.Errorf("planted binary is not runnable: %v", err)
+	}
+}
+
+// The Windows branch of EchoScript is what the marker-based edit tests depend
+// on, and it cannot be exercised from a Unix runner — so the escaping it
+// applies is tested directly. Getting it wrong is not a rendering nit: an
+// unescaped "<" makes cmd.exe fail the whole script with "<< was unexpected at
+// this time", and the fake head exits 255 with no output.
+func TestEscapeBatch_QuotesEveryCmdMetacharacter(t *testing.T) {
+	tests := map[string]string{
+		"<<<HYDRA_FILE_START>>>": "^<^<^<HYDRA_FILE_START^>^>^>",
+		"a & b":                  "a ^& b",
+		"a | b":                  "a ^| b",
+		"100%":                   "100%%",
+		"plain text":             "plain text",
+		"":                       "",
+		// The caret is escaped first, so an existing one is not doubled by a
+		// later replacement.
+		"a ^ b": "a ^^ b",
+		"^<":    "^^^<",
+	}
+	for in, want := range tests {
+		if got := escapeBatch(in); got != want {
+			t.Errorf("escapeBatch(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEchoScript_ProducesAScriptForThisPlatform(t *testing.T) {
+	reply := "<<<HYDRA_FILE_START>>>\npackage main\n<<<HYDRA_FILE_END>>>"
+	got := EchoScript(reply)
+
+	if got == "" {
+		t.Fatal("EchoScript produced nothing")
+	}
+	if runtime.GOOS == "windows" {
+		if strings.Contains(got, "echo <<<") {
+			t.Errorf("the redirection operators were not escaped:\n%s", got)
+		}
+		if !strings.Contains(got, "@echo off") {
+			t.Errorf("not a batch script:\n%s", got)
+		}
+		return
+	}
+	if !strings.HasPrefix(got, "#!/bin/sh") {
+		t.Errorf("not a shell script:\n%s", got)
+	}
+	// A quoted heredoc needs no escaping, so the payload must appear verbatim.
+	if !strings.Contains(got, reply) {
+		t.Errorf("the reply was altered:\n%s", got)
+	}
+	// /bin/cat by absolute path — NewSandbox empties $PATH, so a bare `cat`
+	// exits 127.
+	if !strings.Contains(got, "/bin/cat") {
+		t.Errorf("cat is not named by absolute path:\n%s", got)
+	}
+}
+
+// A round trip through FakeBinary: the script must actually print the reply.
+func TestEchoScript_RoundTripsThroughAFakeBinary(t *testing.T) {
+	s := NewSandbox(t)
+	reply := "<<<HYDRA_FILE_START>>>\nline one\n<<<HYDRA_FILE_END>>>"
+	path := s.FakeBinary(t, "echo-head", EchoScript(reply))
+
+	out, err := exec.Command(path).Output()
+	if err != nil {
+		t.Fatalf("the fake head failed to run: %v", err)
+	}
+	got := strings.ReplaceAll(strings.TrimSpace(string(out)), "\r\n", "\n")
+	if got != reply {
+		t.Errorf("the fake head printed:\n%q\nwant:\n%q", got, reply)
 	}
 }

--- a/internal/tui/cockpit_interaction_test.go
+++ b/internal/tui/cockpit_interaction_test.go
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/rank"
+)
+
+// The cockpit's command bar is how a user drives `hydra tui`. Every command it
+// accepts must do what it says, and every one it does not recognise must say so
+// rather than being swallowed.
+
+func typed(m Cockpit, s string) Cockpit {
+	for _, r := range s {
+		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = next.(Cockpit)
+	}
+	return m
+}
+
+func enter(m Cockpit) (Cockpit, tea.Cmd) {
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	return next.(Cockpit), cmd
+}
+
+func TestCockpit_ViewCommandsSwitchViews(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want int
+	}{
+		{":dash", 1},
+		{":tree", 2},
+		{":chat", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			m, _ := enter(typed(NewCockpit(), tt.cmd))
+			if m.view != tt.want {
+				t.Errorf("%s left view = %d, want %d", tt.cmd, m.view, tt.want)
+			}
+			if m.input != "" {
+				t.Errorf("the input line still holds %q after submitting", m.input)
+			}
+		})
+	}
+}
+
+func TestCockpit_QuitCommands(t *testing.T) {
+	for _, cmd := range []string{":q", ":quit"} {
+		if _, c := enter(typed(NewCockpit(), cmd)); c == nil {
+			t.Errorf("%s did not quit", cmd)
+		}
+	}
+}
+
+// Mode commands change where the next task routes, so the change must be
+// visible in the log — silently switching mode is worse than not switching.
+func TestCockpit_ModeCommandsAreAcknowledged(t *testing.T) {
+	for _, cmd := range []string{"/dispatch", "/swarm", "/trust", "/local"} {
+		m, _ := enter(typed(NewCockpit(), cmd))
+		if m.mode != cmd[1:] {
+			t.Errorf("%s left mode = %q", cmd, m.mode)
+		}
+		if len(m.log) == 0 || !strings.Contains(strings.Join(m.log, "\n"), cmd[1:]) {
+			t.Errorf("%s was not acknowledged in the log", cmd)
+		}
+	}
+}
+
+// An unknown slash command must be reported, not silently ignored — a user who
+// typos a command otherwise thinks it worked.
+func TestCockpit_UnknownCommandIsReported(t *testing.T) {
+	before := len(NewCockpit().log)
+	m, _ := enter(typed(NewCockpit(), "/nonsense"))
+	if len(m.log) <= before {
+		t.Fatal("an unknown command produced no output")
+	}
+	if !strings.Contains(strings.Join(m.log, "\n"), "unknown") {
+		t.Errorf("the log does not say the command was unrecognised: %v", m.log)
+	}
+	if m.mode == "nonsense" {
+		t.Error("an unknown command was accepted as a mode")
+	}
+}
+
+// An empty submit is a no-op, not a dispatch of the empty string.
+func TestCockpit_EmptySubmitDoesNothing(t *testing.T) {
+	before := NewCockpit()
+	m, cmd := enter(before)
+	if len(m.log) != len(before.log) {
+		t.Errorf("an empty submit appended to the log: %v", m.log)
+	}
+	if cmd != nil {
+		t.Error("an empty submit scheduled work")
+	}
+
+	// Whitespace only is the same thing.
+	m, cmd = enter(typed(NewCockpit(), "   "))
+	if len(m.log) != len(before.log) || cmd != nil {
+		t.Error("a whitespace-only submit was treated as a task")
+	}
+}
+
+// With no heads discovered there is no route to preview. Inventing one is
+// exactly what #189 removed, so the cockpit must say so and start no stream.
+func TestCockpit_NoHeadsDiscoveredSaysSoAndStreamsNothing(t *testing.T) {
+	before := NewCockpit()
+	before.heads = nil
+
+	m, _ := enter(typed(before, "add pagination"))
+	joined := strings.Join(m.log, "\n")
+	if !strings.Contains(joined, "no heads discovered") {
+		t.Errorf("the log does not say why nothing was routed:\n%s", joined)
+	}
+	if !strings.Contains(joined, "hyctl probe") {
+		t.Error("the message does not tell the user how to find out why")
+	}
+	if len(m.codeLines) != 0 {
+		t.Error("a code stream started with nothing to route to")
+	}
+}
+
+// Submitting a task previews the routing decision and starts the code stream.
+func TestCockpit_SubmittingATaskLogsARoutingPreviewAndStreams(t *testing.T) {
+	before := NewCockpit()
+	before.heads = testHeads()
+
+	m, cmd := enter(typed(before, "add pagination to the users endpoint"))
+
+	if len(m.log) <= len(before.log) {
+		t.Fatal("submitting a task produced no log output")
+	}
+	if cmd == nil {
+		t.Error("no code-stream tick was scheduled")
+	}
+	if m.codeGen == before.codeGen {
+		t.Error("the stream generation did not advance; a second task would " +
+			"double-speed the first one's stream")
+	}
+	if len(m.codeLines) == 0 {
+		t.Error("no code lines to stream")
+	}
+	if m.codeShown != 0 {
+		t.Errorf("codeShown = %d before the first tick", m.codeShown)
+	}
+	joined := strings.Join(m.log, "\n")
+	if !strings.Contains(joined, "routing preview only") {
+		t.Errorf("the log does not say the cockpit executes nothing:\n%s", joined)
+	}
+	if !strings.Contains(joined, "add pagination") {
+		t.Error("the log does not echo what was asked")
+	}
+	if m.runs != before.runs+1 {
+		t.Errorf("runs = %d, want it incremented", m.runs)
+	}
+}
+
+// The tick reveals one line at a time and stops at the end. A tick from a
+// superseded run must be ignored, or two streams interleave.
+func TestCockpit_CodeStreamRevealsOneLineAndIgnoresStaleTicks(t *testing.T) {
+	c := NewCockpit()
+	c.heads = testHeads()
+	m, _ := enter(typed(c, "write a handler"))
+	if len(m.codeLines) == 0 {
+		t.Fatal("no code lines for this task")
+	}
+
+	next, cmd := m.Update(ckCodeTickMsg{gen: m.codeGen})
+	m = next.(Cockpit)
+	if m.codeShown != 1 {
+		t.Fatalf("codeShown = %d after one tick, want 1", m.codeShown)
+	}
+	if cmd == nil && m.codeShown < len(m.codeLines) {
+		t.Error("the stream stopped before reaching the end")
+	}
+
+	// A tick tagged with a previous generation must not advance anything.
+	stale := m.codeShown
+	next, _ = m.Update(ckCodeTickMsg{gen: m.codeGen - 1})
+	if got := next.(Cockpit).codeShown; got != stale {
+		t.Errorf("a stale tick advanced the stream from %d to %d", stale, got)
+	}
+
+	// Run to the end; the last tick must schedule nothing further.
+	for i := m.codeShown; i < len(m.codeLines); i++ {
+		next, cmd = m.Update(ckCodeTickMsg{gen: m.codeGen})
+		m = next.(Cockpit)
+	}
+	if m.codeShown != len(m.codeLines) {
+		t.Errorf("codeShown = %d, want all %d lines", m.codeShown, len(m.codeLines))
+	}
+	if cmd != nil {
+		t.Error("the stream scheduled another tick after revealing the last line")
+	}
+}
+
+// A resize must be recorded, since every panel is laid out against it.
+func TestCockpit_ResizeIsRecorded(t *testing.T) {
+	next, _ := NewCockpit().Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m := next.(Cockpit)
+	if m.w != 120 || m.h != 40 || !m.ready {
+		t.Errorf("resize left w=%d h=%d ready=%v", m.w, m.h, m.ready)
+	}
+	if NewCockpit().Init() != nil {
+		t.Error("Init() returned a command; the cockpit has nothing to do on start")
+	}
+}
+
+// The snapshot is what `hyctl tui --snapshot` prints. All three views must
+// render and be labelled, or the output is unreadable in a bug report.
+func TestCockpitSnapshot_RendersAllThreeViews(t *testing.T) {
+	got := CockpitSnapshot()
+	if strings.TrimSpace(got) == "" {
+		t.Fatal("CockpitSnapshot rendered nothing")
+	}
+	for _, want := range []string{"VIEW 1/3", "VIEW 2/3", "VIEW 3/3"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the snapshot is missing %q", want)
+		}
+	}
+}
+
+// baseline is the "route everything to the top tier" reference the savings
+// percentage is measured against. It must be the priciest *available* head, and
+// must never be a hardcoded vendor.
+func TestCockpitBaseline_IsThePriciestLiveHead(t *testing.T) {
+	m := NewCockpit()
+	m.heads = []ckHead{
+		{name: "anthropic · claude-opus", price: 15, up: true},
+		{name: "openai · gpt-4o", price: 5, up: true},
+		{name: "google · gemini-ultra", price: 99, up: false}, // down: not available
+	}
+
+	price, name := m.baseline()
+	if price != 15 {
+		t.Errorf("baseline price = %v, want the priciest *live* head (15)", price)
+	}
+	if name != "claude-opus" {
+		t.Errorf("baseline name = %q, want the model part only", name)
+	}
+
+	// With nothing up there is no reference; the label must still be neutral
+	// rather than naming a vendor that was never discovered.
+	m.heads = []ckHead{{name: "x", price: 9, up: false}}
+	if price, name := m.baseline(); price != 0 || name == "" {
+		t.Errorf("baseline with no live heads = (%v, %q), want (0, a neutral label)",
+			price, name)
+	}
+}
+
+func TestCkBaseName_TrimsTheProviderPrefix(t *testing.T) {
+	tests := map[string]string{
+		"anthropic · claude-sonnet-4.5": "claude-sonnet-4.5",
+		"claude-sonnet-4.5":             "claude-sonnet-4.5",
+		"a · b · c":                     "c",
+		"":                              "",
+	}
+	for in, want := range tests {
+		if got := ckBaseName(in); got != want {
+			t.Errorf("ckBaseName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// ── syntax highlighting ───────────────────────────────────────────────────────
+
+// ckHighlight styles one line of code. Colour is not testable here, but the
+// text must survive: a highlighter that drops or duplicates characters
+// corrupts the code the user is reading.
+func TestCkHighlight_PreservesEveryCharacter(t *testing.T) {
+	lines := []string{
+		`func main() { fmt.Println("hello") }`,
+		`// a comment with "quotes" and 'apostrophes'`,
+		"x := `a raw string`",
+		`s := "unterminated`,
+		`if err != nil { return fmt.Errorf("x: %w", err) }`,
+		`interface Foo { bar: string }`,
+		``,
+		`   `,
+		`日本語のコメント // with a trailing comment`,
+	}
+	for _, line := range lines {
+		got := stripANSI(ckHighlight(line))
+		if got != line {
+			t.Errorf("ckHighlight changed the text:\n in: %q\nout: %q", line, got)
+		}
+	}
+}
+
+func TestIsWordChar(t *testing.T) {
+	for _, r := range []rune{'a', 'Z', '0', '9', '_'} {
+		if !isWordChar(r) {
+			t.Errorf("isWordChar(%q) = false", r)
+		}
+	}
+	for _, r := range []rune{' ', '(', '.', '"', '·', '日'} {
+		if isWordChar(r) {
+			t.Errorf("isWordChar(%q) = true", r)
+		}
+	}
+}
+
+// ckSnippet must return a language tag and at least one line for every enum,
+// including one it has never seen — the code panel renders whatever it gets.
+func TestCkSnippet_EveryEnumYieldsRenderableCode(t *testing.T) {
+	for _, enum := range []string{"CORE", "COMPLEX", "STANDARD", "SIMPLE", "GRUNT", "", "NOT_AN_ENUM"} {
+		lang, lines := ckSnippet(enum)
+		if lang == "" {
+			t.Errorf("ckSnippet(%q) returned no language tag", enum)
+		}
+		if len(lines) == 0 {
+			t.Errorf("ckSnippet(%q) returned no lines; the code panel would be blank", enum)
+		}
+		for i, l := range lines {
+			if strings.Contains(l, "\n") {
+				t.Errorf("ckSnippet(%q) line %d contains a newline; the panel reveals "+
+					"one line per tick", enum, i)
+			}
+		}
+	}
+}
+
+// stripANSI removes lipgloss's escape sequences so the underlying text can be
+// compared.
+func stripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			i++ // skip the 'm'
+			continue
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// testHeads is a fixed roster so routing assertions do not depend on what
+// happens to be installed on the machine running the test.
+func testHeads() []ckHead {
+	return []ckHead{
+		{id: "opus", name: "anthropic · claude-opus", tier: 1, price: 15, up: true},
+		{id: "sonnet", name: "anthropic · claude-sonnet", tier: 3, price: 3, up: true},
+		{id: "qwen", name: "ollama · qwen2.5-coder", tier: 10, price: 0, up: true},
+	}
+}
+
+// ckHeadsFrom is what turns a real probe into the cockpit's roster. It must
+// rank heads the way dispatch does, mark unroutable ones down, and never
+// fabricate a price for a head whose cost is unknown (#189).
+func TestCkHeadsFrom_MirrorsRoutingAndDoesNotFabricatePrices(t *testing.T) {
+	heads := []provider.Head{
+		{ID: "claude", Name: "anthropic · Claude Code", Provider: "anthropic",
+			Source: "cli", CapScore: 95, AuthReady: true},
+		{ID: "qwen", Name: "ollama · qwen", Provider: "ollama", Source: "port",
+			CapScore: 60, LocalOnly: true, AuthReady: true},
+		// Discovered but not routable: the ollama binary with no server behind
+		// it. probe lists it; nothing can drive it (#248).
+		{ID: "ollama-bin", Name: "ollama", Provider: "local", Source: "cli",
+			CapScore: 60, LocalOnly: true},
+	}
+
+	// nil pricing DB: every price must be 0, which renders as "—" rather than
+	// as a figure the user might believe.
+	rows := ckHeadsFrom(heads, nil)
+	if len(rows) != len(heads) {
+		t.Fatalf("got %d rows for %d heads", len(rows), len(heads))
+	}
+	for _, r := range rows {
+		if r.price != 0 {
+			t.Errorf("%s priced at %v with no pricing DB loaded", r.id, r.price)
+		}
+		if r.tier != rank.UITier(headByID(heads, r.id)) {
+			t.Errorf("%s shows tier %d but routing ranks it %d", r.id, r.tier,
+				rank.UITier(headByID(heads, r.id)))
+		}
+	}
+
+	byID := map[string]ckHead{}
+	for _, r := range rows {
+		byID[r.id] = r
+	}
+	if !byID["claude"].up {
+		t.Error("a routable head is shown as down")
+	}
+	if byID["ollama-bin"].up {
+		t.Error("a head nothing can execute is shown as up; the user looks at " +
+			"probe, sees it listed, and learns nothing (#248)")
+	}
+	// A local head belongs at the cheapest tier regardless of its score.
+	if byID["qwen"].tier != 10 {
+		t.Errorf("the local head is at tier %d, want 10", byID["qwen"].tier)
+	}
+
+	if got := ckHeadsFrom(nil, nil); len(got) != 0 {
+		t.Errorf("ckHeadsFrom(nil) = %v", got)
+	}
+}
+
+func headByID(heads []provider.Head, id string) provider.Head {
+	for _, h := range heads {
+		if h.ID == id {
+			return h
+		}
+	}
+	return provider.Head{}
+}
+
+// The tier colour ramp must be defined for every tier, including ones outside
+// the documented 1–10 range.
+func TestCkTierColor_CoversEveryTier(t *testing.T) {
+	seen := map[lipgloss.Color]bool{}
+	for tier := -1; tier <= 12; tier++ {
+		c := ckTierColor(tier)
+		if c == "" {
+			t.Errorf("tier %d has no colour", tier)
+		}
+		seen[c] = true
+	}
+	if len(seen) < 3 {
+		t.Errorf("the ramp collapsed to %d colours; cheap, mid and expensive "+
+			"heads would look the same", len(seen))
+	}
+}
+
+// The header names the heads actually discovered. It replaced a hardcoded list
+// that named heads the machine may not have (#189), so an empty roster must say
+// "no heads" rather than an empty label.
+func TestHeadSummary_NamesWhatWasDiscovered(t *testing.T) {
+	m := NewCockpit()
+	m.heads = nil
+	if got := m.headSummary(); got != "no heads" {
+		t.Errorf("headSummary with an empty roster = %q, want \"no heads\"", got)
+	}
+
+	m.heads = testHeads()
+	got := m.headSummary()
+	if !strings.Contains(got, "claude-opus") || !strings.Contains(got, "qwen2.5-co") {
+		t.Errorf("headSummary = %q, does not name the discovered heads", got)
+	}
+	if strings.Contains(got, "anthropic ·") {
+		t.Errorf("headSummary = %q, want the model names only", got)
+	}
+
+	// A long roster must be truncated, not wrapped — the header is one line.
+	var many []ckHead
+	for i := 0; i < 20; i++ {
+		many = append(many, ckHead{name: "vendor · a-fairly-long-model-name", up: true})
+	}
+	m.heads = many
+	if n := len([]rune(m.headSummary())); n > 46 {
+		t.Errorf("headSummary is %d runes; the header bar would wrap", n)
+	}
+}
+
+// The code panel renders whether or not anything has streamed yet, and must
+// survive a column budget far too small to lay out.
+func TestCodePanel_RendersAtEverySize(t *testing.T) {
+	m := NewCockpit()
+	if got := m.codePanel(40, 20); !strings.Contains(got, "awaiting dispatch") {
+		t.Errorf("the empty state does not tell the user what to do:\n%s", got)
+	}
+
+	m.heads = testHeads()
+	after, _ := enter(typed(m, "write a handler"))
+	after.codeShown = len(after.codeLines)
+
+	for _, w := range []int{0, 1, 5, 40, 200} {
+		got := after.codePanel(w, 20)
+		if strings.TrimSpace(got) == "" {
+			t.Errorf("codePanel(%d) rendered nothing", w)
+		}
+	}
+	// codeShown beyond the line count must clamp rather than index out of range.
+	after.codeShown = len(after.codeLines) + 50
+	if got := after.codePanel(60, 20); strings.TrimSpace(got) == "" {
+		t.Error("codePanel rendered nothing with codeShown past the end")
+	}
+}
+
+// Every lifecycle state must have a distinct enough style that a failed agent
+// does not read as a returned one.
+func TestCkStateStyle_CoversEveryState(t *testing.T) {
+	for _, state := range []string{"returned", "running", "await", "failed", "pending", "", "unknown"} {
+		if got := ckStateStyle(state).Render("x"); got == "" {
+			t.Errorf("state %q renders nothing", state)
+		}
+	}
+	// Compared on the style, not the rendered string: lipgloss strips colour
+	// when stdout is not a terminal, so both would render as a bare "x" under
+	// `go test` and the assertion would pass on identical styles.
+	if ckStateStyle("failed").GetForeground() == ckStateStyle("returned").GetForeground() {
+		t.Error("a failed agent is coloured identically to a returned one")
+	}
+	if ckStateStyle("running").GetForeground() == ckStateStyle("pending").GetForeground() {
+		t.Error("a running agent is coloured identically to a pending one")
+	}
+}

--- a/internal/tui/cockpit_interaction_test.go
+++ b/internal/tui/cockpit_interaction_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ankit373/hydra/internal/rank"
 )
 
-// The cockpit's command bar is how a user drives `hydra tui`. Every command it
+// The cockpit's command bar is how a user drives `hyctl tui`. Every command it
 // accepts must do what it says, and every one it does not recognise must say so
 // rather than being swallowed.
 

--- a/internal/tui/init_wizard_test.go
+++ b/internal/tui/init_wizard_test.go
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/probe"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// `hyctl init` is the first thing a user runs and the only thing that writes
+// their config. Nothing about it was covered: a wizard that walks through
+// cleanly and then saves the wrong tiers is indistinguishable from one that
+// works, until every dispatch routes somewhere unexpected.
+
+func wizardHeads() *probe.Result {
+	return &probe.Result{Heads: []provider.Head{
+		{ID: "claude", Name: "Claude Code", Provider: "anthropic", CapScore: 95},
+		{ID: "gemini", Name: "Gemini CLI", Provider: "google", CapScore: 82},
+		{ID: "cody", Name: "Cody", Provider: "sourcegraph", CapScore: 75},
+		{ID: "qwen", Name: "Qwen 7B", Provider: "ollama", CapScore: 60, LocalOnly: true},
+	}}
+}
+
+func key(s string) tea.KeyMsg {
+	if s == " " {
+		return tea.KeyMsg{Type: tea.KeySpace}
+	}
+	if len(s) == 1 {
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "ctrl+c":
+		return tea.KeyMsg{Type: tea.KeyCtrlC}
+	}
+	panic("unhandled key " + s)
+}
+
+// send pushes a sequence of keys through the model and returns the final state.
+func send(m tea.Model, keys ...string) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	for _, k := range keys {
+		m, cmd = m.Update(key(k))
+	}
+	return m, cmd
+}
+
+// A full walk through the wizard must write a config that later runs can load.
+func TestInitWizard_FullWalkWritesALoadableConfig(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(NewInitModel(wizardHeads()))
+	// Cortex: move down twice, pick "cody".
+	m, _ = send(m, "down", "down", "enter")
+	// Tiers: confirm.
+	m, _ = send(m, "enter")
+	// Privacy: cursor 0 is local-only.
+	m, _ = send(m, "enter")
+	// Skills: confirm and save.
+	m, cmd := send(m, "enter")
+
+	im := m.(InitModel)
+	if im.err != nil {
+		t.Fatalf("the wizard reported an error: %v", im.err)
+	}
+	if cmd == nil {
+		t.Error("the final step returned no command, so the wizard never quits")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("the wizard wrote no loadable config: %v", err)
+	}
+	if cfg.Cortex != "cody" {
+		t.Errorf("Cortex = %q, want the head the user selected", cfg.Cortex)
+	}
+	if len(cfg.Skills) == 0 {
+		t.Error("no skills were enabled")
+	}
+	// Cursor 0 on the privacy step is "yes, keep PII local".
+	if cfg.Policies["pii"].Action != "local-only" {
+		t.Errorf("pii policy = %q, want local-only — the user chose it and every "+
+			"PII dispatch depends on it", cfg.Policies["pii"].Action)
+	}
+	// The Cortex is the orchestrator; it must not also be listed as a delegate
+	// tier, or work routes back to the model that is doing the routing.
+	for _, tier := range cfg.Tiers {
+		for _, h := range tier.Heads {
+			if h == cfg.Cortex {
+				t.Errorf("the Cortex %q is also in tier %q", h, tier.Name)
+			}
+		}
+	}
+}
+
+// Declining local-only must leave no PII policy, rather than writing one that
+// says something else.
+func TestInitWizard_DecliningLocalOnlyWritesNoPIIPolicy(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(NewInitModel(wizardHeads()))
+	m, _ = send(m, "enter")         // cortex: claude
+	m, _ = send(m, "enter")         // tiers
+	m, _ = send(m, "down", "enter") // privacy: cursor 1 = no
+	m, _ = send(m, "enter")         // skills → save
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := cfg.Policies["pii"]; present {
+		t.Errorf("a pii policy was written despite the user declining: %v", cfg.Policies)
+	}
+}
+
+// The cursor must not run off either end of a list — an out-of-range index is
+// a panic in confirm(), which indexes m.result.Heads directly.
+func TestInitWizard_CursorStaysInRange(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(NewInitModel(wizardHeads()))
+	// Far past the end of a four-head list.
+	for i := 0; i < 20; i++ {
+		m, _ = send(m, "down")
+	}
+	if got := m.(InitModel).cursor; got > 3 {
+		t.Fatalf("cursor = %d with 4 heads; confirm() would index out of range", got)
+	}
+
+	// And back past the start.
+	for i := 0; i < 20; i++ {
+		m, _ = send(m, "up")
+	}
+	if got := m.(InitModel).cursor; got != 0 {
+		t.Errorf("cursor = %d after running off the top, want 0", got)
+	}
+
+	// Selecting at the boundary must not panic.
+	m, _ = send(m, "down", "down", "down", "down", "down", "enter")
+	if m.(InitModel).cortex == nil {
+		t.Error("no cortex was selected at the list boundary")
+	}
+}
+
+// The privacy step is a two-option list, so its cursor is bounded at 1
+// regardless of how many heads were discovered.
+func TestInitWizard_PrivacyStepIsATwoOptionList(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(NewInitModel(wizardHeads()))
+	m, _ = send(m, "enter", "enter") // through cortex and tiers
+	for i := 0; i < 10; i++ {
+		m, _ = send(m, "down")
+	}
+	if got := m.(InitModel).cursor; got != 1 {
+		t.Errorf("privacy cursor = %d, want it bounded at 1", got)
+	}
+}
+
+// Quitting must not write a partial config — a half-configured Hydra is worse
+// than an unconfigured one, because Exists() then reports it as set up.
+func TestInitWizard_QuittingWritesNothing(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(NewInitModel(wizardHeads()))
+	m, _ = send(m, "enter") // pick a cortex
+	_, cmd := send(m, "q")
+	if cmd == nil {
+		t.Error("q did not quit")
+	}
+	if config.Exists() {
+		t.Error("a config was written by a wizard the user quit halfway through")
+	}
+
+	_, cmd = send(tea.Model(NewInitModel(wizardHeads())), "ctrl+c")
+	if cmd == nil {
+		t.Error("ctrl+c did not quit")
+	}
+}
+
+// Every step must render something. A blank screen is a wizard the user cannot
+// complete.
+func TestInitWizard_EveryStepRenders(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(NewInitModel(wizardHeads()))
+	seen := map[step]string{}
+	for i := 0; i < 5; i++ {
+		im := m.(InitModel)
+		view := im.View()
+		if strings.TrimSpace(view) == "" {
+			t.Fatalf("step %d rendered nothing", im.step)
+		}
+		if !strings.Contains(view, "Hydra") {
+			t.Errorf("step %d does not identify itself:\n%s", im.step, view)
+		}
+		seen[im.step] = view
+		m, _ = send(m, "enter")
+	}
+	if len(seen) != 5 {
+		t.Errorf("reached %d distinct steps, want all 5", len(seen))
+	}
+	// The head list must actually name the discovered heads, or the user is
+	// choosing blind.
+	if !strings.Contains(seen[stepCortex], "Claude Code") {
+		t.Errorf("the cortex step does not list the discovered heads:\n%s", seen[stepCortex])
+	}
+	// Non-key messages must be ignored rather than advancing the wizard.
+	before := m.(InitModel).step
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	if m.(InitModel).step != before {
+		t.Error("a window resize advanced the wizard")
+	}
+	if NewInitModel(wizardHeads()).Init() != nil {
+		t.Error("Init() returned a command; the wizard has nothing to do on start")
+	}
+}
+
+// buildTiers is what decides where every future dispatch goes. Its bands must
+// place each head exactly once, and never include the Cortex.
+func TestBuildTiers_AssignsEachHeadOnceAndExcludesTheCortex(t *testing.T) {
+	heads := wizardHeads().Heads
+	cortex := &heads[0] // claude, 95
+
+	tiers := buildTiers(heads, cortex)
+
+	seen := map[string]string{}
+	for _, tier := range tiers {
+		if len(tier.Heads) == 0 {
+			t.Errorf("tier %q is empty and should not have been written", tier.Name)
+		}
+		for _, id := range tier.Heads {
+			if prev, dup := seen[id]; dup {
+				t.Errorf("%s appears in both %q and %q", id, prev, tier.Name)
+			}
+			seen[id] = tier.Name
+		}
+	}
+	if _, present := seen["claude"]; present {
+		t.Error("the Cortex was assigned a delegate tier; work would route back to " +
+			"the model doing the routing")
+	}
+	for _, id := range []string{"gemini", "cody", "qwen"} {
+		if _, present := seen[id]; !present {
+			t.Errorf("%s was discovered but assigned no tier, so it can never be routed to", id)
+		}
+	}
+	// Bands are capability-ordered, so a stronger head must not land in a
+	// cheaper tier than a weaker one.
+	if seen["gemini"] == seen["qwen"] {
+		t.Errorf("an 82-score head and a 60-score head landed in the same tier %q",
+			seen["gemini"])
+	}
+
+	// With no cortex chosen every head is available.
+	if got := buildTiers(heads, nil); len(got) == 0 {
+		t.Error("buildTiers with no cortex produced no tiers")
+	}
+	if got := buildTiers(nil, cortex); len(got) != 0 {
+		t.Errorf("buildTiers with no heads produced %v", got)
+	}
+}
+
+func TestDefaultSkills_LocalCortexGetsNoPaidSkills(t *testing.T) {
+	cloud := &provider.Head{ID: "claude"}
+	local := &provider.Head{ID: "qwen", LocalOnly: true}
+
+	cloudSkills := defaultSkills(cloud)
+	localSkills := defaultSkills(local)
+
+	if len(cloudSkills) <= len(localSkills) {
+		t.Errorf("a cloud cortex got %v and a local one %v; swarm and cost-stats "+
+			"only make sense with a paid head", cloudSkills, localSkills)
+	}
+	for _, s := range localSkills {
+		if s == "swarm" || s == "cost-stats" {
+			t.Errorf("a local-only cortex was given %q", s)
+		}
+	}
+	if len(defaultSkills(nil)) == 0 {
+		t.Error("defaultSkills(nil) is empty; a wizard that skipped selection gets no skills")
+	}
+}
+
+func TestClamp(t *testing.T) {
+	if got := clamp(5, 0, 3); got != 3 {
+		t.Errorf("clamp(5,0,3) = %d, want 3", got)
+	}
+	if got := clamp(-1, 0, 3); got != 0 {
+		t.Errorf("clamp(-1,0,3) = %d, want 0", got)
+	}
+	if got := clamp(2, 0, 3); got != 2 {
+		t.Errorf("clamp(2,0,3) = %d, want 2", got)
+	}
+	// An inverted range must not return something outside both bounds.
+	if got := clamp(5, 3, 0); got != 0 && got != 3 {
+		t.Errorf("clamp(5,3,0) = %d, outside both bounds", got)
+	}
+}
+
+// exportToRoutingYAML is written back into the operator's own registry file. It
+// must replace its previous block rather than appending a new one every run,
+// and must never touch the hand-written part above it.
+func TestExportToRoutingYAML_ReplacesItsOwnBlockAndKeepsTheRest(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	regDir := filepath.Join(s.HydraHome, "registry")
+	if err := os.MkdirAll(regDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(regDir, "routing.yaml")
+	handWritten := "version: \"1.0\"\n# an operator's own comment\nenums:\n  SIMPLE: 8\n"
+	if err := os.WriteFile(path, []byte(handWritten), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	heads := wizardHeads().Heads
+	cortex := &heads[0]
+	tiers := buildTiers(heads, cortex)
+
+	if err := exportToRoutingYAML(tiers, cortex); err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(first), "an operator's own comment") {
+		t.Errorf("the operator's own content was destroyed:\n%s", first)
+	}
+	if !strings.Contains(string(first), "discovered_heads:") {
+		t.Errorf("no discovered block was written:\n%s", first)
+	}
+	if !strings.Contains(string(first), "cortex: claude") {
+		t.Errorf("the block does not name the chosen cortex:\n%s", first)
+	}
+
+	// A second run must replace the block, not stack another one.
+	if err := exportToRoutingYAML(tiers, cortex); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(second), "discovered_heads:"); n != 1 {
+		t.Errorf("routing.yaml holds %d discovered blocks after two runs; every "+
+			"`hyctl init` would append another", n)
+	}
+	if !strings.Contains(string(second), "an operator's own comment") {
+		t.Error("the second run destroyed the operator's content")
+	}
+}
+
+// An install layout with no routing.yaml on disk is the normal case — the
+// registry is embedded in the binary. Skipping silently is correct; failing
+// would make `hyctl init` error on every installed build.
+func TestExportToRoutingYAML_NoFileOnDiskIsNotAnError(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if err := exportToRoutingYAML(nil, nil); err != nil {
+		t.Errorf("exportToRoutingYAML errored with no on-disk routing.yaml: %v — "+
+			"that is every installed binary (#238)", err)
+	}
+}
+
+// A save that cannot write must surface on the done screen rather than showing
+// a success the user will act on.
+func TestInitWizard_SaveFailureIsSurfaced(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	// ~/.hydra is a regular file, so the config directory cannot be created.
+	if err := os.WriteFile(filepath.Join(s.Home, ".hydra"), []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := tea.Model(NewInitModel(wizardHeads()))
+	m, _ = send(m, "enter", "enter", "enter", "enter")
+
+	im := m.(InitModel)
+	if im.err == nil {
+		t.Fatal("the wizard reported success with an unwritable config directory")
+	}
+	if !strings.Contains(im.View(), "Setup failed") {
+		t.Errorf("the done screen does not show the failure:\n%s", im.View())
+	}
+}

--- a/internal/tui/init_wizard_test.go
+++ b/internal/tui/init_wizard_test.go
@@ -116,7 +116,7 @@ func TestInitWizard_DecliningLocalOnlyWritesNoPIIPolicy(t *testing.T) {
 	m, _ = send(m, "enter")         // cortex: claude
 	m, _ = send(m, "enter")         // tiers
 	m, _ = send(m, "down", "enter") // privacy: cursor 1 = no
-	m, _ = send(m, "enter")         // skills → save
+	_, _ = send(m, "enter")         // skills → save; the config is the assertion
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/internal/tui/install_wizard_test.go
+++ b/internal/tui/install_wizard_test.go
@@ -142,8 +142,8 @@ func TestInstallWizard_DecliningRunsNothing(t *testing.T) {
 		t.Fatalf("step = %v, want confirm", m.(InstallModel).step)
 	}
 
-	m, cmd := m.Update(key("down")) // cursor 1 = "I'll do it myself"
-	m, cmd = m.Update(key("enter"))
+	m, _ = m.Update(key("down")) // cursor 1 = "I'll do it myself"
+	m, cmd := m.Update(key("enter"))
 
 	im := m.(InstallModel)
 	if !im.done {

--- a/internal/tui/install_wizard_test.go
+++ b/internal/tui/install_wizard_test.go
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ankit373/hydra/internal/sysinfo"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// The install wizard runs shell commands on the user's machine. What it offers,
+// and which command each option carries, is the whole of its behaviour.
+
+func TestBuildInstallOptions_EveryOptionIsActionable(t *testing.T) {
+	specs := &sysinfo.Specs{TotalRAMGB: 32, FreeRAMGB: 20, IsAppleSilicon: true}
+	opts := buildInstallOptions(specs)
+
+	if len(opts) == 0 {
+		t.Fatal("no install options were offered")
+	}
+	for _, o := range opts {
+		if o.name == "" || o.description == "" {
+			t.Errorf("option %+v has nothing to show the user", o)
+		}
+		// Every option must either run something or tell the user what to do.
+		// One that does neither is a dead menu entry.
+		if o.installCmd == "" && o.envKey == "" && o.postInstall == "" {
+			t.Errorf("option %q does nothing and explains nothing", o.name)
+		}
+	}
+
+	// The Ollama entry must name the model that actually fits this machine —
+	// recommending one that does not fit is how a user ends up swapping.
+	var ollama *installOption
+	for i := range opts {
+		if strings.Contains(opts[i].name, "Ollama") {
+			ollama = &opts[i]
+		}
+	}
+	if ollama == nil {
+		t.Fatal("no Ollama option was offered")
+	}
+	if !ollama.local {
+		t.Error("the Ollama option is not marked local")
+	}
+	best := specs.BestOllamaModel()
+	if !strings.Contains(ollama.postInstall, best.Model) {
+		t.Errorf("post-install %q does not name the recommended model %q",
+			ollama.postInstall, best.Model)
+	}
+	if !strings.Contains(ollama.description, best.DisplayName) {
+		t.Errorf("description %q does not name the model that fits", ollama.description)
+	}
+}
+
+// On a machine too small for any local model the description must say so
+// rather than recommending one that will swap.
+func TestBuildInstallOptions_TightMemorySaysSo(t *testing.T) {
+	tight := &sysinfo.Specs{TotalRAMGB: 4, FreeRAMGB: 1.8}
+	if tight.AnyLocalModelFits() {
+		t.Skip("a 4GB machine unexpectedly fits a model")
+	}
+
+	for _, o := range buildInstallOptions(tight) {
+		if strings.Contains(o.name, "Ollama") {
+			if !strings.Contains(o.description, "memory") {
+				t.Errorf("description = %q, want it to warn about memory", o.description)
+			}
+			return
+		}
+	}
+	t.Fatal("no Ollama option was offered")
+}
+
+// Unknown hardware must not produce a confident recommendation.
+func TestBuildInstallOptions_UnknownHardwareDoesNotRecommend(t *testing.T) {
+	for _, o := range buildInstallOptions(&sysinfo.Specs{}) {
+		if strings.Contains(o.name, "Ollama") {
+			if strings.Contains(o.description, "Best for your machine") {
+				t.Errorf("a machine whose memory could not be read got a confident "+
+					"recommendation: %q", o.description)
+			}
+			return
+		}
+	}
+}
+
+// The Ollama branch selects the model, so it needs an extra step; every other
+// option goes straight to confirm.
+func TestInstallWizard_OllamaGetsAModelPicker(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(newInstallModelFor(&sysinfo.Specs{TotalRAMGB: 32, FreeRAMGB: 20}))
+	// Move to the Ollama entry.
+	im := m.(InstallModel)
+	idx := -1
+	for i, o := range im.options {
+		if strings.Contains(o.name, "Ollama") {
+			idx = i
+		}
+	}
+	if idx < 0 {
+		t.Fatal("no Ollama option")
+	}
+	for i := 0; i < idx; i++ {
+		m, _ = m.Update(key("down"))
+	}
+	m, _ = m.Update(key("enter"))
+
+	im = m.(InstallModel)
+	if im.step != installStepOllama {
+		t.Fatalf("step = %v after choosing Ollama, want the model picker", im.step)
+	}
+	// The cursor must start on a model that actually fits, not on the largest.
+	if len(im.models) > 0 && !im.models[im.cursor].Fits && im.specs.AnyLocalModelFits() {
+		t.Errorf("the picker opened on %q, which does not fit", im.models[im.cursor].Model)
+	}
+
+	// Choosing a model carries it into the post-install instruction.
+	m, _ = m.Update(key("enter"))
+	im = m.(InstallModel)
+	if im.step != installStepConfirm {
+		t.Fatalf("step = %v after picking a model, want confirm", im.step)
+	}
+	if !strings.Contains(im.selected.postInstall, im.chosenModel.Model) {
+		t.Errorf("post-install %q does not name the model the user picked (%q)",
+			im.selected.postInstall, im.chosenModel.Model)
+	}
+}
+
+// "I'll do it myself" must run nothing.
+func TestInstallWizard_DecliningRunsNothing(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(newInstallModelFor(&sysinfo.Specs{TotalRAMGB: 32, FreeRAMGB: 20}))
+	m, _ = m.Update(key("enter")) // pick the first option → confirm
+	if m.(InstallModel).step != installStepConfirm {
+		t.Fatalf("step = %v, want confirm", m.(InstallModel).step)
+	}
+
+	m, cmd := m.Update(key("down")) // cursor 1 = "I'll do it myself"
+	m, cmd = m.Update(key("enter"))
+
+	im := m.(InstallModel)
+	if !im.done {
+		t.Error("declining did not finish the wizard")
+	}
+	if im.step == installStepRunning {
+		t.Error("declining started the install anyway")
+	}
+	if cmd == nil {
+		t.Error("declining did not quit")
+	}
+}
+
+// An option that only sets an environment variable has nothing to run, so
+// confirming it must finish rather than shelling out to an empty command.
+func TestInstallWizard_EnvKeyOptionRunsNothing(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	im := newInstallModelFor(&sysinfo.Specs{TotalRAMGB: 32, FreeRAMGB: 20})
+	idx := -1
+	for i, o := range im.options {
+		if o.envKey != "" {
+			idx = i
+		}
+	}
+	if idx < 0 {
+		t.Skip("no env-key option in this build")
+	}
+
+	m := tea.Model(im)
+	for i := 0; i < idx; i++ {
+		m, _ = m.Update(key("down"))
+	}
+	m, _ = m.Update(key("enter")) // → confirm
+	m, cmd := m.Update(key("enter"))
+
+	got := m.(InstallModel)
+	if got.step == installStepRunning {
+		t.Error("an option with no command to run started an install")
+	}
+	if !got.done || cmd == nil {
+		t.Errorf("the wizard did not finish: done=%v cmd=%v", got.done, cmd)
+	}
+}
+
+// The cursor is bounded per step, and each step's list has a different length.
+// An unbounded cursor is an index panic in confirm().
+func TestInstallWizard_CursorIsBoundedPerStep(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(newInstallModelFor(&sysinfo.Specs{TotalRAMGB: 32, FreeRAMGB: 20}))
+	for i := 0; i < 50; i++ {
+		m, _ = m.Update(key("down"))
+	}
+	im := m.(InstallModel)
+	if im.cursor > len(im.options)-1 {
+		t.Fatalf("cursor = %d with %d options; confirm() would index out of range",
+			im.cursor, len(im.options))
+	}
+
+	// Selecting at the boundary must not panic.
+	m, _ = m.Update(key("enter"))
+	if m.(InstallModel).selected == nil {
+		t.Error("nothing was selected at the list boundary")
+	}
+
+	// The confirm step is a two-option list.
+	for i := 0; i < 20; i++ {
+		m, _ = m.Update(key("down"))
+	}
+	if got := m.(InstallModel); got.step == installStepConfirm && got.cursor > 1 {
+		t.Errorf("confirm cursor = %d, want it bounded at 1", got.cursor)
+	}
+}
+
+// A finished install reports its outcome rather than leaving the user on a
+// spinner, and a failure is reported as a failure.
+func TestInstallWizard_ReportsTheOutcome(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(newInstallModelFor(&sysinfo.Specs{TotalRAMGB: 32, FreeRAMGB: 20}))
+	m, cmd := m.Update(installDoneMsg{})
+	im := m.(InstallModel)
+	if !im.done || im.err {
+		t.Errorf("a successful install reported done=%v err=%v", im.done, im.err)
+	}
+	if cmd == nil {
+		t.Error("a finished install did not quit")
+	}
+	if v := im.View(); strings.TrimSpace(v) == "" {
+		t.Error("the done screen renders nothing")
+	}
+
+	m2, _ := tea.Model(newInstallModelFor(&sysinfo.Specs{TotalRAMGB: 32})).
+		Update(installDoneMsg{err: errFake{}})
+	if !m2.(InstallModel).err {
+		t.Error("a failed install was reported as a success")
+	}
+	if v := m2.(InstallModel).View(); !strings.Contains(strings.ToLower(v), "fail") {
+		t.Errorf("the failure is not visible on screen:\n%s", v)
+	}
+}
+
+// Every step must render something the user can act on.
+func TestInstallWizard_EveryStepRenders(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(newInstallModelFor(&sysinfo.Specs{TotalRAMGB: 32, FreeRAMGB: 20}))
+	for i := 0; i < 4; i++ {
+		if v := m.(InstallModel).View(); strings.TrimSpace(v) == "" {
+			t.Fatalf("step %v rendered nothing", m.(InstallModel).step)
+		}
+		m, _ = m.Update(key("enter"))
+	}
+
+	// Quitting works from any step.
+	_, cmd := tea.Model(newInstallModelFor(&sysinfo.Specs{})).Update(key("q"))
+	if cmd == nil {
+		t.Error("q did not quit the install wizard")
+	}
+	if newInstallModelFor(&sysinfo.Specs{}).Init() != nil {
+		t.Error("Init() returned a command; there is nothing to do on start")
+	}
+	// A non-key, non-done message must be ignored.
+	before := m.(InstallModel).step
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	if m.(InstallModel).step != before {
+		t.Error("a window resize advanced the install wizard")
+	}
+}
+
+// newInstallModelFor builds an InstallModel against fixed specs, so the test
+// does not depend on the machine it runs on. NewInstallModel() itself calls
+// sysinfo.Detect and is covered separately.
+func newInstallModelFor(specs *sysinfo.Specs) InstallModel {
+	return InstallModel{
+		specs:   specs,
+		options: buildInstallOptions(specs),
+		models:  specs.OllamaRecommendations(),
+	}
+}
+
+func TestNewInstallModel_ReadsTheRealMachine(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := NewInstallModel()
+	if m.specs == nil {
+		t.Fatal("NewInstallModel read no specs")
+	}
+	if len(m.options) == 0 {
+		t.Error("NewInstallModel offered no options")
+	}
+	if len(m.models) == 0 {
+		t.Error("NewInstallModel listed no Ollama models")
+	}
+}
+
+type errFake struct{}
+
+func (errFake) Error() string { return "install failed" }
+
+// ── splash ────────────────────────────────────────────────────────────────────
+
+// The splash and dashboard are the first thing a user sees. They must render
+// without panicking on any input and must contain what they claim to show.
+func TestSplashAndDashboard_Render(t *testing.T) {
+	logo := Logo()
+	if strings.TrimSpace(logo) == "" {
+		t.Fatal("Logo() rendered nothing")
+	}
+
+	splash := Splash("Claude Code")
+	if !strings.Contains(splash, "Claude Code") {
+		t.Errorf("Splash does not name the cortex:\n%s", splash)
+	}
+
+	dash := Dashboard("Claude Code", Stats{Heads: 7, Tasks: 42, CostUSD: 1.2345, SavePct: 87})
+	for _, want := range []string{"Claude Code", "7", "42", "87"} {
+		if !strings.Contains(dash, want) {
+			t.Errorf("Dashboard is missing %q:\n%s", want, dash)
+		}
+	}
+
+	// Zero values and an empty cortex name must still render — a fresh install
+	// has both.
+	if got := Dashboard("", Stats{}); strings.TrimSpace(got) == "" {
+		t.Error("Dashboard rendered nothing for a fresh install")
+	}
+	if got := Splash(""); strings.TrimSpace(got) == "" {
+		t.Error("Splash rendered nothing with no cortex")
+	}
+	// A very long name must not panic the layout.
+	if got := Dashboard(strings.Repeat("very-long-model-name-", 20), Stats{Heads: 999999}); got == "" {
+		t.Error("Dashboard rendered nothing for an over-long name")
+	}
+}

--- a/internal/update/fetch_test.go
+++ b/internal/update/fetch_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: MIT
+
+package update
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/build"
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// The update check runs at startup on every command. Its failure modes are
+// asymmetric: a missed update is a minor annoyance, but a check that blocks,
+// fetches on every invocation, or fires inside CI is a cost paid by everyone.
+
+func stubReleases(t *testing.T, status int, body string) *int {
+	t.Helper()
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Errorf("Accept = %q, want GitHub's own media type", got)
+		}
+		if got := r.Header.Get("X-GitHub-Api-Version"); got == "" {
+			t.Error("no X-GitHub-Api-Version header; the response shape is unpinned")
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	orig := releaseURL
+	releaseURL = srv.URL
+	t.Cleanup(func() { releaseURL = orig })
+	return &calls
+}
+
+func TestFetchLatest_ReadsTheTagName(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubReleases(t, 200, `{"tag_name":"v1.4.0","name":"ignored"}`)
+
+	if got := fetchLatest(); got != "v1.4.0" {
+		t.Errorf("fetchLatest() = %q, want v1.4.0", got)
+	}
+}
+
+// Every failure must be silent and empty. An update check that surfaces a
+// network error on a plane is worse than no update check.
+func TestFetchLatest_FailuresAreSilentAndEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"rate limited", http.StatusForbidden, `{"message":"API rate limit exceeded"}`},
+		{"not found", http.StatusNotFound, `{}`},
+		{"server error", http.StatusInternalServerError, ``},
+		{"unparsable body", http.StatusOK, `{truncated`},
+		{"no tag in the payload", http.StatusOK, `{}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.NewSandbox(t)
+			stubReleases(t, tt.status, tt.body)
+			if got := fetchLatest(); got != "" {
+				t.Errorf("fetchLatest() = %q, want empty", got)
+			}
+		})
+	}
+
+	// Nothing listening at all.
+	testutil.NewSandbox(t)
+	orig := releaseURL
+	releaseURL = "http://127.0.0.1:1/releases"
+	t.Cleanup(func() { releaseURL = orig })
+	if got := fetchLatest(); got != "" {
+		t.Errorf("fetchLatest() = %q with a dead endpoint, want empty", got)
+	}
+}
+
+// A GITHUB_TOKEN in the environment is used, which is what keeps a CI-adjacent
+// machine from being rate-limited into never checking.
+func TestFetchLatest_UsesGitHubTokenWhenPresent(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"tag_name":"v1.0.0"}`))
+	}))
+	defer srv.Close()
+	orig := releaseURL
+	releaseURL = srv.URL
+	defer func() { releaseURL = orig }()
+
+	t.Setenv("GITHUB_TOKEN", "ghp_test")
+	fetchLatest()
+	if gotAuth != "Bearer ghp_test" {
+		t.Errorf("Authorization = %q, want the token as a bearer", gotAuth)
+	}
+}
+
+// The 24h cache is what stops every hyctl invocation hitting GitHub.
+func TestResolveLatest_CachesForTwentyFourHours(t *testing.T) {
+	testutil.NewSandbox(t)
+	if err := os.MkdirAll(config.Dir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	calls := stubReleases(t, 200, `{"tag_name":"v2.0.0"}`)
+
+	if got := resolveLatest(); got != "v2.0.0" {
+		t.Fatalf("resolveLatest() = %q", got)
+	}
+	if *calls != 1 {
+		t.Fatalf("made %d calls on a cold cache, want 1", *calls)
+	}
+
+	// Second call must be served from the cache.
+	if got := resolveLatest(); got != "v2.0.0" {
+		t.Errorf("resolveLatest() = %q from cache", got)
+	}
+	if *calls != 1 {
+		t.Errorf("made %d calls with a warm cache — every command would hit GitHub", *calls)
+	}
+
+	// A cache older than the TTL is refetched.
+	stale := state{CheckedAt: time.Now().Add(-25 * time.Hour), LatestVersion: "v1.0.0"}
+	raw, err := json.Marshal(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config.Dir(), cacheFile), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveLatest(); got != "v2.0.0" {
+		t.Errorf("resolveLatest() = %q with a stale cache, want a refetch", got)
+	}
+	if *calls != 2 {
+		t.Errorf("made %d calls, want a refetch after the TTL", *calls)
+	}
+}
+
+// A corrupt cache must be refetched, not treated as "no update".
+func TestResolveLatest_CorruptCacheIsRefetched(t *testing.T) {
+	testutil.NewSandbox(t)
+	if err := os.MkdirAll(config.Dir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config.Dir(), cacheFile), []byte("{truncated"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubReleases(t, 200, `{"tag_name":"v3.0.0"}`)
+
+	if got := resolveLatest(); got != "v3.0.0" {
+		t.Errorf("resolveLatest() = %q with a corrupt cache", got)
+	}
+}
+
+// A failed fetch must not write a cache entry, or the failure is remembered for
+// 24 hours and the user is never told about a release.
+func TestResolveLatest_AFailedFetchIsNotCached(t *testing.T) {
+	testutil.NewSandbox(t)
+	if err := os.MkdirAll(config.Dir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stubReleases(t, http.StatusForbidden, `{}`)
+
+	if got := resolveLatest(); got != "" {
+		t.Errorf("resolveLatest() = %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(config.Dir(), cacheFile)); err == nil {
+		t.Error("a failed fetch wrote a cache entry, so the failure is remembered " +
+			"for 24h and no update is ever reported")
+	}
+}
+
+// The three environment gates run before anything touches the network. A check
+// that fires inside CI is a request per job, on every job, forever.
+func TestDoCheck_RefusesBeforeTouchingTheNetwork(t *testing.T) {
+	tests := []struct {
+		name string
+		env  [2]string
+	}{
+		{"HYDRA_NO_UPDATE_CHECK is set", [2]string{"HYDRA_NO_UPDATE_CHECK", "1"}},
+		{"running in CI", [2]string{"CI", "true"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutil.NewSandbox(t)
+			calls := stubReleases(t, 200, `{"tag_name":"v9.9.9"}`)
+			t.Setenv(tt.env[0], tt.env[1])
+
+			if got := doCheck(); got != "" {
+				t.Errorf("doCheck() = %q, want empty", got)
+			}
+			if *calls != 0 {
+				t.Errorf("made %d network calls despite the gate", *calls)
+			}
+		})
+	}
+
+	// A dev build has no release to compare against.
+	t.Run("dev build", func(t *testing.T) {
+		testutil.NewSandbox(t)
+		calls := stubReleases(t, 200, `{"tag_name":"v9.9.9"}`)
+		orig := build.Version
+		build.Version = "dev"
+		t.Cleanup(func() { build.Version = orig })
+
+		if got := doCheck(); got != "" {
+			t.Errorf("doCheck() = %q on a dev build", got)
+		}
+		if *calls != 0 {
+			t.Errorf("a dev build made %d network calls", *calls)
+		}
+	})
+
+	// Non-interactive output is the last gate: `hyctl cost --json | jq` must not
+	// have an update banner appended to its stdout. Tests run with stdout piped,
+	// so this is the state under test here.
+	t.Run("non-interactive stdout", func(t *testing.T) {
+		testutil.NewSandbox(t)
+		calls := stubReleases(t, 200, `{"tag_name":"v9.9.9"}`)
+		orig := build.Version
+		build.Version = "v0.0.1"
+		t.Cleanup(func() { build.Version = orig })
+
+		if got := doCheck(); got != "" {
+			t.Errorf("doCheck() = %q with stdout piped — the banner would land in "+
+				"whatever is parsing the output", got)
+		}
+		if *calls != 0 {
+			t.Errorf("made %d network calls with no terminal to show a banner on", *calls)
+		}
+	})
+}
+
+// Check memoises, so a command that consults it more than once fetches at most
+// once per process.
+func TestCheckAndCheckAsync_FetchAtMostOncePerProcess(t *testing.T) {
+	testutil.NewSandbox(t)
+	calls := stubReleases(t, 200, `{"tag_name":"v9.9.9"}`)
+
+	first := Check()
+	second := Check()
+	if first != second {
+		t.Errorf("Check() returned %q then %q", first, second)
+	}
+
+	got := <-CheckAsync()
+	if got != first {
+		t.Errorf("CheckAsync() = %q, want the same answer as Check() %q", got, first)
+	}
+	if *calls > 1 {
+		t.Errorf("made %d network calls; the check is memoised for the process", *calls)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -22,10 +22,14 @@ import (
 )
 
 const (
-	releaseURL = "https://api.github.com/repos/ankit373/hydra/releases/latest"
-	cacheFile  = "update_state.json"
-	cacheTTL   = 24 * time.Hour
+	cacheFile = "update_state.json"
+	cacheTTL  = 24 * time.Hour
 )
+
+// releaseURL is a var so tests can point it at an httptest server, matching
+// pricing's openRouterModelsURL. The alternative is a test that either reaches
+// GitHub for real or does not run at all.
+var releaseURL = "https://api.github.com/repos/ankit373/hydra/releases/latest"
 
 type state struct {
 	CheckedAt     time.Time `json:"checked_at"`


### PR DESCRIPTION
## Summary

Phase D of the coverage epic. The packages that actually talk to providers and
write to the user's files, plus two real defects found on the way.

| package | before | after |
|---|---|---|
| `internal/executor` | 26.4% | 88.7% |
| `internal/parallel` | 33.9% | 88.7% |
| `internal/editor` | 42.9% | 86.3% |
| `internal/provider` | 47.8% | **100%** |
| `internal/swarm` | 51.1% | 92.3% |
| `internal/update` | 51.6% | 93.5% |
| `internal/tui` | 40.9% | 84.7% |
| `cmd/hydra` | 20.1% | 45.4% |

## Four real fixes

**Replicate answers arrived one token per line.** Its predictions API streams a
text answer as an array of token fragments — `["Hel", "lo", ", wor", "ld"]` —
and its own clients concatenate them. `stringifyAny` joined with `"\n"`, so
every Replicate answer came back one fragment per line. The existing test
asserted that shape: it pinned the implementation rather than the format.

**The loopback check accepted attacker-controlled hostnames.** `OllamaHost`
restricts plain `http` to loopback on purpose — a prompt is the user's source
code, and sending it in cleartext because an env var said so is not a silent
tradeoff. The check was `strings.HasPrefix(host, "127.")`, which is not an
address check: `127.0.0.1.evil.com` is a valid hostname someone else controls,
resolving wherever they point it, and it passed. It now parses the address and
asks `net.IP.IsLoopback`.

**`hyctl status` panicked on a negative claude_pct.** `budgetBar` computed
`filled := pct * width / 100` and handed it to `strings.Repeat`, which panics on
a negative count. `state.json` is written by another process — and by hand, per
the orchestrator protocol's `jq '.claude_pct = 52'` — so a malformed value there
crashed the command that only meant to display it.

**The fake-head scripts were broken on Windows.** The `.bat` branch emitted
`echo <<<HYDRA_FILE_START>>>`, and `<`/`>` are cmd.exe redirection operators —
the interpreter failed the whole script and the head exited 255, so six
marker-based edit tests went red on the Windows leg for a reason that had
nothing to do with the code under test. `testutil.EchoScript` now builds that
script for both platforms in one place, with the escaping tested directly since
the branch it protects cannot run on a Unix runner.

## One test-hygiene fix

`testutil.NewSandbox` never cleared model-pin variables. `APIKeyVars` covers
credentials, but `ANTHROPIC_MODEL`, `AWS_REGION`, `AZURE_OPENAI_DEPLOYMENT` and
the rest are not credentials — so a developer with any of them exported had
every model-resolution test read their shell instead of the default under test.
Found when a new test resolved `"sonnet"` out of my own environment.
`ModelPinVars` now scrubs them, and a sync test keeps the list in step by
probing each provider rather than by inspection.

## What is covered

- **Six of seven HTTP provider adapters** had nothing. Each builds a request in
  its vendor's wire format and picks the answer out of that vendor's response
  shape; a wrong response field is an empty string reported as a successful
  answer. Now driven against stub servers, asserting what goes on the wire —
  Anthropic's `x-api-key` and version header, Gemini's path-escaped model and
  `system_instruction`, Cohere's `usage.tokens` nesting (read at the top level
  it is a silent 0/0 and free-looking spend), Azure's three settings, Bedrock's
  SigV4 signature, Replicate's poll loop and its refusal of a poll URL on
  another host.
- **The agy settings swap** — the only place Hydra mutates a file the user owns.
  Round trip, SIGKILL recovery, refusing a hand-broken settings.json, and eight
  concurrent runs leaving it intact. The auth check is pinned to read stderr and
  the first three lines of stdout only: a model asked about authentication
  writes "please log in" in its answer, and scanning the whole output would
  discard a paid answer and send the user to a login page.
- **Both edit paths** (`internal/editor`, `internal/parallel`) end to end against
  a real dispatch with a fake head on `$PATH`. The refusals matter most: an
  empty replacement, a leaked marker, and an answer with no markers must each
  leave the file byte-identical.
- **The swarm judge**, whose parser reads free-form model output — every
  malformed shape it accepts is a wrong answer presented as the best one.
- **The update checker's** gates, each asserted to make zero network requests: a
  check that fires inside CI is one request per job, forever.

Also covers the TUI: `hyctl init` is the first thing a user runs and the only
thing that writes their config, and none of it was covered — a wizard that walks
through cleanly and then saves the wrong tiers is indistinguishable from one
that works, until every dispatch routes somewhere unexpected.

Also lands the first half of **#267's CLI surface contract**: every subcommand
driven through the real `rootCmd` in a sandbox — help text present and `--help`
succeeding for each (which catches a flag definition that panics at
construction), `version` and `--version` agreeing, unknown commands and flags
failing rather than exiting 0 on a typo, the read commands surviving a fresh
install, `--json` parsing, and a dry run writing neither cost rows nor a
handoff. Exit codes cannot be asserted in-process — `os.Exit` takes the test
binary with it — so `hyctl edit`'s 2 and the MCP gate's 3 run against a real
built binary, along with JSON going to stdout alone with no banner mixed in.

## Still below 90

`cmd/hydra` is at 45.4%. The rest is Cobra `RunE` bodies that need live heads or
a populated ledger; the remaining half of #267 covers them.
`internal/testutil` reports a low figure because it is test-support code
exercised from other packages, so its own number is not meaningful.

`go test -race ./...` green on the full suite; `go vet ./...` clean.

Part of #308.

