### PR TITLE
ci: coverage floors, zero-test-package gate and a skip budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,23 @@ jobs:
       - name: Test
         run: go test ./... -race -count=1
 
+      # Coverage floors, the zero-test-package allow-list and the skip budget.
+      #
+      # Linux only: all three are properties of the source, not of the runner,
+      # and the numbers would differ per OS anyway — a test that legitimately
+      # skips on Windows moves that package's coverage there. Enforcing one set
+      # of floors on the platform they were measured on is the only version of
+      # this that means anything.
+      #
+      # Run without -race: the detector does not change coverage, and this is a
+      # second full pass over the suite.
+      - name: Coverage floors
+        if: runner.os == 'Linux'
+        run: |
+          go test ./internal/... ./cmd/... ./registry/... \
+            -coverprofile=cover.out -count=1
+          go run ./ci/covergate -profile cover.out -config ci/coverage-floors.txt
+
   # The desktop app ships for all three OSes, so its Go backend is tested on all
   # three too — same reasoning as the root job above (#257).
   desktop:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,53 @@ go test ./internal/somepkg -count=1     # must PASS
 `-count=1` is required — Go caches test results, and a cached PASS from before
 your change looks identical to a real one.
 
+### The coverage gate
+
+`ci/coverage-floors.txt` is a checked-in contract, enforced on every PR by
+`go run ./ci/covergate`. It fails on three things, all of which are otherwise
+invisible — they happen one PR at a time and never turn CI red on their own:
+
+**Per-package coverage floors.** Every package has a minimum. The gate names
+the package, what it measured, and the floor it missed.
+
+Floors are a **ratchet**: raise them freely, in the same PR that raises the
+coverage. Lowering one is allowed — sometimes the right move is to delete a
+test that pinned the wrong thing — but it must be an explicit edit to this file
+that a reviewer sees in the diff. That is the entire mechanism. Nothing else
+stops coverage sliding back down.
+
+The gate also prints `consider ratcheting` for any package sitting ten points
+or more above its floor: a floor that has drifted far below reality no longer
+protects anything.
+
+**Packages with no test files.** A new package with no tests fails the gate.
+The allow-list started at eleven — the whole platform and discovery layer — and
+is down to two, both permanent: `internal/build` is four ldflags-injected
+strings, and `cmd/specstest` is a debug main whose logic is covered in
+`internal/sysinfo`. Adding to the list requires a reason on the line, because a
+package with no tests is not a package with nothing to test.
+
+**A skip budget.** The total number of `t.Skip` calls across the suite is
+capped, and each needs a reason. Skips are how a cross-platform suite hides the
+problem it exists to catch: a three-OS matrix where every awkward test skips on
+two of them is decorative. Prefer rule 4 above — parametrise by platform — and
+if you genuinely need a skip, raise the budget in the same commit so the
+increase is visible.
+
+`t.Skip()` inside an `f.Fuzz` body is not counted: there it is the fuzzer's own
+control flow for rejecting a generated input, it happens thousands of times per
+run, and a reason string would be noise.
+
+Run it locally exactly as CI does:
+
+```bash
+go test ./internal/... ./cmd/... ./registry/... -coverprofile=cover.out -count=1
+go run ./ci/covergate -profile cover.out -config ci/coverage-floors.txt
+```
+
+The gate has its own tests (`ci/covergate`), driven to both verdicts — a gate
+that cannot go red is not a gate.
+
 ---
 
 ## Commit Style

