### PR TITLE
feat(docs,install): install-app.sh + a real page for the desktop app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,9 +187,14 @@ jobs:
 
       # Only fail on real errors (SC severity=error).
       # Warnings and style hints are surfaced but don't block the PR.
+      #
+      # Both installers are piped straight into `sh` by users following the
+      # README, so a syntax error here reaches them mid-install. Naming them
+      # explicitly rather than globbing keeps that intent visible — and is why
+      # a new installer must be added to this list, not just written.
       - name: Lint shell scripts
         run: |
-          shellcheck --severity=error install.sh
+          shellcheck --severity=error install.sh install-app.sh
 
   # install.ps1's counterpart to the shellcheck job above. It runs on Windows
   # because that is where PowerShell's own parser lives — and because nobody

--- a/README.md
+++ b/README.md
@@ -668,7 +668,19 @@ persistent chat dock.
 It reads `~/.hydra/logs/` directly. No daemon, no telemetry, and its numbers are the CLI's numbers:
 Dashboard totals are asserted equal to `hyctl cost` and `hyctl stats` for the same data.
 
-**Download** — every release carries a build for each platform, on the
+**Install** — macOS and Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh | sh
+```
+
+It resolves the newest release (the asset names embed their version, so GitHub's `/latest/download/`
+shortcut cannot address them), verifies the download against the published `.sha256`, installs the
+`.app` to `/Applications` — or the binary to `~/.local/share/hydra` with a `~/.local/bin` symlink on
+Linux — and clears the macOS quarantine flag so the first launch works. `HYDRA_VERSION=v1.1.0` pins
+a release; `HYDRA_APP_DIR` changes where it lands.
+
+**Or take the artifact directly**, from the
 [releases page](https://github.com/ankit373/hydra/releases/latest):
 
 | platform | artifact |

--- a/docs/app.html
+++ b/docs/app.html
@@ -185,12 +185,39 @@ table.mini td.n{text-align:right;color:var(--ink);}
 .feat .tag{font-family:var(--mono);font-size:9.5px;letter-spacing:1.4px;text-transform:uppercase;
   color:var(--aqua);margin-bottom:9px;}
 .feat p{font-size:14px;color:var(--dim);margin:0;}
-.dl{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:14px;margin-top:30px;}
-.dl a{display:block;border:1px solid var(--line);border-radius:10px;padding:18px 20px;background:var(--panel);
-  transition:.18s;color:var(--ink);}
-.dl a:hover{border-color:var(--aqua);text-decoration:none;transform:translateY(-2px);}
-.dl .os{font-family:var(--display);font-size:17px;margin-bottom:4px;}
+/* ── install command ───────────────────────────────────────────────────── */
+.term{font-family:var(--mono);font-size:12.5px;background:#070912;border:1px solid var(--line);border-radius:9px;
+  padding:13px 15px;color:#c7d0e8;overflow-x:auto;}
+.term .p{color:var(--aqua);}.term .c{color:var(--faint);}.term .o{color:var(--dim);}
+.term .g{color:var(--cheap);}
+.copyline{display:flex;align-items:center;gap:14px;justify-content:space-between;cursor:pointer;}
+.copyline .cp{font-size:10.5px;color:var(--faint);transition:.15s;flex-shrink:0;}
+.copyline:hover .cp{color:var(--aqua);}
+.copyline.copied .cp{color:var(--cheap);}
+.term .o{margin-top:2px;}
+
+/* ── direct downloads ──────────────────────────────────────────────────── */
+.dl{margin-top:18px;border:1px solid var(--line);border-radius:11px;overflow:hidden;background:var(--panel);}
+.dl .row{display:grid;grid-template-columns:145px 1fr auto auto auto;gap:20px;align-items:center;
+  padding:13px 18px;border-top:1px solid var(--line);}
+.dl .row:first-child{border-top:0;}
+.dl .row.off{opacity:.55;}
+.dl .os{font-family:var(--display);font-size:15px;}
 .dl .meta{font-family:var(--mono);font-size:11px;color:var(--faint);}
+.dl .sz{font-family:var(--mono);font-size:11px;color:var(--faint);text-align:right;}
+.dl .get{font-family:var(--mono);font-size:11.5px;border:1px solid var(--line-2);border-radius:7px;
+  padding:6px 14px;color:var(--aqua);white-space:nowrap;transition:.16s;}
+.dl .get:hover{background:var(--aqua);color:#06070F;text-decoration:none;border-color:var(--aqua);}
+.dl .sum{font-family:var(--mono);font-size:10.5px;color:var(--faint);white-space:nowrap;}
+.dl .sum:hover{color:var(--aqua);}
+@media(max-width:760px){
+  .dl .row{grid-template-columns:1fr auto;gap:5px 14px;}
+  .dl .os{grid-column:1;grid-row:1;}
+  .dl .meta{grid-column:1;grid-row:2;}
+  .dl .sz{grid-column:1;grid-row:3;text-align:left;}
+  .dl .get{grid-column:2;grid-row:1/3;align-self:center;}
+  .dl .sum{grid-column:2;grid-row:3;text-align:right;}
+}
 .note{border-left:2px solid var(--line-2);padding:10px 0 10px 16px;margin-top:26px;color:var(--dim);font-size:14px;}
 .note b{color:var(--ink);}
 footer{border-top:1px solid var(--line);padding:34px 0 56px;color:var(--faint);
@@ -431,45 +458,75 @@ footer a{color:var(--dim);}
 <!-- ══ DOWNLOAD ════════════════════════════════════════════════════════ -->
 <section class="blk wrap" id="download">
   <div class="klabel"><span>Download</span><b>free · MIT · no sign-up</b></div>
-  <h2>Built and published with <span class="grad">every release</span>.</h2>
+  <h2>One command on <span class="grad">macOS and Linux</span>.</h2>
   <p>
-    Each build is attached to its GitHub release with a SHA-256 checksum beside it.
-    The app expects <span class="mono">hyctl</span> to be installed — it reads the
-    logs the CLI writes, so install that first if you have not.
+    It resolves the newest release, checks the download against the SHA-256 published
+    beside it, and refuses to install on a mismatch. Nothing runs as root and nothing
+    is written outside your applications directory.
   </p>
 
+  <div class="term" style="margin-top:22px;">
+    <div class="copyline" data-copy="curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh | sh"><span><span class="p">$</span> curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh | sh</span><span class="cp">copy</span></div>
+    <div class="o">&nbsp;&nbsp;Release&nbsp;: <span class="g">v1.1.0</span></div>
+    <div class="o">&nbsp;&nbsp;Target&nbsp;&nbsp;: darwin_universal</div>
+    <div class="o">&nbsp;&nbsp;Checksum: <span class="g">verified</span></div>
+    <div class="o">&nbsp;&nbsp;Installed: /Applications/Hydra.app</div>
+  </div>
+  <p style="font-size:13.5px;color:var(--faint);margin-top:12px;">
+    Pin a version with <span class="mono">HYDRA_VERSION=v1.1.0</span>, or change where it
+    lands with <span class="mono">HYDRA_APP_DIR=~/Applications</span>.
+    <a href="https://github.com/ankit373/hydra/blob/main/install-app.sh">Read the script</a>
+    before you pipe it to a shell — it is under 200 lines and you should.
+  </p>
+
+  <h3 style="font-family:var(--display);font-size:19px;margin-top:40px;">Or take the binary directly</h3>
   <div class="dl">
-    <a href="https://github.com/ankit373/hydra/releases/latest">
+    <div class="row">
       <div class="os">macOS</div>
       <div class="meta">universal · Apple Silicon + Intel</div>
-    </a>
-    <a href="https://github.com/ankit373/hydra/releases/latest">
+      <div class="sz">8.3 MB</div>
+      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.1.0/hydra-desktop_v1.1.0_darwin_universal.zip">.zip</a>
+      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.1.0/hydra-desktop_v1.1.0_darwin_universal.zip.sha256">sha256</a>
+    </div>
+    <div class="row">
       <div class="os">Linux</div>
-      <div class="meta">x86-64 · tar.gz</div>
-    </a>
-    <a href="https://github.com/ankit373/hydra/releases/latest">
+      <div class="meta">x86-64</div>
+      <div class="sz">4.3 MB</div>
+      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.1.0/hydra-desktop_v1.1.0_linux_amd64.tar.gz">.tar.gz</a>
+      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.1.0/hydra-desktop_v1.1.0_linux_amd64.tar.gz.sha256">sha256</a>
+    </div>
+    <div class="row">
       <div class="os">Windows</div>
-      <div class="meta">x86-64 · zip</div>
-    </a>
+      <div class="meta">x86-64 · unzip and run Hydra.exe</div>
+      <div class="sz">4.8 MB</div>
+      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.1.0/hydra-desktop_v1.1.0_windows_amd64.zip">.zip</a>
+      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.1.0/hydra-desktop_v1.1.0_windows_amd64.zip.sha256">sha256</a>
+    </div>
+    <div class="row off">
+      <div class="os">Linux ARM64</div>
+      <div class="meta">not built yet — <a href="https://github.com/ankit373/hydra/issues/263">#263</a></div>
+      <div class="sz">—</div>
+      <div class="sum"></div>
+      <div class="sum"></div>
+    </div>
+  </div>
+  <p style="font-size:13px;color:var(--faint);margin-top:12px;font-family:var(--mono);">
+    v1.1.0 · <a href="https://github.com/ankit373/hydra/releases">all releases</a>
+  </p>
+
+  <div class="note">
+    <b>Not code-signed yet.</b> The build carries no Apple Developer signature, so
+    macOS quarantines it and the first launch fails with "damaged". The install
+    script clears that flag for you; if you unzipped it by hand, run
+    <span class="mono">xattr -dr com.apple.quarantine /Applications/Hydra.app</span>
+    or right-click → Open. Gatekeeper is telling you the truth: nobody has paid
+    Apple to vouch for this. The checksum is what you can verify instead.
   </div>
 
   <div class="note">
-    <b>Not code-signed yet.</b> On macOS the first launch needs right-click →
-    Open, because the build carries no Apple Developer signature. Gatekeeper is
-    telling you the truth: nobody has paid Apple to vouch for it. The checksum
-    beside each download is what you can verify instead.
-  </div>
-
-  <div class="note">
-    <b>ARM64 Linux and Windows are not built yet.</b> The CLI ships for both; the
-    desktop app does not, and we would rather say so than let you download
-    something that will not start. Progress is tracked in
-    <a href="https://github.com/ankit373/hydra/issues/263">issue #263</a>.
-  </div>
-
-  <div class="note">
-    <b>Don't have the CLI yet?</b>
-    <span class="mono">brew install ankit373/tap/hyctl</span> — or see
+    <b>Install the CLI too.</b> The app reads the logs <span class="mono">hyctl</span>
+    writes — without it there is nothing to show and the app will look empty rather
+    than unconfigured. <span class="mono">brew install ankit373/hydra/hyctl</span>, or
     <a href="/#start">the other install paths</a>.
   </div>
 </section>
@@ -482,6 +539,33 @@ footer a{color:var(--dim);}
     MIT licensed · runs on your machine
   </div>
 </footer>
+
+<script>
+// Copy-to-clipboard on the install command. Same behaviour as the landing page;
+// kept as its own copy because this page ships no other JS and pulling in a
+// shared bundle for eight lines would cost a request.
+(function(){
+  function copy(text,done){
+    if(navigator.clipboard&&navigator.clipboard.writeText){navigator.clipboard.writeText(text).then(done,done);return;}
+    try{var ta=document.createElement('textarea');ta.value=text;ta.style.position='fixed';ta.style.opacity=0;
+      document.body.appendChild(ta);ta.select();document.execCommand('copy');document.body.removeChild(ta);}catch(e){}
+    done();
+  }
+  Array.prototype.forEach.call(document.querySelectorAll('[data-copy]'),function(el){
+    el.setAttribute('role','button');el.setAttribute('tabindex','0');
+    function fire(){
+      copy(el.getAttribute('data-copy'),function(){
+        el.classList.add('copied');
+        var cp=el.querySelector('.cp'),prev=cp?cp.textContent:'';
+        if(cp)cp.textContent='✓ copied';
+        setTimeout(function(){el.classList.remove('copied');if(cp)cp.textContent=prev;},1400);
+      });
+    }
+    el.addEventListener('click',fire);
+    el.addEventListener('keydown',function(e){if(e.key==='Enter'||e.key===' '){e.preventDefault();fire();}});
+  });
+})();
+</script>
 
 </body>
 </html>

--- a/docs/app.html
+++ b/docs/app.html
@@ -1,0 +1,487 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hydra Desktop — watch every agent, every dollar, live</title>
+  <meta name="description" content="The Hydra desktop app: four views over your local control plane — Dashboard, Fleet, Session, Code. See what each agent is doing and what it costs, as it happens. macOS, Linux and Windows.">
+  <meta name="keywords" content="AI agent dashboard, LLM cost dashboard, desktop app, multi-model orchestration UI, agent monitoring, Hydra desktop">
+
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://hydra.uvansa.com/app.html">
+  <meta property="og:title" content="Hydra Desktop — watch every agent, every dollar, live">
+  <meta property="og:description" content="Four views over your local control plane: Dashboard, Fleet, Session, Code. Free, open source, runs entirely on your machine.">
+  <meta property="og:image" content="https://hydra.uvansa.com/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@ankit373">
+  <meta name="twitter:title" content="Hydra Desktop — watch every agent, every dollar, live">
+  <meta name="twitter:description" content="Four views over your local control plane. See what each agent is doing and what it costs, as it happens.">
+  <meta name="twitter:image" content="https://hydra.uvansa.com/logo.png">
+
+  <link rel="canonical" href="https://hydra.uvansa.com/app.html">
+  <link rel="icon" type="image/png" href="logo.png">
+  <link rel="ai-context" href="https://hydra.uvansa.com/llms.txt" type="text/plain">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Hydra Desktop",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "macOS, Linux, Windows",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "license": "https://opensource.org/licenses/MIT",
+    "url": "https://hydra.uvansa.com/app.html",
+    "downloadUrl": "https://github.com/ankit373/hydra/releases/latest",
+    "isPartOf": { "@type": "SoftwareApplication", "name": "Hydra", "url": "https://hydra.uvansa.com/" }
+  }
+  </script>
+
+<style>
+@font-face{font-family:"Space Grotesk";font-style:normal;font-weight:400 700;font-display:swap;
+  src:url("fonts/SpaceGrotesk.woff2") format("woff2");}
+@font-face{font-family:"JetBrains Mono";font-style:normal;font-weight:400 700;font-display:swap;
+  src:url("fonts/JetBrainsMono.woff2") format("woff2");}
+
+/* Tokens are copied from the same source the desktop app itself uses
+   (desktop/frontend/src/tokens.css) so this page and the app cannot drift
+   into looking like two different products. */
+:root{
+  color-scheme:dark;
+  --bg:#06070F;--bg2:#0A0C18;--panel:rgba(18,20,38,.62);
+  --line:rgba(150,140,255,.16);--line-2:rgba(150,140,255,.30);
+  --ink:#E7E9F5;--dim:#9aa0c4;--faint:#5a5f85;
+  --cyan:#2AF0E0;--aqua:#00E6C3;--violet:#8B5CF6;--magenta:#E852C8;
+  --cheap:#3FD98A;--mid:#E0A93A;--exp:#FF5A6E;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,Roboto,Helvetica,Arial,sans-serif;
+  --mono:"JetBrains Mono",ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace;
+  --display:"Space Grotesk",system-ui,sans-serif;
+  --maxw:1200px;
+}
+*{box-sizing:border-box;}
+html{scroll-behavior:smooth;}
+@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55;
+  overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px;}
+h1,h2,h3{margin:0;text-wrap:balance;}
+a{color:var(--aqua);text-decoration:none;}
+a:hover{text-decoration:underline;}
+.mono{font-family:var(--mono);}
+.grad{background:linear-gradient(90deg,var(--cyan),var(--violet),var(--magenta));
+  -webkit-background-clip:text;background-clip:text;color:transparent;}
+
+/* ── top bar ─────────────────────────────────────────────────────────── */
+.topbar{position:sticky;top:0;z-index:60;display:flex;align-items:center;justify-content:space-between;
+  gap:18px;padding:10px 24px;font-family:var(--mono);font-size:12.5px;
+  background:rgba(6,7,15,.55);backdrop-filter:blur(14px);border-bottom:1px solid var(--line);}
+.topbar nav{display:flex;gap:18px;flex-wrap:wrap;}
+.topbar a{color:var(--dim);}
+.topbar a:hover{color:var(--ink);text-decoration:none;}
+.topbar .brand{color:var(--ink);font-weight:700;letter-spacing:.5px;}
+.topbar .ghost{border:1px solid var(--line-2);border-radius:6px;padding:5px 12px;color:var(--ink);}
+
+/* ── hero ────────────────────────────────────────────────────────────── */
+.hero{padding:76px 0 44px;text-align:center;position:relative;overflow:hidden;}
+.hero::before{content:"";position:absolute;inset:-40% 20% auto;height:520px;
+  background:radial-gradient(closest-side,rgba(139,92,246,.20),transparent 70%);pointer-events:none;}
+.klabel{display:inline-flex;gap:8px;align-items:center;font-family:var(--mono);font-size:10.5px;
+  letter-spacing:2px;text-transform:uppercase;color:var(--faint);margin-bottom:18px;}
+.klabel b{color:var(--aqua);font-weight:600;}
+.hero h1{font-family:var(--display);font-size:clamp(34px,6vw,64px);line-height:1.04;letter-spacing:-1.5px;}
+.hero p.lede{max-width:640px;margin:20px auto 0;color:var(--dim);font-size:17px;}
+.cta{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-top:30px;}
+.btn{display:inline-flex;align-items:center;gap:8px;padding:11px 20px;border-radius:8px;
+  font-family:var(--mono);font-size:13px;border:1px solid var(--line-2);color:var(--ink);transition:.15s;}
+.btn:hover{border-color:var(--aqua);text-decoration:none;transform:translateY(-1px);}
+.btn.primary{background:linear-gradient(90deg,var(--cyan),var(--violet));border:none;color:#06070F;font-weight:700;}
+.btn.primary:hover{filter:brightness(1.12);}
+
+/* ── the app preview ─────────────────────────────────────────────────── */
+.stage{margin:52px auto 0;max-width:1000px;padding:0 24px;}
+.win{border:1px solid var(--line-2);border-radius:12px;overflow:hidden;background:var(--bg2);
+  box-shadow:0 40px 120px -30px rgba(139,92,246,.45), 0 0 0 1px rgba(255,255,255,.02) inset;}
+.win-bar{display:flex;align-items:center;gap:8px;padding:9px 14px;border-bottom:1px solid var(--line);
+  background:rgba(10,12,24,.9);}
+.dot{width:10px;height:10px;border-radius:50%;background:#2a2f4a;}
+.dot.r{background:#FF5A6E;}.dot.y{background:#E0A93A;}.dot.g{background:#3FD98A;}
+.win-title{margin-left:10px;font-family:var(--mono);font-size:11px;color:var(--faint);}
+.win-body{display:grid;grid-template-columns:132px 1fr;min-height:376px;}
+.side{border-right:1px solid var(--line);padding:14px 10px;background:rgba(6,7,15,.5);}
+.side .lbl{font-family:var(--mono);font-size:9.5px;letter-spacing:1.6px;color:var(--faint);
+  text-transform:uppercase;padding:0 8px 10px;}
+.nav-item{display:flex;align-items:center;gap:8px;padding:7px 9px;border-radius:6px;
+  font-family:var(--mono);font-size:12px;color:var(--dim);margin-bottom:2px;}
+.nav-item i{width:5px;height:5px;border-radius:50%;background:currentColor;opacity:.5;font-style:normal;}
+.pane{padding:18px 20px;position:relative;}
+
+/* Each pane fades in on its own slice of one 24s loop. Four views, 6s each. */
+.view{position:absolute;inset:18px 20px;opacity:0;animation:cycle 24s infinite;}
+.view:nth-child(1){animation-delay:0s;}
+.view:nth-child(2){animation-delay:6s;}
+.view:nth-child(3){animation-delay:12s;}
+.view:nth-child(4){animation-delay:18s;}
+@keyframes cycle{
+  0%,1%   {opacity:0;transform:translateY(6px);}
+  3%,23%  {opacity:1;transform:none;}
+  25%,100%{opacity:0;transform:translateY(-4px);}
+}
+/* The sidebar highlight tracks the same 24s clock. */
+.nav-item{animation:navlit 24s infinite;}
+.nav-item:nth-of-type(1){animation-delay:0s;}
+.nav-item:nth-of-type(2){animation-delay:6s;}
+.nav-item:nth-of-type(3){animation-delay:12s;}
+.nav-item:nth-of-type(4){animation-delay:18s;}
+@keyframes navlit{
+  0%,1%   {background:transparent;color:var(--dim);}
+  3%,23%  {background:rgba(0,230,195,.10);color:var(--aqua);}
+  25%,100%{background:transparent;color:var(--dim);}
+}
+/* Anyone who has asked the OS to stop moving things gets a static first view. */
+@media(prefers-reduced-motion:reduce){
+  .view,.nav-item{animation:none;}
+  .view{opacity:0;}
+  .view:nth-child(1){opacity:1;}
+  .nav-item:nth-of-type(1){background:rgba(0,230,195,.10);color:var(--aqua);}
+}
+
+.vhead{font-family:var(--display);font-size:15px;margin-bottom:2px;}
+.vsub{font-family:var(--mono);font-size:10.5px;color:var(--faint);margin-bottom:14px;}
+.cards{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-bottom:16px;}
+.card{border:1px solid var(--line);border-radius:8px;padding:10px 12px;background:var(--panel);}
+.card .k{font-family:var(--mono);font-size:9.5px;color:var(--faint);text-transform:uppercase;letter-spacing:1.2px;}
+.card .v{font-family:var(--display);font-size:20px;margin-top:3px;}
+table.mini{width:100%;border-collapse:collapse;font-family:var(--mono);font-size:11.5px;}
+table.mini th{text-align:left;color:var(--faint);font-weight:400;padding:5px 6px;
+  border-bottom:1px solid var(--line);text-transform:uppercase;font-size:9.5px;letter-spacing:1px;}
+table.mini td{padding:5px 6px;border-bottom:1px solid rgba(150,140,255,.07);color:var(--dim);}
+table.mini td.n{text-align:right;color:var(--ink);}
+.bar{height:5px;border-radius:3px;background:rgba(150,140,255,.14);overflow:hidden;}
+.bar i{display:block;height:100%;border-radius:3px;}
+.row{display:flex;align-items:center;gap:10px;padding:8px 6px;border-bottom:1px solid rgba(150,140,255,.07);
+  font-family:var(--mono);font-size:11.5px;}
+.pill{font-family:var(--mono);font-size:9.5px;padding:2px 7px;border-radius:99px;border:1px solid var(--line-2);color:var(--dim);}
+.pill.live{border-color:var(--aqua);color:var(--aqua);}
+.pill.ok{border-color:var(--cheap);color:var(--cheap);}
+.pill.fail{border-color:var(--exp);color:var(--exp);}
+.blink{display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--aqua);
+  animation:pulse 1.4s ease-in-out infinite;}
+@keyframes pulse{0%,100%{opacity:1;}50%{opacity:.25;}}
+@media(prefers-reduced-motion:reduce){.blink{animation:none;}}
+.diff{font-family:var(--mono);font-size:11px;line-height:1.75;}
+.diff .add{color:var(--cheap);}
+.diff .del{color:var(--exp);}
+.diff .ctx{color:var(--faint);}
+.caption{text-align:center;font-family:var(--mono);font-size:11px;color:var(--faint);margin-top:14px;}
+
+/* ── content blocks ──────────────────────────────────────────────────── */
+.blk{padding:74px 0;border-top:1px solid var(--line);}
+.blk h2{font-family:var(--display);font-size:clamp(24px,3.6vw,38px);letter-spacing:-.8px;margin-bottom:14px;}
+.blk p{color:var(--dim);max-width:760px;}
+.grid4{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;margin-top:32px;}
+.feat{border:1px solid var(--line);border-radius:10px;padding:20px;background:var(--panel);transition:.18s;}
+.feat:hover{border-color:var(--line-2);transform:translateY(-2px);}
+.feat h3{font-family:var(--display);font-size:17px;margin-bottom:8px;}
+.feat .tag{font-family:var(--mono);font-size:9.5px;letter-spacing:1.4px;text-transform:uppercase;
+  color:var(--aqua);margin-bottom:9px;}
+.feat p{font-size:14px;color:var(--dim);margin:0;}
+.dl{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:14px;margin-top:30px;}
+.dl a{display:block;border:1px solid var(--line);border-radius:10px;padding:18px 20px;background:var(--panel);
+  transition:.18s;color:var(--ink);}
+.dl a:hover{border-color:var(--aqua);text-decoration:none;transform:translateY(-2px);}
+.dl .os{font-family:var(--display);font-size:17px;margin-bottom:4px;}
+.dl .meta{font-family:var(--mono);font-size:11px;color:var(--faint);}
+.note{border-left:2px solid var(--line-2);padding:10px 0 10px 16px;margin-top:26px;color:var(--dim);font-size:14px;}
+.note b{color:var(--ink);}
+footer{border-top:1px solid var(--line);padding:34px 0 56px;color:var(--faint);
+  font-family:var(--mono);font-size:12px;}
+footer a{color:var(--dim);}
+@media(max-width:720px){
+  .win-body{grid-template-columns:1fr;}
+  .side{display:none;}
+  .cards{grid-template-columns:1fr;}
+  .view{position:static;opacity:1;animation:none;display:none;}
+  .view:nth-child(1){display:block;}
+  .pane{min-height:0;}
+}
+</style>
+</head>
+<body>
+
+<div class="topbar">
+  <nav>
+    <a class="brand" href="/">HYDRA</a>
+    <a href="/#universe">Universe</a>
+    <a href="/docs.html">Docs</a>
+    <a href="/app.html" style="color:var(--aqua)">Desktop app</a>
+    <a href="/pricing.html">Pricing</a>
+    <a href="https://github.com/ankit373/hydra">GitHub</a>
+  </nav>
+  <a class="ghost" href="#download">Download</a>
+</div>
+
+<!-- ══ HERO ════════════════════════════════════════════════════════════ -->
+<section class="hero">
+  <div class="wrap">
+    <div class="klabel"><span>Hydra Desktop</span><b>ships with every release</b></div>
+    <h1>Your agents are already running.<br><span class="grad">Now you can watch them.</span></h1>
+    <p class="lede">
+      The CLI routes the work. The desktop app shows you what it did — which head
+      answered, how long it took, what it cost, how confident it was, and which
+      files changed. It reads the same local logs <span class="mono">hyctl</span>
+      writes, so there is nothing to connect and nothing to sign in to.
+    </p>
+    <div class="cta">
+      <a class="btn primary" href="#download">Download for your platform</a>
+      <a class="btn" href="#views">See the four views</a>
+    </div>
+  </div>
+
+  <!-- The preview below is a live HTML rendering, built from the app's own
+       design tokens — not a screenshot and not a recording. It shows the real
+       view names and the real shape of each screen; the numbers in it are
+       illustrative sample data. -->
+  <div class="stage">
+    <div class="win">
+      <div class="win-bar">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span class="win-title">Hydra — localhost · no account, no telemetry</span>
+      </div>
+      <div class="win-body">
+        <div class="side">
+          <div class="lbl">Views</div>
+          <div class="nav-item"><i></i>Dashboard</div>
+          <div class="nav-item"><i></i>Fleet</div>
+          <div class="nav-item"><i></i>Session</div>
+          <div class="nav-item"><i></i>Code</div>
+        </div>
+
+        <div class="pane">
+          <!-- 1 · Dashboard -->
+          <div class="view">
+            <div class="vhead">Dashboard</div>
+            <div class="vsub">spend, grouped by model · tier · day</div>
+            <div class="cards">
+              <div class="card"><div class="k">Calls today</div><div class="v">128</div></div>
+              <div class="card"><div class="k">Spend today</div><div class="v" style="color:var(--aqua)">$0.42</div></div>
+              <div class="card"><div class="k">vs all-frontier</div><div class="v" style="color:var(--cheap)">−83%</div></div>
+            </div>
+            <table class="mini">
+              <tr><th>Model</th><th>Tier</th><th style="text-align:right">Calls</th><th style="text-align:right">Cost</th></tr>
+              <tr><td>claude-sonnet</td><td>2</td><td class="n">14</td><td class="n">$0.31</td></tr>
+              <tr><td>gemini-flash</td><td>6</td><td class="n">37</td><td class="n">$0.11</td></tr>
+              <tr><td>qwen2.5-coder:7b</td><td>10</td><td class="n">77</td><td class="n" style="color:var(--cheap)">free</td></tr>
+            </table>
+          </div>
+
+          <!-- 2 · Fleet -->
+          <div class="view">
+            <div class="vhead">Fleet</div>
+            <div class="vsub">every run on this machine, newest first</div>
+            <div class="row"><span class="blink"></span><span style="flex:1">add pagination to /users</span>
+              <span class="pill live">live</span><span style="color:var(--dim)">tier 6</span></div>
+            <div class="row"><span style="width:6px"></span><span style="flex:1">rotate the signing key</span>
+              <span class="pill ok">done</span><span style="color:var(--dim)">tier 1</span></div>
+            <div class="row"><span style="width:6px"></span><span style="flex:1">write DTO tests</span>
+              <span class="pill ok">done</span><span style="color:var(--cheap)">local</span></div>
+            <div class="row"><span style="width:6px"></span><span style="flex:1">refactor the ledger globs</span>
+              <span class="pill fail">failed</span><span style="color:var(--dim)">tier 3</span></div>
+            <div style="margin-top:14px">
+              <div style="font-family:var(--mono);font-size:10px;color:var(--faint);margin-bottom:5px">
+                CONTEXT USED · 52%</div>
+              <div class="bar"><i style="width:52%;background:var(--cheap)"></i></div>
+            </div>
+          </div>
+
+          <!-- 3 · Session -->
+          <div class="view">
+            <div class="vhead">Session <span class="pill live" style="margin-left:6px">live</span></div>
+            <div class="vsub">run-4b1 · what this agent is doing, in order</div>
+            <div class="row"><span style="color:var(--faint);width:52px">00:00.0</span>
+              <span style="flex:1">head selected — <span style="color:var(--aqua)">gemini-flash</span> (tier 6)</span></div>
+            <div class="row"><span style="color:var(--faint);width:52px">00:01.2</span>
+              <span style="flex:1">candidate 1 failed — falling through</span><span class="pill fail">retry</span></div>
+            <div class="row"><span style="color:var(--faint);width:52px">00:02.9</span>
+              <span style="flex:1">dispatch finished — 1.4k tok</span><span class="pill ok">ok</span></div>
+            <div class="row"><span style="color:var(--faint);width:52px">00:03.1</span>
+              <span style="flex:1">handed off to hydra-tier-6</span></div>
+            <div class="row"><span style="color:var(--faint);width:52px">00:03.4</span>
+              <span style="flex:1">edited <span class="mono">internal/api/users.go</span></span>
+              <span style="color:var(--cheap)">+18</span><span style="color:var(--exp)">−4</span></div>
+            <div style="margin-top:12px;font-family:var(--mono);font-size:10px;color:var(--faint)">
+              TIMELINE · a layered graph appears here when a run fans out</div>
+          </div>
+
+          <!-- 4 · Code -->
+          <div class="view">
+            <div class="vhead">Code</div>
+            <div class="vsub">what this run actually changed on disk</div>
+            <div style="font-family:var(--mono);font-size:11px;color:var(--dim);margin-bottom:10px">
+              internal/api/users.go <span style="color:var(--cheap)">+18</span>
+              <span style="color:var(--exp)">−4</span></div>
+            <div class="diff">
+              <div class="ctx">  func ListUsers(w http.ResponseWriter, r *http.Request) {</div>
+              <div class="del">-   users := store.All()</div>
+              <div class="add">+   page, size := paging.FromQuery(r.URL.Query())</div>
+              <div class="add">+   users, total := store.Page(page, size)</div>
+              <div class="ctx">  </div>
+              <div class="add">+   w.Header().Set("X-Total-Count", strconv.Itoa(total))</div>
+              <div class="ctx">    json.NewEncoder(w).Encode(users)</div>
+              <div class="ctx">  }</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="caption">
+      A live rendering of the app's four views, built from its own design tokens.
+      Not a screenshot — the numbers are sample data.
+    </p>
+  </div>
+</section>
+
+<!-- ══ THE FOUR VIEWS ══════════════════════════════════════════════════ -->
+<section class="blk wrap" id="views">
+  <div class="klabel"><span>What's in it</span><b>four views, one question each</b></div>
+  <h2>Each screen answers something you'd otherwise <span class="grad">grep the logs for</span>.</h2>
+  <p>
+    The app is a reader, not a second brain. Everything it shows comes from the
+    JSONL files <span class="mono">hyctl</span> already writes to
+    <span class="mono">~/.hydra</span> — so the numbers on screen are the same
+    ones <span class="mono">hyctl cost</span> and <span class="mono">hyctl stats</span>
+    print, by construction.
+  </p>
+
+  <div class="grid4">
+    <div class="feat">
+      <div class="tag">Dashboard</div>
+      <h3>Where the money went</h3>
+      <p>Spend grouped by model, by tier and by day, with call counts beside each —
+        alongside the governor's context pressure and your trust record, so cost
+        and confidence sit on one screen.</p>
+    </div>
+    <div class="feat">
+      <div class="tag">Fleet</div>
+      <h3>What's running right now</h3>
+      <p>Runs in flight and the agents inside them, newest first, with the live
+        ones marked. Answers "is something still going, and should I be worried
+        about it".</p>
+    </div>
+    <div class="feat">
+      <div class="tag">Session</div>
+      <h3>Why it did that</h3>
+      <p>One run's timeline in order: which head was selected, which candidates
+        failed and why it fell through, how long each step took, where it handed
+        off — and a layered graph when the run fanned out, so a swarm reads as a
+        shape rather than a list.</p>
+    </div>
+    <div class="feat">
+      <div class="tag">Code</div>
+      <h3>What changed on disk</h3>
+      <p>The files a run touched and the diff for each. If a run says it edited
+        something, this is where you check what it actually wrote.</p>
+    </div>
+  </div>
+
+  <div class="note">
+    <b>Plus a chat dock.</b> Collapsed by default, on every screen. Type a task,
+    let Hydra auto-route it, and watch the run appear in Fleet — without leaving
+    the view you were reading.
+  </div>
+</section>
+
+<!-- ══ WHY IT'S DIFFERENT ══════════════════════════════════════════════ -->
+<section class="blk wrap">
+  <div class="klabel"><span>The shape of it</span><b>local by construction</b></div>
+  <h2>No account. No server. <span class="grad">Nothing leaves the machine.</span></h2>
+  <p>
+    There is no Hydra backend to sign in to, because there is no Hydra backend.
+    The app opens the same files on your disk that the CLI writes, and that is the
+    whole data path. Close it and the CLI keeps working exactly as before — it is
+    a window onto the control plane, not a dependency of it.
+  </p>
+  <div class="grid4">
+    <div class="feat">
+      <div class="tag">Same numbers</div>
+      <h3>Agrees with the CLI</h3>
+      <p>Both read <span class="mono">cost.jsonl</span>. A figure that differed
+        between them would be a bug, and there is a test that says so.</p>
+    </div>
+    <div class="feat">
+      <div class="tag">Provider-neutral</div>
+      <h3>Whatever you have installed</h3>
+      <p>Claude, Gemini, Codex, an API key, a local Ollama model — the app shows
+        whichever heads your machine actually has, and marks the ones it cannot drive.</p>
+    </div>
+    <div class="feat">
+      <div class="tag">Estimated vs measured</div>
+      <h3>Labelled, never conflated</h3>
+      <p>Where a provider reports real token usage it says so; where Hydra
+        estimated it, it says that instead. A guess is never shown as a measurement.</p>
+    </div>
+    <div class="feat">
+      <div class="tag">MIT</div>
+      <h3>Read the whole thing</h3>
+      <p>Frontend and backend are in the same repo as the CLI. If you want to know
+        what it does with your data, the answer is in <span class="mono">desktop/</span>.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ══ DOWNLOAD ════════════════════════════════════════════════════════ -->
+<section class="blk wrap" id="download">
+  <div class="klabel"><span>Download</span><b>free · MIT · no sign-up</b></div>
+  <h2>Built and published with <span class="grad">every release</span>.</h2>
+  <p>
+    Each build is attached to its GitHub release with a SHA-256 checksum beside it.
+    The app expects <span class="mono">hyctl</span> to be installed — it reads the
+    logs the CLI writes, so install that first if you have not.
+  </p>
+
+  <div class="dl">
+    <a href="https://github.com/ankit373/hydra/releases/latest">
+      <div class="os">macOS</div>
+      <div class="meta">universal · Apple Silicon + Intel</div>
+    </a>
+    <a href="https://github.com/ankit373/hydra/releases/latest">
+      <div class="os">Linux</div>
+      <div class="meta">x86-64 · tar.gz</div>
+    </a>
+    <a href="https://github.com/ankit373/hydra/releases/latest">
+      <div class="os">Windows</div>
+      <div class="meta">x86-64 · zip</div>
+    </a>
+  </div>
+
+  <div class="note">
+    <b>Not code-signed yet.</b> On macOS the first launch needs right-click →
+    Open, because the build carries no Apple Developer signature. Gatekeeper is
+    telling you the truth: nobody has paid Apple to vouch for it. The checksum
+    beside each download is what you can verify instead.
+  </div>
+
+  <div class="note">
+    <b>ARM64 Linux and Windows are not built yet.</b> The CLI ships for both; the
+    desktop app does not, and we would rather say so than let you download
+    something that will not start. Progress is tracked in
+    <a href="https://github.com/ankit373/hydra/issues/263">issue #263</a>.
+  </div>
+
+  <div class="note">
+    <b>Don't have the CLI yet?</b>
+    <span class="mono">brew install ankit373/tap/hyctl</span> — or see
+    <a href="/#start">the other install paths</a>.
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <a href="/">Hydra</a> · <a href="/docs.html">Docs</a> ·
+    <a href="/pricing.html">Pricing</a> ·
+    <a href="https://github.com/ankit373/hydra">GitHub</a> ·
+    MIT licensed · runs on your machine
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -427,6 +427,9 @@ table.cmp td:first-child,table.cmp th[scope=row]{text-align:left;font-family:var
 table.cmp tbody tr:last-child td,table.cmp tbody tr:last-child th{border-bottom:none;}
 .cmp-note{font-family:var(--mono);font-size:12px;color:var(--faint);margin-top:16px;}
 .cmp-note b{color:var(--aqua);}
+.cmp-note a{color:var(--dim);text-decoration:underline;text-underline-offset:2px;
+  text-decoration-color:var(--line-2);}
+.cmp-note a:hover{color:var(--aqua);text-decoration-color:var(--aqua);}
 
 /* ── section 7 · getting started ───────────────────────────────────────── */
 .steps{display:grid;gap:18px;margin-top:34px;grid-template-columns:1fr;}
@@ -779,10 +782,16 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
       See the app <span aria-hidden="true">→</span>
     </a>
   </div>
-  <p class="cmp-note" style="margin-top:18px">
+  <div class="term" style="margin-top:20px;max-width:720px">
+    <div class="copyline" data-copy="curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh | sh"><span><span class="p">$</span> curl -fsSL …/install-app.sh | sh</span><span class="cp">copy</span></div>
+    <div class="o"><span class="g">✓</span> checksum verified · <span class="c">/Applications/Hydra.app</span></div>
+  </div>
+  <p class="cmp-note" style="margin-top:16px">
     macOS · Linux · Windows, attached to every GitHub release with a SHA-256
     checksum. Not yet code-signed, so macOS needs right-click → Open the first
-    time. ARM64 desktop builds are not there yet (<a href="https://github.com/ankit373/hydra/issues/263">#263</a>).
+    time — the install script clears that for you. Linux ARM64 is not built yet
+    (<a href="https://github.com/ankit373/hydra/issues/263">#263</a>).
+    <a href="/app.html#download">Direct downloads</a>.
   </p>
 </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -481,6 +481,21 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
   .reveal{opacity:1!important;transform:none!important;transition:none!important;}
   .scrollhint,.foot-bottom .egg .cur{animation:none!important;}
 }
+/* ── desktop app tease (section 6b) ─────────────────────────────────────── */
+.app-tease{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:22px;
+  margin-top:28px;padding:22px 24px;border:1px solid var(--line);border-radius:12px;
+  background:linear-gradient(120deg,rgba(42,240,224,.05),rgba(232,82,200,.05));}
+.app-tease-views{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:16px;flex:1;}
+.app-tease-views span{display:flex;flex-direction:column;gap:3px;font-family:var(--mono);
+  font-size:11px;color:var(--faint);}
+.app-tease-views b{font-family:var(--display);font-size:14px;color:var(--ink);font-weight:600;}
+.app-tease-cta{display:inline-flex;align-items:center;gap:9px;padding:11px 20px;border-radius:8px;
+  font-family:var(--mono);font-size:13px;font-weight:700;color:#06070F;
+  background:linear-gradient(90deg,var(--cyan),var(--violet));transition:.15s;white-space:nowrap;}
+.app-tease-cta:hover{filter:brightness(1.12);text-decoration:none;transform:translateY(-1px);}
+@media(max-width:640px){.app-tease{flex-direction:column;align-items:stretch;}
+  .app-tease-cta{justify-content:center;}}
+
 </style>
 <script src="https://analytics.ahrefs.com/analytics.js" data-key="yRz83E87rXgYWlhmro5mIg" async></script>
 </head>
@@ -495,6 +510,7 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
     <a href="#universe">Universe</a>
     <a href="/docs.html">Docs</a>
     <a href="/first-principles.html">First principles</a>
+    <a href="/app.html">Desktop app</a>
     <a href="#compare">Compare</a>
     <a href="/pricing.html">Pricing</a>
     <a href="https://github.com/ankit373/hydra">GitHub</a>
@@ -739,6 +755,35 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
     </table>
   </div>
   <p class="cmp-note"><b>Every row checked above ships today</b> — <code>hyctl dispatch --confidence</code>, <code>hyctl graph blast</code>, <code>hyctl mcp</code>. The agent-tree cockpit (<code>hyctl tui</code>) now renders real runs from the per-run event log, and the desktop app ships as a download for macOS, Windows and Linux with every release — not yet code-signed, so macOS needs right-click → Open on first launch.</p>
+</section>
+
+<!-- ══ 6b · DESKTOP APP NUDGE ═══════════════════════════════════════════════ -->
+<section class="blk wrap reveal" id="app">
+  <div class="klabel"><span>Hydra Desktop</span><b>ships with every release</b></div>
+  <h2 class="big">Prefer to <span class="grad">watch</span> it rather than grep it?</h2>
+  <p style="max-width:720px;color:var(--dim)">
+    Everything above is the CLI. The same control plane has a desktop app —
+    four views over the logs <code>hyctl</code> already writes: where the money
+    went, what is running now, why a run picked the head it did, and which files
+    it changed. No account, no server, nothing leaves the machine.
+  </p>
+
+  <div class="app-tease">
+    <div class="app-tease-views">
+      <span><b>Dashboard</b>where the money went</span>
+      <span><b>Fleet</b>what is running now</span>
+      <span><b>Session</b>why it did that</span>
+      <span><b>Code</b>what changed on disk</span>
+    </div>
+    <a class="app-tease-cta" href="/app.html">
+      See the app <span aria-hidden="true">→</span>
+    </a>
+  </div>
+  <p class="cmp-note" style="margin-top:18px">
+    macOS · Linux · Windows, attached to every GitHub release with a SHA-256
+    checksum. Not yet code-signed, so macOS needs right-click → Open the first
+    time. ARM64 desktop builds are not there yet (<a href="https://github.com/ankit373/hydra/issues/263">#263</a>).
+  </p>
 </section>
 
 <!-- ══ 7 · GETTING STARTED ══════════════════════════════════════════════════ -->

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -78,6 +78,7 @@ Typical savings: 75-85% vs routing everything through Claude. Run `hyctl pricing
 ## Key Links
 
 - Homepage: https://hydra.uvansa.com/
