### PR TITLE
chore(desktop): pin an explicit Go toolchain — govulncheck flags 21 stdlib CVEs

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -10,6 +10,16 @@ module github.com/ankit373/hydra/desktop
 
 go 1.25.0
 
+// Pinned explicitly rather than left to resolve from the `go` line above.
+// actions/setup-go reads this file (go-version-file: desktop/go.mod) to decide
+// what to install, and without a toolchain line it installed exactly go1.25.0
+// — confirmed from the real shipped v1.2.0-rc.2 binary's own `go version -m`
+// output, not assumed. govulncheck found 21 reachable stdlib CVEs; go1.26.4
+// (the root module's own pin) closed 20 of them, one — GO-2026-5856, an ECH
+// privacy leak in crypto/tls — needing 1.26.5. Went one further than matching
+// root rather than leave a known-fixed CVE open for no reason.
+toolchain go1.26.5
+
 require (
 	github.com/ankit373/hydra v0.0.0
 	github.com/wailsapp/wails/v2 v2.13.0


### PR DESCRIPTION
## What's wrong

\`desktop/go.mod\` pinned \`go 1.25.0\` with no \`toolchain\` line. \`actions/setup-go\` (\`go-version-file: desktop/go.mod\`, used in both \`ci.yml\` and \`desktop-build.yml\`) installs exactly what the file resolves to — confirmed from the **real shipped v1.2.0-rc.2 binary**, not assumed: \`go version -m Hydra.app/.../Hydra\` reports \`go1.25.0\` as the build toolchain.

\`govulncheck ./api/...\` in \`desktop/\`: 21 reachable Go-**standard-library** CVEs (crypto/tls, crypto/x509, net/url, net/http, encoding/asn1). None of these are \`go.sum\` entries — a toolchain gap, not a Dependabot one, which is why it never showed up as an alert.

## Fix

\`toolchain go1.26.5\` — one better than just matching the root module's \`go1.26.4\` pin. 20 of the 21 findings clear at 1.26.4; the last (\`GO-2026-5856\`, an ECH privacy leak in \`crypto/tls\`) needs 1.26.5, which is already out. No reason to leave a known-fixed CVE open when the newer patch exists.

## Verified

- \`go env GOVERSION\` inside \`desktop/\` now resolves to \`1.26.5\`, not \`1.25.0\`
- \`go build ./...\`, \`go vet ./...\`, \`go test ./... -race -count=1\` all clean
- \`govulncheck ./...\`, forced onto the matching toolchain (the installed \`govulncheck\` binary itself needed reinstalling — an older one can't parse source gated behind \`//go:build go1.26\`): **zero vulnerabilities**, down from 21

Closes #333