### PR TITLE
fix(desktop): frontend has no vite-env.d.ts — TS2882 on stricter compilers

### DIFF
--- a/desktop/frontend/src/vite-env.d.ts
+++ b/desktop/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## What broke and why

Dependabot PR #286 (typescript 5.9.3→7.0.2, vite 7.3.6→8.2.0, @vitejs/plugin-react 5→6) fails identically in `TypeScript typecheck` and `Desktop app build / linux/amd64`:

```
src/main.tsx(3,8): error TS2882: Cannot find module or type declarations for side-effect import of './tokens.css'.
src/main.tsx(4,8): error TS2882: Cannot find module or type declarations for side-effect import of './app.css'.
```

`desktop/frontend/src/` never had `vite-env.d.ts` — the one line every Vite+TS scaffold ships with, `/// <reference types="vite/client" />`. That's what declares ambient module types for side-effect imports like `import './app.css'`. TypeScript 5.9 tolerated the gap silently; 7.0's stricter checker does not. This was latent, not introduced by the bump.

## Fix

One file, one line.

## Verified, not assumed

- **Current pinned toolchain** (typescript 5.9.3, vite 7.3.6): `npm run typecheck` was already fine without this file — confirms the fix doesn't change today's behavior, only unblocks the future bump.
- **The exact versions PR #286 bumps to** (typescript@7.0.2, vite@8.2.0, @vitejs/plugin-react@6.0.5), in a scratch copy: `typecheck`, full `build` (`tsc -b && vite build`), and the dev server (curl → HTTP 200) all green with just this file added — no other breakage from the three-major-version jump.

Closes #329