+- Desktop app — the four views (Dashboard, Fleet, Session, Code), what each answers, and the platform downloads: https://hydra.uvansa.com/app.html
 - Documentation — every command (what it does, how it works, the logic/calculation, how to use): https://hydra.uvansa.com/docs.html
 - Pricing — free and open source (MIT); bring your own keys, pay providers directly. Custom builds on request: https://hydra.uvansa.com/pricing.html
 - Source code: https://github.com/ankit373/hydra

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -56,6 +56,14 @@ curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install.sh | sh
 irm https://raw.githubusercontent.com/ankit373/hydra/main/install.ps1 | iex        # standalone (Windows)
 ```
 
+The desktop app installs separately, with its own script (macOS and Linux):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh | sh
+```
+
+It resolves the newest release tag (desktop asset names embed their version, so GitHub's `/latest/download/` shortcut cannot address them), verifies the download against the `.sha256` published beside it, installs the `.app` to `/Applications` on macOS or the binary to `~/.local/share/hydra` with a `~/.local/bin` symlink on Linux, and clears the macOS quarantine flag. `HYDRA_VERSION` pins a release; `HYDRA_APP_DIR` changes the install directory. Windows has no script — download `hydra-desktop_<version>_windows_amd64.zip` from the releases page and unzip it.
+
 Platform support: `hyctl` is built for macOS, Linux and Windows on both x86-64 and ARM64 — six targets, every release. Homebrew covers macOS and Linux; npm/npx and pip cover all three OSes; `install.sh` covers macOS and Linux and `install.ps1` covers Windows (per-user, no admin rights; both verify the release checksum). The desktop app ships for macOS (universal), Windows x86-64 and Linux x86-64; ARM64 desktop builds are not yet available.
 
 Or build from source (requires Go 1.22+):

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/app.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,9 +2,15 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://hydra.uvansa.com/app.html</loc>
+    <lastmod>2026-08-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/docs.html</loc>

--- a/install-app.sh
+++ b/install-app.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env sh
+# Hydra Desktop — standalone app installer
+#
+#   curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh | sh
+#
+# Downloads the prebuilt desktop app for your OS/arch from the latest GitHub
+# release, verifies it against the published .sha256, and installs it.
+#
+# The release assets embed their version in the filename
+# (hydra-desktop_v1.2.0_darwin_universal.zip), so GitHub's /latest/download/
+# shortcut cannot address them — the tag has to be resolved first. That is most
+# of what this script is for.
+#
+# Environment overrides:
+#   HYDRA_VERSION=v1.2.0     pin a specific release (default: latest)
+#   HYDRA_APP_DIR=/opt/hydra install directory (default: /Applications on macOS,
+#                            ~/.local/share/hydra elsewhere)
+set -eu
+
+REPO="ankit373/hydra"
+BASE="https://github.com/${REPO}/releases"
+
+info()  { printf '  %s\n' "$*"; }
+warn()  { printf '  ! %s\n' "$*" >&2; }
+die()   { printf '  x %s\n' "$*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "required tool not found: $1"; }
+
+# ── Detect a downloader ────────────────────────────────────────────────────────
+if command -v curl >/dev/null 2>&1; then
+  DL="curl -fsSL"
+  DLO="curl -fsSL -o"
+elif command -v wget >/dev/null 2>&1; then
+  DL="wget -qO-"
+  DLO="wget -qO"
+else
+  die "need curl or wget to download"
+fi
+
+# ── Detect OS / arch ───────────────────────────────────────────────────────────
+#
+# The desktop app is not built for every target the CLI is. Saying so here beats
+# downloading an archive that will not start (#263).
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64)  ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *)             die "unsupported architecture: $arch" ;;
+esac
+
+case "$os" in
+  Darwin)
+    # macOS ships as a universal binary — one archive for Apple Silicon and Intel.
+    PLATFORM="darwin_universal"
+    EXT="zip"
+    ;;
+  Linux)
+    [ "$ARCH" = "amd64" ] || die "the desktop app has no linux/${ARCH} build yet — \
+the CLI does (install.sh). Progress: ${BASE%/releases}/issues/263"
+    PLATFORM="linux_amd64"
+    EXT="tar.gz"
+    ;;
+  MINGW*|MSYS*|CYGWIN*)
+    die "on Windows, download the .zip from ${BASE}/latest and unzip it — \
+this script needs a POSIX shell"
+    ;;
+  *)
+    die "unsupported OS: $os"
+    ;;
+esac
+
+echo "Hydra Desktop installer"
+
+# ── Resolve version ────────────────────────────────────────────────────────────
+if [ "${HYDRA_VERSION:-}" != "" ]; then
+  TAG="$HYDRA_VERSION"
+else
+  # Read the whole body before parsing. Piping straight into `grep -m1` closes
+  # the pipe early and curl then prints a scary "Failure writing output to
+  # destination" to stderr even though the fetch succeeded.
+  LATEST="$($DL "https://api.github.com/repos/${REPO}/releases/latest" || true)"
+  TAG="$(printf '%s' "$LATEST" \
+    | sed -n -E 's/.*"tag_name" *: *"([^"]+)".*/\1/p' \
+    | head -n 1)"
+  [ "${TAG:-}" != "" ] || die "could not determine latest release — set HYDRA_VERSION=vX.Y.Z"
+fi
+
+ARCHIVE="hydra-desktop_${TAG}_${PLATFORM}.${EXT}"
+URL="${BASE}/download/${TAG}/${ARCHIVE}"
+SUM_URL="${URL}.sha256"
+
+info "Release : ${TAG}"
+info "Target  : ${PLATFORM}"
+info "Archive : ${ARCHIVE}"
+
+# ── Download ───────────────────────────────────────────────────────────────────
+TMP="$(mktemp -d 2>/dev/null || mktemp -d -t hydra-desktop)"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+echo "-> Downloading..."
+$DLO "$TMP/$ARCHIVE" "$URL" || die "download failed: $URL
+  (the desktop app first shipped in v1.1.0 — older tags have no build)"
+
+# ── Verify checksum ────────────────────────────────────────────────────────────
+#
+# Each desktop asset carries its own .sha256 rather than appearing in the shared
+# checksums.txt, so this reads that file instead of grepping the combined one.
+if $DLO "$TMP/expected.sha256" "$SUM_URL" 2>/dev/null; then
+  if command -v sha256sum >/dev/null 2>&1; then
+    SHA="$(sha256sum "$TMP/$ARCHIVE" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    SHA="$(shasum -a 256 "$TMP/$ARCHIVE" | awk '{print $1}')"
+  else
+    SHA=""
+    warn "no sha256 tool found — skipping checksum verification"
+  fi
+  if [ "${SHA:-}" != "" ]; then
+    EXPECTED="$(awk '{print $1}' "$TMP/expected.sha256")"
+    [ "${EXPECTED:-}" != "" ] || die "published .sha256 for ${ARCHIVE} is empty"
+    [ "$SHA" = "$EXPECTED" ] || die "checksum mismatch — refusing to install (expected ${EXPECTED}, got ${SHA})"
+    info "Checksum: verified"
+  fi
+else
+  warn "no .sha256 published for ${ARCHIVE} — skipping verification"
+fi
+
+# ── Extract ────────────────────────────────────────────────────────────────────
+echo "-> Extracting..."
+if [ "$EXT" = "zip" ]; then
+  need unzip
+  unzip -q "$TMP/$ARCHIVE" -d "$TMP/out" || die "could not unzip ${ARCHIVE}"
+else
+  need tar
+  mkdir -p "$TMP/out"
+  tar -xzf "$TMP/$ARCHIVE" -C "$TMP/out" || die "could not untar ${ARCHIVE}"
+fi
+
+# ── Install ────────────────────────────────────────────────────────────────────
+if [ "$os" = "Darwin" ]; then
+  APP="$(find "$TMP/out" -maxdepth 2 -name '*.app' -print -quit)"
+  [ -n "${APP:-}" ] || die "no .app bundle inside ${ARCHIVE}"
+  DEST="${HYDRA_APP_DIR:-/Applications}"
+  mkdir -p "$DEST" 2>/dev/null || true
+  if [ ! -w "$DEST" ]; then
+    DEST="$HOME/Applications"
+    mkdir -p "$DEST"
+    warn "/Applications is not writable — installing to ${DEST}"
+  fi
+  NAME="$(basename "$APP")"
+  rm -rf "${DEST:?}/${NAME}"
+  cp -R "$APP" "$DEST/$NAME"
+
+  # The build is not notarised, so Gatekeeper quarantines it and the first
+  # launch fails with "damaged". Clearing the quarantine flag on a file the
+  # user just chose to install is the same decision right-click → Open makes,
+  # made once here instead of confusingly at launch.
+  if command -v xattr >/dev/null 2>&1; then
+    xattr -dr com.apple.quarantine "$DEST/$NAME" 2>/dev/null || true
+  fi
+  info "Installed: ${DEST}/${NAME}"
+  echo ""
+  echo "Done — open it from Launchpad, or:  open \"${DEST}/${NAME}\""
+else
+  BIN="$(find "$TMP/out" -maxdepth 2 -type f -perm -u+x -print -quit)"
+  [ -n "${BIN:-}" ] || die "no executable inside ${ARCHIVE}"
+  DEST="${HYDRA_APP_DIR:-$HOME/.local/share/hydra}"
+  mkdir -p "$DEST"
+  cp "$BIN" "$DEST/hydra-desktop"
+  chmod +x "$DEST/hydra-desktop"
+  info "Installed: ${DEST}/hydra-desktop"
+
+  # A launcher on PATH, so it can be started by name like any other tool.
+  LINKDIR="$HOME/.local/bin"
+  mkdir -p "$LINKDIR"
+  ln -sf "$DEST/hydra-desktop" "$LINKDIR/hydra-desktop"
+  case ":$PATH:" in
+    *":$LINKDIR:"*) : ;;
+    *) warn "add ${LINKDIR} to your PATH:  export PATH=\"\$PATH:${LINKDIR}\"" ;;
+  esac
+  echo ""
+  echo "Done — run:  hydra-desktop"
+fi
+
+# ── Point at the CLI if it is missing ──────────────────────────────────────────
+#
+# The app reads the logs hyctl writes. Without it there is nothing to display,
+# and an empty app looks broken rather than unconfigured.
+if ! command -v hyctl >/dev/null 2>&1; then
+  echo ""
+  warn "hyctl is not on your PATH. The app reads the logs the CLI writes, so"
+  warn "install it too:  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh"
+fi


