### PR TITLE
fix(docs): reposition Trust Control Plane as shipped, lead with confidence not cost

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,20 +2,21 @@
 # Provider-neutral, local-first control plane. The orchestrator delegates; cheaper/local heads do the work.
 
 ## What Hydra Is
-A **local-first, multi-vendor AI control plane** shipped as a Go CLI (`hyctl`). It discovers every
-model on your machine (CLI agents, API keys, local servers), scores each, and routes tasks by
-complexity/cost with automatic fallback — enforcing policy (PII/local-only) and logging spend.
+A **local-first, multi-vendor Trust Control Plane** shipped as a Go CLI (`hyctl`). It discovers
+every model on your machine (CLI agents, API keys, local servers), scores each, and routes tasks by
+complexity/cost with automatic fallback — enforcing policy (PII/local-only) and logging spend. It
+also routes to a target *confidence of correctness*: calibration (`internal/trust`) + an
+optimal-stopping SPRT ensemble (`hyctl dispatch --confidence`), graph-aware routing
+(`internal/graph`), causal A2A handoffs (`internal/a2a`), a context-entropy governor
+(`internal/entropy`), a local MCP accountability ledger (`internal/ledger`), and a pluggable
+verification-oracle interface (`internal/oracle`) — all shipped, not roadmap. See the package map
+below, and the private planning docs (`ROADMAP_TRUST_CONTROL_PLANE.md`, `HYDRA_MANIFESTO.md`,
+`SPEC_TRUST_V1.md`) for the theory/math behind it.
 
 Whatever model you drive Hydra with acts as the **orchestrator**; Antigravity (agy), API providers,
 and Ollama are interchangeable **heads**. No single vendor is privileged — the whole point is
 routing *across* providers (and *away* from expensive ones), so keep it provider-neutral.
 Never do work yourself that belongs to a lower tier. Never escalate work to yourself that a cheaper head can handle.
-
-> **Direction (roadmap, not yet shipped):** Hydra is evolving from a cost router into a *Trust
-> Control Plane* — routing to a target *confidence of correctness* (calibration + optimal-stopping
-> ensembles), graph-aware routing, and a local MCP accountability ledger. See the private planning
-> docs (`ROADMAP_TRUST_CONTROL_PLANE.md`, `HYDRA_MANIFESTO.md`, `SPEC_TRUST_V1.md`). Do not describe
-> those features as shipped until they land.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ You have Claude Code for complex problems, Codex for code generation, Ollama run
 
 **Hydra is the control plane that sits in front of all of it.**
 
-It discovers every AI model on your machine, assigns each a capability score, routes tasks to the right model by complexity and cost, enforces PII policy so sensitive data never leaves your machine, and logs every dispatch with token counts and cost — without any manual configuration.
+It discovers every AI model on your machine, assigns each a capability score, and routes tasks not just to the cheapest one but to a *target confidence of correctness* — enforcing PII policy so sensitive data never leaves your machine, and logging every dispatch with token counts and cost, without any manual configuration.
 
