### PR TITLE
perf(trust,cost): stop replaying/reading entire unbounded JSONL logs on every invocation

### DIFF
--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -6,6 +6,7 @@ package cost
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -239,17 +240,25 @@ func ByRun(runID string) (*ByRunResult, error) {
 	}, nil
 }
 
-// Tail returns the last N rows.
+// Tail returns the last N rows, newest first, via a backward tail-seek rather
+// than loading the whole log.
 func Tail(n int) ([]Row, error) {
-	all, err := LoadAll()
+	if n <= 0 {
+		return LoadAll()
+	}
+	lines, err := tailLines(costLogPath(), n)
 	if err != nil {
 		return nil, err
 	}
-	if n <= 0 || n > len(all) {
-		n = len(all)
+	rows := make([]Row, 0, len(lines))
+	for _, line := range lines {
+		var r Row
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			continue // skip malformed rows, same tolerance as loadRows
+		}
+		rows = append(rows, r)
 	}
-	rows := all[len(all)-n:]
-	// Reverse so newest first.
+	// lines is oldest-first; reverse so the newest row is first.
 	out := make([]Row, len(rows))
 	for i, r := range rows {
 		out[len(rows)-1-i] = r
@@ -531,6 +540,51 @@ func loadRows(path string) ([]Row, error) {
 		rows = append(rows, r)
 	}
 	return rows, scanner.Err()
+}
+
+// tailLines returns the last n non-empty lines, oldest first, reading
+// backward from EOF in chunks (the tail -n algorithm) instead of the whole file.
+func tailLines(path string, n int) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w at %s — has anything dispatched yet?", ErrNoLog, path)
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	const chunkSize = 64 * 1024
+	var buf []byte
+	pos := info.Size()
+	for pos > 0 && bytes.Count(buf, []byte("\n")) <= n {
+		readSize := int64(chunkSize)
+		if readSize > pos {
+			readSize = pos
+		}
+		pos -= readSize
+		chunk := make([]byte, readSize)
+		if _, err := f.ReadAt(chunk, pos); err != nil {
+			return nil, err
+		}
+		buf = append(chunk, buf...)
+	}
+
+	var lines []string
+	for _, l := range strings.Split(string(buf), "\n") {
+		if strings.TrimSpace(l) != "" {
+			lines = append(lines, l)
+		}
+	}
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return lines, nil
 }
 
 func aggregate(rows []Row) Totals {

--- a/internal/cost/cost_log_test.go
+++ b/internal/cost/cost_log_test.go
@@ -5,6 +5,7 @@ package cost
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -584,6 +585,34 @@ func TestTail_NewestFirstAndClamped(t *testing.T) {
 		}
 		if len(all) != 3 {
 			t.Errorf("Tail(%d) returned %d rows, want all 3 clamped", n, len(all))
+		}
+	}
+}
+
+// A log spanning several 64 KiB chunks must still tail correctly, not off-by-a-chunk.
+func TestTailLines_CorrectAcrossChunkBoundaries(t *testing.T) {
+	var lines []string
+	pad := strings.Repeat("x", 100)
+	for i := 0; i < 2000; i++ {
+		lines = append(lines, row(t, Row{TS: "2026-08-01T00:00:00Z", Model: fmt.Sprintf("m%d-%s", i, pad), PromptTokens: 1}))
+	}
+	path := fixture(t, lines...)
+
+	got, err := tailLines(path, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("tailLines returned %d lines, want 5", len(got))
+	}
+	for i, want := range []int{1995, 1996, 1997, 1998, 1999} {
+		var r Row
+		if err := json.Unmarshal([]byte(got[i]), &r); err != nil {
+			t.Fatalf("line %d did not parse: %v", i, err)
+		}
+		wantModel := fmt.Sprintf("m%d-%s", want, pad)
+		if r.Model != wantModel {
+			t.Errorf("line %d: Model = %q, want %q — tailLines must be exact across chunk boundaries", i, r.Model, wantModel)
 		}
 	}
 }

--- a/internal/trust/calibration.go
+++ b/internal/trust/calibration.go
@@ -3,9 +3,9 @@
 package trust
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -93,8 +93,8 @@ type record struct {
 	Outcome     int    `json:"outcome"`
 }
 
