### PR TITLE
feat(docs): publish funding.json to apply for OSS funding programs

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://hydra.uvansa.com/funding.json

--- a/docs/funding.json
+++ b/docs/funding.json
@@ -5,7 +5,7 @@
     "type": "individual",
     "role": "owner",
     "name": "Ankit Jha",
-    "email": "ankit.jha@tradomate.one",
+    "email": "jhanakit373@gmail.com",
     "description": "Independent developer building Hydra and other open-source, local-first developer tooling under the Uvansa product umbrella.",
     "webpageUrl": {
       "url": "https://hydra.uvansa.com/"

--- a/docs/funding.json
+++ b/docs/funding.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://fundingjson.org/schema/v1.1.0.json",
+  "version": "1.0.0",
+  "entity": {
+    "type": "individual",
+    "role": "owner",
+    "name": "Ankit Jha",
+    "email": "ankit.jha@tradomate.one",
+    "description": "Independent developer building Hydra and other open-source, local-first developer tooling under the Uvansa product umbrella.",
+    "webpageUrl": {
+      "url": "https://hydra.uvansa.com/"
+    }
+  },
+  "projects": [
+    {
+      "guid": "hydra",
+      "name": "Hydra",
+      "description": "Hydra is an open source CLI (hyctl), written in Go, that routes developer tasks across every AI model on your machine to a target confidence of correctness. It cuts LLM API costs 70-85% by using cheap or local models for simple tasks and reserving frontier models for work that needs them, enforces PII/local-only policy, and logs spend.",
+      "webpageUrl": {
+        "url": "https://hydra.uvansa.com/"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/ankit373/hydra",
+        "wellKnown": "https://raw.githubusercontent.com/ankit373/hydra/main/.well-known/funding-manifest-urls"
+      },
+      "licenses": ["spdx:MIT"],
+      "tags": ["ai", "llm", "cli", "developer-tools", "devops", "orchestration", "go"]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "github-sponsors",
+        "type": "payment-provider",
+        "description": "GitHub Sponsors, via Open Source Collective as fiscal host — being set up. Will cover Hydra and other Uvansa open-source projects (e.g. Mainspring) as separate projects under one collective."
+      },
+      {
+        "guid": "open-collective",
+        "type": "payment-provider",
+        "description": "Open Collective, hosted by Open Source Collective — not yet created. Reserved slug: opencollective.com/hyctl."
+      }
+    ],
+    "plans": [
+      {
+        "guid": "sponsor-hydra",
+        "status": "active",
+        "name": "Sponsor Hydra development",
+        "description": "Recurring or one-time support for Hydra's development — the routing engine, trust control plane, and desktop app.",
+        "amount": 0,
+        "currency": "USD",
+        "frequency": "monthly",
+        "channels": ["github-sponsors", "open-collective"]
+      }
+    ]
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,8 @@
   <link rel="ai-context" href="https://hydra.uvansa.com/llms.txt" type="text/plain">
   <!-- Machine-readable pricing for AI agents evaluating dev tools -->
   <link rel="ai-pricing" href="https://hydra.uvansa.com/pricing.md" type="text/markdown">
+  <!-- funding.json (fundingjson.org) — machine-readable funding manifest -->
+  <link rel="funding" href="https://hydra.uvansa.com/funding.json" type="application/json">
 
   <!-- Structured Data: SoftwareApplication -->
   <script type="application/ld+json">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -96,6 +96,7 @@ Typical savings: 75-85% vs routing everything through Claude. Run `hyctl pricing
 - Where Hydra fits (local-first + trust quadrant): https://hydra.uvansa.com/#universe
 - Cost comparison vs gateways: https://hydra.uvansa.com/#compare
 - Changelog: https://github.com/ankit373/hydra/blob/main/CHANGELOG.md
+- Funding — machine-readable funding manifest (fundingjson.org): https://hydra.uvansa.com/funding.json
 
 ## License
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -30,4 +30,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+  <url>
+    <loc>https://hydra.uvansa.com/funding.json</loc>
+    <lastmod>2026-08-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Adds `docs/funding.json` — a fundingjson.org v1.1.0 manifest, served at hydra.uvansa.com/funding.json
- Adds `.well-known/funding-manifest-urls` at repo root for cross-domain verification back from github.com
- Links it from `docs/index.html` (`<link rel="funding">`), `docs/llms.txt`, and `docs/sitemap.xml`

Entity: Ankit Jha (individual, matches LICENSE + existing author metadata). Funding channels
(GitHub Sponsors, Open Collective) are declared but marked not-yet-live with no address, rather
than a dead link — same pattern OpenSSF's own funding.json uses for an unconfigured channel.

Once live on hydra.uvansa.com, this can be submitted to https://dir.floss.fund/submit.

## Test plan
- [x] `python3 -c "import json; json.load(open('docs/funding.json'))"` — valid JSON
- [ ] After merge reaches main and GitHub Pages redeploys, confirm https://hydra.uvansa.com/funding.json serves it
- [ ] Confirm https://raw.githubusercontent.com/ankit373/hydra/main/.well-known/funding-manifest-urls resolves

Closes #343