--- a/ci/coverage-floors.txt
+++ b/ci/coverage-floors.txt
@@ -1,0 +1,75 @@
+# Per-package coverage floors, enforced by `go run ./ci/covergate`.
+#
+# Floors are a ratchet: they may be raised freely, but lowering one requires an
+# explicit commit a reviewer can see. That is the whole point — nothing here
+# stops coverage sliding back down except the fact that doing so must be
+# written down.
+#
+# Values are today's real numbers minus a small margin, so the gate lands green
+# and stays green under the ordinary variation a coverage run has (a test that
+# skips on one platform moves a package by a fraction of a percent). Raise a
+# floor in the same PR that raises the coverage.
+#
+# Format:  <import path relative to the module root>  <minimum percent>
+
+floor cmd/hydra                     44
+floor internal/a2a                  95
+floor internal/budget               95
+floor internal/capabilities         92
+floor internal/config               86
+floor internal/cost                 93
+floor internal/diff                 94
+floor internal/dispatch             90
+floor internal/editor               84
+floor internal/entropy              90
+floor internal/executor             86
+floor internal/glob                 99
+floor internal/graph                90
+floor internal/ledger               88
+floor internal/optimal              99
+floor internal/oracle               87
+floor internal/parallel             86
+floor internal/policy               90
+floor internal/pricing              88
+floor internal/probe                93
+floor internal/provider             99
+floor internal/provider/agy         92
+floor internal/provider/cli         89
+floor internal/provider/env         93
+floor internal/provider/port        86
+floor internal/rank                 93
+floor internal/review               90
+floor internal/runid                99
+floor internal/runlog               88
+floor internal/swarm                90
+floor internal/sysinfo              92
+floor internal/testutil             69
+floor internal/tree                 88
+floor internal/trust                90
+floor internal/tui                  82
+floor internal/update               91
+floor internal/util                 92
+floor internal/workspace            91
+floor registry                      88
+
+# Packages allowed to have no test files at all.
+#
+# The list started at eleven — the entire platform and discovery layer. It is
+# down to two, and both are permanent:
+#
+#   internal/build   is four ldflags-injected string vars and nothing else.
+#   cmd/specstest    is a debug main that prints sysinfo.Detect()'s output; the
+#                    logic it prints is covered in internal/sysinfo.
+#
+# Adding anything here needs a reason on the line. A package with no tests is
+# not a package with nothing to test.
+no-tests internal/build   ldflags-injected version vars only
+no-tests cmd/specstest    debug main; the logic it prints is covered in internal/sysinfo
+
+# Maximum number of t.Skip/t.Skipf calls across the whole test suite.
+#
+# Skips are how a cross-platform suite hides the problem it exists to catch: a
+# three-OS matrix where every awkward test skips on two of them is decorative.
+# Each skip must carry a reason, and the total cannot grow without this number
+# being edited — which a reviewer sees.
+skip-budget 32

--- a/ci/coverage-floors.txt
+++ b/ci/coverage-floors.txt
@@ -12,8 +12,10 @@
 # measures ~10 points apart. Enforcing macOS numbers on a Linux runner would
 # fail for a reason that has nothing to do with the change under review.
 #
-# Set from a real CI run, with a small margin for the ordinary variation a
-# coverage run has. Raise a floor in the same PR that raises the coverage; the
+# Set from a real CI run (30941076262), with a small margin for the ordinary
+# variation a coverage run has. internal/sysinfo is the widest gap: it reads
+# memory through darwinRAM/darwinMemoryState on macOS and /proc on Linux, so it
+# measures 94.5% there and 83.9% here. Raise a floor in the same PR that raises the coverage; the
 # gate prints every package's measured value, so the number to use is in the
 # log of the run you are looking at.
 #
@@ -49,13 +51,13 @@ floor internal/review               90
 floor internal/runid                99
 floor internal/runlog               88
 floor internal/swarm                90
-floor internal/sysinfo              92
+floor internal/sysinfo              82
 floor internal/testutil             69
 floor internal/tree                 88
 floor internal/trust                90
 floor internal/tui                  82
-floor internal/update               91
-floor internal/util                 92
+floor internal/update               87
+floor internal/util                 99
 floor internal/workspace            91
 floor registry                      88
 

--- a/ci/coverage-floors.txt
+++ b/ci/coverage-floors.txt
@@ -5,10 +5,17 @@
 # stops coverage sliding back down except the fact that doing so must be
 # written down.
 #
-# Values are today's real numbers minus a small margin, so the gate lands green
-# and stays green under the ordinary variation a coverage run has (a test that
-# skips on one platform moves a package by a fraction of a percent). Raise a
-# floor in the same PR that raises the coverage.
+# Values are the numbers measured **on Linux**, because that is where the gate
+# runs. They are not the numbers you will see on a Mac: internal/sysinfo reads
+# memory through darwinRAM/darwinMemoryState there and through /proc on Linux,
+# so each platform leaves the other's readers uncovered and the same package
+# measures ~10 points apart. Enforcing macOS numbers on a Linux runner would
+# fail for a reason that has nothing to do with the change under review.
+#
+# Set from a real CI run, with a small margin for the ordinary variation a
+# coverage run has. Raise a floor in the same PR that raises the coverage; the
+# gate prints every package's measured value, so the number to use is in the
+# log of the run you are looking at.
 #
 # Format:  <import path relative to the module root>  <minimum percent>
 