-// load replays the jsonl file into the in-memory posterior. A missing file is
-// not an error — it just means no calibration has been recorded yet.
+// load replays the jsonl file into the in-memory posterior, resuming from the
+// last snapshot (calibration_snapshot.go) instead of the start when one exists.
 func (c *Calibrator) load() error {
 	f, err := os.Open(c.path)
 	if err != nil {
@@ -105,10 +105,32 @@ func (c *Calibrator) load() error {
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	var startOffset int64
+	if snap, offset, ok := loadSnapshot(snapshotPath(c.path), info.Size()); ok {
+		c.store = snap
+		startOffset = offset
+	}
+	if startOffset > 0 {
+		if _, err := f.Seek(startOffset, io.SeekStart); err != nil {
+			return err
+		}
+	}
+
+	// Bounded by the snapshot's own threshold except on the very first load of
+	// a pre-existing history — no worse than the old full-file replay.
+	delta, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	var replayed int
+	for _, line := range strings.Split(string(delta), "\n") {
+		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
 		}
@@ -117,8 +139,13 @@ func (c *Calibrator) load() error {
 			continue // skip malformed rows
 		}
 		c.apply(r.Source, r.Domain, r.SaidCorrect, Outcome(r.Outcome))
+		replayed++
 	}
-	return scanner.Err()
+
+	if replayed >= snapshotThreshold {
+		_ = saveSnapshot(snapshotPath(c.path), c.store, startOffset+int64(len(delta)))
+	}
+	return nil
 }
 
 // apply folds one observation into the in-memory posterior (no persistence).

--- a/internal/trust/calibration_snapshot.go
+++ b/internal/trust/calibration_snapshot.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+package trust
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// snapshotSchema is the calibration snapshot file's schema version.
+const snapshotSchema = 1
+
+// snapshotThreshold: replay at least this many records before checkpointing.
+const snapshotThreshold = 200
+
+// snapshotEntry is one (source, domain) confusion-matrix row.
+type snapshotEntry struct {
+	Source string  `json:"source"`
+	Domain string  `json:"domain"`
+	TP     float64 `json:"tp"`
+	FP     float64 `json:"fp"`
+	TN     float64 `json:"tn"`
+	FN     float64 `json:"fn"`
+}
+
+// snapshotFile is a checkpoint: the confusion-matrix state as of a byte offset
+// into the jsonl log, so load() only has to replay what's after it.
+type snapshotFile struct {
+	Schema  int             `json:"schema"`
+	Offset  int64           `json:"offset"`
+	Entries []snapshotEntry `json:"entries"`
+}
+
+func snapshotPath(jsonlPath string) string {
+	return jsonlPath + ".snapshot"
+}
+
+// loadSnapshot never errors — missing/corrupt/stale-offset just means "no
+// usable checkpoint," so load() falls back to a full replay.
+func loadSnapshot(path string, jsonlSize int64) (store map[calibKey]*confusion, offset int64, ok bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, false
+	}
+	var snap snapshotFile
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, 0, false
+	}
+	if snap.Schema != snapshotSchema || snap.Offset < 0 || snap.Offset > jsonlSize {
+		return nil, 0, false
+	}
+	store = make(map[calibKey]*confusion, len(snap.Entries))
+	for _, e := range snap.Entries {
+		store[calibKey{e.Source, e.Domain}] = &confusion{TP: e.TP, FP: e.FP, TN: e.TN, FN: e.FN}
+	}
+	return store, snap.Offset, true
+}
+
+// saveSnapshot writes temp-then-renames for atomicity; a write failure is
+// non-fatal, it just costs the next load a full replay.
+func saveSnapshot(path string, store map[calibKey]*confusion, offset int64) error {
+	entries := make([]snapshotEntry, 0, len(store))
+	for k, c := range store {
+		entries = append(entries, snapshotEntry{Source: k.source, Domain: k.domain, TP: c.TP, FP: c.FP, TN: c.TN, FN: c.FN})
+	}
+	data, err := json.Marshal(snapshotFile{Schema: snapshotSchema, Offset: offset, Entries: entries})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/trust/calibration_snapshot_test.go
+++ b/internal/trust/calibration_snapshot_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+
+package trust
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Crossing snapshotThreshold must write a checkpoint that replays to the same state.
+func TestSnapshot_WrittenAfterThresholdAndReplaysToTheSameState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "calibration.jsonl")
+
+	c1, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed(t, c1, "model:good", "go", 150, 50, 0, 0) // c1 only appends; it never replays its own writes
+	want := c1.D("model:good", "go")
+
+	// c2's construction is the load() that actually replays the file and crosses the threshold.
+	c2, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(snapshotPath(path)); err != nil {
+		t.Fatalf("expected a snapshot file after c2's load crossed the threshold, stat failed: %v", err)
+	}
+	got := c2.D("model:good", "go")
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("D after snapshot-assisted replay = %.6f, want %.6f", got, want)
+	}
+	if n := c2.Report()[0].N; n != 200 {
+		t.Errorf("observations after snapshot-assisted replay = %v, want 200", n)
+	}
+}
+
+// Records appended after a snapshot must still be picked up by the next load.
+func TestSnapshot_RecordsAppendedAfterSnapshotAreStillReplayed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "calibration.jsonl")
+
+	c1, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed(t, c1, "model:good", "go", 150, 50, 0, 0)
+
+	c2, err := New(path) // this load crosses the threshold and writes the snapshot
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed(t, c2, "model:good", "go", 10, 0, 0, 0) // appended after the snapshot existed
+
+	c3, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := c3.Report()[0].N; n != 210 {
+		t.Errorf("observations = %v, want 210 (200 pre-snapshot + 10 post-snapshot)", n)
+	}
+}
+
+// A corrupt snapshot must never lose data or error out of New.
+func TestSnapshot_CorruptFileFallsBackToFullReplay(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "calibration.jsonl")
+
+	c1, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed(t, c1, "model:good", "go", 150, 50, 0, 0)
+	want := c1.D("model:good", "go")
+
+	if err := os.WriteFile(snapshotPath(path), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := New(path)
+	if err != nil {
+		t.Fatalf("New must tolerate a corrupt snapshot, got error: %v", err)
+	}
+	got := c2.D("model:good", "go")
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("D after corrupt-snapshot fallback = %.6f, want %.6f (data was lost)", got, want)
+	}
+	if n := c2.Report()[0].N; n != 200 {
+		t.Errorf("observations after corrupt-snapshot fallback = %v, want 200", n)
+	}
+}
+
+// An offset past the file's actual size (truncated/rotated) must be rejected, not seeked-to.
+func TestSnapshot_OffsetPastFileSizeIsRejected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "calibration.jsonl")
+
+	c1, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed(t, c1, "model:good", "go", 150, 50, 0, 0)
+	want := c1.D("model:good", "go")
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := saveSnapshot(snapshotPath(path), map[calibKey]*confusion{}, info.Size()+1_000_000); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := c2.D("model:good", "go")
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("D after rejecting a too-far-ahead snapshot = %.6f, want %.6f (real history was skipped)", got, want)
+	}
+}
+
+// Below snapshotThreshold, load() must not write a snapshot file at all.
+func TestSnapshot_NotWrittenBelowThreshold(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "calibration.jsonl")
+
+	c1, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed(t, c1, "model:good", "go", 2, 1, 0, 0)
+
+	if _, err := New(path); err != nil { // replays 3 records — well under snapshotThreshold
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(snapshotPath(path)); !os.IsNotExist(err) {
+		t.Errorf("expected no snapshot file below the threshold, stat err = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Grounded in an actual codebase survey (not speculative): `trust.Calibrator.load()` replayed the
entire `calibration.jsonl` from scratch on every process start — every `hyctl dispatch
--confidence`, every swarm run. `cost.Tail(n)` read the whole `cost.jsonl` then sliced the last n.
Both logs are append-only and grow without bound; neither had an index, snapshot, or rotation. No
benchmark existed guarding either against growth — this is a cost that only ever grows with
calendar time, not with any input Hydra controls.

Everything else checked (graph blast-radius BFS, swarm's small-n clustering, budget's closed-form
governor, pricing's O(1) map lookups, parallel provider discovery) was already algorithmically
appropriate for its real scale — deliberately left alone rather than "improved," per this repo's
own stated engineering philosophy.

## Changes

- **`trust.Calibrator`**: snapshot + incremental replay. The confusion-matrix counts (`TP/FP/TN/FN`
  per source×domain) are a commutative, associative sufficient statistic, so a periodic checkpoint
  (the same idea as a database write-ahead-log) plus replaying only the delta since it reconstructs
  the identical posterior a full replay would. A corrupt, missing, or stale-offset snapshot (offset
  past the file's real size — file truncated/rotated/replaced) is never trusted; falls back to a
  full replay rather than risk silently losing history.
- **`cost.Tail(n)`**: a genuine backward tail-seek (the `tail -n` algorithm) — reads roughly n lines
  from the end instead of the whole file.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./...` — whole repo green
- [x] New tests: snapshot written after crossing the threshold and replays to the exact same
      posterior; records appended after a snapshot are still picked up; corrupt snapshot falls back
      safely; offset-past-file-size is rejected; below-threshold writes no snapshot;
      `tailLines` correct across multi-chunk (>64 KiB) backward reads

Closes #349