### PR TITLE
feat(editor,review): thread head identity so edit validation and review outcomes feed calibration

### DIFF
--- a/internal/editor/edit_test.go
+++ b/internal/editor/edit_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/testutil"
+	"github.com/ankit373/hydra/internal/trust"
 
 	// Providers register themselves in init(), and this package does not import
 	// them — without these blanks provider.All() is empty in the test binary and
@@ -275,6 +276,51 @@ func TestEdit_PassingValidationKeepsTheEdit(t *testing.T) {
 	if raw, _ := os.ReadFile(file); !strings.Contains(string(raw), "validated") {
 		t.Errorf("the edit was rolled back despite passing: %q", raw)
 	}
+	if res.Head != "cody" {
+		t.Errorf("Head = %q, want cody", res.Head)
+	}
+}
+
+// A validator's exit code is real ground truth — it must reach calibration
+// automatically, both when it passes and when it fails, without a human
+// ever running `hyctl trust record`.
+func TestEdit_ValidationOutcomeReachesCalibration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the workspace validator template is a POSIX command line here")
+	}
+	for _, tt := range []struct {
+		name      string
+		validator string
+	}{
+		{"pass", "/usr/bin/true {file}"},
+		{"fail", "/usr/bin/false {file}"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := editSandbox(t, marked("content"))
+			writeWorkspaceYAML(t, repo, tt.validator)
+			file := filepath.Join(repo, "a.go")
+			if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := Edit(context.Background(), Request{
+				File: file, Enum: "MODERATE", Prompt: "x", Validate: true,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			cal, err := trust.New(trust.DefaultPath())
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, s := range cal.Report() {
+				if s.Source == "cody" && s.Domain == "go" && s.N == 1 {
+					return
+				}
+			}
+			t.Errorf("no calibration observation recorded for cody/go: %+v", cal.Report())
+		})
+	}
 }
 
 // The backup is a verbatim copy of the user's source sitting beside it until