--- a/ci/covergate/main.go
+++ b/ci/covergate/main.go
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: MIT
+
+// Command covergate enforces three things CI cannot otherwise see:
+//
+//  1. per-package coverage against a checked-in floor,
+//  2. that no package has zero test files unless it is allow-listed with a
+//     reason,
+//  3. that the number of t.Skip calls has not grown past a checked-in budget.
+//
+// All three exist because the failure they catch is invisible: coverage slides
+// down one PR at a time, a new package ships with no tests at all, and a
+// cross-platform suite fills with `t.Skip("not on windows")` until the
+// three-OS matrix is decorative. None of those turn CI red on their own.
+//
+// Usage:
+//
+//	go test ./... -coverprofile=cover.out
+//	go run ./ci/covergate -profile cover.out -config ci/coverage-floors.txt
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	var (
+		profile = flag.String("profile", "cover.out", "coverage profile from `go test -coverprofile`")
+		config  = flag.String("config", "ci/coverage-floors.txt", "floors, allow-list and skip budget")
+		root    = flag.String("root", ".", "module root to scan for packages and skips")
+	)
+	flag.Parse()
+
+	cfg, err := loadConfig(*config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "covergate: %v\n", err)
+		os.Exit(2)
+	}
+
+	problems, skipsUsed, err := check(cfg, *profile, *root)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "covergate: %v\n", err)
+		os.Exit(2)
+	}
+
+	if len(problems) == 0 {
+		fmt.Printf("covergate: %d floors met, %d allow-listed packages, %d/%d skips used\n",
+			len(cfg.Floors), len(cfg.NoTests), skipsUsed, cfg.SkipBudget)
+		return
+	}
+	for _, p := range problems {
+		// ::error:: is GitHub Actions' annotation prefix, so each problem lands
+		// on the PR rather than only in the log.
+		fmt.Printf("::error::%s\n", p)
+	}
+	fmt.Fprintf(os.Stderr, "\ncovergate: %d problem(s)\n", len(problems))
+	os.Exit(1)
+}
+
+// Config is the checked-in contract.
+type Config struct {
+	Floors     map[string]float64
+	NoTests    map[string]string // package → reason
+	SkipBudget int
+}
+
+func loadConfig(path string) (*Config, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	cfg := &Config{
+		Floors:     map[string]float64{},
+		NoTests:    map[string]string{},
+		SkipBudget: -1,
+	}
+
+	for i, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		switch fields[0] {
+		case "floor":
+			if len(fields) != 3 {
+				return nil, fmt.Errorf("%s:%d: floor needs a package and a percent", path, i+1)
+			}
+			pct, err := strconv.ParseFloat(fields[2], 64)
+			if err != nil {
+				return nil, fmt.Errorf("%s:%d: %q is not a percent", path, i+1, fields[2])
+			}
+			cfg.Floors[fields[1]] = pct
+		case "no-tests":
+			if len(fields) < 3 {
+				// A package with no tests is not a package with nothing to
+				// test. Requiring the reason is what stops the list growing by
+				// habit.
+				return nil, fmt.Errorf("%s:%d: no-tests needs a reason", path, i+1)
+			}
+			cfg.NoTests[fields[1]] = strings.Join(fields[2:], " ")
+		case "skip-budget":
+			if len(fields) != 2 {
+				return nil, fmt.Errorf("%s:%d: skip-budget needs a number", path, i+1)
+			}
+			n, err := strconv.Atoi(fields[1])
+			if err != nil {
+				return nil, fmt.Errorf("%s:%d: %q is not a number", path, i+1, fields[1])
+			}
+			cfg.SkipBudget = n
+		default:
+			return nil, fmt.Errorf("%s:%d: unknown directive %q", path, i+1, fields[0])
+		}
+	}
+	if cfg.SkipBudget < 0 {
+		return nil, fmt.Errorf("%s: no skip-budget set", path)
+	}
+	return cfg, nil
+}
+
+// check returns every problem found, plus how many skips the suite used — so a
+// green run still reports the headroom rather than only the verdict.
+func check(cfg *Config, profile, root string) (problems []string, skips int, err error) {
+	coverage, err := parseProfile(profile)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// 1. Floors.
+	for _, pkg := range sortedKeys(cfg.Floors) {
+		floor := cfg.Floors[pkg]
+		got, measured := coverage[pkg]
+		if !measured {
+			problems = append(problems, fmt.Sprintf(
+				"%s has a floor of %.0f%% but no coverage was measured — was it deleted, "+
+					"or did its tests stop running?", pkg, floor))
+			continue
+		}
+		if got < floor {
+			problems = append(problems, fmt.Sprintf(
+				"%s is at %.1f%%, below its floor of %.0f%%. Raise the coverage, or lower "+
+					"the floor in ci/coverage-floors.txt — which is a change a reviewer sees.",
+				pkg, got, floor))
+		}
+	}
+
+	// A package measured well above its floor is not a problem, but a floor
+	// that has drifted far below reality no longer protects anything. Report it
+	// without failing.
+	for _, pkg := range sortedKeys(cfg.Floors) {
+		if got, ok := coverage[pkg]; ok && got-cfg.Floors[pkg] >= 10 {
+			fmt.Printf("covergate: %s is %.1f%% against a floor of %.0f%% — consider ratcheting\n",
+				pkg, got, cfg.Floors[pkg])
+		}
+	}
+
+	// 2. Packages with no test files.
+	untested, err := packagesWithoutTests(root)
+	if err != nil {
+		return nil, 0, err
+	}
+	for _, pkg := range untested {
+		if _, allowed := cfg.NoTests[pkg]; !allowed {
+			problems = append(problems, fmt.Sprintf(
+				"%s has no test files. Add some, or allow-list it in "+
+					"ci/coverage-floors.txt with a reason.", pkg))
+		}
+	}
+	// An allow-list entry for a package that now has tests is stale, and a
+	// stale entry silently exempts it again if its tests are ever removed.
+	for _, pkg := range sortedKeys(cfg.NoTests) {
+		if !contains(untested, pkg) {
+			if _, exists := os.Stat(filepath.Join(root, pkg)); exists == nil {
+				problems = append(problems, fmt.Sprintf(
+					"%s is allow-listed as having no tests, but it has some. Remove the "+
+						"no-tests line — a stale entry exempts it again if they are deleted.", pkg))
+			}
+		}
+	}
+
+	// 3. Skip budget.
+	skips, unexplained, err := countSkips(root)
+	if err != nil {
+		return nil, 0, err
+	}
+	if skips > cfg.SkipBudget {
+		problems = append(problems, fmt.Sprintf(
+			"the suite has %d t.Skip calls, over the budget of %d. A three-OS matrix "+
+				"where every awkward test skips on two of them is decorative — either "+
+				"make the test run, or raise the budget deliberately.", skips, cfg.SkipBudget))
+	}
+	for _, loc := range unexplained {
+		problems = append(problems, fmt.Sprintf(
+			"%s: t.Skip with no reason. The next person needs to know whether it is "+
+				"still true.", loc))
+	}
+
+	return problems, skips, nil
+}
+
+// parseProfile computes per-package coverage from a Go coverage profile.
+//
+// Lines look like:
+//
+//	github.com/ankit373/hydra/internal/x/file.go:10.2,12.16 2 1
+//
+// where the trailing numbers are the statement count in that block and how many
+// times it ran. Package coverage is covered statements over total statements —
+// the same arithmetic `go tool cover -func` reports.
+func parseProfile(path string) (map[string]float64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	type counts struct{ total, covered int }
+	byPkg := map[string]*counts{}
+
+	scanner := bufio.NewScanner(f)
+	// A profile line is short, but a long file path plus a huge module path can
+	// approach the default 64 KiB token limit; raise it rather than have the
+	// scanner stop silently mid-file.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "mode:") {
+			continue
+		}
+		colon := strings.LastIndex(line, ":")
+		if colon < 0 {
+			continue
+		}
+		fileRef := line[:colon]
+		fields := strings.Fields(line[colon+1:])
+		if len(fields) != 3 {
+			continue
+		}
+		stmts, err1 := strconv.Atoi(fields[1])
+		hits, err2 := strconv.Atoi(fields[2])
+		if err1 != nil || err2 != nil {
+			continue
+		}
+
+		pkg := packageOf(fileRef)
+		c := byPkg[pkg]
+		if c == nil {
+			c = &counts{}
+			byPkg[pkg] = c
+		}
+		c.total += stmts
+		if hits > 0 {
+			c.covered += stmts
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]float64, len(byPkg))
+	for pkg, c := range byPkg {
+		if c.total == 0 {
+			continue
+		}
+		out[pkg] = float64(c.covered) / float64(c.total) * 100
+	}
+	return out, nil
+}
+
+// modulePath is trimmed from profile entries so floors are written the way a
+// contributor refers to a package, not as a full import path.
+const modulePath = "github.com/ankit373/hydra/"
+
+// packageOf turns a profile file reference into the package path used in the
+// config file.
+func packageOf(fileRef string) string {
+	dir := filepath.ToSlash(filepath.Dir(fileRef))
+	dir = strings.TrimPrefix(dir, modulePath)
+	dir = strings.TrimPrefix(dir, strings.TrimSuffix(modulePath, "/"))
+	return strings.TrimPrefix(dir, "/")
+}
+
+// packagesWithoutTests walks root for directories holding .go files but no
+// _test.go, skipping anything not part of the module's own source.
+func packagesWithoutTests(root string) ([]string, error) {
+	var out []string
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if path != root && (strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") ||
+			name == "vendor" || name == "node_modules" || name == "testdata" ||
+			name == "desktop" || name == "bench" || name == "ci") {
+			return filepath.SkipDir
+		}
+
+		entries, rerr := os.ReadDir(path)
+		if rerr != nil {
+			return rerr
+		}
+		var hasGo, hasTest bool
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+				continue
+			}
+			hasGo = true
+			if strings.HasSuffix(e.Name(), "_test.go") {
+				hasTest = true
+			}
+		}
+		if hasGo && !hasTest {
+			rel, rerr := filepath.Rel(root, path)
+			if rerr != nil {
+				return rerr
+			}
+			out = append(out, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	sort.Strings(out)
+	return out, err
+}
+
+// countSkips counts t.Skip/t.Skipf calls and reports the ones with no reason.
+func countSkips(root string) (total int, unexplained []string, err error) {
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			name := d.Name()
+			// ci/ is the gate's own tooling, not the suite it measures, and its
+			// tests hold fixture text that reads as skips.
+			if path != root && (strings.HasPrefix(name, ".") || name == "vendor" ||
+				name == "node_modules" || name == "desktop" || name == "bench" ||
+				name == "ci") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		rel, _ := filepath.Rel(root, path)
+		inTest := false
+		for i, line := range strings.Split(string(raw), "\n") {
+			if kind, ok := enclosingFunc(line); ok {
+				inTest = kind == "Test"
+			}
+			call, ok := skipCall(line)
+			if !ok || !inTest {
+				continue
+			}
+			total++
+			if call == "" {
+				unexplained = append(unexplained,
+					fmt.Sprintf("%s:%d", filepath.ToSlash(rel), i+1))
+			}
+		}
+		return nil
+	})
+	return total, unexplained, err
+}
+
+// enclosingFunc reports which kind of top-level test function a line opens.
+//
+// The distinction matters: `t.Skip()` inside an f.Fuzz body rejects a generated
+// input and moves on — it is the fuzzer's own control flow, happens thousands
+// of times per run, and a reason string there would be noise. A skip inside a
+// Test function is the thing this budget exists to bound: a platform or
+// environment exemption that quietly stops covering something.
+func enclosingFunc(line string) (kind string, ok bool) {
+	if !strings.HasPrefix(line, "func ") {
+		return "", false
+	}
+	name := strings.TrimPrefix(line, "func ")
+	switch {
+	case strings.HasPrefix(name, "Fuzz"):
+		return "Fuzz", true
+	case strings.HasPrefix(name, "Test"):
+		return "Test", true
+	case strings.HasPrefix(name, "Benchmark"), strings.HasPrefix(name, "Example"):
+		return "Other", true
+	}
+	// A plain helper: skips inside it belong to whatever calls it, and the
+	// caller's own function line has already set the mode.
+	return "", false
+}
+
+// skipCall reports whether the line calls t.Skip/t.Skipf and what it passed.
+// It is deliberately textual: the alternative is parsing every test file, and
+// the thing being counted is a convention, not a type.
+func skipCall(line string) (args string, ok bool) {
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(trimmed, "//") {
+		return "", false
+	}
+	for _, form := range []string{".Skipf(", ".Skip("} {
+		idx := strings.Index(trimmed, form)
+		if idx < 0 {
+			continue
+		}
+		// .SkipNow() takes no reason by design and is a different thing.
+		rest := trimmed[idx+len(form):]
+		close := strings.LastIndex(rest, ")")
+		if close < 0 {
+			return rest, true // continued on the next line; assume it has one
+		}
+		return strings.TrimSpace(rest[:close]), true
+	}
+	return "", false
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/ci/covergate/main.go
+++ b/ci/covergate/main.go
@@ -151,15 +151,24 @@ func check(cfg *Config, profile, root string) (problems []string, skips int, err
 		}
 	}
 
