### PR TITLE
feat(graph): ship hyctl graph generate — Go package-graph generator

### DIFF
--- a/cmd/hydra/cli_data_test.go
+++ b/cmd/hydra/cli_data_test.go
@@ -229,6 +229,51 @@ func TestCLI_GraphParallel_ScalesWithTheWork(t *testing.T) {
 	}
 }
 
+// `hyctl graph generate` must produce a graph.json that `hyctl graph blast`
+// can actually read — against a real Go module, not a hand-built fixture.
+func TestCLI_GraphGenerate_ProducesAGraphBlastCanRead(t *testing.T) {
+	s := populated(t)
+	if !s.AllowHostBinary(t, "go") {
+		t.Skip("go is not on the host PATH, which should be impossible here")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/gentest\n\ngo 1.21\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for rel, body := range map[string]string{
+		"a/a.go": "package a\n",
+		"b/b.go": "package b\n\nimport _ \"example.com/gentest/a\"\n",
+	} {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := filepath.Join(dir, "graph.json")
+
+	genOut, cobraOut, err := run(t, "graph", "generate", dir, "--out", out)
+	if err != nil {
+		t.Fatalf("`hyctl graph generate` failed: %v (%s)", err, cobraOut)
+	}
+	if !strings.Contains(genOut+cobraOut, "nodes") {
+		t.Errorf("generate did not report a node count:\n%s", genOut+cobraOut)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("no graph.json was written: %v", err)
+	}
+
+	blastOut, cobraOut, err := run(t, "graph", "blast", "b", "--graph", out)
+	if err != nil {
+		t.Fatalf("`hyctl graph blast` could not read the generated graph: %v (%s)", err, cobraOut)
+	}
+	if strings.Contains(strings.ToLower(blastOut+cobraOut), "not in the graph") {
+		t.Errorf("blast did not recognize a node generate produced:\n%s", blastOut+cobraOut)
+	}
+}
+
 // ── cost and stats over real rows ─────────────────────────────────────────────
 
 func TestCLI_CostSubcommands_AgainstRealRows(t *testing.T) {

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1265,7 +1265,45 @@ func cmdGraph() *cobra.Command {
 	parallelCmd.Flags().BoolVar(&parJSON, "json", false, "machine-readable JSON output")
 	parallelCmd.Flags().Float64Var(&serial, "serial", optimal.DefaultSerialFraction, "serial (non-parallelizable) work fraction s")
 
-	cmd.AddCommand(blast, parallelCmd)
+	var genOut, genExclude string
+	generate := &cobra.Command{
+		Use:   "generate [path]",
+		Short: "Generate graph.json from a Go module's package-import graph (go list -json)",
+		Long: "Generate graph.json from a Go module's package-import graph via `go list -json`.\n" +
+			"Go package granularity only — not a general tree-sitter indexer. For other\n" +
+			"languages, use Graphify or any indexer that produces the same {nodes,edges} schema.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+			var exclude []string
+			for _, e := range strings.Split(genExclude, ",") {
+				if e = strings.TrimSpace(e); e != "" {
+					exclude = append(exclude, e)
+				}
+			}
+			doc, err := graph.GenerateGo(dir, exclude)
+			if err != nil {
+				return err
+			}
+			raw, err := json.MarshalIndent(doc, "", "  ")
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(genOut, raw, 0o644); err != nil {
+				return err
+			}
+			fmt.Printf("  %s %d nodes, %d edges → %s\n",
+				cortexStyle.Render("graph:"), len(doc.Nodes), len(doc.Edges), genOut)
+			return nil
+		},
+	}
+	generate.Flags().StringVar(&genOut, "out", "graph.json", "output path")
+	generate.Flags().StringVar(&genExclude, "exclude", "", "comma-separated module-relative path prefixes to skip (e.g. bench,cmd/specstest)")
+
+	cmd.AddCommand(blast, parallelCmd, generate)
 	return cmd
 }
 

--- a/internal/graph/generate.go
+++ b/internal/graph/generate.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+package graph
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// GenerateGo builds a Doc from `go list -json ./...` rooted at dir — a Go
+// package-import graph (dependency edges at package granularity), not a
+// general tree-sitter indexer. exclude skips any package whose short
+// (module-relative) import path has one of these prefixes.
+func GenerateGo(dir string, exclude []string) (*Doc, error) {
+	modOut, err := runIn(dir, "go", "list", "-m")
+	if err != nil {
+		return nil, fmt.Errorf("go list -m failed (not a Go module?): %w", err)
+	}
+	modulePath := strings.TrimSpace(modOut)
+	prefix := modulePath + "/"
+
+	listOut, err := runIn(dir, "go", "list", "-json", "./...")
+	if err != nil {
+		return nil, fmt.Errorf("go list -json failed: %w", err)
+	}
+
+	type pkg struct {
+		ImportPath string
+		Imports    []string
+	}
+	short := func(importPath string) string {
+		if importPath == modulePath {
+			return "."
+		}
+		return strings.TrimPrefix(importPath, prefix)
+	}
+	skip := func(importPath string) bool {
+		s := short(importPath)
+		for _, e := range exclude {
+			if e != "" && strings.HasPrefix(s, e) {
+				return true
+			}
+		}
+		return false
+	}
+
+	dec := json.NewDecoder(strings.NewReader(listOut))
+	var pkgs []pkg
+	for dec.More() {
+		var p pkg
+		if err := dec.Decode(&p); err != nil {
+			return nil, fmt.Errorf("decode failed: %w", err)
+		}
+		pkgs = append(pkgs, p)
+	}
+
+	d := &Doc{}
+	for _, p := range pkgs {
+		if skip(p.ImportPath) {
+			continue
+		}
+		id := short(p.ImportPath)
+		d.Nodes = append(d.Nodes, Node{ID: id, File: id})
+	}
+	for _, p := range pkgs {
+		if skip(p.ImportPath) {
+			continue
+		}
+		from := short(p.ImportPath)
+		for _, imp := range p.Imports {
+			if !strings.HasPrefix(imp, prefix) || imp == p.ImportPath || skip(imp) {
+				continue
+			}
+			d.Edges = append(d.Edges, Edge{From: from, To: short(imp)})
+		}
+	}
+	return d, nil
+}
+
+func runIn(dir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	return string(out), err
+}

--- a/internal/graph/generate_test.go
+++ b/internal/graph/generate_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+
+package graph
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeGoModule builds a real, tiny Go module on disk: a <- b, and a third
+// package (skip) that also imports a, so GenerateGo runs against the real
+// `go` toolchain rather than a hand-built fixture.
+func writeGoModule(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/testmod\n\ngo 1.21\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pkgs := map[string]string{
+		"a/a.go":    "package a\n",
+		"b/b.go":    "package b\n\nimport _ \"example.com/testmod/a\"\n",
+		"skip/s.go": "package skip\n\nimport _ \"example.com/testmod/a\"\n",
+	}
+	for rel, body := range pkgs {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestGenerateGo_BuildsTheRealImportGraph(t *testing.T) {
+	dir := writeGoModule(t)
+
+	doc, err := GenerateGo(dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids := map[string]bool{}
+	for _, n := range doc.Nodes {
+		ids[n.ID] = true
+	}
+	for _, want := range []string{"a", "b", "skip"} {
+		if !ids[want] {
+			t.Errorf("nodes = %v, missing %q", ids, want)
+		}
+	}
+
+	var sawBToA bool
+	for _, e := range doc.Edges {
+		if e.From == "b" && e.To == "a" {
+			sawBToA = true
+		}
+	}
+	if !sawBToA {
+		t.Errorf("edges = %+v, want an edge b -> a", doc.Edges)
+	}
+}
+
+func TestGenerateGo_ExcludeSkipsMatchingPrefixes(t *testing.T) {
+	dir := writeGoModule(t)
+
+	doc, err := GenerateGo(dir, []string{"skip"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range doc.Nodes {
+		if n.ID == "skip" {
+			t.Errorf("excluded package still present in nodes: %+v", doc.Nodes)
+		}
+	}
+	for _, e := range doc.Edges {
+		if e.From == "skip" || e.To == "skip" {
+			t.Errorf("excluded package still present in an edge: %+v", e)
+		}
+	}
+}
+
+// GenerateGo's whole purpose is feeding internal/graph.Load — its output must
+// actually be loadable, not merely well-formed JSON.
+func TestGenerateGo_OutputRoundTripsThroughLoad(t *testing.T) {
+	dir := writeGoModule(t)
+	doc, err := GenerateGo(dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "graph.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := Load(path)
+	if err != nil {
+		t.Fatalf("internal/graph could not load GenerateGo's own output: %v", err)
+	}
+	if g.Empty() {
+		t.Error("a graph with real nodes/edges loaded as empty")
+	}
+	if !g.Knows("b") {
+		t.Error("Load did not recognize a node GenerateGo produced")
+	}
+}
+
+func TestGenerateGo_NotAGoModuleIsAnError(t *testing.T) {
+	dir := t.TempDir() // no go.mod
+	if _, err := GenerateGo(dir, nil); err == nil {
+		t.Error("GenerateGo succeeded outside any Go module")
+	}
+}


### PR DESCRIPTION
## Summary
Blast-radius-aware routing (`--file`) depends on `graph.json` existing, but nothing in `hyctl`
generated one — it was documented as depending entirely on an external tool (Graphify or a
tree-sitter indexer). An internal generator already existed at `bench/graph/gen.go` (untracked,
never wired into the CLI), producing `graph.json` in exactly the schema `internal/graph.Load`
expects for Hydra's own Go package graph — but nobody could reach it without knowing it was there.

## Changes
- New `internal/graph.GenerateGo(dir, exclude)` builds a `Doc` from `go list -json ./...`,
  generalized beyond `gen.go`'s Hydra-specific hardcoding: the module path is resolved via
  `go list -m` instead of a hardcoded prefix, so this works against any Go module, not just this
  repo.
- `hyctl graph generate [path]` wires it into the CLI, matching the existing `blast`/`parallel`
  subcommand conventions (`--out`, `RunE`-returned errors). Honestly scoped in `--help`: Go
  package-granularity only, not a general tree-sitter indexer replacement.

Verified end-to-end against Hydra's own real repo (42 nodes, 115 edges, not a tiny test fixture) —
`hyctl graph blast` produces sane output from the generated file.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./...` — whole repo green
- [x] New tests: `GenerateGo` against a real 3-package Go module (correct nodes/edges, `--exclude`
      filters correctly, output round-trips through `graph.Load` without error, a non-Go-module
      directory errors); a CLI-level test that `hyctl graph generate` → `hyctl graph blast` works
      end-to-end
- [x] Manual: ran against Hydra's own repo, confirmed real node/edge counts and sane blast-radius
      output (not just the 10-20-node unit-test fixtures)

Closes #358