### PR TITLE
fix(tui): header truncated model names mid-rune; close the last coverage gaps

### DIFF
--- a/ci/coverage-floors.txt
+++ b/ci/coverage-floors.txt
@@ -15,7 +15,9 @@
 # Set from a real CI run (30941076262), with a small margin for the ordinary
 # variation a coverage run has. internal/sysinfo is the widest gap: it reads
 # memory through darwinRAM/darwinMemoryState on macOS and /proc on Linux, so it
-# measures 94.5% there and 83.9% here. Raise a floor in the same PR that raises the coverage; the
+# measures 94.5% there and 83.9% here. Running this on a Mac therefore prints a
+# "consider ratcheting" line for sysinfo every time — that advisory is comparing
+# a macOS measurement against a Linux floor, and acting on it would break CI. Raise a floor in the same PR that raises the coverage; the
 # gate prints every package's measured value, so the number to use is in the
 # log of the run you are looking at.
 #
@@ -36,7 +38,7 @@ floor internal/config               86
 floor internal/cost                 93
 floor internal/diff                 94
 floor internal/dispatch             90
-floor internal/editor               84
+floor internal/editor               87
 floor internal/entropy              90
 floor internal/executor             86
 floor internal/glob                 99
@@ -52,7 +54,7 @@ floor internal/provider             99
 floor internal/provider/agy         92
 floor internal/provider/cli         89
 floor internal/provider/env         93
-floor internal/provider/port        86
+floor internal/provider/port        90
 floor internal/rank                 93
 floor internal/review               90
 floor internal/runid                99
@@ -62,7 +64,7 @@ floor internal/sysinfo              82
 floor internal/testutil             69
 floor internal/tree                 88
 floor internal/trust                90
-floor internal/tui                  82
+floor internal/tui                  85
 floor internal/update               87
 floor internal/util                 99
 floor internal/workspace            91

--- a/internal/cost/testdata/render_summary.golden
+++ b/internal/cost/testdata/render_summary.golden
@@ -2,7 +2,7 @@
   Hydra cost summary
   ═════════════════════════════════════════════════════════════
 
-  Today (2026-08-04)
+  Today (<date>)
     calls          3
     tokens in/out  1200 / 450
     est cost       <usd>

--- a/internal/editor/edit_test.go
+++ b/internal/editor/edit_test.go
@@ -685,3 +685,163 @@ func TestRollback_UsesGitInARepository(t *testing.T) {
 		t.Error("an untracked file the edit created survived the rollback")
 	}
 }