@@ -482,7 +528,7 @@ func TestDiffStats_CountsFromTheBackupWhenGitIsUnavailable(t *testing.T) {
 func TestWriteLastEdit_IsReadableByReview(t *testing.T) {
 	testutil.NewSandbox(t)
 
-	if err := writeLastEdit("/abs/file.go", "SIMPLE", "ws", 3, 1); err != nil {
+	if err := writeLastEdit("/abs/file.go", "SIMPLE", "ws", "claude", 3, 1); err != nil {
 		t.Fatal(err)
 	}
 	raw, err := os.ReadFile(filepath.Join(config.Dir(), "logs", "last_edit.json"))
@@ -499,6 +545,10 @@ func TestWriteLastEdit_IsReadableByReview(t *testing.T) {
 	}
 	if got["lines_added"] != float64(3) || got["lines_removed"] != float64(1) {
 		t.Errorf("line counts = %v/%v", got["lines_added"], got["lines_removed"])
+	}
+	// review reads this back to attribute an approve/reject to the right head.
+	if got["head_id"] != "claude" {
+		t.Errorf("last_edit.json head_id = %v, want claude", got["head_id"])
 	}
 }
 
@@ -789,7 +839,7 @@ func TestWriteLastEdit_UnwritableLogDirIsAnError(t *testing.T) {
 	if err := os.WriteFile(config.Dir(), []byte("not a dir"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeLastEdit("/abs/f.go", "SIMPLE", "ws", 1, 0); err == nil {
+	if err := writeLastEdit("/abs/f.go", "SIMPLE", "ws", "claude", 1, 0); err == nil {
 		t.Error("writeLastEdit reported success with an uncreatable logs directory")
 	}
 }

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/diff"
 	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/util"
 	"github.com/ankit373/hydra/internal/workspace"
 )
@@ -47,6 +48,7 @@ type Result struct {
 	Workspace       string `json:"workspace"`
 	GitRoot         string `json:"git_root"`
 	Enum            string `json:"enum"`
+	Head            string `json:"head,omitempty"` // head ID that produced the edit
 	LinesAdded      int    `json:"lines_added"`
 	LinesRemoved    int    `json:"lines_removed"`
 	ValidatorPassed bool   `json:"validator_passed"`
@@ -188,6 +190,7 @@ snippet) between these exact markers and nothing else:
 
 		if vtmpl != "" {
 			vout, vrc := runValidatorCmd(vtmpl, req.File)
+			recordValidationOutcome(dispResult.Head.ID, fileExt(req.File), vrc == 0)
 			if vrc != 0 {
 				validatorPassed = false
 				rollback(req.File, origContent, origExisted, resolved.GitRoot, backup)
@@ -197,6 +200,7 @@ snippet) between these exact markers and nothing else:
 					Workspace:       wsName,
 					GitRoot:         resolved.GitRoot,
 					Enum:            req.Enum,
+					Head:            dispResult.Head.ID,
 					ValidatorPassed: false,
 					RolledBack:      true,
 					Error:           "validation_failed: " + firstLine(vout),
@@ -214,7 +218,7 @@ snippet) between these exact markers and nothing else:
 	logEdit(req, origContent, newContent+"\n", added, removed)
 
 	// ── A2A handoff ───────────────────────────────────────────────────────────
-	_ = writeLastEdit(req.File, req.Enum, wsName, added, removed)
+	_ = writeLastEdit(req.File, req.Enum, wsName, dispResult.Head.ID, added, removed)
 
 	return &Result{
 		Status:          "ok",
@@ -222,11 +226,32 @@ snippet) between these exact markers and nothing else:
 		Workspace:       wsName,
 		GitRoot:         resolved.GitRoot,
 		Enum:            req.Enum,
+		Head:            dispResult.Head.ID,
 		LinesAdded:      added,
 		LinesRemoved:    removed,
 		ValidatorPassed: validatorPassed,
 		RolledBack:      false,
 	}, nil
+}
+
+// recordValidationOutcome is a best-effort calibration observation: the
+// validator's exit code is real, objective ground truth (it parsed/compiled
+// or it didn't), so it needs no separate self-assessment step — the produced
+// edit is its own implicit claim of correctness, the same proxy trust.Run
+// already uses. Never lets a calibration failure affect the edit itself.
+func recordValidationOutcome(headID, domain string, passed bool) {
+	if headID == "" {
+		return
+	}
+	cal, err := trust.New(trust.DefaultPath())
+	if err != nil {
+		return
+	}
+	outcome := trust.OutcomeIncorrect
+	if passed {
+		outcome = trust.OutcomeCorrect
+	}
+	_ = cal.Update(headID, domain, true, outcome)
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -487,12 +512,13 @@ func firstLine(s string) string {
 	return s
 }
 
-func writeLastEdit(file, enum, ws string, added, removed int) error {
+func writeLastEdit(file, enum, ws, headID string, added, removed int) error {
 	h := map[string]any{
 		"from":          "hydra-edit-" + enum,
 		"file":          file,
 		"enum":          enum,
 		"workspace":     ws,
+		"head_id":       headID,
 		"lines_added":   added,
 		"lines_removed": removed,
 	}

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/diff"
 	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/workspace"
 )
 
@@ -172,6 +173,7 @@ func Approve(file string) (*ApproveResult, error) {
 		}
 	}
 
+	recordReviewOutcome(file, true)
 	return &ApproveResult{Status: "approved", File: file}, nil
 }
 
@@ -190,6 +192,7 @@ func Reject(file string) (*RejectResult, error) {
 		resolved, _ = reg.Resolve(file)
 	}
 
+	var result *RejectResult
 	gitRoot := resolved.GitRoot
 	if gitUsable(gitRoot) {
 		err := exec.Command("git", "-C", gitRoot, "ls-files", "--error-unmatch", file).Run()
@@ -197,29 +200,36 @@ func Reject(file string) (*RejectResult, error) {
 			if err := exec.Command("git", "-C", gitRoot, "checkout", "--", file).Run(); err != nil {
 				return nil, fmt.Errorf("git checkout failed: %w", err)
 			}
-			return &RejectResult{Status: "rejected", File: file, Method: "git_checkout"}, nil
-		}
-		// Only a clean exit status of 1 means "this path is not tracked". Any
-		// other failure — git missing, .git present but not a repository, a
-		// permissions error — means we do not know, and deleting a file we
-		// cannot prove is disposable is unrecoverable data loss. Before this,
-		// every one of those took the branch below and removed the file.
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && fileExists(file) {
-			_ = os.Remove(file)
-			return &RejectResult{Status: "rejected", File: file, Method: "rm_untracked"}, nil
+			result = &RejectResult{Status: "rejected", File: file, Method: "git_checkout"}
+		} else {
+			// Only a clean exit status of 1 means "this path is not tracked". Any
+			// other failure — git missing, .git present but not a repository, a
+			// permissions error — means we do not know, and deleting a file we
+			// cannot prove is disposable is unrecoverable data loss. Before this,
+			// every one of those took the branch below and removed the file.
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 && fileExists(file) {
+				_ = os.Remove(file)
+				result = &RejectResult{Status: "rejected", File: file, Method: "rm_untracked"}
+			}
 		}
 	}
 
-	backup := file + ".hydra-bak"
-	if fileExists(backup) {
-		if err := os.Rename(backup, file); err != nil {
-			return nil, fmt.Errorf("backup restore failed: %w", err)
+	if result == nil {
+		backup := file + ".hydra-bak"
+		if fileExists(backup) {
+			if err := os.Rename(backup, file); err != nil {
+				return nil, fmt.Errorf("backup restore failed: %w", err)
+			}
+			result = &RejectResult{Status: "rejected", File: file, Method: "backup_restore"}
 		}
-		return &RejectResult{Status: "rejected", File: file, Method: "backup_restore"}, nil
 	}
 
-	return nil, fmt.Errorf("nothing to roll back for %s", file)
+	if result == nil {
+		return nil, fmt.Errorf("nothing to roll back for %s", file)
+	}
+	recordReviewOutcome(file, false)
+	return result, nil
 }
 
 // QA sends a file's diff to a Hydra Head for LLM review.
@@ -371,4 +381,41 @@ func filesFromLogs() []string {
 	}
 
 	return files
+}
+
+// headIDForLastEdit returns the head that produced file's last edit, or ""
+// if last_edit.json's own file doesn't match — its single slot can only
+// answer for whichever file was edited most recently.
+func headIDForLastEdit(file string) string {
+	raw, err := os.ReadFile(filepath.Join(config.Dir(), "logs", "last_edit.json"))
+	if err != nil {
+		return ""
+	}
+	var e struct {
+		File   string `json:"file"`
+		HeadID string `json:"head_id"`
+	}
+	if json.Unmarshal(raw, &e) != nil || e.File != file {
+		return ""
+	}
+	return e.HeadID
+}
+
+// recordReviewOutcome is a best-effort calibration observation: a human's
+// approve/reject is stronger ground truth than editor's own syntax-check.
+func recordReviewOutcome(file string, correct bool) {
+	headID := headIDForLastEdit(file)
+	if headID == "" {
+		return
+	}
+	cal, err := trust.New(trust.DefaultPath())
+	if err != nil {
+		return
+	}
+	outcome := trust.OutcomeIncorrect
+	if correct {
+		outcome = trust.OutcomeCorrect
+	}
+	domain := strings.TrimPrefix(filepath.Ext(file), ".")
+	_ = cal.Update(headID, domain, true, outcome)
 }

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -3,13 +3,16 @@
 package review
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/testutil"
+	"github.com/ankit373/hydra/internal/trust"
 )
 
 // internal/review was at 0%. Approve and Reject are the other half of the
@@ -91,6 +94,38 @@ func write(t *testing.T, path, content string) {
 	}
 }
 
