### PR TITLE
feat(dispatch,swarm): wire the MCP accountability ledger into the real dispatch/swarm path

### DIFF
--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ankit373/hydra/internal/budget"
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/provider"
@@ -178,6 +179,79 @@ func TestDispatch_FallsThroughToTheNextHead(t *testing.T) {
 	if res.Retries != 1 {
 		t.Errorf("Retries = %d, want 1 — the user is told how far the chain fell",
 			res.Retries)
+	}
+}
+
+// A ledger deny rule must actually block a real dispatch to that head, not
+// just log it — the entire point of a policy gate over an accountability log.
+func TestDispatch_LedgerDenyRuleBlocksTheHead(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	writeLedgerPolicy(t, ledger.Policy{Rules: []ledger.Rule{{Tool: "denied", Decision: ledger.Deny}}})
+
+	res, err := liveDispatcher(echoHead(t, s, "denied", 95), echoHead(t, s, "ok", 90)).
+		Dispatch(context.Background(), "go", Options{})
+	if err != nil {
+		t.Fatalf("dispatch gave up instead of falling back past the denied head: %v", err)
+	}
+	if res.Head.ID != "ok" {
+		t.Errorf("answered by %q, want the fallback head — the denied one must never run", res.Head.ID)
+	}
+
+	events, err := ledger.Load(ledger.DefaultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawDeny bool
+	for _, e := range events {
+		if e.Tool == "denied" && e.Decision == ledger.Deny {
+			sawDeny = true
+		}
+	}
+	if !sawDeny {
+		t.Errorf("no deny event recorded for the denied head: %+v", events)
+	}
+}
+
+// With no policy configured, the ledger's default-allow must leave dispatch
+// behavior unchanged — but it must still record the access.
+func TestDispatch_DefaultLedgerPolicyRecordsButNeverBlocks(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res, err := liveDispatcher(echoHead(t, s, "h1", 90)).Dispatch(context.Background(), "go", Options{})
+	if err != nil {
+		t.Fatalf("a dispatch with no ledger policy configured must succeed: %v", err)
+	}
+	if res.Head.ID != "h1" {
+		t.Errorf("Head = %q, want h1", res.Head.ID)
+	}
+
+	events, err := ledger.Load(ledger.DefaultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawAllow bool
+	for _, e := range events {
+		if e.Tool == "h1" && e.Decision == ledger.Allow {
+			sawAllow = true
+		}
+	}
+	if !sawAllow {
+		t.Errorf("no allow event recorded for a real dispatch: %+v", events)
+	}
+}
+
+func writeLedgerPolicy(t *testing.T, p ledger.Policy) {
+	t.Helper()
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := ledger.DefaultPolicyPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/cost"
 	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
@@ -179,6 +180,15 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 			Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
 			Detail: fmt.Sprintf("candidate %d of %d", i+1, len(candidates)),
 		})
+		if decision, lerr := ledger.CheckAndRecordDispatch("hydra-dispatch", h.ID, "", prompt); lerr == nil && decision == ledger.Deny {
+			lastErr = fmt.Errorf("denied by ledger policy: head %s", h.ID)
+			_ = rl.Append(runlog.Event{
+				Kind: runlog.KindError, TaskID: taskID,
+				Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
+				Status: "denied", Detail: "denied by ledger policy",
+			})
+			continue
+		}
 		started := time.Now()
 		exec := executor.For(h)
 		resp, err := exec.Execute(ctx, executor.Request{

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -434,6 +434,23 @@ func Check(path string, p Policy, req CheckRequest) (Decision, error) {
 	return decision, err
 }
 
+// CheckAndRecordDispatch is the automatic-dispatch-path counterpart to the
+// manual `hyctl mcp check`: it loads the default policy, evaluates one head
+// call as a tool/resource access (Action=Exec), and records the decision —
+// so a real dispatch produces a ledger event without anyone invoking
+// `hyctl mcp` by hand. Default (no rules configured) policy is Allow, so this
+// only changes behavior for an install that has deliberately configured a
+// deny rule.
+func CheckAndRecordDispatch(agent, headID, resource, content string) (Decision, error) {
+	pol, err := LoadPolicy(DefaultPolicyPath())
+	if err != nil {
+		return "", err
+	}
+	return Check(DefaultPath(), pol, CheckRequest{
+		Agent: agent, Tool: headID, Resource: resource, Action: Exec, Content: content,
+	})
+}
+
 // Summary is the aggregate accountability report.
 type Summary struct {
 	Total   int            `json:"total"`

--- a/internal/swarm/runner.go
+++ b/internal/swarm/runner.go
@@ -4,10 +4,12 @@ package swarm
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/provider"
 )
 
@@ -41,6 +43,14 @@ func executeHead(ctx context.Context, h provider.Head, prompt string, opts Optio
 		Head:      h,
 		Status:    StatusRunning,
 		StartedAt: time.Now(),
+	}
+
+	if decision, err := ledger.CheckAndRecordDispatch("hydra-swarm", h.ID, "", prompt); err == nil && decision == ledger.Deny {
+		a.FinishedAt = time.Now()
+		a.Duration = a.FinishedAt.Sub(a.StartedAt)
+		a.Status = StatusFailed
+		a.Err = fmt.Errorf("denied by ledger policy: head %s", h.ID)
+		return a
 	}
 
 	execCtx, cancel := context.WithTimeout(ctx, effectiveTimeout(opts))

--- a/internal/swarm/runner_test.go
+++ b/internal/swarm/runner_test.go
@@ -4,12 +4,74 @@ package swarm
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
 )
+
+// countingExecutor always succeeds and counts how many times it actually ran —
+// so a test can prove a denied head's executor was never invoked, not merely
+// that its output was discarded.
+type countingExecutor struct{ calls *int }
+
+func (e countingExecutor) Execute(context.Context, executor.Request) (*executor.Response, error) {
+	*e.calls++
+	return &executor.Response{Output: "ran"}, nil
+}
+
+func writeLedgerPolicy(t *testing.T, p ledger.Policy) {
+	t.Helper()
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := ledger.DefaultPolicyPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A ledger deny rule must stop executeHead before it ever calls the executor —
+// gating, not just logging after the fact.
+func TestExecuteHead_LedgerDenyBlocksExecution(t *testing.T) {
+	testutil.NewSandbox(t)
+	writeLedgerPolicy(t, ledger.Policy{Rules: []ledger.Rule{{Tool: "denied", Decision: ledger.Deny}}})
+	calls := 0
+	withStubExecutor(t, countingExecutor{&calls})
+
+	a := executeHead(context.Background(), registryHead("denied", "Denied", 90), "p", Options{})
+	if a.Status != StatusFailed {
+		t.Errorf("Status = %q, want %q for a denied head", a.Status, StatusFailed)
+	}
+	if calls != 0 {
+		t.Errorf("executor was called %d times for a denied head, want 0", calls)
+	}
+}
+
+// With no policy configured, default-allow must let the head run normally.
+func TestExecuteHead_DefaultLedgerPolicyAllowsExecution(t *testing.T) {
+	testutil.NewSandbox(t)
+	calls := 0
+	withStubExecutor(t, countingExecutor{&calls})
+
+	a := executeHead(context.Background(), registryHead("h1", "H1", 90), "p", Options{})
+	if a.Status != StatusOK {
+		t.Errorf("Status = %q, want %q", a.Status, StatusOK)
+	}
+	if calls != 1 {
+		t.Errorf("executor was called %d times, want 1", calls)
+	}
+}
 
 func TestEffectiveTimeout(t *testing.T) {
 	if got := effectiveTimeout(Options{}); got != defaultPerHeadTimeout {


### PR DESCRIPTION
## Summary
`internal/ledger`'s `Check`/`Record` were only ever called from the manual `hyctl mcp check/record`
command — a normal `hyctl dispatch` produced zero ledger events. To be precise about scope: this
is not a real MCP protocol proxy (it doesn't intercept third-party MCP tool calls from Claude
Code/Cursor/etc.) — it's Hydra's own accountability log + policy gate, and this PR is what makes
Hydra's own head-dispatch decisions actually flow through it automatically, rather than only via a
human typing `hyctl mcp check` by hand.

## Changes
- New `ledger.CheckAndRecordDispatch(agent, headID, resource, content)` consolidates
  `LoadPolicy(default path)` + `CheckRequest` construction + `Check` (which both decides and
  records), matching `cmdMCP check`'s existing shape so the logic lives in one place, not
  duplicated at two call sites.
- `internal/dispatch/dispatch.go`'s fallback loop checks it once per candidate head, before
  executing — a denied head is skipped like a failed one, falling through to the next candidate.
- `internal/swarm`'s `executeHead` (shared by `Run` and `RunSPRT`, since swarm bypasses dispatch
  for the actual head calls) checks it before invoking the executor, returning `StatusFailed`
  without ever running a denied head.

Default policy is default-allow, so this is safe by default and only changes behavior for an
install that has deliberately configured a deny rule — which is the entire point of having the
gate. A `Deny` surfaces as a normal dispatch/head failure, not a panic or silent skip.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./...` — whole repo green
- [x] New tests: a configured deny rule actually blocks a real `dispatch.Dispatch` call (falls
      through to the next head) and a real `swarm.executeHead` call (executor never invoked,
      proven by a call counter); default (no policy configured) behavior is unchanged and still
      records an allow event

Closes #355