-	// A package measured well above its floor is not a problem, but a floor
-	// that has drifted far below reality no longer protects anything. Report it
-	// without failing.
-	for _, pkg := range sortedKeys(cfg.Floors) {
-		if got, ok := coverage[pkg]; ok && got-cfg.Floors[pkg] >= 10 {
-			fmt.Printf("covergate: %s is %.1f%% against a floor of %.0f%% — consider ratcheting\n",
-				pkg, got, cfg.Floors[pkg])
+	// Every measurement, printed whether or not the run passes. Ratcheting a
+	// floor means knowing the current number, and the run you are looking at is
+	// where it should be — not a local run on a different OS, where the same
+	// package can measure ten points apart.
+	fmt.Println("covergate: measured coverage")
+	for _, pkg := range sortedKeys(coverage) {
+		got := coverage[pkg]
+		floor, hasFloor := cfg.Floors[pkg]
+		switch {
+		case !hasFloor:
+			fmt.Printf("  %-32s %5.1f%%  (no floor)\n", pkg, got)
+		case got-floor >= 10:
+			fmt.Printf("  %-32s %5.1f%%  floor %.0f%%  ← consider ratcheting\n", pkg, got, floor)
+		default:
+			fmt.Printf("  %-32s %5.1f%%  floor %.0f%%\n", pkg, got, floor)
 		}
 	}
+	fmt.Println()
 
 	// 2. Packages with no test files.
 	untested, err := packagesWithoutTests(root)

--- a/ci/covergate/main_test.go
+++ b/ci/covergate/main_test.go
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A gate that cannot go red is not a gate. Every check here is driven to both
+// verdicts against real files on disk.
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A profile with a mix of covered and uncovered blocks must yield the same
+// number `go tool cover -func` reports: covered statements over total.
+func TestParseProfile_ComputesPerPackageCoverage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cover.out")
+	writeFile(t, path, strings.Join([]string{
+		"mode: set",
+		// internal/a: 6 of 8 statements covered → 75%
+		"github.com/ankit373/hydra/internal/a/one.go:1.1,3.2 4 1",
+		"github.com/ankit373/hydra/internal/a/one.go:5.1,7.2 2 1",
+		"github.com/ankit373/hydra/internal/a/two.go:1.1,2.2 2 0",
+		// internal/b: nothing covered → 0%
+		"github.com/ankit373/hydra/internal/b/x.go:1.1,2.2 5 0",
+		// cmd/hydra: all covered → 100%
+		"github.com/ankit373/hydra/cmd/hydra/main.go:1.1,2.2 3 7",
+		"",
+	}, "\n"))
+
+	got, err := parseProfile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]float64{
+		"internal/a": 75,
+		"internal/b": 0,
+		"cmd/hydra":  100,
+	}
+	for pkg, w := range want {
+		if g, ok := got[pkg]; !ok {
+			t.Errorf("%s is missing from the parsed profile", pkg)
+		} else if diff := g - w; diff > 0.001 || diff < -0.001 {
+			t.Errorf("%s = %.2f%%, want %.2f%%", pkg, g, w)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("parsed %d packages, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// A truncated or noisy profile must not be read as full coverage. Silently
+// treating a broken profile as "everything passes" is the one failure mode the
+// gate cannot have.
+func TestParseProfile_IgnoresMalformedLinesRatherThanCounting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cover.out")
+	writeFile(t, path, strings.Join([]string{
+		"mode: set",
+		"not a profile line at all",
+		"github.com/ankit373/hydra/internal/a/one.go:1.1,3.2 notanumber 1",
+		"github.com/ankit373/hydra/internal/a/one.go:1.1,3.2 4 0",
+		"",
+	}, "\n"))
+
+	got, err := parseProfile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["internal/a"] != 0 {
+		t.Errorf("internal/a = %.1f%%, want 0 — the malformed line must not count "+
+			"as covered", got["internal/a"])
+	}
+
+	if _, err := parseProfile(filepath.Join(dir, "absent.out")); err == nil {
+		t.Error("a missing profile was read as success; the gate would pass with no data")
+	}
+}
+
+func TestLoadConfig_RejectsWhatItCannotEnforce(t *testing.T) {
+	dir := t.TempDir()
+
+	good := filepath.Join(dir, "good.txt")
+	writeFile(t, good, "# a comment\n\nfloor internal/a 80\nno-tests internal/b because reasons\nskip-budget 5\n")
+	cfg, err := loadConfig(good)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Floors["internal/a"] != 80 {
+		t.Errorf("floor = %v", cfg.Floors["internal/a"])
+	}
+	if cfg.NoTests["internal/b"] != "because reasons" {
+		t.Errorf("reason = %q", cfg.NoTests["internal/b"])
+	}
+	if cfg.SkipBudget != 5 {
+		t.Errorf("skip budget = %d", cfg.SkipBudget)
+	}
+
+	bad := map[string]string{
+		// A no-tests line with no reason is how the allow-list grows by habit.
+		"no-tests with no reason":    "skip-budget 1\nno-tests internal/b\n",
+		"floor with no percent":      "skip-budget 1\nfloor internal/a\n",
+		"floor that is not a number": "skip-budget 1\nfloor internal/a lots\n",
+		"unknown directive":          "skip-budget 1\nfence internal/a 80\n",
+		// Without a budget the skip check silently does nothing.
+		"no skip budget": "floor internal/a 80\n",
+	}
+	for name, body := range bad {
+		t.Run(name, func(t *testing.T) {
+			p := filepath.Join(dir, strings.ReplaceAll(name, " ", "_")+".txt")
+			writeFile(t, p, body)
+			if cfg, err := loadConfig(p); err == nil {
+				t.Errorf("loadConfig accepted %s: %+v", name, cfg)
+			}
+		})
+	}
+}
+
+// The floor check must go red when breached, and must say what to do about it.
+func TestCheck_FloorBreachIsReportedWithTheNumbers(t *testing.T) {
+	dir := t.TempDir()
+	profile := filepath.Join(dir, "cover.out")
+	writeFile(t, profile, "mode: set\ngithub.com/ankit373/hydra/internal/a/x.go:1.1,2.2 4 0\n"+
+		"github.com/ankit373/hydra/internal/a/x.go:3.1,4.2 6 1\n") // 60%
+
+	// Above the floor: no problem.
+	cfg := &Config{Floors: map[string]float64{"internal/a": 50}, NoTests: map[string]string{}, SkipBudget: 100}
+	problems, _, err := check(cfg, profile, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 0 {
+		t.Fatalf("a package above its floor was reported: %v", problems)
+	}
+
+	// Below it: exactly one problem, naming both numbers and the file to edit.
+	cfg.Floors["internal/a"] = 90
+	problems, _, err = check(cfg, profile, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 1 {
+		t.Fatalf("got %d problems, want 1: %v", len(problems), problems)
+	}
+	msg := problems[0]
+	for _, want := range []string{"internal/a", "60.0", "90", "coverage-floors.txt"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the message does not mention %q: %s", want, msg)
+		}
+	}
+}
+
+// A floor for a package that produced no coverage at all must fail. Otherwise
+// deleting a package's tests silently removes it from the gate.
+func TestCheck_AFloorWithNoMeasurementFails(t *testing.T) {
+	dir := t.TempDir()
+	profile := filepath.Join(dir, "cover.out")
+	writeFile(t, profile, "mode: set\n")
+
+	cfg := &Config{Floors: map[string]float64{"internal/gone": 80}, NoTests: map[string]string{}, SkipBudget: 100}
+	problems, _, err := check(cfg, profile, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) == 0 {
+		t.Fatal("a floor with no coverage behind it passed; deleting a package's " +
+			"tests would silently remove it from the gate")
+	}
+	if !strings.Contains(problems[0], "internal/gone") {
+		t.Errorf("the message does not name the package: %s", problems[0])
+	}
+}
+
+// A package with no test files must fail unless allow-listed, and a stale
+// allow-list entry must fail too.
+func TestCheck_ZeroTestPackages(t *testing.T) {
+	dir := t.TempDir()
+	profile := filepath.Join(dir, "cover.out")
+	writeFile(t, profile, "mode: set\n")
+
+	writeFile(t, filepath.Join(dir, "internal", "untested", "x.go"), "package untested\n")
+	writeFile(t, filepath.Join(dir, "internal", "tested", "x.go"), "package tested\n")
+	writeFile(t, filepath.Join(dir, "internal", "tested", "x_test.go"), "package tested\n")
+
+	cfg := &Config{Floors: map[string]float64{}, NoTests: map[string]string{}, SkipBudget: 100}
+	problems, _, err := check(cfg, profile, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 1 || !strings.Contains(problems[0], "internal/untested") {
+		t.Fatalf("got %v, want one problem naming internal/untested", problems)
+	}
+
+	// Allow-listed: silent.
+	cfg.NoTests["internal/untested"] = "a reason"
+	problems, _, err = check(cfg, profile, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 0 {
+		t.Fatalf("an allow-listed package was reported: %v", problems)
+	}
+
+	// Allow-listing a package that *does* have tests is stale, and a stale
+	// entry exempts it again the moment its tests are deleted.
+	cfg.NoTests["internal/tested"] = "out of date"
+	problems, _, err = check(cfg, profile, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 1 || !strings.Contains(problems[0], "internal/tested") {
+		t.Errorf("got %v, want the stale allow-list entry reported", problems)
+	}
+}
+
+// The skip budget must go red when exceeded, and a skip with no reason must be
+// reported wherever it is.
+func TestCheck_SkipBudgetAndReasons(t *testing.T) {
+	dir := t.TempDir()
+	profile := filepath.Join(dir, "cover.out")
+	writeFile(t, profile, "mode: set\n")
+
+	writeFile(t, filepath.Join(dir, "pkg", "a_test.go"), strings.Join([]string{
+		"package a",
+		"func TestOne(t *testing.T) {",
+		`	t.Skip("no git on this machine")`,
+		"}",
+		"func TestTwo(t *testing.T) {",
+		`	t.Skipf("no %s here", "tsc")`,
+		"}",
+		"func TestThree(t *testing.T) {",
+		"	t.Skip()",
+		"}",
+		"// t.Skip( in a comment must not count",
+		"",
+	}, "\n"))
+
+	cfg := &Config{Floors: map[string]float64{}, NoTests: map[string]string{}, SkipBudget: 3}
+	problems, _, err := check(cfg, profile, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Three real skips, within budget — but one has no reason.
+	if len(problems) != 1 {
+		t.Fatalf("got %v, want only the reasonless skip reported", problems)
+	}
+	if !strings.Contains(problems[0], "a_test.go:9") {
+		t.Errorf("the reasonless skip was not located: %s", problems[0])
+	}
+
+	// Over budget: an additional problem.
+	cfg.SkipBudget = 2
+	problems, _, err = check(cfg, profile, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(problems) != 2 {
+		t.Fatalf("got %v, want the budget breach reported too", problems)
+	}
+	var sawBudget bool
+	for _, p := range problems {
+		if strings.Contains(p, "budget of 2") {
+			sawBudget = true
+		}
+	}
+	if !sawBudget {
+		t.Errorf("the budget breach does not state the budget: %v", problems)
+	}
+}
+
+func TestSkipCall(t *testing.T) {
+	tests := []struct {
+		line string
+		args string
+		ok   bool
+	}{
+		{`	t.Skip("a reason")`, `"a reason"`, true},
+		{`	t.Skipf("no %s", x)`, `"no %s", x`, true},
+		{`	t.Skip()`, ``, true},
+		{`	// t.Skip("commented out")`, ``, false},
+		{`	t.SkipNow()`, ``, false},
+		{`	fmt.Println("nothing to do with skipping")`, ``, false},
+		{``, ``, false},
+	}
+	for _, tt := range tests {
+		args, ok := skipCall(tt.line)
+		if ok != tt.ok {
+			t.Errorf("skipCall(%q) ok = %v, want %v", tt.line, ok, tt.ok)
+			continue
+		}
+		if ok && args != tt.args {
+			t.Errorf("skipCall(%q) = %q, want %q", tt.line, args, tt.args)
+		}
+	}
+}
+
+func TestPackageOf(t *testing.T) {
+	tests := map[string]string{
+		"github.com/ankit373/hydra/internal/a/one.go": "internal/a",
+		"github.com/ankit373/hydra/cmd/hydra/main.go": "cmd/hydra",
+		"github.com/ankit373/hydra/registry/x.go":     "registry",
+	}
+	for in, want := range tests {
+		if got := packageOf(in); got != want {
+			t.Errorf("packageOf(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The checked-in config must be loadable and internally consistent, or the gate
+// fails for its own reasons rather than the repo's.
+func TestCheckedInConfig_IsValid(t *testing.T) {
+	cfg, err := loadConfig(filepath.Join("..", "coverage-floors.txt"))
+	if err != nil {
+		t.Fatalf("the checked-in config does not load: %v", err)
+	}
+	if len(cfg.Floors) == 0 {
+		t.Error("no floors are set, so the gate enforces nothing")
+	}
+	for pkg, floor := range cfg.Floors {
+		if floor < 0 || floor > 100 {
+			t.Errorf("%s has a floor of %v, outside 0–100", pkg, floor)
+		}
+	}
+	// A package cannot both have a floor and be allow-listed as untested — one
+	// of the two is wrong, and the gate would enforce the weaker.
+	for pkg := range cfg.NoTests {
+		if _, hasFloor := cfg.Floors[pkg]; hasFloor {
+			t.Errorf("%s has both a coverage floor and a no-tests exemption", pkg)
+		}
+	}
+	if cfg.SkipBudget <= 0 {
+		t.Errorf("skip budget = %d; a budget of zero or less disables the check",
+			cfg.SkipBudget)
+	}
+}


### PR DESCRIPTION
## Summary

A CI gate for three things that are otherwise invisible — each happens one PR at
a time and never turns anything red on its own:

1. **Per-package coverage floors**, checked into `ci/coverage-floors.txt` at
   today's real numbers.
2. **Packages with zero test files**, allow-listed down from the eleven the
   issue opened with to two.
3. **A skip budget**, because a three-OS matrix where every awkward test skips
   on two of them is decorative.

## The ratchet

Floors may be raised freely, in the same PR that raises the coverage. Lowering
one is allowed — sometimes deleting a test that pinned the wrong thing is right
— but it must be an explicit edit a reviewer sees in the diff. **That is the
entire mechanism.** Nothing else stops the slide.

The gate also prints `consider ratcheting` for any package sitting ten points or
more above its floor, since a floor that has drifted far below reality no longer
protects anything.

## Zero-test allow-list: 11 → 2

Both remaining entries are permanent, and each carries its reason on the line:

- `internal/build` — four ldflags-injected string vars and nothing else.
- `cmd/specstest` — a debug main; the logic it prints is covered in
  `internal/sysinfo`.

A **stale** entry also fails: allow-listing a package that now has tests would
exempt it again the moment those tests were deleted.

## Skip budget: 32, with 29 in use

`t.Skip()` inside an `f.Fuzz` body is deliberately not counted — there it is the
fuzzer's own control flow for rejecting a generated input, it fires thousands of
times per run, and a reason string would be noise. Every skip in a `Test`
function does need one, and nine were found without.

## Verification

The gate has its own tests, driven to both verdicts — a gate that cannot go red
is not a gate. Including:

- a malformed coverage profile is **not** read as full coverage (the one failure
  mode this tool cannot have);
- a floor with no measurement behind it fails, so deleting a package's tests
  cannot silently drop it from the gate.

All three checks were also driven red against the real repo and then green
again:

```
::error::internal/tui is at 84.7%, below its floor of 99%. …
::error::internal/gateprobe has no test files. …
::error::the suite has 29 t.Skip calls, over the budget of 1. …
```

Clean run:

```
covergate: 39 floors met, 2 allow-listed packages, 29/32 skips used
```

## Why Linux only

All three are properties of the source, not the runner, and the numbers differ
per OS anyway — a test that legitimately skips on Windows moves that package's
coverage there. Enforcing one set of floors on the platform they were measured
on is the only version of this that means anything.

## Docs

`CONTRIBUTING.md` already told contributors to "see the coverage gate". This
adds the section it pointed at.

Closes #270