### PR TITLE
chore(ci): dependabot opens PRs against develop, not main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,16 @@
 version: 2
+
+# target-branch: develop on every entry, and NOT the omit-and-let-it-default
+# option. Dependabot's default is the repo's default branch — main here — which
+# is exactly what CLAUDE.md's branch policy forbids: "Never open a PR directly
+# to main from a feature branch." Every dependency PR was landing on main
+# unreviewed by that policy until this was noticed (#334). main only ever moves
+# via a release-branch PR or a hotfix; a dependency bump is neither.
 updates:
   # Keep GitHub Actions up to date
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: develop
     schedule:
       interval: "weekly"
     commit-message:
@@ -13,6 +21,7 @@ updates:
   # pulls ~25 transitive deps and ungrouped updates would bury the queue.
   - package-ecosystem: "gomod"
     directory: "/desktop"
+    target-branch: develop
     schedule:
       interval: "weekly"
     commit-message:
@@ -25,6 +34,7 @@ updates:
   # Desktop frontend (React/TS).
   - package-ecosystem: "npm"
     directory: "/desktop/frontend"
+    target-branch: develop
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
No entry in `.github/dependabot.yml` had a `target-branch`, so Dependabot used the repo's default — `main`. That's exactly what CLAUDE.md's branch policy forbids: only a release-branch merge or a hotfix should ever land on `main` directly; everything else targets `develop`. Every dependency PR has been doing it anyway.

Three currently-open PRs are affected — #285, #286, #287, all targeting `main`. Handling those separately in a comment on this PR once it's in, since retargeting/closing them isn't a config change.

`target-branch: develop` added explicitly to all three entries.

Closes #334