### PR TITLE
feat(dispatch): auto-populate defect-cost risk signals in the real dispatch path

### DIFF
--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -180,6 +180,39 @@ func TestCLI_Dispatch_SwarmDryRunFiresNothing(t *testing.T) {
 	}
 }
 
+// A real risk signal — PII in the prompt, or --irreversible/--production —
+// must trigger SPRT mode on its own, not just --file's blast radius.
+func TestCLI_Dispatch_RiskSignalsTriggerSPRTWithoutFileOrConfidence(t *testing.T) {
+	dispatchable(t, "answered")
+
+	out, cobraOut, err := run(t, "dispatch", "--irreversible", "--production",
+		"--dry-run", "--tier", "6", "mail alice.smith@example.co.uk about it")
+	if err != nil {
+		t.Fatalf("dry run failed: %v (%s)", err, cobraOut)
+	}
+	combined := out + cobraOut
+	if !strings.Contains(combined, "SPRT") {
+		t.Errorf("a prompt with PII + --irreversible + --production did not select SPRT mode:\n%s", combined)
+	}
+	if !strings.Contains(combined, "irreversible=true") || !strings.Contains(combined, "pii=true") || !strings.Contains(combined, "prod=true") {
+		t.Errorf("the defect line does not reflect all three risk signals:\n%s", combined)
+	}
+}
+
+// With none of --confidence/--file/--irreversible/--production, and no PII,
+// dispatch must not silently enter SPRT mode.
+func TestCLI_Dispatch_NoRiskSignalsStaysInSingleDispatchMode(t *testing.T) {
+	dispatchable(t, "answered")
+
+	out, cobraOut, err := run(t, "dispatch", "--dry-run", "--tier", "6", "implement a rate limiter")
+	if err != nil {
+		t.Fatalf("dry run failed: %v (%s)", err, cobraOut)
+	}
+	if strings.Contains(out+cobraOut, "SPRT") {
+		t.Errorf("a plain dispatch with no risk signal entered SPRT mode:\n%s", out+cobraOut)
+	}
+}
+
 // An SPRT dry run is the same contract for --confidence.
 func TestCLI_Dispatch_ConfidenceDryRunFiresNothing(t *testing.T) {
 	dispatchable(t, "answered")

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ankit373/hydra/internal/optimal"
 	"github.com/ankit373/hydra/internal/oracle"
 	"github.com/ankit373/hydra/internal/parallel"
+	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/provider"
@@ -445,10 +446,12 @@ func cmdDispatch() *cobra.Command {
 		swarmMaxCost  float64
 		swarmJudge    string
 		// trust / SPRT flags
-		confidence float64
-		domain     string
-		file       string
-		graphPath  string
+		confidence   float64
+		domain       string
+		file         string
+		graphPath    string
+		irreversible bool
+		production   bool
 	)
 
 	cmd := &cobra.Command{
@@ -496,30 +499,42 @@ func cmdDispatch() *cobra.Command {
 			}
 
 			// ── SPRT confidence mode ──────────────────────────────────────
-			// Triggered by --confidence, or by --file (blast radius derives a
-			// target on its own). Blast radius raises the bar but never lowers a
-			// target the user explicitly asked for.
+			// Triggered by --confidence, or by any real risk signal (--file's
+			// blast radius, --irreversible, --production, or PII auto-detected
+			// in the prompt). Risk raises the bar but never lowers a target the
+			// user explicitly asked for.
 			effectiveConf := confidence
-			if file != "" {
-				g, err := graph.Load(graphPath)
-				if err != nil {
-					return err
+			touchesPII := policy.ContainsPII(policy.Request{Prompt: prompt})
+			if file != "" || irreversible || production || touchesPII {
+				radius := 1.0
+				if file != "" {
+					g, err := graph.Load(graphPath)
+					if err != nil {
+						return err
+					}
+					radius = g.BlastRadiusForFile(file)
+					// --file exists to RAISE the bar for risky files. With no graph
+					// it silently never raises, while printing a line that reads
+					// exactly like blast-radius-aware routing happened (#251). The
+					// bar itself is unchanged — only the claim about it.
+					if g.Empty() {
+						fmt.Printf("  %s\n", warnStyle.Render(
+							"graph: no graph at "+graphPath+" — radius 1.00 is a default, not a measurement"))
+					} else if !g.Knows(file) {
+						fmt.Printf("  %s\n", warnStyle.Render(
+							"graph: "+file+" is not in the graph — radius 1.00 is a default, not a measurement"))
+					}
 				}
-				task := trust.Task{Domain: domain, BlastRadius: g.BlastRadiusForFile(file)}
+				task := trust.Task{
+					Domain:       domain,
+					BlastRadius:  radius,
+					Irreversible: irreversible,
+					TouchesPII:   touchesPII,
+					Production:   production,
+				}
 				derived := trust.NewDefectModel().RequiredConfidence(task)
-				fmt.Printf("  %s blast radius %.2f → demands confidence ≥ %.1f%%\n",
-					dimStyle.Render("graph:"), task.BlastRadius, derived*100)
-				// --file exists to RAISE the bar for risky files. With no graph
-				// it silently never raises, while printing a line that reads
-				// exactly like blast-radius-aware routing happened (#251). The
-				// bar itself is unchanged — only the claim about it.
-				if g.Empty() {
-					fmt.Printf("  %s\n", warnStyle.Render(
-						"graph: no graph at "+graphPath+" — radius 1.00 is a default, not a measurement"))
-				} else if !g.Knows(file) {
-					fmt.Printf("  %s\n", warnStyle.Render(
-						"graph: "+file+" is not in the graph — radius 1.00 is a default, not a measurement"))
-				}
+				fmt.Printf("  %s blast=%.2f irreversible=%v pii=%v prod=%v → demands confidence ≥ %.1f%%\n",
+					dimStyle.Render("defect:"), task.BlastRadius, irreversible, touchesPII, production, derived*100)
 				if derived > effectiveConf {
 					effectiveConf = derived
 				}
@@ -671,6 +686,8 @@ func cmdDispatch() *cobra.Command {
 	cmd.Flags().StringVar(&domain, "domain", "", "calibration domain for --confidence (default: \"default\")")
 	cmd.Flags().StringVar(&file, "file", "", "target file — derives a confidence target from its blast radius, so this alone selects the SPRT ensemble")
 	cmd.Flags().StringVar(&graphPath, "graph", "graph.json", "path to the dependency graph used with --file")
+	cmd.Flags().BoolVar(&irreversible, "irreversible", false, "change cannot be cheaply undone — raises the required confidence")
+	cmd.Flags().BoolVar(&production, "production", false, "target is production — raises the required confidence")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary
`DefectModel.RequiredConfidence` takes `BlastRadius`/`Irreversible`/`TouchesPII`/`Production`, but
the real `hyctl dispatch` path only ever populated `BlastRadius` via `--file` — the other three
risk dimensions were only reachable through the separate, manual `hyctl trust defect` preview
command. "Route more carefully near PII/irreversible/production work" wasn't actually automatic.

## Changes
- `TouchesPII` is now auto-detected from the real prompt via the existing `policy.ContainsPII`
  (already used for PII/local-only enforcement, just never threaded into `trust.Task`) — no new
  surface.
- `--irreversible`/`--production` are new explicit `hyctl dispatch` flags, mirroring what
  `hyctl trust defect` already exposes for the manual command. Deliberately **not** a file-glob
  heuristic — a guesser that silently does nothing until hand-configured isn't a real fix, and the
  orchestrator usually knows when a task is irreversible/production-facing.
- The confidence-escalation trigger is broadened from "only when `--file` is given" to "when
  `--file`, `--irreversible`, `--production` is given, or the prompt contains PII" — any real risk
  signal can now auto-raise the confidence bar, not just blast radius.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./...` — whole repo green
- [x] New tests: a prompt containing PII + `--irreversible --production` selects SPRT mode with no
      `--file`/`--confidence`, and the printed defect line reflects all three; a plain dispatch
      with no risk signal stays in single-dispatch mode; existing `--file`/`--confidence` dry-run
      tests unchanged

Closes #351