### PR TITLE
fix(tui): the cockpit previewed a route to a head nothing can drive

### DIFF
--- a/ci/coverage-floors.txt
+++ b/ci/coverage-floors.txt
@@ -90,4 +90,8 @@ no-tests cmd/specstest    debug main; the logic it prints is covered in internal
 # three-OS matrix where every awkward test skips on two of them is decorative.
 # Each skip must carry a reason, and the total cannot grow without this number
 # being edited — which a reviewer sees.
-skip-budget 32
+# Raised from 32 when the oracle's {file}-staging test landed: it needs
+# /bin/test, which is POSIX, and the staging contract it guards is covered on
+# every platform by TestDefaultWriteTemp. Raising this is the deliberate act the
+# gate exists to force — the increase is in the diff.
+skip-budget 34

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/ankit373/hydra/internal/trust"
@@ -101,5 +102,75 @@ func TestLLR_CalibratedVerifierDominates(t *testing.T) {
 	}
 	if pass <= modelPass {
 		t.Errorf("calibrated verifier (%.3f) should dominate a middling model (%.3f)", pass, modelPass)
+	}
+}
+
+// defaultWriteTemp materialises the candidate for a {file} oracle. Its failure
+// paths matter because an oracle that cannot stage its input must report that,
+// not return a verdict — a verdict drawn from nothing is confident false
+// evidence, and an oracle's LLR outweighs several models' votes.
+func TestDefaultWriteTemp(t *testing.T) {
+	path, cleanup, err := defaultWriteTemp("the candidate answer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the temp file was not written: %v", err)
+	}
+	if string(raw) != "the candidate answer" {
+		t.Errorf("content = %q", raw)
+	}
+	cleanup()
+	if _, err := os.Stat(path); err == nil {
+		t.Error("cleanup left the temp file behind; every {file} verification " +
+			"would leak one")
+	}
+
+	// An unwritable temp directory must be an error rather than a verdict.
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMPDIR", blocker)
+	if p, c, err := defaultWriteTemp("x"); err == nil {
+		if c != nil {
+			c()
+		}
+		t.Errorf("defaultWriteTemp succeeded at %q with an unusable TMPDIR", p)
+	}
+}
+
+// A {file} oracle must actually receive the candidate on disk, and the file
+// must be gone afterwards.
+func TestCommandOracle_FileTemplateStagesAndCleansUp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/bin/test is POSIX; the staging contract is covered by " +
+			"TestDefaultWriteTemp on every platform")
+	}
+
+	var staged string
+	o := &CommandOracle{
+		Template: "/bin/test -s {file}",
+		Source:   "verifier:test",
+		writeTemp: func(content string) (string, func(), error) {
+			p, c, err := defaultWriteTemp(content)
+			staged = p
+			return p, c, err
+		},
+	}
+
+	v, err := o.Verify(context.Background(), "some content", trust.Task{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !v.Passed {
+		t.Errorf("a non-empty staged file failed `test -s`: %+v", v)
+	}
+	if staged == "" {
+		t.Fatal("nothing was staged")
+	}
+	if _, err := os.Stat(staged); err == nil {
+		t.Error("the staged file survived the verification")
 	}
 }

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -128,11 +128,18 @@ func TestDefaultWriteTemp(t *testing.T) {
 	}
 
 	// An unwritable temp directory must be an error rather than a verdict.
+	//
+	// All three variables: os.TempDir reads $TMPDIR on unix and %TMP%/%TEMP% on
+	// Windows. Setting only TMPDIR made this pass everywhere and assert nothing
+	// on the Windows runner, where the write simply succeeded in the real temp
+	// directory.
 	blocker := filepath.Join(t.TempDir(), "not-a-dir")
 	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("TMPDIR", blocker)
+	for _, v := range []string{"TMPDIR", "TMP", "TEMP"} {
+		t.Setenv(v, blocker)
+	}
 	if p, c, err := defaultWriteTemp("x"); err == nil {
 		if c != nil {
 			c()

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -368,7 +368,7 @@ func (m Cockpit) run(task string) Cockpit {
 	// a machine with nothing installed. There is no route to preview then, and
 	// inventing one is exactly what this PR removes.
 	if idx < 0 {
-		m.log = append(m.log, ckDimS.Render("  no heads discovered — run `hyctl probe` to see why"))
+		m.log = append(m.log, ckDimS.Render("  no routable head — run `hyctl probe` to see why"))
 		return m
 	}
 	h := m.heads[idx]
@@ -449,7 +449,12 @@ func (m Cockpit) pickHead(wantTier int) int {
 				return i
 			}
 		}
-		return len(m.heads) - 1 // -1 when the roster is empty; callers must check
+		// Nothing is routable. This used to fall back to the last head in the
+		// roster whether or not it was up, so a machine with only an
+		// unroutable head — the ollama binary with no server behind it — got a
+		// routing preview naming a head nothing can drive. Same shape as #248:
+		// a surface claiming a head is usable when it is not.
+		return -1
 	}
 	return best
 }

--- a/internal/tui/cockpit_interaction_test.go
+++ b/internal/tui/cockpit_interaction_test.go
@@ -122,7 +122,7 @@ func TestCockpit_NoHeadsDiscoveredSaysSoAndStreamsNothing(t *testing.T) {
 
 	m, _ := enter(typed(before, "add pagination"))
 	joined := strings.Join(m.log, "\n")
-	if !strings.Contains(joined, "no heads discovered") {
+	if !strings.Contains(joined, "no routable head") {
 		t.Errorf("the log does not say why nothing was routed:\n%s", joined)
 	}
 	if !strings.Contains(joined, "hyctl probe") {
@@ -758,5 +758,93 @@ func TestCockpitTruncate_CountsRunesNotBytes(t *testing.T) {
 	}
 	if got := truncate("日本語モデル", 3); got != "日本…" {
 		t.Errorf("truncate = %q, want the first two runes plus an ellipsis", got)
+	}
+}
+
+// pickHead is the cockpit's own routing: the cheapest head at or below the
+// wanted strength, falling back down the ladder. It must never answer
+// "cheapest" with "most expensive" — the same inversion #165 fixed in the
+// router itself.
+func TestPickHead_NeverAnswersCheapestWithStrongest(t *testing.T) {
+	m := NewCockpit()
+	m.heads = []ckHead{
+		{id: "opus", name: "opus", tier: 1, up: true},
+		{id: "sonnet", name: "sonnet", tier: 3, up: true},
+		{id: "qwen", name: "qwen", tier: 10, up: true},
+	}
+
+	// Asking for the cheapest tier must land on the local head.
+	if got := m.pickHead(10); got < 0 || m.heads[got].id != "qwen" {
+		t.Errorf("pickHead(10) = %d (%v), want the local head", got, m.heads)
+	}
+	// Asking for tier 3 must not escalate to tier 1.
+	if got := m.pickHead(3); m.heads[got].tier < 3 {
+		t.Errorf("pickHead(3) selected tier %d — stronger than requested",
+			m.heads[got].tier)
+	}
+	// Asking for tier 1 gets tier 1.
+	if got := m.pickHead(1); m.heads[got].id != "opus" {
+		t.Errorf("pickHead(1) = %s", m.heads[got].id)
+	}
+
+	// A head that is down is not selectable, and the search falls to the
+	// terminal tier rather than picking it anyway.
+	m.heads[2].up = false
+	if got := m.pickHead(10); got >= 0 && m.heads[got].id == "qwen" {
+		t.Error("pickHead selected a head that is down")
+	}
+
+	// With everything down there is nothing to route to. Returning an index
+	// anyway would have the cockpit preview a route to a head nothing can
+	// drive — the same shape as #248.
+	for i := range m.heads {
+		m.heads[i].up = false
+	}
+	if got := m.pickHead(1); got >= 0 {
+		t.Errorf("pickHead = %d with every head down; the cockpit would preview a "+
+			"route to %q, which nothing can execute", got, m.heads[got].id)
+	}
+
+	empty := NewCockpit()
+	empty.heads = nil
+	if got := empty.pickHead(1); got >= 0 {
+		t.Errorf("pickHead on an empty roster = %d, want a negative index so the "+
+			"caller's guard fires", got)
+	}
+}
+
+// A prompt naming a file that is in the graph gets a real blast radius; one
+// naming a file that is not gets none, rather than a fabricated figure (#193).
+func TestCockpitRun_BlastRadiusOnlyForFilesTheGraphKnows(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	base := NewCockpit()
+	base.heads = testHeads()
+
+	withFile, _ := enter(typed(base, "rotate the key in internal/nowhere/absent.go"))
+	joined := strings.Join(withFile.log, "\n")
+	// No graph is loaded in a sandbox, so there is nothing to report — and a
+	// literal blast line for any prompt containing a path is exactly what #193
+	// removed.
+	if strings.Contains(joined, "κ=") {
+		t.Errorf("a blast radius was printed for a file no graph knows:\n%s", joined)
+	}
+	if !strings.Contains(joined, "routing preview only") {
+		t.Errorf("the run did not complete:\n%s", joined)
+	}
+}
+
+// The header carries the governor percentage and the head roster. It must
+// render at any width without wrapping past its budget.
+func TestCockpitHeader_RendersAtEveryWidth(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := NewCockpit()
+	m.heads = testHeads()
+	for _, w := range []int{0, 10, 40, 80, 200} {
+		m.w, m.h, m.ready = w, 24, true
+		if got := m.header(); strings.TrimSpace(got) == "" {
+			t.Errorf("header rendered nothing at width %d", w)
+		}
 	}
 }


### PR DESCRIPTION
## The fix

`pickHead` falls back down the tier ladder, and when nothing was routable it
returned `len(m.heads) - 1` — the last head in the roster, up or not. Its own
comment said callers must check for a negative index, but a negative index was
only ever returned for an **empty** roster.

So on a machine whose only head is unroutable — the `ollama` binary discovered
on `$PATH` with no server behind it — the cockpit printed a routing preview
naming it.

That is the #248 shape exactly: a surface claiming a head is usable when nothing
can execute it. It now returns `-1`, which `run()` already handles, and the
message says **"no routable head"** rather than "no heads discovered" — they
*were* discovered, which is why pointing at `hyctl probe` is the right advice
(probe marks unroutable heads with ✗ and the reason).

Verified red against the old implementation:

```
--- FAIL: TestPickHead_NeverAnswersCheapestWithStrongest
    pickHead selected a head that is down
    pickHead = 2 with every head down; the cockpit would preview a route to
    "qwen", which nothing can execute
```

## Also covered

- **`pickHead`'s ordering contract** — asking for the cheapest tier must never
  answer with the strongest, the same inversion #165 fixed in the router itself.
- **The blast-radius branch** fires only for a file the graph actually knows,
  which is what #193 removed the literal version of.
- **The header** renders at every width from 0 up.
- **The oracle's `{file}` staging** — the candidate reaches disk, and the temp
  file is gone afterwards rather than leaking one per verification.

## Skip budget: 32 → 34

For the oracle's POSIX `/bin/test` case. **That raise is the deliberate act the
gate exists to force** — the increase is in this diff with the reason next to
it, which is exactly how it is supposed to work.

Part of #308.