+
+// A model that ignored the instruction entirely — no markers, no content —
+// against a file that does not exist yet is a different failure from an empty
+// replacement: there is nothing to preserve, and the file must not be created.
+func TestEdit_MarkerParseFailedOnANewFile(t *testing.T) {
+	repo := editSandbox(t, "I would suggest the following approach: ...")
+	file := filepath.Join(repo, "never-created.go")
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "create it",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" {
+		t.Fatalf("status = %q, want fail", res.Status)
+	}
+	if res.Error != "marker_parse_failed" {
+		t.Errorf("Error = %q, want marker_parse_failed — an empty_replacement "+
+			"would imply there was content to lose", res.Error)
+	}
+	if _, statErr := os.Stat(file); statErr == nil {
+		t.Error("a file was created from an answer that parsed to nothing")
+	}
+}
+
+// A model that echoes the terminator back inside its content would write it
+// into the file, and the next edit would parse against it.
+func TestEdit_TerminatorLeakageIsRefused(t *testing.T) {
+	repo := editSandbox(t, "line one\n<<<HYDRA_FILE_END>>>\n<<<HYDRA_FILE_END>>>")
+	file := filepath.Join(repo, "a.go")
+	original := "package main\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{File: file, Enum: "MODERATE", Prompt: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status == "ok" {
+		if raw, _ := os.ReadFile(file); strings.Contains(string(raw), "HYDRA_FILE_END") {
+			t.Errorf("a marker was written into the file: %q", raw)
+		}
+	}
+}
+
+// A write that cannot land must be reported as write_failed and must not
+// consume the backup — the file is unchanged, so its baseline still applies.
+func TestEdit_UnwritableTargetIsReportedNotSilent(t *testing.T) {
+	repo := editSandbox(t, marked("new content"))
+
+	// The target path's parent is a file, so no temp file can be created
+	// beside it and the rename can never happen.
+	blocker := filepath.Join(repo, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(blocker, "child.go")
+
+	res, err := Edit(context.Background(), Request{File: file, Enum: "MODERATE", Prompt: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" {
+		t.Fatalf("status = %q writing under a regular file, want fail", res.Status)
+	}
+	if !strings.Contains(res.Error, "write_failed") && !strings.Contains(res.Error, "scope") {
+		t.Errorf("Error = %q, want it to name the write failure", res.Error)
+	}
+}
+
+// firstLine trims the validator's output down to what fits on one line of the
+// result. An empty output must stay empty rather than becoming a blank line
+// that reads as a message.
+func TestFirstLine_TrimsAndBounds(t *testing.T) {
+	tests := map[string]string{
+		"one\ntwo\nthree": "one",
+		// TrimSpace runs on the whole string before the split, so leading
+		// whitespace goes and trailing whitespace on the first line stays.
+		// Cosmetic in a one-line error, and pinned so it does not drift.
+		"  padded  \nnext": "padded  ",
+		"only":             "only",
+		"":                 "",
+		"\n\n\n":           "",
+		"\n\nreal message": "real message",
+	}
+	for in, want := range tests {
+		if got := firstLine(in); got != want {
+			t.Errorf("firstLine(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// writeLastEdit must fail loudly when it cannot write. `hyctl review` with no
+// arguments reads that file, so losing it silently means the user reviews
+// nothing and is told the tree is clean.
+func TestWriteLastEdit_UnwritableLogDirIsAnError(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	// ~/.hydra is a regular file, so logs/ cannot be created.
+	if err := os.WriteFile(config.Dir(), []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeLastEdit("/abs/f.go", "SIMPLE", "ws", 1, 0); err == nil {
+		t.Error("writeLastEdit reported success with an uncreatable logs directory")
+	}
+}
+
+// logEdit is best-effort: an edit that succeeded must not be reported as failed
+// because its observability record could not be written.
+func TestLogEdit_IsBestEffort(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	// Nothing to write into, and nothing may panic or block.
+	if err := os.WriteFile(config.Dir(), []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	logEdit(Request{File: "/abs/f.go", RunID: "run-x", TaskID: "task-x"},
+		"before", "after", 1, 0)
+}
+
+// diffStats prefers git when there is a repository, since git knows about
+// staged and committed state that a .hydra-bak does not.
+func TestDiffStats_UsesGitInARepository(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if !s.AllowHostBinary(t, "git") {
+		t.Skip("git is not installed on this machine")
+	}
+
+	repo := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "t"},
+		{"config", "core.autocrlf", "false"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", repo}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	file := filepath.Join(repo, "a.go")
+	if err := os.WriteFile(file, []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "a.go"}, {"commit", "-qm", "init"}} {
+		if out, err := exec.Command("git", append([]string{"-C", repo}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+	if err := os.WriteFile(file, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	added, removed := diffStats(file, "one\n", repo, file+".hydra-bak", true)
+	if added != 2 || removed != 0 {
+		t.Errorf("diffStats = (%d, %d), want (2, 0) from git's own numstat", added, removed)
+	}
+}

--- a/internal/provider/port/provider_test.go
+++ b/internal/provider/port/provider_test.go
@@ -304,3 +304,116 @@ func TestServiceAddrs_DeriveFromTheirBases(t *testing.T) {
 		t.Errorf("lmstudio addr with no port = %q, want localhost:1234", got)
 	}
 }
+
+// Each probe reads a different vendor's response shape. A non-200, an
+// unparsable body or an empty catalogue must each yield no heads rather than a
+// head Hydra cannot drive — discovery reporting something that is not there is
+// the #248 defect class.
+func TestProbes_RejectBadResponses(t *testing.T) {
+	caps, err := capabilities.Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"server error", http.StatusInternalServerError, ``},
+		{"not found", http.StatusNotFound, `{}`},
+		{"unparsable body", http.StatusOK, `{truncated`},
+		{"empty catalogue", http.StatusOK, `{"models":[],"data":[]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			for _, svc := range []portService{
+				&ollamaService{base: srv.URL},
+				&lmStudioService{base: srv.URL},
+			} {
+				heads, err := svc.probe(context.Background(), caps)
+				if len(heads) != 0 {
+					t.Errorf("%T returned %d heads for a %s response: %+v",
+						svc, len(heads), tt.name, heads)
+				}
+				if tt.status != http.StatusOK && err == nil {
+					t.Errorf("%T reported success on HTTP %d", svc, tt.status)
+				}
+			}
+		})
+	}
+
+	// Nothing listening at all: an error, not a silent empty success that
+	// looks the same as "the server is up and has no models".
+	for _, svc := range []portService{
+		&ollamaService{base: "http://127.0.0.1:1"},
+		&lmStudioService{base: "http://127.0.0.1:1"},
+	} {
+		if heads, err := svc.probe(context.Background(), caps); err == nil {
+			t.Errorf("%T reported success against a dead port: %+v", svc, heads)
+		}
+	}
+}
+
+// LM Studio speaks the OpenAI catalogue shape, Ollama its own. Each head must
+// carry the address it was actually found at — the executor dials it later, so
+// a head discovered at one address and stamped with another fails at the point
+// of use (#282).
+func TestProbes_StampTheAddressTheyWereFoundAt(t *testing.T) {
+	caps, err := capabilities.Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"models":[{"name":"qwen2.5-coder:7b"},{"name":"llama3.2:3b"}]}`))
+	}))
+	defer ollama.Close()
+
+	heads, err := (&ollamaService{base: ollama.URL}).probe(context.Background(), caps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 2 {
+		t.Fatalf("got %d heads, want one per model", len(heads))
+	}
+	for _, h := range heads {
+		if h.Endpoint != ollama.URL {
+			t.Errorf("%s is stamped with %q but was found at %q; the executor "+
+				"dials the stamp (#282)", h.ID, h.Endpoint, ollama.URL)
+		}
+		if !h.LocalOnly {
+			t.Errorf("%s is not marked local; it would not sit at the terminal tier", h.ID)
+		}
+		if h.CapScore <= 0 {
+			t.Errorf("%s has no capability score, so it cannot be ranked", h.ID)
+		}
+	}
+
+	lms := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":"mistral-7b-instruct"}]}`))
+	}))
+	defer lms.Close()
+
+	lmHeads, err := (&lmStudioService{base: lms.URL}).probe(context.Background(), caps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lmHeads) != 1 {
+		t.Fatalf("got %d LM Studio heads, want 1", len(lmHeads))
+	}
+	if lmHeads[0].Endpoint != lms.URL {
+		t.Errorf("LM Studio head stamped with %q, found at %q", lmHeads[0].Endpoint, lms.URL)
+	}
+	// The two services must not collide in the head-id namespace.
+	if lmHeads[0].ID == heads[0].ID {
+		t.Error("an LM Studio head and an Ollama head share an id")
+	}
+}

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -36,8 +36,16 @@ var normalisers = []struct {
 	{regexp.MustCompile(`\bv?\d+\.\d+\.\d+(-[0-9A-Za-z.\-]+)?(\+[0-9A-Za-z.\-]+)?\b`), "<ver>"},
 	// Git short SHAs (7-12 hex). Longer runs of hex are content, not a commit.
 	{regexp.MustCompile(`\b[0-9a-f]{7,12}\b`), "<sha>"},
-	// RFC3339 timestamps.
+	// RFC3339 timestamps. Must run before the bare-date rule below, or the
+	// date half would be substituted and the time half left behind.
 	{regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}T[\d:.]+(Z|[+\-]\d{2}:\d{2})`), "<ts>"},
+	// Bare calendar dates: "Today (2026-08-04)".
+	//
+	// Added after the cost summary's golden broke overnight. It pins a date
+	// derived from time.Now(), so the fixture was only ever correct on the day
+	// it was blessed — a test that fails tomorrow, for everyone, with no change
+	// to the code. Normalising it is the fix; re-blessing daily is not.
+	{regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`), "<date>"},
 	// Dollar amounts.
 	{regexp.MustCompile(`\$\d+\.\d+`), "<usd>"},
 }

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -668,14 +668,21 @@ func containsAny(s string, subs ...string) bool {
 	return false
 }
 
+// truncate bounds a label to n display cells.
+//
+// Counted in runes, not bytes. Slicing a string at a byte offset cuts a
+// multi-byte rune in half: "日本語モデル" truncated to 8 came out as
+// "日本\xe8…", which a terminal draws as a replacement character in the header
+// bar. cmd/hydra's truncLabel already counted runes; this one did not.
 func truncate(s string, n int) string {
-	if len(s) <= n {
+	r := []rune(s)
+	if len(r) <= n {
 		return s
 	}
 	if n <= 1 {
-		return s[:n]
+		return string(r[:n])
 	}
-	return s[:n-1] + "…"
+	return string(r[:n-1]) + "…"
 }
 
 // headSummary names the discovered heads for the header, truncated to keep the

--- a/internal/tui/cockpit_interaction_test.go
+++ b/internal/tui/cockpit_interaction_test.go
@@ -3,14 +3,20 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
+	"github.com/ankit373/hydra/internal/testutil"
+	"github.com/ankit373/hydra/internal/tree"
 )
 
 // The cockpit's command bar is how a user drives `hyctl tui`. Every command it
@@ -504,5 +510,253 @@ func TestCkStateStyle_CoversEveryState(t *testing.T) {
 	}
 	if ckStateStyle("running").GetForeground() == ckStateStyle("pending").GetForeground() {
 		t.Error("a running agent is coloured identically to a pending one")
+	}
+}
+
+// Tab cycles the views, and the arrow keys only move the tree selection while
+// the tree is the view being shown — otherwise a stray arrow in the chat pane
+// silently moves a selection the user cannot see.
+func TestCockpit_KeyBindings(t *testing.T) {
+	m := NewCockpit()
+	m.treeRows = make([]tree.Row, 4)
+
+	start := m.view
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	if next.(Cockpit).view == start {
+		t.Error("tab did not change the view")
+	}
+	// Tab wraps rather than running off the end.
+	c := next.(Cockpit)
+	for i := 0; i < 10; i++ {
+		n, _ := c.Update(tea.KeyMsg{Type: tea.KeyTab})
+		c = n.(Cockpit)
+		if c.view < 0 || c.view >= ckViewCount() {
+			t.Fatalf("tab left view = %d, outside 0..%d", c.view, ckViewCount()-1)
+		}
+	}
+
+	// Arrows in the chat view must not move the tree selection.
+	chat := NewCockpit()
+	chat.view = 0
+	chat.treeRows = make([]tree.Row, 4)
+	n, _ := chat.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if n.(Cockpit).treeSel != 0 {
+		t.Error("an arrow key in the chat view moved a selection the user cannot see")
+	}
+
+	// In the tree view they do, bounded at both ends.
+	treeView := NewCockpit()
+	treeView.view = 2
+	treeView.treeRows = make([]tree.Row, 3)
+	cur := tea.Model(treeView)
+	for i := 0; i < 10; i++ {
+		cur, _ = cur.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if got := cur.(Cockpit).treeSel; got != 2 {
+		t.Errorf("treeSel = %d after running off the bottom of a 3-row tree, want 2", got)
+	}
+	for i := 0; i < 10; i++ {
+		cur, _ = cur.Update(tea.KeyMsg{Type: tea.KeyUp})
+	}
+	if got := cur.(Cockpit).treeSel; got != 0 {
+		t.Errorf("treeSel = %d after running off the top, want 0", got)
+	}
+
+	// Text editing: runes accumulate, space is a rune, backspace removes one,
+	// escape clears. Backspace on an empty line must not underflow the slice.
+	edit := tea.Model(NewCockpit())
+	edit = typedModel(edit, "abc")
+	edit, _ = edit.Update(tea.KeyMsg{Type: tea.KeySpace})
+	edit = typedModel(edit, "d")
+	if got := edit.(Cockpit).input; got != "abc d" {
+		t.Errorf("input = %q, want %q", got, "abc d")
+	}
+	edit, _ = edit.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if got := edit.(Cockpit).input; got != "abc " {
+		t.Errorf("input = %q after backspace", got)
+	}
+	edit, _ = edit.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if got := edit.(Cockpit).input; got != "" {
+		t.Errorf("input = %q after escape, want empty", got)
+	}
+	for i := 0; i < 5; i++ {
+		edit, _ = edit.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	if got := edit.(Cockpit).input; got != "" {
+		t.Errorf("backspace on an empty line produced %q", got)
+	}
+
+	if _, cmd := NewCockpit().Update(tea.KeyMsg{Type: tea.KeyCtrlC}); cmd == nil {
+		t.Error("ctrl+c did not quit")
+	}
+}
+
+func typedModel(m tea.Model, s string) tea.Model {
+	for _, r := range s {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	return m
+}
+
+// The dashboard's numbers are read from the same files `hyctl status` and
+// `hyctl cost` read. Absent or corrupt state must render as unknown, never as
+// a number the user would act on (#189).
+func TestCockpitDashboardReaders_AbsentDataIsUnknownNotZero(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if got := ckClaudePct(); got != 0 {
+		t.Errorf("ckClaudePct() = %d with no state.json, want 0 (rendered as unknown)", got)
+	}
+	if got := ckSpendToday(); got != 0 {
+		t.Errorf("ckSpendToday() = %v with no cost log, want 0", got)
+	}
+
+	dir := filepath.Join(config.Dir(), "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("{truncated"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ckClaudePct(); got != 0 {
+		t.Errorf("ckClaudePct() = %d on corrupt state.json", got)
+	}
+
+	// With real data both must report it — a reader that always says 0 is
+	// indistinguishable from one that works on an empty machine.
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{"claude_pct":73}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ckClaudePct(); got != 73 {
+		t.Errorf("ckClaudePct() = %d with 73 on disk", got)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	row := `{"ts":"` + now + `","tier":1,"model":"m","prompt_tokens":10,` +
+		`"response_tokens":5,"est_cost_usd":0.25}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "cost.jsonl"), []byte(row), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ckSpendToday(); got != 0.25 {
+		t.Errorf("ckSpendToday() = %v with $0.25 spent today", got)
+	}
+}
+
+// classifyTask picks the enum and tier a prompt routes to. Getting it wrong
+// sends architectural work to a 7B local model, or a one-line rename to the
+// most expensive head on the machine.
+func TestClassifyTask_RoutesByWhatTheWorkActuallyIs(t *testing.T) {
+	tests := []struct {
+		task     string
+		mode     string
+		wantEnum string
+		wantTier int
+	}{
+		// --local overrides everything: the point of the flag is that nothing
+		// leaves the machine, whatever the task looks like.
+		{"design a multi-tenant security model", "local", "LOCAL", 10},
+		{"rotate the signing key without breaking live tokens", "", "CORE", 1},
+		{"design the migration", "", "CORE", 1},
+		{"refactor this for a data race", "", "COMPLEX", 3},
+		{"review the concurrency here", "", "COMPLEX", 3},
+		{"add pagination to the users endpoint", "", "STANDARD", 6},
+		{"write a handler test", "", "STANDARD", 6},
+		{"rename x to y", "", "SIMPLE", 8},
+		{"", "", "SIMPLE", 8},
+	}
+	for _, tt := range tests {
+		enum, tier := classifyTask(tt.task, tt.mode)
+		if enum != tt.wantEnum || tier != tt.wantTier {
+			t.Errorf("classifyTask(%q, %q) = (%s, %d), want (%s, %d)",
+				tt.task, tt.mode, enum, tier, tt.wantEnum, tt.wantTier)
+		}
+	}
+
+	// A long prompt with no keyword is more than trivial, so it must not land
+	// at the cheapest tier by default.
+	long := strings.Repeat("please do the thing carefully ", 5)
+	enum, tier := classifyTask(long, "")
+	if tier >= 8 {
+		t.Errorf("a %d-character prompt classified as %s/tier %d — length alone "+
+			"should lift it above trivial", len(long), enum, tier)
+	}
+
+	// Every classification must name a routable tier.
+	for _, tt := range tests {
+		if _, tier := classifyTask(tt.task, tt.mode); tier < 1 || tier > 10 {
+			t.Errorf("classifyTask(%q) produced tier %d, outside 1..10", tt.task, tier)
+		}
+	}
+}
+
+// The cockpit lays out three views against whatever terminal it is given. A
+// panel that panics or renders nothing at an awkward width is a blank screen.
+func TestCockpit_RendersAtEveryTerminalSize(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	base := NewCockpit()
+	base.heads = testHeads()
+	m, _ := enter(typed(base, "add pagination to the users endpoint"))
+
+	sizes := []struct{ w, h int }{
+		{0, 0},     // before the first resize
+		{20, 5},    // absurdly small
+		{40, 12},   // too narrow to split chat and code
+		{80, 24},   // the usual
+		{200, 60},  // very wide
+		{500, 200}, // wider than anything real
+	}
+	for _, view := range []int{0, 1, 2} {
+		for _, sz := range sizes {
+			m.view = view
+			m.w, m.h, m.ready = sz.w, sz.h, true
+			out := m.View()
+			if strings.TrimSpace(out) == "" {
+				t.Errorf("view %d rendered nothing at %dx%d", view, sz.w, sz.h)
+			}
+		}
+	}
+
+	// Before the first WindowSizeMsg the model is not ready; it must still
+	// render something rather than a blank terminal.
+	fresh := NewCockpit()
+	if strings.TrimSpace(fresh.View()) == "" {
+		t.Error("the cockpit renders nothing before its first resize")
+	}
+}
+
+// truncate bounds the header and every table label. It must never exceed its
+// budget in *display cells*, and must never cut a rune in half — the header
+// draws model names, which are not all ASCII.
+func TestCockpitTruncate_CountsRunesNotBytes(t *testing.T) {
+	inputs := []string{
+		"",
+		"ab",
+		"a-fairly-long-model-name",
+		strings.Repeat("x", 200),
+		"日本語モデル",                // every rune is 3 bytes
+		"qwen2.5-coder:7b-日本語",  // mixed
+		strings.Repeat("é", 60), // 2 bytes each
+	}
+	for _, n := range []int{0, 1, 2, 5, 8, 46} {
+		for _, s := range inputs {
+			got := truncate(s, n)
+			if r := []rune(got); len(r) > n && len([]rune(s)) > n {
+				t.Errorf("truncate(%q, %d) returned %d runes", s, n, len(r))
+			}
+			// A split rune renders as a replacement character in the header.
+			for _, r := range got {
+				if r == '\uFFFD' {
+					t.Errorf("truncate(%q, %d) = %q — it cut a rune in half", s, n, got)
+					break
+				}
+			}
+		}
+	}
+	if got := truncate("short", 46); got != "short" {
+		t.Errorf("truncate = %q", got)
+	}
+	if got := truncate("日本語モデル", 3); got != "日本…" {
+		t.Errorf("truncate = %q, want the first two runes plus an ellipsis", got)
 	}
 }


### PR DESCRIPTION
## Two real fixes

**The cockpit's `truncate` cut multi-byte runes in half.** It sliced by byte
offset, so `"日本語モデル"` bounded to 8 came out as `"日本\xe8…"` — invalid
UTF-8, which a terminal draws as a replacement character in the header bar.
`cmd/hydra`'s `truncLabel` already counted runes; this one did not. Verified red
against the old implementation before fixing.

**A golden test was pinned to a calendar date.** `internal/cost`'s summary
prints `Today (2026-08-04)` from `time.Now()`, and `testutil.Normalise` only
handled full RFC3339 timestamps — so the fixture was correct on the day it was
blessed and wrong every day after. **It broke overnight during this session, for
no change to the code.** `Normalise` now substitutes bare dates too, ordered
after the RFC3339 rule so a timestamp is not half-replaced. Re-blessing daily
would not have been a fix.

## Coverage

| package | before | after | floor |
|---|---:|---:|---:|
| `internal/provider/port` | 88.3% | **93.3%** | 90 |
| `internal/editor` | 86.3% | **90.6%** | 87 |
| `internal/tui` | 84.7% | **88.5%** | 85 |

**`provider/port`** — each probe reads a different vendor's response shape, so a
non-200, an unparsable body, an empty catalogue and a dead port must each yield
*no heads* rather than a head Hydra cannot drive (#248). Each head is asserted to
carry the address it was actually found at: the executor dials the stamp, so a
head discovered at one address and stamped with another fails at the point of
use (#282).

**`editor`** — `marker_parse_failed` on a new file is distinguished from
`empty_replacement` on an existing one; there is nothing to preserve, and the
file must not be created. An unwritable target is reported rather than silently
dropped, and `logEdit` is confirmed best-effort so an edit that succeeded is
never reported as failed because its observability record could not be written.

**`tui`** — the key bindings (tab wrapping, arrows only moving the tree
selection while the tree is the visible view, backspace not underflowing an
empty line), `classifyTask`'s routing table, the dashboard readers rendering
absent data as unknown rather than as a number (#189), and all three views laid
out at six terminal sizes from 0×0 up.

## A note on the ratchet advisory

Running the gate on a Mac prints `consider ratcheting` for `internal/sysinfo`
every time. That is comparing a macOS measurement (94.5%) against a Linux floor
(82), and acting on it would break CI — sysinfo reads `darwinRAM` on one
platform and `/proc` on the other. Now written into
`ci/coverage-floors.txt` so the next person does not act on it.

Part of #308.