### PR TITLE
fix(ci): Edge Build races on the shared edge tag under back-to-back pushes

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -9,6 +9,19 @@ on:
 permissions:
   contents: write
 
+# Multiple pushes to develop within seconds of each other (three squash-merges
+# in a row, say) each fire their own run, and the "delete previous edge
+# release, then recreate it" step below is not atomic across concurrent runs:
+# two runs can both pass the delete before either recreates, and whichever
+# creates second then finds the tag the first run just made and fails (#337).
+# Worse, an older commit's run finishing after a newer one's would silently
+# publish a stale edge build under a "successful" green check. Cancelling an
+# in-flight run for a superseded commit is correct here — this is a nightly
+# convenience build, not a gated release, so there is nothing worth finishing.
+concurrency:
+  group: edge-build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   edge:
     name: Build & publish edge release


### PR DESCRIPTION
## What happened

Three squash-merges into \`develop\` in a row (#330, #332, #335 — 8 seconds apart in practice) each fired their own \`Edge Build\` run. No concurrency group, so all three ran in parallel. The middle one (commit \`b5cfeb5\`) failed:

\`\`\`
a release with the same tag name already exists: edge
##[error]Process completed with exit code 1
\`\`\`

The workflow already has a "delete previous edge release, then recreate it" step meant to make repeated runs safe — it just isn't atomic across *concurrent* runs. Two runs can both pass the delete before either recreates, and whichever creates second finds the tag the first just made.

## Impact

The live \`edge\` release right now happens to be correct — the last of the three runs to finish was also the newest commit, so it won the race and published the right content. That's the runs' relative speed lining up with commit order by luck. A different interleaving publishes a stale edge build under a green check, with nothing in the release list to say so.

## Fix

\`concurrency: cancel-in-progress\` on the workflow+ref. Correct specifically because this is a nightly convenience build, not a gated release — an in-flight run for an already-superseded commit has nothing worth finishing.

## Verified, not assumed

Dispatched two runs against this branch 3 seconds apart:

| run | result |
|---|---|
| first | \`cancelled\` |
| second | ran to completion |

Exactly the intended behavior.

Closes #337