+// writeLastEditFixture stands in for editor.writeLastEdit without importing
+// the editor package — same file, same shape.
+func writeLastEditFixture(t *testing.T, file, headID string) {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{"file": file, "head_id": headID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	logDir := filepath.Join(config.Dir(), "logs")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logDir, "last_edit.json"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// calibrationObservation reports N for (source, domain), or -1 if absent.
+func calibrationObservation(t *testing.T, source, domain string) float64 {
+	t.Helper()
+	cal, err := trust.New(trust.DefaultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range cal.Report() {
+		if s.Source == source && s.Domain == domain {
+			return s.N
+		}
+	}
+	return -1
+}
+
 // ── Approve ───────────────────────────────────────────────────────────────────
 
 // Approving a non-git edit consumes the backup. Leaving it behind means the
@@ -119,6 +154,23 @@ func TestApprove_ConsumesTheBackup(t *testing.T) {
 	}
 	if string(body) != "new" {
 		t.Errorf("file = %q after approve, want the edited content", body)
+	}
+}
+
+// Approve is a real ground-truth signal for calibration — the head that
+// produced the edit gets a "correct" observation, without a human ever
+// running `hyctl trust record`.
+func TestApprove_RecordsACalibrationObservation(t *testing.T) {
+	repo := repoSandbox(t, false)
+	file := filepath.Join(repo, "src", "a.go")
+	write(t, file, "new")
+	writeLastEditFixture(t, file, "cody")
+
+	if _, err := Approve(file); err != nil {
+		t.Fatal(err)
+	}
+	if n := calibrationObservation(t, "cody", "go"); n != 1 {
+		t.Errorf("observations for cody/go = %v, want 1", n)
 	}
 }
 
@@ -167,6 +219,24 @@ func TestReject_RestoresFromTheBackup(t *testing.T) {
 	}
 	if _, err := os.Stat(backup); !os.IsNotExist(err) {
 		t.Error("the backup was left behind after being consumed")
+	}
+}
+
+// Reject is the negative ground-truth signal: the head's edit was bad enough
+// to undo, so it must reach calibration as an incorrect observation.
+func TestReject_RecordsACalibrationObservation(t *testing.T) {
+	repo := repoSandbox(t, false)
+	file := filepath.Join(repo, "src", "a.go")
+	backup := file + ".hydra-bak"
+	write(t, file, "BROKEN")
+	write(t, backup, "ORIGINAL")
+	writeLastEditFixture(t, file, "cody")
+
+	if _, err := Reject(file); err != nil {
+		t.Fatal(err)
+	}
+	if n := calibrationObservation(t, "cody", "go"); n != 1 {
+		t.Errorf("observations for cody/go = %v, want 1", n)
 	}
 }
 


### PR DESCRIPTION
## Summary
`trust.Calibrator.Update` had exactly one real caller: the manual `hyctl trust record` command.
`hyctl edit`'s validation exit code and `hyctl review`'s approve/reject never touched it — by
review time the identity of the model that produced the edit was already lost, since
`last_edit.json`/`review.FileEntry` carried only a file path. This is the biggest gap in Hydra's
Trust Control Plane: the entire premise of routing by *measured* reliability depends on
calibration data accumulating from real outcomes, and it only grew when a human manually typed
`hyctl trust record`.

## Changes
- `editor.Result` and `last_edit.json` now carry `head_id`, threaded from the `dispatch.Result`
  the edit's own `Dispatch` call already returns (previously discarded).
- `editor.Edit`'s existing per-extension validator (`runValidatorCmd`) becomes a real, automatic
  calibration observation: exit 0/non-zero maps to `OutcomeCorrect`/`OutcomeIncorrect` — best
  effort, a calibration write failure never fails or rolls back the edit itself.
- `review.Approve`/`Reject` read `head_id` off the matching `last_edit.json` entry and record a
  stronger, human-verified outcome the same way — `Approve` → `OutcomeCorrect`, `Reject` →
  `OutcomeIncorrect`. Both writing to the same `(source, domain)` cell as editor's own observation
  is correct, not double-counting: two independent signals about the same edit.
- Domain is the file extension without the dot (`"go"`, `"py"`, `"ts"`) — reuses the same
  extension-keying convention `workspace.Registry.ValidatorFor` already uses, no new mapping table.

**Explicitly not doing git-revert detection here** — it needs commit-message stamping plus a hook
or periodic scan, a bigger, separate decision (touches the user's git workflow) that deserves its
own design conversation, not a bolt-on.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./...` — whole repo green
- [x] New tests: `editor.Result`/`last_edit.json` carry `head_id`; a passing AND a failing
      validator each produce exactly one calibration observation; `hyctl review approve/reject`
      each produce exactly one calibration observation with the right outcome direction

Closes #353