### PR TITLE
feat(swarm): calibration-weighted judge for ModeBest/ModeAll

### DIFF
--- a/internal/swarm/calibrated_judge.go
+++ b/internal/swarm/calibrated_judge.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+// CalibratedJudge is a Dawid-Skene naive-Bayes combiner (Dawid & Skene, 1979:
+// P(votes|z=k) = Π_i C_i[k,vote_i] over each rater's confusion matrix) over
+// the K distinct answers in a completed swarm round, using trust.Calibrator's
+// already-estimated per-source confusion matrices as the emission model.
+//
+// It is the batch/simultaneous dual of trust.Run's SPRT ensemble: SPRT
+// accumulates the identical LLR evidence sequentially against one evolving
+// candidate with early stopping, which fits sampling sources one at a time at
+// a cost; ModeBest already has all N attempts in hand with nothing left to
+// sample, so the right move is to score every candidate hypothesis at once
+// (see lambdaFor) and take the log-posterior argmax, rather than pick a
+// winner via a single independent LLM judge call or a static CapScore rank —
+// neither of which is calibration-aware, and both of which are exactly the
+// naive-voting shape the correlated-error literature (e.g. Zhou et al.,
+// "Variation in Verification," arXiv:2509.17995) finds captures only a
+// fraction of the available gain.
+//
+// trust.CorrelationDiscount — reused, not duplicated — is the mean-field
+// correction for the one documented way the naive-Bayes independence
+// assumption breaks: models make more correlated errors as they get
+// stronger, so a repeat vote from an already-seen model family is discounted
+// rather than counted as independent confirmation.
+//
+// Returns an error when every hypothesis' Λ is exactly 0 — every source is
+// uncalibrated (se=sp=0.5 ⟹ LLR≡0) — letting CompositeJudge fall through to
+// LLMJudge/CapScoreJudge unchanged. Any install that has never run `hyctl
+// trust record` gets byte-identical behavior to before this existed.
+type CalibratedJudge struct {
+	cal    *trust.Calibrator
+	domain string
+	equiv  trust.AnswerEquivalence // nil → trust.TextEquivalence (no extra LLM calls)
+}
+
+// newCalibratedJudge constructs a CalibratedJudge. A nil equiv defaults to
+// trust.TextEquivalence rather than a semantic (LLM-backed) comparator: this
+// mirrors trust.Run's own v1-default-is-textual, semantic-is-opt-in pattern,
+// and keeps ModeBest's cheapest-mode judge overhead at zero extra LLM calls —
+// spending more model calls to fix naive voting would be a regression in
+// exactly the resource this rework is meant to protect.
+func newCalibratedJudge(cal *trust.Calibrator, domain string, equiv trust.AnswerEquivalence) *CalibratedJudge {
+	if equiv == nil {
+		equiv = trust.TextEquivalence
+	}
+	return &CalibratedJudge{cal: cal, domain: domain, equiv: equiv}
+}
+
+// agreementGroup is one candidate hypothesis: the cluster of attempt indices
+// whose outputs the judge's equivalence function treats as the same answer.
+type agreementGroup struct {
+	members []int // indices into the attempts slice
+}
+
+func (j *CalibratedJudge) Judge(_ context.Context, _ string, attempts []Attempt) (*JudgeVerdict, error) {
+	successful := successfulAttempts(attempts)
+	if len(successful) == 0 {
+		return nil, fmt.Errorf("calibrated judge: no successful attempts to evaluate")
+	}
+	if len(successful) == 1 {
+		idx := successful[0]
+		scores := make([]int, len(attempts))
+		scores[idx] = attempts[idx].Head.CapScore
+		return &JudgeVerdict{
+			WinnerIndex: idx,
+			Scores:      scores,
+			Reason:      "only one successful response",
+		}, nil
+	}
+
+	groups := clusterByAgreement(attempts, successful, j.equiv)
+	lambda := make([]float64, len(groups))
+	for k := range groups {
+		lambda[k] = j.lambdaFor(groups[k], successful, attempts)
+	}
+
+	best := 0
+	for k := range lambda {
+		if lambda[k] > lambda[best] {
+			best = k
+		}
+	}
+	if allZero(lambda) {
+		return nil, fmt.Errorf("calibrated judge: no calibration data for any candidate in domain %q", j.domain)
+	}
+
+	winner := representative(groups[best], attempts, j.cal, j.domain)
+	probs := softmax(lambda)
+
+	scores := make([]int, len(attempts))
+	for k, g := range groups {
+		share := int(math.Round(100 * probs[k]))
+		for _, idx := range g.members {
+			scores[idx] = share
+		}
+	}
+
+	return &JudgeVerdict{
+		WinnerIndex: winner,
+		Scores:      scores,
+		Reason: fmt.Sprintf(
+			"Dawid-Skene MAP over %d candidate answers: %s's cluster carries %.0f%% posterior weight",
+			len(groups), attempts[winner].Head.Name, 100*probs[best],
+		),
+	}, nil
+}
+
+// lambdaFor computes Λ_k, the Dawid-Skene log-posterior (uniform prior) of
+// the hypothesis "hypothesis is the correct answer": every successful
+// attempt casts an implicit binary vote — agree if it's a member of
+// hypothesis, disagree otherwise — weighted by that source's calibrated LLR
+// for the vote it cast, with a same-family repeat discounted per
+// trust.CorrelationDiscount (family-seen state is local to this one
+// hypothesis's tally, since a different hypothesis reassigns which attempts
+// agree vs. disagree).
+func (j *CalibratedJudge) lambdaFor(hypothesis agreementGroup, successful []int, attempts []Attempt) float64 {
+	inGroup := make(map[int]bool, len(hypothesis.members))
+	for _, idx := range hypothesis.members {
+		inGroup[idx] = true
+	}
+	seenFamily := map[string]bool{}
+	var lambda float64
+	for _, idx := range successful {
+		llr := j.cal.LLR(attempts[idx].Head.ID, j.domain, inGroup[idx])
+		if fam := attempts[idx].Head.Provider; fam != "" {
+			if seenFamily[fam] {
+				llr *= trust.CorrelationDiscount
+			}
+			seenFamily[fam] = true
+		}
+		lambda += llr
+	}
+	return lambda
+}
+
+// representative picks which member of the winning hypothesis becomes the
+// returned WinnerIndex. Every member agrees (they're the same answer by
+// construction), so this is a tie-break, not a second decision: the member
+// with the strongest individual evidence for correctness, then CapScore.
+func representative(g agreementGroup, attempts []Attempt, cal *trust.Calibrator, domain string) int {
+	best := g.members[0]
+	bestLLR := cal.LLR(attempts[best].Head.ID, domain, true)
+	for _, idx := range g.members[1:] {
+		llr := cal.LLR(attempts[idx].Head.ID, domain, true)
+		if llr > bestLLR || (llr == bestLLR && attempts[idx].Head.CapScore > attempts[best].Head.CapScore) {
+			best, bestLLR = idx, llr
+		}
+	}
+	return best
+}
+
+// clusterByAgreement groups successful attempt indices whose outputs the
+// equivalence function treats as the same answer. Greedy: each attempt joins
+// the first existing group it agrees with (compared against that group's
+// first member), or starts a new group. Attempt counts here are bounded by
+// MaxHeads (default 5), so this is cheap regardless of the O(n²) shape.
+func clusterByAgreement(attempts []Attempt, successful []int, equiv trust.AnswerEquivalence) []agreementGroup {
+	var groups []agreementGroup
+	for _, idx := range successful {
+		placed := false
+		for gi := range groups {
+			rep := groups[gi].members[0]
+			if equiv(attempts[rep].Output, attempts[idx].Output) {
+				groups[gi].members = append(groups[gi].members, idx)
+				placed = true
+				break
+			}
+		}
+		if !placed {
+			groups = append(groups, agreementGroup{members: []int{idx}})
+		}
+	}
+	return groups
+}
+
+func allZero(xs []float64) bool {
+	for _, x := range xs {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// softmax turns K hypotheses' log-posteriors into a normalized probability
+// distribution — the direct K-ary generalization of sigmoid, which is what
+// trust.Run already uses to turn a single Λ into P(correct) for its binary
+// (accept candidate / reject candidate) decision.
+func softmax(lambda []float64) []float64 {
+	max := lambda[0]
+	for _, l := range lambda[1:] {
+		if l > max {
+			max = l
+		}
+	}
+	sum := 0.0
+	exp := make([]float64, len(lambda))
+	for i, l := range lambda {
+		exp[i] = math.Exp(l - max)
+		sum += exp[i]
+	}
+	probs := make([]float64, len(lambda))
+	for i := range exp {
+		probs[i] = exp[i] / sum
+	}
+	return probs
+}

--- a/internal/swarm/calibrated_judge.go
+++ b/internal/swarm/calibrated_judge.go
@@ -10,45 +10,20 @@ import (
 	"github.com/ankit373/hydra/internal/trust"
 )
 
-// CalibratedJudge is a Dawid-Skene naive-Bayes combiner (Dawid & Skene, 1979:
-// P(votes|z=k) = Π_i C_i[k,vote_i] over each rater's confusion matrix) over
-// the K distinct answers in a completed swarm round, using trust.Calibrator's
-// already-estimated per-source confusion matrices as the emission model.
-//
-// It is the batch/simultaneous dual of trust.Run's SPRT ensemble: SPRT
-// accumulates the identical LLR evidence sequentially against one evolving
-// candidate with early stopping, which fits sampling sources one at a time at
-// a cost; ModeBest already has all N attempts in hand with nothing left to
-// sample, so the right move is to score every candidate hypothesis at once
-// (see lambdaFor) and take the log-posterior argmax, rather than pick a
-// winner via a single independent LLM judge call or a static CapScore rank —
-// neither of which is calibration-aware, and both of which are exactly the
-// naive-voting shape the correlated-error literature (e.g. Zhou et al.,
-// "Variation in Verification," arXiv:2509.17995) finds captures only a
-// fraction of the available gain.
-//
-// trust.CorrelationDiscount — reused, not duplicated — is the mean-field
-// correction for the one documented way the naive-Bayes independence
-// assumption breaks: models make more correlated errors as they get
-// stronger, so a repeat vote from an already-seen model family is discounted
-// rather than counted as independent confirmation.
-//
-// Returns an error when every hypothesis' Λ is exactly 0 — every source is
-// uncalibrated (se=sp=0.5 ⟹ LLR≡0) — letting CompositeJudge fall through to
-// LLMJudge/CapScoreJudge unchanged. Any install that has never run `hyctl
-// trust record` gets byte-identical behavior to before this existed.
+// CalibratedJudge is a Dawid-Skene naive-Bayes combiner over the K distinct
+// answers in a swarm round — the batch dual of trust.Run's sequential SPRT,
+// scoring every candidate hypothesis at once instead of picking via a single
+// LLM judge call or a static CapScore rank. Errors when every hypothesis'
+// Λ is 0 (no calibration data anywhere), so CompositeJudge falls through to
+// LLMJudge/CapScoreJudge unchanged.
 type CalibratedJudge struct {
 	cal    *trust.Calibrator
 	domain string
 	equiv  trust.AnswerEquivalence // nil → trust.TextEquivalence (no extra LLM calls)
 }
 
-// newCalibratedJudge constructs a CalibratedJudge. A nil equiv defaults to
-// trust.TextEquivalence rather than a semantic (LLM-backed) comparator: this
-// mirrors trust.Run's own v1-default-is-textual, semantic-is-opt-in pattern,
-// and keeps ModeBest's cheapest-mode judge overhead at zero extra LLM calls —
-// spending more model calls to fix naive voting would be a regression in
-// exactly the resource this rework is meant to protect.
+// newCalibratedJudge defaults a nil equiv to trust.TextEquivalence, keeping
+// ModeBest's judge overhead at zero extra LLM calls unless a caller opts in.
 func newCalibratedJudge(cal *trust.Calibrator, domain string, equiv trust.AnswerEquivalence) *CalibratedJudge {
 	if equiv == nil {
 		equiv = trust.TextEquivalence
@@ -115,14 +90,8 @@ func (j *CalibratedJudge) Judge(_ context.Context, _ string, attempts []Attempt)
 	}, nil
 }
 
-// lambdaFor computes Λ_k, the Dawid-Skene log-posterior (uniform prior) of
-// the hypothesis "hypothesis is the correct answer": every successful
-// attempt casts an implicit binary vote — agree if it's a member of
-// hypothesis, disagree otherwise — weighted by that source's calibrated LLR
-// for the vote it cast, with a same-family repeat discounted per
-// trust.CorrelationDiscount (family-seen state is local to this one
-// hypothesis's tally, since a different hypothesis reassigns which attempts
-// agree vs. disagree).
+// lambdaFor computes Λ_k: every attempt votes agree/disagree with hypothesis,
+// weighted by its calibrated LLR, same-family repeats discounted.
 func (j *CalibratedJudge) lambdaFor(hypothesis agreementGroup, successful []int, attempts []Attempt) float64 {
 	inGroup := make(map[int]bool, len(hypothesis.members))
 	for _, idx := range hypothesis.members {
@@ -143,10 +112,8 @@ func (j *CalibratedJudge) lambdaFor(hypothesis agreementGroup, successful []int,
 	return lambda
 }
 
-// representative picks which member of the winning hypothesis becomes the
-// returned WinnerIndex. Every member agrees (they're the same answer by
-// construction), so this is a tie-break, not a second decision: the member
-// with the strongest individual evidence for correctness, then CapScore.
+// representative breaks the tie among a hypothesis's equally-valid members by
+// individual evidence, then CapScore.
 func representative(g agreementGroup, attempts []Attempt, cal *trust.Calibrator, domain string) int {
 	best := g.members[0]
 	bestLLR := cal.LLR(attempts[best].Head.ID, domain, true)
@@ -159,11 +126,7 @@ func representative(g agreementGroup, attempts []Attempt, cal *trust.Calibrator,
 	return best
 }
 
-// clusterByAgreement groups successful attempt indices whose outputs the
-// equivalence function treats as the same answer. Greedy: each attempt joins
-// the first existing group it agrees with (compared against that group's
-// first member), or starts a new group. Attempt counts here are bounded by
-// MaxHeads (default 5), so this is cheap regardless of the O(n²) shape.
+// clusterByAgreement greedily groups attempts whose outputs equiv treats as the same answer.
 func clusterByAgreement(attempts []Attempt, successful []int, equiv trust.AnswerEquivalence) []agreementGroup {
 	var groups []agreementGroup
 	for _, idx := range successful {
@@ -192,10 +155,7 @@ func allZero(xs []float64) bool {
 	return true
 }
 
-// softmax turns K hypotheses' log-posteriors into a normalized probability
-// distribution — the direct K-ary generalization of sigmoid, which is what
-// trust.Run already uses to turn a single Λ into P(correct) for its binary
-// (accept candidate / reject candidate) decision.
+// softmax is the K-ary generalization of the sigmoid trust.Run uses for its binary decision.
 func softmax(lambda []float64) []float64 {
 	max := lambda[0]
 	for _, l := range lambda[1:] {

--- a/internal/swarm/calibrated_judge_test.go
+++ b/internal/swarm/calibrated_judge_test.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+const testDomain = "calibrated-judge-test"
+
+func attemptWith(id, family string, capScore int, output string) Attempt {
+	return Attempt{
+		Head:   provider.Head{ID: id, Name: id, Provider: family, CapScore: capScore},
+		Status: StatusOK,
+		Output: output,
+	}
+}
+
+// seedReliable feeds a calibrator enough correct, self-reported-correct
+// observations that se and sp both land well above 0.5 — an informative,
+// well-calibrated source, in contrast to one nobody has ever called
+// hyctl trust record for (D=0, uninformative prior).
+func seedReliable(t *testing.T, cal *trust.Calibrator, source, domain string) {
+	t.Helper()
+	for i := 0; i < 20; i++ {
+		if err := cal.Update(source, domain, true, trust.OutcomeCorrect); err != nil {
+			t.Fatalf("seeding calibration for %s: %v", source, err)
+		}
+	}
+	for i := 0; i < 4; i++ {
+		if err := cal.Update(source, domain, false, trust.OutcomeIncorrect); err != nil {
+			t.Fatalf("seeding calibration for %s: %v", source, err)
+		}
+	}
+}
+
+func newTestCalibrator(t *testing.T) *trust.Calibrator {
+	t.Helper()
+	cal, err := trust.New("") // in-memory only
+	if err != nil {
+		t.Fatalf("trust.New: %v", err)
+	}
+	return cal
+}
+
+// A calibrated, historically-reliable low-CapScore source must be able to
+// beat an uncalibrated high-CapScore one — this is the entire point of the
+// rework: CapScore alone (today's fallback) cannot express "I have never
+// seen this source be right before."
+func TestCalibratedJudge_CalibratedWinnerOverridesCapScore(t *testing.T) {
+	cal := newTestCalibrator(t)
+	seedReliable(t, cal, "model:reliable", testDomain)
+	// "model:flashy" is left entirely uncalibrated (D=0).
+
+	attempts := []Attempt{
+		attemptWith("model:reliable", "acme", 40, "the answer is 42"),
+		attemptWith("model:flashy", "other", 99, "the answer is 7"),
+	}
+
+	j := newCalibratedJudge(cal, testDomain, nil)
+	verdict, err := j.Judge(context.Background(), "what is the answer?", attempts)
+	if err != nil {
+		t.Fatalf("Judge returned error: %v", err)
+	}
+	if verdict.WinnerIndex != 0 {
+		t.Errorf("WinnerIndex = %d, want 0 (the calibrated source), CapScore-based pick would be 1", verdict.WinnerIndex)
+	}
+}
+
+// Zero calibration history anywhere must produce an error (not an arbitrary
+// pick), so CompositeJudge falls through to LLMJudge/CapScoreJudge — any
+// install that has never run `hyctl trust record` gets byte-identical
+// behavior to before CalibratedJudge existed.
+func TestCalibratedJudge_NoCalibrationData_ErrorsForFallback(t *testing.T) {
+	cal := newTestCalibrator(t)
+	attempts := []Attempt{
+		attemptWith("model:a", "acme", 40, "the answer is 42"),
+		attemptWith("model:b", "other", 99, "the answer is 7"),
+	}
+
+	j := newCalibratedJudge(cal, testDomain, nil)
+	_, err := j.Judge(context.Background(), "prompt", attempts)
+	if err == nil {
+		t.Fatal("expected an error with zero calibration data, got a verdict — CompositeJudge cannot fall back")
+	}
+}
+
+// The single-success case must short-circuit without consulting calibration
+// at all — mirrors LLMJudge's own trivial case.
+func TestCalibratedJudge_SingleSuccess_ShortCircuits(t *testing.T) {
+	cal := newTestCalibrator(t)
+	attempts := []Attempt{
+		attemptWith("model:a", "acme", 40, "the only answer"),
+		failedAttempt("model:b"),
+	}
+
+	j := newCalibratedJudge(cal, testDomain, nil)
+	verdict, err := j.Judge(context.Background(), "prompt", attempts)
+	if err != nil {
+		t.Fatalf("Judge returned error: %v", err)
+	}
+	if verdict.WinnerIndex != 0 {
+		t.Errorf("WinnerIndex = %d, want 0", verdict.WinnerIndex)
+	}
+	if verdict.Reason != "only one successful response" {
+		t.Errorf("Reason = %q, want the trivial-case message", verdict.Reason)
+	}
+}
+
+// A repeat vote from an already-counted model family must be discounted:
+// two agreeing votes from the SAME family must win by a smaller posterior
+// margin than two agreeing votes from DIFFERENT families, holding every
+// other input identical. This is trust.CorrelationDiscount doing its job —
+// a swarm of near-duplicate models must not out-vote a single dissenter
+// through sheer headcount.
+func TestCalibratedJudge_SameFamilyRepeatIsDiscounted(t *testing.T) {
+	posteriorFor := func(secondFamily string) float64 {
+		cal := newTestCalibrator(t)
+		seedReliable(t, cal, "model:x1", testDomain)
+		seedReliable(t, cal, "model:x2", testDomain)
+		seedReliable(t, cal, "model:y1", testDomain)
+
+		attempts := []Attempt{
+			attemptWith("model:x1", "acme", 80, "42"),
+			attemptWith("model:x2", secondFamily, 80, "42"), // agrees with x1
+			attemptWith("model:y1", "other", 80, "43"),      // dissents
+		}
+
+		j := newCalibratedJudge(cal, testDomain, nil)
+		verdict, err := j.Judge(context.Background(), "prompt", attempts)
+		if err != nil {
+			t.Fatalf("Judge returned error: %v", err)
+		}
+		if verdict.WinnerIndex != 0 && verdict.WinnerIndex != 1 {
+			t.Fatalf("expected the \"42\" cluster to win regardless of discount, got winner index %d", verdict.WinnerIndex)
+		}
+		return float64(verdict.Scores[verdict.WinnerIndex])
+	}
+
+	sameFamilyPosterior := posteriorFor("acme")   // x2 shares x1's family → discounted
+	diffFamilyPosterior := posteriorFor("other2") // x2 is independent → full weight
+
+	if sameFamilyPosterior >= diffFamilyPosterior {
+		t.Errorf("same-family posterior = %.0f%%, different-family posterior = %.0f%%; "+
+			"a same-family repeat vote must win by a strictly smaller margin than an independent one",
+			sameFamilyPosterior, diffFamilyPosterior)
+	}
+}
+
+func TestRankByCalibratedScore_NoDataFallsBackToCapScoreOrder(t *testing.T) {
+	cal := newTestCalibrator(t)
+	attempts := []Attempt{
+		attemptWith("model:a", "acme", 40, "a"),
+		attemptWith("model:b", "other", 90, "b"),
+		attemptWith("model:c", "third", 70, "c"),
+	}
+
+	rankByCalibratedScore(attempts, cal, testDomain)
+
+	// Fresh install, zero calibration data: must rank exactly like rankByCapScore.
+	want := map[string]int{"model:b": 1, "model:c": 2, "model:a": 3}
+	for _, a := range attempts {
+		if a.Rank != want[a.Head.ID] {
+			t.Errorf("%s: Rank = %d, want %d (CapScore-order fallback)", a.Head.ID, a.Rank, want[a.Head.ID])
+		}
+	}
+}
+
+func TestRankByCalibratedScore_PrefersCalibratedOverCapScore(t *testing.T) {
+	cal := newTestCalibrator(t)
+	seedReliable(t, cal, "model:reliable", testDomain)
+	attempts := []Attempt{
+		attemptWith("model:reliable", "acme", 40, "a"), // low CapScore, high D
+		attemptWith("model:flashy", "other", 99, "b"),  // high CapScore, D=0
+	}
+
+	rankByCalibratedScore(attempts, cal, testDomain)
+
+	for _, a := range attempts {
+		if a.Head.ID == "model:reliable" && a.Rank != 1 {
+			t.Errorf("model:reliable Rank = %d, want 1 — calibration must outrank a bare CapScore lead", a.Rank)
+		}
+	}
+}

--- a/internal/swarm/calibrated_judge_test.go
+++ b/internal/swarm/calibrated_judge_test.go
@@ -20,10 +20,7 @@ func attemptWith(id, family string, capScore int, output string) Attempt {
 	}
 }
 
-// seedReliable feeds a calibrator enough correct, self-reported-correct
-// observations that se and sp both land well above 0.5 — an informative,
-// well-calibrated source, in contrast to one nobody has ever called
-// hyctl trust record for (D=0, uninformative prior).
+// seedReliable feeds enough observations that se/sp land well above 0.5 (informative, D>0).
 func seedReliable(t *testing.T, cal *trust.Calibrator, source, domain string) {
 	t.Helper()
 	for i := 0; i < 20; i++ {
@@ -47,10 +44,7 @@ func newTestCalibrator(t *testing.T) *trust.Calibrator {
 	return cal
 }
 
-// A calibrated, historically-reliable low-CapScore source must be able to
-// beat an uncalibrated high-CapScore one — this is the entire point of the
-// rework: CapScore alone (today's fallback) cannot express "I have never
-// seen this source be right before."
+// A calibrated low-CapScore source must beat an uncalibrated high-CapScore one.
 func TestCalibratedJudge_CalibratedWinnerOverridesCapScore(t *testing.T) {
 	cal := newTestCalibrator(t)
 	seedReliable(t, cal, "model:reliable", testDomain)
@@ -71,10 +65,7 @@ func TestCalibratedJudge_CalibratedWinnerOverridesCapScore(t *testing.T) {
 	}
 }
 
-// Zero calibration history anywhere must produce an error (not an arbitrary
-// pick), so CompositeJudge falls through to LLMJudge/CapScoreJudge — any
-// install that has never run `hyctl trust record` gets byte-identical
-// behavior to before CalibratedJudge existed.
+// Zero calibration history anywhere must error, not pick arbitrarily, so CompositeJudge falls back.
 func TestCalibratedJudge_NoCalibrationData_ErrorsForFallback(t *testing.T) {
 	cal := newTestCalibrator(t)
 	attempts := []Attempt{
@@ -89,8 +80,7 @@ func TestCalibratedJudge_NoCalibrationData_ErrorsForFallback(t *testing.T) {
 	}
 }
 
-// The single-success case must short-circuit without consulting calibration
-// at all — mirrors LLMJudge's own trivial case.
+// The single-success case must short-circuit without consulting calibration.
 func TestCalibratedJudge_SingleSuccess_ShortCircuits(t *testing.T) {
 	cal := newTestCalibrator(t)
 	attempts := []Attempt{
@@ -111,12 +101,7 @@ func TestCalibratedJudge_SingleSuccess_ShortCircuits(t *testing.T) {
 	}
 }
 
-// A repeat vote from an already-counted model family must be discounted:
-// two agreeing votes from the SAME family must win by a smaller posterior
-// margin than two agreeing votes from DIFFERENT families, holding every
-// other input identical. This is trust.CorrelationDiscount doing its job —
-// a swarm of near-duplicate models must not out-vote a single dissenter
-// through sheer headcount.
+// Two agreeing votes from the SAME family must win by a smaller margin than from DIFFERENT families.
 func TestCalibratedJudge_SameFamilyRepeatIsDiscounted(t *testing.T) {
 	posteriorFor := func(secondFamily string) float64 {
 		cal := newTestCalibrator(t)

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -240,11 +240,8 @@ func buildJudge(d *dispatch.Dispatcher, opts Options, cfg *config.Config) Judge 
 	return newCompositeJudge(newCalibratedJudge(cal, domain, nil), fallback)
 }
 
-// loadCalibrationFor resolves the calibrator + domain a ModeBest/ModeAll run
-// should use. A load error degrades to (nil, domain): calibration is an
-// enhancement to these modes, not a dependency, so callers must treat a nil
-// Calibrator as "no calibration data" and fall back to their pre-existing
-// behavior rather than fail the dispatch.
+// loadCalibrationFor degrades to (nil, domain) on a load error — callers
+// treat nil as "no calibration data" and fall back rather than fail.
 func loadCalibrationFor(opts Options) (*trust.Calibrator, string) {
 	domain := opts.Domain
 	if domain == "" {
@@ -257,17 +254,8 @@ func loadCalibrationFor(opts Options) (*trust.Calibrator, string) {
 	return cal, domain
 }
 
-// rankByCalibratedScore ranks successful attempts by measured diagnostic
-// power D(source, domain) instead of static CapScore, so ModeAll surfaces the
-// most-trustworthy-in-this-domain answer first once calibration data exists.
-// D (not the Dawid-Skene Λ CalibratedJudge computes) is the right quantity
-// here: D is a property of a single source, which is exactly what ranking
-// candidates by "how trustworthy is this one" needs, whereas Λ scores a
-// specific hypothesis against the whole ensemble's votes — the question
-// CalibratedJudge answers, not the question a display ranking asks.
-// Falls back to rankByCapScore's exact ordering when no successful attempt
-// has any calibration history yet (every D is 0) — a fresh install ranks
-// identically to before this existed.
+// rankByCalibratedScore ranks by D(source, domain) instead of static CapScore,
+// falling back to rankByCapScore's exact order when no attempt has any D.
 func rankByCalibratedScore(attempts []Attempt, cal *trust.Calibrator, domain string) {
 	type indexed struct {
 		idx int

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/trust"
 )
 
 // SwarmMode is the response selection strategy.
@@ -198,7 +199,11 @@ func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmRes
 			result.Winner = capScoreWinner(attempts)
 		}
 	case ModeAll:
-		rankByCapScore(attempts)
+		if cal, domain := loadCalibrationFor(opts); cal != nil {
+			rankByCalibratedScore(attempts, cal, domain)
+		} else {
+			rankByCapScore(attempts)
+		}
 		if w := firstSuccessful(attempts); w != nil {
 			result.Winner = w
 		}
@@ -226,7 +231,73 @@ func buildJudge(d *dispatch.Dispatcher, opts Options, cfg *config.Config) Judge 
 	}
 	llm := newLLMJudge(d, tierHint, opts.JudgeTimeout)
 	cap_ := &CapScoreJudge{}
-	return newCompositeJudge(llm, cap_)
+	fallback := newCompositeJudge(llm, cap_)
+
+	cal, domain := loadCalibrationFor(opts)
+	if cal == nil {
+		return fallback
+	}
+	return newCompositeJudge(newCalibratedJudge(cal, domain, nil), fallback)
+}
+
+// loadCalibrationFor resolves the calibrator + domain a ModeBest/ModeAll run
+// should use. A load error degrades to (nil, domain): calibration is an
+// enhancement to these modes, not a dependency, so callers must treat a nil
+// Calibrator as "no calibration data" and fall back to their pre-existing
+// behavior rather than fail the dispatch.
+func loadCalibrationFor(opts Options) (*trust.Calibrator, string) {
+	domain := opts.Domain
+	if domain == "" {
+		domain = "default"
+	}
+	cal, err := trust.New(trust.DefaultPath())
+	if err != nil {
+		return nil, domain
+	}
+	return cal, domain
+}
+
+// rankByCalibratedScore ranks successful attempts by measured diagnostic
+// power D(source, domain) instead of static CapScore, so ModeAll surfaces the
+// most-trustworthy-in-this-domain answer first once calibration data exists.
+// D (not the Dawid-Skene Λ CalibratedJudge computes) is the right quantity
+// here: D is a property of a single source, which is exactly what ranking
+// candidates by "how trustworthy is this one" needs, whereas Λ scores a
+// specific hypothesis against the whole ensemble's votes — the question
+// CalibratedJudge answers, not the question a display ranking asks.
+// Falls back to rankByCapScore's exact ordering when no successful attempt
+// has any calibration history yet (every D is 0) — a fresh install ranks
+// identically to before this existed.
+func rankByCalibratedScore(attempts []Attempt, cal *trust.Calibrator, domain string) {
+	type indexed struct {
+		idx int
+		d   float64
+	}
+	var ok []indexed
+	maxD := 0.0
+	for i, a := range attempts {
+		if a.Status != StatusOK {
+			continue
+		}
+		d := cal.D(a.Head.ID, domain)
+		ok = append(ok, indexed{i, d})
+		if d > maxD {
+			maxD = d
+		}
+	}
+	if maxD <= 0 {
+		rankByCapScore(attempts)
+		return
+	}
+	sort.Slice(ok, func(i, j int) bool {
+		if ok[i].d != ok[j].d {
+			return ok[i].d > ok[j].d
+		}
+		return attempts[ok[i].idx].Head.CapScore > attempts[ok[j].idx].Head.CapScore
+	})
+	for rank, item := range ok {
+		attempts[item.idx].Rank = rank + 1
+	}
 }
 
 func raceWinner(attempts []Attempt) *Attempt {

--- a/internal/trust/sprt.go
+++ b/internal/trust/sprt.go
@@ -10,13 +10,8 @@ import (
 	"strings"
 )
 
-// CorrelationDiscount caps the evidence from a model family that has already
-// voted: two heads backed by the same base model are not independent, so a
-// repeat vote counts for half. Prevents false agreement from inflating Λ.
-// Exported so other ensembling paths (internal/swarm's CalibratedJudge) share
-// this one source of truth instead of hardcoding a second copy of the same
-// constant; a future empirical per-family coupling (issue #118) replaces this
-// single definition and every caller upgrades with it.
+// CorrelationDiscount halves a repeat vote from an already-seen model family.
+// Exported so internal/swarm's CalibratedJudge shares this one constant too.
 const CorrelationDiscount = 0.5
 
 // Target configures an SPRT run. The domain used for calibration lookups comes

--- a/internal/trust/sprt.go
+++ b/internal/trust/sprt.go
@@ -10,10 +10,14 @@ import (
 	"strings"
 )
 
-// correlationDiscount caps the evidence from a model family that has already
+// CorrelationDiscount caps the evidence from a model family that has already
 // voted: two heads backed by the same base model are not independent, so a
 // repeat vote counts for half. Prevents false agreement from inflating Λ.
-const correlationDiscount = 0.5
+// Exported so other ensembling paths (internal/swarm's CalibratedJudge) share
+// this one source of truth instead of hardcoding a second copy of the same
+// constant; a future empirical per-family coupling (issue #118) replaces this
+// single definition and every caller upgrades with it.
+const CorrelationDiscount = 0.5
 
 // Target configures an SPRT run. The domain used for calibration lookups comes
 // from the Task, not here, so there is exactly one source of truth for it.
@@ -146,7 +150,7 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 
 		llr := cal.LLR(src.ID, task.Domain, agreed)
 		if src.Family != "" && familySeen[src.Family] {
-			llr *= correlationDiscount
+			llr *= CorrelationDiscount
 		}
 		familySeen[src.Family] = true
 


### PR DESCRIPTION
## Summary

An independent research pass ("Hydra — The Frontier Check," Aug 2026) checked Hydra's swarm
ensembling against the 2025-2026 correlated-error literature (Zhou et al., "Variation in
Verification," arXiv:2509.17995): majority voting across models captures only 10-19% of the
available oracle gain, and gets *worse*, not better, as models improve, because stronger models
make more *similar* mistakes, not more independent ones.

`ModeBest`/`ModeAll` (`--swarm --swarm-mode best|all`) never touched `trust.Calibrator` at all:
`LLMJudge` is one independent LLM call picking a winner (not a vote, not calibration-weighted),
`CapScoreJudge` is a static rank with zero content-awareness — exactly the naive-voting shape the
research flags. Meanwhile `internal/trust`'s SPRT ensemble already does the principled thing
(weighs each source by measured diagnostic power, discounts repeat same-family votes) — but that
machinery was entirely SPRT-only.

## The math

`CalibratedJudge` is a **Dawid-Skene naive-Bayes combiner** (Dawid & Skene, 1979: `P(votes|z=k) =
Π_i C_i[k,vote_i]` over each rater's confusion matrix), using `trust.Calibrator`'s already-estimated
per-source confusion matrices (`se`, `sp`) as the emission model. It's the **batch/simultaneous dual**
of `trust.Run`'s SPRT ensemble: SPRT accumulates the identical LLR evidence sequentially against one
evolving candidate with early stopping (the right shape when sampling costs something); `ModeBest`
already has all N attempts in hand with nothing left to sample, so it scores every candidate
hypothesis at once:

```
Λ_k = Σ_{i in cluster k}     LLR_i(agree)     ← sources whose answer IS k
    + Σ_{i not in cluster k} LLR_i(disagree)  ← sources whose answer differs from k

k*  = argmax_k Λ_k
P(z=k) ≈ softmax(Λ)_k   — the K-ary generalization of sigmoid(Λ), which is what
                          trust.Run already uses for its binary accept/reject decision
```

`trust.CorrelationDiscount` (exported from the SPRT-only `correlationDiscount`, not duplicated)
corrects for the one documented way the naive-Bayes independence assumption is violated: a repeat
vote from an already-seen model family is discounted rather than counted as independent
confirmation — directly answering Zhou et al.'s finding.

## Changes
- `internal/trust/sprt.go` — export `correlationDiscount` → `CorrelationDiscount` (mechanical rename,
  one call site, no behavior change)
- `internal/swarm/calibrated_judge.go` (new) — `CalibratedJudge`, the Dawid-Skene batch combiner
- `internal/swarm/swarm.go` — `buildJudge` wires `CalibratedJudge` ahead of the existing
  `LLMJudge`/`CapScoreJudge` fallback chain; `ModeAll` gets `rankByCalibratedScore` (ranks by
  diagnostic power `D` instead of static `CapScore` once calibration data exists)
- `internal/swarm/calibrated_judge_test.go` (new) — calibrated winner overriding CapScore,
  same-family discount reducing the winning margin, zero-data fallback, trivial single-success case

**No regression for any existing install**: whenever no candidate carries any calibration weight
(provably `Λ_k = 0` for every `k` with zero `hyctl trust record` history), `CalibratedJudge` errors
and `CompositeJudge` falls through to exactly today's `LLMJudge → CapScoreJudge` behavior.

**Explicitly out of scope**: issue #118 (replacing the flat `CorrelationDiscount` with an empirically
measured per-family coupling) is a separate, larger statistics project — both call sites share the
one exported constant and upgrade together automatically once it lands.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./...` — whole repo green
- [x] New tests: calibrated winner beats CapScore winner when calibration disagrees; same-family
      repeat vote wins by a strictly smaller margin than an independent one; zero calibration data
      → error → fallback; trivial one-success short-circuit; `rankByCalibratedScore` zero-data
      fallback matches `rankByCapScore` exactly

Closes #347