-And it's growing into a **Trust Control Plane**: route not just to the cheapest model, but to a *target confidence of correctness* — sampling models adaptively and stopping the moment you're sure enough (see **Confidence Routing** under [Features](#features)).
+**Confidence routing** samples models adaptively (SPRT) and stops the moment you're sure enough, using per-model calibration built from real outcomes (see **Confidence Routing** under [Features](#features)) — and because cheap or local models handle the tasks that don't need a frontier model, this typically cuts LLM spend 70-85% along the way.
 
 ```bash
 brew install ankit373/hydra/hyctl && hyctl init

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Hydra — Multi-Model AI Orchestration CLI</title>
-  <meta name="description" content="Cut AI API costs 70–85% without changing your workflow. Hydra routes each dev task to the cheapest capable model — Claude, Gemini, or free local Qwen.">
-  <meta name="keywords" content="multi-model AI orchestration, LLM router, Claude Code, Ollama, local LLM, AI model routing, LLM cost optimization, AI coding assistant, llm orchestration CLI, model routing open source">
+  <title>Hydra — The Trust Control Plane for AI Development</title>
+  <meta name="description" content="Route to a target confidence of correctness, not just the cheapest model. Hydra samples models adaptively (SPRT), cuts AI API costs 70-85% along the way, and keeps sensitive data local.">
+  <meta name="keywords" content="trust control plane, AI confidence routing, multi-model AI orchestration, LLM router, Claude Code, Ollama, local LLM, AI model routing, LLM cost optimization, AI coding assistant, llm orchestration CLI, model routing open source">
 
   <!-- Open Graph / Social sharing -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://hydra.uvansa.com/">
-  <meta property="og:title" content="Hydra — Multi-Model AI Orchestration CLI">
-  <meta property="og:description" content="Cut AI API costs 80% without changing your workflow. Hydra routes each task to the cheapest model that can handle it — open source, MIT license, installs via Homebrew.">
+  <meta property="og:title" content="Hydra — The Trust Control Plane for AI Development">
+  <meta property="og:description" content="Hydra routes tasks across every model on your machine to a target confidence of correctness — sampling adaptively (SPRT) and stopping once the evidence is strong enough. Cuts AI costs 70-85% along the way. Open source, MIT license.">
   <meta property="og:image" content="https://hydra.uvansa.com/logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@ankit373">
-  <meta name="twitter:title" content="Hydra — Multi-Model AI Orchestration CLI">
-  <meta name="twitter:description" content="Route every dev task to the right AI model automatically. Claude when it matters, Ollama when it's free. Open source LLM router CLI written in Go.">
+  <meta name="twitter:title" content="Hydra — The Trust Control Plane for AI Development">
+  <meta name="twitter:description" content="Route to a confidence of correctness, not just the cheapest model. One command, every AI model, provable trust — open source LLM orchestration CLI in Go.">
   <meta name="twitter:image" content="https://hydra.uvansa.com/logo.png">
 
   <!-- Canonical URL -->
@@ -39,12 +39,12 @@
     "alternateName": "Hydra Trust Control Plane",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "macOS, Linux",
-    "description": "Route every dev task to the right AI model automatically. Hydra orchestrates Claude, Gemini, GPT, and local Qwen via Ollama — cutting LLM costs without sacrificing quality.",
+    "description": "Hydra is the Trust Control Plane for AI development: it routes tasks across every model on your machine to a target confidence of correctness — sampling models adaptively (SPRT) and stopping once the evidence is strong enough — while cutting AI API costs 70-85% along the way.",
     "url": "https://hydra.uvansa.com/",
     "downloadUrl": "https://github.com/ankit373/hydra",
     "softwareVersion": "1.0.0",
     "datePublished": "2026-01-01",
-    "dateModified": "2026-07-25",
+    "dateModified": "2026-08-09",
     "license": "https://github.com/ankit373/hydra/blob/main/LICENSE",
     "author": {
       "@type": "Person",
@@ -57,10 +57,14 @@
       "price": "0",
       "priceCurrency": "USD"
     },
-    "keywords": "multi-model AI orchestration, LLM router, Claude Code, Ollama, local LLM, AI model routing, LLM cost optimization, AI coding assistant, go cli, swarm dispatch",
+    "keywords": "trust control plane, AI confidence routing, multi-model AI orchestration, LLM router, Claude Code, Ollama, local LLM, AI model routing, LLM cost optimization, AI coding assistant, go cli, swarm dispatch",
     "image": "https://hydra.uvansa.com/logo.png",
     "sameAs": "https://github.com/ankit373/hydra",
     "featureList": [
+      "Confidence routing — hyctl dispatch --confidence samples models adaptively (SPRT) and stops once a target confidence of correctness is reached",
+      "Per-source calibration (hyctl trust calibration) — measures each model's diagnostic power from real outcomes",
+      "Blast-radius aware routing — a code dependency graph raises the confidence bar for widely-depended-on files",
+      "Local MCP accountability ledger — records and gates what each agent's tools touch",
       "10-tier model routing by task complexity",
       "Automatic fallback chains terminating at always-on local Qwen",
       "Local Ollama + cloud model hybrid — provider-neutral discovery",
@@ -71,7 +75,7 @@
       "Token budget enforcement — per-model context window tracking with pressure modes",
       "Dynamic live pricing — OpenRouter API pricing with 24h cache and tier fallback",
       "hyctl stats — real-time session cost rollup by model, tier, and day",
-      "A2A agent-to-agent handoff protocol",
+      "A2A agent-to-agent handoff protocol with vector clocks for causal ordering",
       "Homebrew installable on macOS and Linux"
     ]
   }
@@ -85,7 +89,7 @@
     "name": "Hydra",
     "alternateName": "Hydra Trust Control Plane",
     "url": "https://hydra.uvansa.com/",
-    "description": "Open source multi-model AI orchestration CLI written in Go"
+    "description": "The Trust Control Plane for AI development — open source, written in Go"
   }
   </script>
 
@@ -100,7 +104,15 @@
         "name": "What is Hydra?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Hydra is an open source multi-model AI orchestration CLI written in Go. It routes developer tasks to the right AI model automatically — using Claude for complex reasoning, Gemini for standard tasks, and free local Qwen/Ollama for boilerplate. The result is a 70-85% reduction in LLM API costs without sacrificing output quality."
+          "text": "Hydra is the Trust Control Plane for AI development — an open source CLI written in Go that routes developer tasks across every AI model on your machine to a target confidence of correctness, not just the cheapest one. It samples models adaptively (SPRT) and stops as soon as the evidence is strong enough, which also cuts AI API costs 70-85% along the way."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What is a Trust Control Plane?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A Trust Control Plane routes work to a target confidence of correctness rather than just the cheapest or fastest model. Hydra measures each model's calibration from real outcomes (hyctl trust calibration), runs a sequential probability ratio test (SPRT) that samples models adaptively and stops once confidence crosses your target, and automatically raises the bar for code with a wider blast radius — spending more only where accuracy demands it."
         }
       },
       {
@@ -154,7 +166,7 @@
     "@type": "SoftwareSourceCode",
     "name": "Hydra",
     "alternateName": "Hydra Trust Control Plane",
-    "description": "Open source multi-model AI orchestration CLI written in Go. Routes developer tasks to the cheapest model capable of handling them.",
+    "description": "Hydra is the Trust Control Plane for AI development — an open source CLI written in Go that routes tasks across every model on your machine to a target confidence of correctness.",
     "codeRepository": "https://github.com/ankit373/hydra",
     "programmingLanguage": "Go",
     "license": "https://opensource.org/licenses/MIT",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Hydra — The Trust Control Plane for AI Development
 
-> Hydra is an open source CLI written in Go that routes developer tasks across every AI model on your machine — not just to the cheapest one, but to a target *confidence of correctness*. It reduces LLM API costs by 70-85% by using cheap or free models for simple tasks and reserving frontier models for work that needs them, and it can route to a calibrated confidence: sampling models adaptively (SPRT) and stopping as soon as the evidence is strong enough, spending more only where accuracy demands it.
+> Hydra is the Trust Control Plane for AI development: an open source CLI written in Go that routes developer tasks across every AI model on your machine to a target *confidence of correctness*, not just the cheapest one — sampling models adaptively (SPRT) and stopping as soon as the evidence is strong enough, spending more only where accuracy demands it. It also reduces LLM API costs by 70-85% along the way, by using cheap or free models for simple tasks and reserving frontier models for work that needs them.
 
 ## What It Does
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
An independent research pass ("Hydra — The Frontier Check," Aug 2026) validated Hydra's shift
from router to Trust Control Plane against the 2025-2026 literature — but flagged that Hydra's
own docs hadn't caught up:

- `CLAUDE.md`'s banner still said "Direction (roadmap, not yet shipped)... Do not describe those
  features as shipped until they land" — contradicted by its own package map and by
  `BUILD_STATE.md`'s record that all 9 Trust Control Plane phases merged to `develop` on 2026-07-24.
- `docs/index.html`'s `<title>`, meta description, OG/Twitter tags, and all four JSON-LD blocks
  were 100% cost-first ("Cut AI API costs 70-85%..."), with zero mention of confidence/trust/
  governance anywhere in the actual text — despite `alternateName: "Hydra Trust Control Plane"`
  already being set. This is the most-crawled surface (search engines, AI crawlers).
- `docs/llms.txt` and `README.md` still had the cost figure as a co-opening claim rather than a
  clearly supporting one.

The research's explicit recommendation: lead messaging with governance/calibrated-confidence, not
"save money by switching providers" — confirmed independently to be exactly the commodity layer
AWS/Azure/GCP already give away free.

## Changes
- `CLAUDE.md` — banner now states the Trust Control Plane is shipped
- `docs/index.html` — title/meta/OG/Twitter + all 4 JSON-LD blocks lead with confidence routing;
  added a "What is a Trust Control Plane?" FAQ entry and confidence/calibration/MCP-ledger
  `featureList` entries that were entirely absent before
- `docs/llms.txt`, `README.md` — confidence leads standalone; cost is now clearly supporting
- `docs/sitemap.xml` — `lastmod` bumped for the homepage

## Test plan
- [x] All 4 JSON-LD blocks in `docs/index.html` parse as valid JSON
- [x] `docs/sitemap.xml` is well-formed XML
- [x] No file in the repo still calls the Trust Control Plane "roadmap, not yet shipped"

Closes #345