### PR DESCRIPTION
## Summary

The desktop app shipped in v1.1.0 with no installer and no page. This adds both.

**`install-app.sh`** — the one-liner that did not exist. The desktop assets embed their version in the filename (`hydra-desktop_v1.1.0_darwin_universal.zip`), so GitHub's `/releases/latest/download/<name>` shortcut cannot address them; the tag has to be resolved from the API first, which is most of what the script does.

```bash
curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh | sh
```

- resolves the newest tag, or takes `HYDRA_VERSION`
- verifies the download against the per-asset `.sha256` (desktop assets carry their own rather than appearing in `checksums.txt`) and refuses on mismatch
- macOS: `.app` to `/Applications`, falls back to `~/Applications` when not writable, clears `com.apple.quarantine` so the first launch works instead of failing with "damaged"
- Linux: `~/.local/share/hydra` with a `~/.local/bin` symlink, warns if that is not on `PATH`
- dies with a specific message on linux/arm64 (#263) and Windows rather than downloading something that will not start
- warns when `hyctl` is missing, since the app reads the logs the CLI writes and looks broken rather than unconfigured without it

**`docs/app.html`** — a page for the app. A live HTML/CSS rendering of its four views built from the app's own design tokens (not a screenshot; the caption says so), a feature grid, and a download section that gives the command with its real output, then a table of version-pinned direct links with sizes and a `sha256` beside each, plus an explicit not-built-yet row for Linux ARM64.

**Landing page** gets a nudge section with the same command and a link through.

## Verification

Ran against the real v1.1.0 release, not a mock:

| case | result |
|---|---|
| default install | ✅ checksum verified, `Hydra.app` installed |
| `HYDRA_VERSION=v1.1.0` | ✅ pins correctly |
| `HYDRA_APP_DIR=…` | ✅ installs there |
| `HYDRA_VERSION=v0.0.99` | ✅ exit 1, temp dir cleaned, nothing installed |
| installed bundle | ✅ `lipo -archs` → `x86_64 arm64` |
| quarantine flag | ✅ cleared |

Also confirmed all three published archive layouts match what the extraction step expects: macOS `Hydra.app/` at depth 1, Linux `Hydra` at the root, Windows `Hydra.exe` at the root.

`sh -n` clean. Both pages render (headless Chrome) and the HTML parses with no unclosed tags.

## Also fixed

Both pages claimed "ARM64 Linux and Windows are not built yet". Windows x86-64 **is** built and published. It is Linux ARM64 that is not.

## Docs

Per the sync rules: `README.md`, `docs/llms.txt`, `docs/sitemap.xml` all updated here, not in a later pass. Nothing aspirational in `llms.txt` — the script is in this PR.

Closes #322