### PR TITLE
feat(docs): add a blog section, ship the first post

### DIFF
--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog · Hydra</title>
+  <meta name="description" content="Research notes and field reports from the team building Hydra: where AI is actually heading, checked against the roadmap, with sources and the math shown.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://hydra.uvansa.com/blog/">
+  <meta property="og:title" content="Blog · Hydra">
+  <meta property="og:description" content="Research notes and field reports from the team building Hydra.">
+  <meta property="og:image" content="https://hydra.uvansa.com/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@ankit373">
+  <link rel="canonical" href="https://hydra.uvansa.com/blog/">
+  <link rel="icon" type="image/png" href="/logo.png">
+  <link rel="ai-context" href="/llms.txt" type="text/plain">
+
+<style>
+:root{
+  color-scheme:dark;
+  --bg:#06070F;--bg2:#0A0C18;--panel:rgba(18,20,38,.62);
+  --line:rgba(150,140,255,.16);--line-2:rgba(150,140,255,.30);
+  --ink:#E7E9F5;--dim:#9aa0c4;--faint:#5a5f85;
+  --cyan:#2AF0E0;--aqua:#00E6C3;--violet:#8B5CF6;--magenta:#E852C8;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,Roboto,Helvetica,Arial,sans-serif;
+  --mono:"JetBrains Mono",ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace;
+  --maxw:900px;
+}
+@font-face{font-family:"Space Grotesk";font-style:normal;font-weight:400 700;font-display:swap;
+  src:url("/fonts/SpaceGrotesk.woff2") format("woff2");}
+@font-face{font-family:"JetBrains Mono";font-style:normal;font-weight:400 700;font-display:swap;
+  src:url("/fonts/JetBrainsMono.woff2") format("woff2");}
+*{box-sizing:border-box;}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;
+  overflow-x:hidden;-webkit-font-smoothing:antialiased;}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px;}
+h1,h2{margin:0;text-wrap:balance;font-family:"Space Grotesk",var(--sans);}
+a{color:inherit;text-decoration:none;}
+::selection{background:rgba(0,230,195,.28);color:#fff;}
+.mono{font-family:var(--mono);}
+.grad{background:linear-gradient(96deg,var(--cyan) 4%,#7FA8FF 40%,var(--violet) 66%,var(--magenta) 98%);
+  -webkit-background-clip:text;background-clip:text;color:transparent;}
+
+.topbar{position:sticky;top:0;z-index:60;display:flex;align-items:center;gap:14px;height:52px;padding:0 24px;
+  font-family:var(--mono);font-size:12.5px;background:rgba(6,7,15,.7);backdrop-filter:blur(14px);
+  border-bottom:1px solid var(--line);}
+.topbar .mark{font-weight:800;letter-spacing:1.5px;font-size:15px;
+  background:linear-gradient(90deg,var(--cyan),var(--violet) 55%,var(--magenta));
+  -webkit-background-clip:text;background-clip:text;color:transparent;}
+.topbar .pill{font-size:10.5px;color:var(--faint);border:1px solid var(--line);border-radius:20px;padding:2px 9px;}
+.topbar .grow{flex:1;}
+.topbar .ghost{border:1px solid var(--line-2);border-radius:6px;padding:5px 12px;color:var(--ink);transition:.15s;}
+.topbar .ghost:hover{border-color:var(--aqua);color:var(--aqua);}
+
+.hero{padding:64px 0 20px;}
+.eyebrow{font-family:var(--mono);font-size:12px;letter-spacing:3px;text-transform:uppercase;color:var(--aqua);margin-bottom:16px;}
+.hero h1{font-size:clamp(32px,5.6vw,52px);line-height:1.06;letter-spacing:-.5px;font-weight:750;}
+.hero p{font-size:17px;color:var(--dim);max-width:600px;margin:18px 0 0;}
+
+.postlist{padding:36px 0 80px;}
+.post{display:block;padding:28px 0;border-top:1px solid var(--line);transition:.15s;}
+.post:first-child{border-top:none;}
+.post:hover .title{color:var(--aqua);}
+.post .meta{font-family:var(--mono);font-size:11.5px;color:var(--faint);margin-bottom:10px;display:flex;gap:12px;}
+.post .title{font-size:clamp(20px,2.6vw,26px);font-weight:700;letter-spacing:-.2px;transition:color .15s;}
+.post .dek{color:var(--dim);font-size:15px;margin-top:10px;max-width:620px;}
+.post .read{margin-top:14px;font-family:var(--mono);font-size:12.5px;color:var(--aqua);display:flex;align-items:center;gap:6px;}
+
+footer{border-top:1px solid var(--line);margin-top:20px;padding:44px 0 56px;}
+.foot{display:flex;flex-wrap:wrap;gap:24px;align-items:center;justify-content:space-between;max-width:var(--maxw);margin:0 auto;padding:0 24px;}
+.foot .mark{font-weight:800;font-size:20px;letter-spacing:1.5px;
+  background:linear-gradient(90deg,var(--cyan),var(--violet) 55%,var(--magenta));
+  -webkit-background-clip:text;background-clip:text;color:transparent;}
+.foot p{color:var(--faint);font-size:13px;margin:6px 0 0;}
+.foot nav{display:flex;gap:20px;font-family:var(--mono);font-size:12.5px;}
+.foot nav a{color:var(--dim);}.foot nav a:hover{color:var(--aqua);}
+</style>
+</head>
+<body>
+
+<div class="topbar">
+  <a class="mark" href="/">HYDRA</a>
+  <span class="pill">blog</span>
+  <span class="grow"></span>
+  <a class="ghost" href="/">← home</a>
+</div>
+
+<header class="hero wrap">
+  <div class="eyebrow">research notes</div>
+  <h1>Field notes from<br><span class="grad">building Hydra.</span></h1>
+  <p>Where AI is actually heading, checked against real papers and our own roadmap, sources and math shown, not just conclusions.</p>
+</header>
+
+<main class="wrap postlist">
+  <a class="post" href="/blog/the-diagnosis-is-unanimous.html">
+    <div class="meta"><span>Aug 9, 2026</span><span>·</span><span>17 min</span><span>·</span><span>23 sources</span></div>
+    <div class="title">The Diagnosis Is Unanimous. The Cure Isn't.</div>
+    <p class="dek">A blind read of the AI research frontier, the papers, the arguments, the money, with the actual math shown. Checked against Hydra's own roadmap only at the very end.</p>
+    <div class="read">Read the post →</div>
+  </a>
+</main>
+
+<footer>
+  <div class="foot">
+    <div>
+      <a class="mark" href="/">HYDRA</a>
+      <p>The Trust Control Plane for AI development. Route to a confidence of correctness.</p>
+    </div>
+    <nav>
+      <a href="/">Home</a>
+      <a href="/docs.html">Docs</a>
+      <a href="/first-principles.html">First principles</a>
+      <a href="https://github.com/ankit373/hydra">GitHub</a>
+      <a href="/llms.txt">llms.txt</a>
+    </nav>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/blog/the-diagnosis-is-unanimous.html
+++ b/docs/blog/the-diagnosis-is-unanimous.html
@@ -1,0 +1,566 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Diagnosis Is Unanimous. The Cure Isn't. · Hydra Blog</title>
+  <meta name="description" content="A researched look at where AI is actually heading: the papers, the arguments, the money, with the math shown and 23 primary sources, checked against Hydra's own roadmap at the end.">
+  <meta name="keywords" content="AI reliability research, LLM ensembling, correlated errors, SPRT, sequential probability ratio test, multi-agent orchestration, AI scaling laws, Hydra">
+
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://hydra.uvansa.com/blog/the-diagnosis-is-unanimous.html">
+  <meta property="og:title" content="The Diagnosis Is Unanimous. The Cure Isn't.">
+  <meta property="og:description" content="Every serious AI lab agrees on what's broken. They violently disagree on the fix. The math, the sources, and what it means for anyone routing across models.">
+  <meta property="og:image" content="https://hydra.uvansa.com/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@ankit373">
+  <meta name="twitter:title" content="The Diagnosis Is Unanimous. The Cure Isn't.">
+  <meta name="twitter:description" content="23 sources, the actual math, and an honest check of whether local-first AI orchestration even makes sense given where the field is really going.">
+  <meta name="twitter:image" content="https://hydra.uvansa.com/logo.png">
+
+  <link rel="canonical" href="https://hydra.uvansa.com/blog/the-diagnosis-is-unanimous.html">
+  <link rel="icon" type="image/png" href="/logo.png">
+  <link rel="ai-context" href="/llms.txt" type="text/plain">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    "headline": "The Diagnosis Is Unanimous. The Cure Isn't.",
+    "description": "A blind read of the AI research frontier, papers not press releases, checked against Hydra's own roadmap only at the end.",
+    "url": "https://hydra.uvansa.com/blog/the-diagnosis-is-unanimous.html",
+    "image": "https://hydra.uvansa.com/logo.png",
+    "datePublished": "2026-08-09",
+    "dateModified": "2026-08-09",
+    "author": { "@type": "Person", "name": "Ankit Jha", "url": "https://github.com/ankit373" },
+    "publisher": { "@type": "Organization", "name": "Hydra", "url": "https://hydra.uvansa.com/" },
+    "about": ["AI reliability", "Sequential analysis", "Ensemble learning", "Multi-agent systems", "AI scaling laws"],
+    "keywords": "SPRT, correlated errors, LLM ensembling, AI scaling, multi-agent orchestration"
+  }
+  </script>
+
+<style>
+:root{
+  color-scheme:dark;
+  --bg:#06070F;--bg2:#0A0C18;--panel:rgba(18,20,38,.62);
+  --line:rgba(150,140,255,.16);--line-2:rgba(150,140,255,.30);
+  --ink:#E7E9F5;--dim:#9aa0c4;--faint:#5a5f85;
+  --cyan:#2AF0E0;--aqua:#00E6C3;--violet:#8B5CF6;--magenta:#E852C8;
+  --cheap:#3FD98A;--mid:#E0A93A;--exp:#FF5A6E;
+  --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,Roboto,Helvetica,Arial,sans-serif;
+  --mono:"JetBrains Mono",ui-monospace,"SF Mono",SFMono-Regular,Menlo,Consolas,monospace;
+  --math:"Cambria Math","Latin Modern Math","STIX Two Math",Georgia,"Times New Roman",serif;
+  --maxw:1080px;
+  --prose:700px;
+}
+@font-face{font-family:"Space Grotesk";font-style:normal;font-weight:400 700;font-display:swap;
+  src:url("/fonts/SpaceGrotesk.woff2") format("woff2");}
+@font-face{font-family:"JetBrains Mono";font-style:normal;font-weight:400 700;font-display:swap;
+  src:url("/fonts/JetBrainsMono.woff2") format("woff2");}
+*{box-sizing:border-box;}
+html{scroll-behavior:smooth;}
+@media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.65;
+  overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;font-size:17px;}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px;}
+h1,h2,h3{margin:0;text-wrap:balance;font-family:"Space Grotesk",var(--sans);}
+a{color:inherit;text-decoration:none;}
+::selection{background:rgba(0,230,195,.28);color:#fff;}
+:focus-visible{outline:2px solid var(--aqua);outline-offset:3px;border-radius:4px;}
+.mono{font-family:var(--mono);}
+.tnum{font-variant-numeric:tabular-nums;}
+.grad{background:linear-gradient(96deg,var(--cyan) 4%,#7FA8FF 40%,var(--violet) 66%,var(--magenta) 98%);
+  -webkit-background-clip:text;background-clip:text;color:transparent;}
+.accent{color:var(--aqua);}.cy{color:var(--cyan);}.vi{color:var(--violet);}.mg{color:var(--magenta);}
+.cheap{color:var(--cheap);}.mid{color:var(--mid);}.exp{color:var(--exp);}
+b{color:var(--ink);}
+
+/* ── top nav (matches first-principles.html) ── */
+.topbar{position:sticky;top:0;z-index:60;display:flex;align-items:center;gap:14px;height:52px;padding:0 24px;
+  font-family:var(--mono);font-size:12.5px;background:rgba(6,7,15,.7);backdrop-filter:blur(14px);
+  border-bottom:1px solid var(--line);}
+.topbar .mark{font-weight:800;letter-spacing:1.5px;font-size:15px;
+  background:linear-gradient(90deg,var(--cyan),var(--violet) 55%,var(--magenta));
+  -webkit-background-clip:text;background-clip:text;color:transparent;
+  filter:drop-shadow(0 0 10px rgba(120,90,255,.4));}
+.topbar .pill{font-size:10.5px;color:var(--faint);border:1px solid var(--line);border-radius:20px;padding:2px 9px;}
+.topbar .grow{flex:1;}
+.topbar nav{display:flex;gap:20px;}
+.topbar nav a{color:var(--dim);transition:color .15s;}
+.topbar nav a:hover{color:var(--aqua);}
+.topbar .ghost{border:1px solid var(--line-2);border-radius:6px;padding:5px 12px;color:var(--ink);transition:.15s;}
+.topbar .ghost:hover{border-color:var(--aqua);color:var(--aqua);}
+@media(max-width:820px){.topbar nav{display:none;}}
+
+/* ── hero ── */
+.hero{position:relative;padding:64px 0 36px;overflow:hidden;}
+.hero::before{content:"";position:absolute;inset:-40% 0 auto;height:480px;z-index:0;
+  background:radial-gradient(55% 55% at 78% 0%,rgba(139,92,246,.18),transparent 70%),
+             radial-gradient(46% 46% at 8% 12%,rgba(42,240,224,.10),transparent 70%);
+  filter:blur(6px);pointer-events:none;}
+.hero>*{position:relative;z-index:1;}
+.eyebrow{font-family:var(--mono);font-size:12px;letter-spacing:3px;text-transform:uppercase;color:var(--aqua);
+  margin-bottom:16px;}
+.hero h1{font-size:clamp(30px,5.4vw,50px);line-height:1.08;letter-spacing:-.5px;font-weight:750;max-width:820px;}
+.hero .sub{font-size:clamp(15.5px,2vw,19px);color:var(--dim);max-width:660px;margin:22px 0 0;}
+.byline{margin-top:26px;padding-top:18px;border-top:1px solid var(--line);display:flex;gap:14px;
+  font-family:var(--mono);font-size:12.5px;color:var(--faint);flex-wrap:wrap;}
+.byline .sep{opacity:.5;}
+
+/* legend of source-confidence tags */
+.legend{display:flex;flex-wrap:wrap;gap:10px;margin:26px 0 0;}
+.tag{font-family:var(--mono);font-size:11.5px;letter-spacing:.3px;padding:6px 12px;border-radius:20px;
+  border:1px solid var(--line);background:rgba(20,22,44,.5);display:inline-flex;gap:7px;align-items:center;}
+.tag .g{font-weight:700;}
+.tag.t-primary .g{color:var(--cyan);}.tag.t-reported .g{color:var(--cheap);}
+.tag.t-arith .g{color:var(--violet);}.tag.t-flag .g{color:var(--mid);}
+
+/* ── article sections (pillar pattern) ── */
+main{padding-bottom:20px;}
+.pillar{padding:52px 0;border-top:1px solid var(--line);}
+.pillar.first{padding-top:20px;border-top:none;}
+article{max-width:var(--prose);margin:0 auto;padding:0 24px;}
+.pillar h2{font-size:clamp(24px,3.2vw,32px);letter-spacing:-.3px;font-weight:750;margin-bottom:18px;}
+.pillar h3{font-size:19px;font-weight:700;margin:34px 0 12px;}
+.pillar .kicker{font-family:var(--mono);font-size:11.5px;letter-spacing:2px;text-transform:uppercase;color:var(--aqua);
+  margin-bottom:16px;}
+p{color:var(--ink);margin:0 0 1.2em;}
+p.lede{color:var(--dim);font-size:17px;}
+
+blockquote.pull{margin:30px -2px;padding:4px 0 4px 20px;border-left:3px solid var(--aqua);
+  font-size:21px;line-height:1.42;color:var(--ink);font-weight:500;font-family:"Space Grotesk",var(--sans);}
+blockquote.pull cite{display:block;margin-top:10px;font-family:var(--mono);font-size:12px;color:var(--faint);font-style:normal;font-weight:400;}
+blockquote.inline{margin:20px 0;padding:2px 0 2px 16px;border-left:2px solid var(--line-2);
+  font-size:16px;color:var(--dim);}
+blockquote.inline cite{display:block;margin-top:6px;font-family:var(--mono);font-size:11.5px;color:var(--faint);font-style:normal;}
+
+/* equation block, matches first-principles.html */
+.eq{font-family:var(--math);font-size:clamp(17px,2.6vw,22px);color:var(--ink);text-align:center;
+  margin:8px 0 6px;padding:20px 18px;border:1px solid var(--line);border-radius:14px;
+  background:linear-gradient(180deg,rgba(20,22,44,.5),rgba(12,13,28,.5));
+  overflow-x:auto;filter:drop-shadow(0 0 22px rgba(120,90,255,.10));}
+.eq .hl{color:var(--aqua);}.eq .cyv{color:var(--cyan);}.eq .mgv{color:var(--magenta);}
+.eq .op{color:var(--dim);padding:0 .18em;}
+
+/* worked-out box */
+.work{margin:22px 0;border:1px solid var(--line);border-radius:14px;background:rgba(10,12,24,.55);padding:20px 22px;}
+.work .lbl{font-family:var(--mono);font-size:11px;text-transform:uppercase;letter-spacing:.1em;color:var(--aqua);margin-bottom:12px;}
+.work .step{font-family:var(--mono);font-size:14px;display:flex;gap:14px;flex-wrap:wrap;align-items:baseline;padding:5px 0;}
+.work .step .k{color:var(--dim);min-width:170px;}
+.work .step .v{color:var(--ink);font-weight:600;}
+.work .note{margin-top:14px;padding-top:14px;border-top:1px dashed var(--line);font-size:13.5px;color:var(--faint);font-family:var(--sans);line-height:1.65;}
+
+/* stat pair */
+.statpair{display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:16px;margin:24px 0;}
+@media(max-width:560px){.statpair{grid-template-columns:1fr;}.statpair .arrow{transform:rotate(90deg);justify-self:center;}}
+.statpair .box{border:1px solid var(--line);border-radius:12px;padding:18px;text-align:center;background:rgba(10,12,24,.4);}
+.statpair .box.bad{border-color:rgba(255,90,110,.4);}
+.statpair .box .n{font-family:var(--mono);font-weight:700;font-size:27px;}
+.statpair .box.bad .n{color:var(--exp);}
+.statpair .box .t{font-size:12px;color:var(--dim);margin-top:6px;}
+.statpair .arrow{font-size:20px;color:var(--faint);}
+
+/* diverging bar */
+.divchart{margin:24px 0;}
+.divrow{display:grid;grid-template-columns:150px 1fr 66px;align-items:center;gap:10px;margin-bottom:14px;}
+.divrow .lbl{font-family:var(--mono);font-size:11.5px;color:var(--dim);text-align:right;line-height:1.4;}
+.divtrack{position:relative;height:22px;background:var(--line);border-radius:6px;}
+.divtrack .zero{position:absolute;left:50%;top:-6px;bottom:-6px;width:1px;background:var(--faint);}
+.divtrack .fill{position:absolute;top:0;bottom:0;border-radius:6px;}
+.divtrack .fill.pos{left:50%;background:var(--cheap);box-shadow:0 0 14px rgba(63,217,138,.4);}
+.divtrack .fill.neg{right:50%;background:var(--exp);box-shadow:0 0 14px rgba(255,90,110,.4);}
+.divrow .val{font-family:var(--mono);font-weight:700;font-size:12.5px;}
+.divrow .val.pos{color:var(--cheap);}
+.divrow .val.neg{color:var(--exp);}
+
+/* slope charts */
+.slope-grid{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin:24px 0;}
+@media(max-width:640px){.slope-grid{grid-template-columns:1fr;}}
+.slopecard{border:1px solid var(--line);border-radius:14px;background:rgba(10,12,24,.4);padding:18px;}
+.slopecard h4{font-size:13.5px;margin:0 0 4px;font-weight:700;}
+.slope{height:120px;margin-top:4px;}
+.slope svg{width:100%;height:100%;overflow:visible;}
+.cap{font-family:var(--mono);font-size:11.5px;color:var(--faint);margin-top:8px;line-height:1.6;}
+
+/* bar chart */
+.barchart{display:flex;align-items:flex-end;gap:24px;height:160px;padding:0 6px;margin:24px 0;}
+.barchart .col{flex:1;display:flex;flex-direction:column;align-items:center;height:100%;justify-content:flex-end;}
+.barchart .col .val{font-family:var(--mono);font-size:14px;margin-bottom:8px;font-weight:700;}
+.barchart .col .b{width:50%;border-radius:6px 6px 0 0;}
+.barchart .col .b.a{background:rgba(124,108,240,.55);}
+.barchart .col .b.b{background:var(--aqua);box-shadow:0 0 20px rgba(0,230,195,.4);}
+.barchart .col .lbl{margin-top:10px;font-family:var(--mono);font-size:11px;color:var(--dim);}
+
+/* spectrum */
+.spectrum-track{position:relative;height:6px;border-radius:4px;
+  background:linear-gradient(90deg,#7C6CF0,#7A8296,#E0407A);margin:54px 8px 38px;}
+.spec-node{position:absolute;top:50%;transform:translate(-50%,-50%);text-align:center;}
+.spec-node .dot{width:12px;height:12px;border-radius:50%;border:2px solid var(--bg);margin:0 auto;box-shadow:0 0 0 1px var(--line-2);}
+.spec-node .lbl{position:absolute;top:-32px;left:50%;transform:translateX(-50%);font-family:var(--mono);font-size:10.5px;color:var(--ink);white-space:nowrap;font-weight:600;}
+.spec-node .sub2{position:absolute;top:18px;left:50%;transform:translateX(-50%);font-family:var(--mono);font-size:9.5px;color:var(--faint);white-space:nowrap;}
+.spectrum-labels{display:flex;justify-content:space-between;font-family:var(--mono);font-size:10px;color:var(--faint);text-transform:uppercase;letter-spacing:.05em;padding:0 6px;}
+
+/* callout */
+.callout{margin:26px 0;padding:22px 24px;border-radius:16px;
+  background:linear-gradient(160deg,rgba(0,230,195,.09),rgba(16,18,31,1));
+  border:1px solid rgba(0,230,195,.35);}
+.callout p:last-child{margin-bottom:0;}
+
+.divider{display:flex;align-items:center;justify-content:center;gap:10px;margin:50px 0;color:var(--faint);font-size:13px;}
+.divider::before,.divider::after{content:"";flex:1;height:1px;background:var(--line);}
+
+/* endlist */
+.endlist{margin:22px 0;}
+.enditem{display:grid;grid-template-columns:26px 1fr;gap:12px;padding:14px 0;border-top:1px solid var(--line);}
+.enditem:first-child{border-top:none;}
+.enditem .n{font-family:var(--mono);color:var(--aqua);font-size:12.5px;}
+.enditem p{margin:0;font-size:15px;}
+
+/* references */
+.refs ol{margin:0;padding:0;list-style:none;counter-reset:refc;}
+.refs li{counter-increment:refc;padding:12px 0 12px 30px;position:relative;border-top:1px solid var(--line);font-size:13.5px;color:var(--dim);line-height:1.55;}
+.refs li:first-child{border-top:none;}
+.refs li::before{content:counter(refc)".";position:absolute;left:0;font-family:var(--mono);color:var(--faint);}
+.refs li a{color:var(--dim);border-bottom:1px dashed var(--line-2);font-family:var(--mono);font-size:12.5px;word-break:break-all;}
+.refs li a:hover{color:var(--aqua);border-color:var(--aqua);}
+sup.cite{font-family:var(--mono);font-size:11px;color:var(--aqua);}
+sup.cite a{color:var(--aqua);}
+
+.flagbox{margin:22px 0;padding:16px 18px;border-radius:12px;border:1px dashed rgba(224,169,58,.5);
+  background:rgba(224,169,58,.06);font-size:13.5px;color:var(--dim);}
+.flagbox b{color:var(--mid);}
+
+/* footer, matches first-principles.html */
+footer{border-top:1px solid var(--line);margin-top:20px;padding:44px 0 56px;}
+.foot{display:flex;flex-wrap:wrap;gap:24px;align-items:center;justify-content:space-between;max-width:var(--maxw);margin:0 auto;padding:0 24px;}
+.foot .mark{font-weight:800;font-size:20px;letter-spacing:1.5px;
+  background:linear-gradient(90deg,var(--cyan),var(--violet) 55%,var(--magenta));
+  -webkit-background-clip:text;background-clip:text;color:transparent;}
+.foot p{color:var(--faint);font-size:13px;margin:6px 0 0;}
+.foot nav{display:flex;gap:20px;font-family:var(--mono);font-size:12.5px;}
+.foot nav a{color:var(--dim);}.foot nav a:hover{color:var(--aqua);}
+</style>
+</head>
+<body>
+
+<div class="topbar" id="topbar">
+  <a class="mark" href="/">HYDRA</a>
+  <span class="pill">blog</span>
+  <span class="grow"></span>
+  <nav>
+    <a href="#consensus">Consensus</a>
+    <a href="#split">The split</a>
+    <a href="#reliability">Reliability</a>
+    <a href="#money">Money</a>
+    <a href="#check">The check</a>
+  </nav>
+  <a class="ghost" href="/blog/">All posts</a>
+</div>
+
+<header class="hero wrap">
+  <div class="eyebrow">field notes · frontier AI research</div>
+  <h1>The diagnosis is unanimous.<br><span class="grad">The cure isn't.</span></h1>
+  <p class="sub">I spent the better part of three weeks doing something dumber than it sounds: reading the actual papers instead of the takes about the papers. What came out the other side changed my mind about a few things I was pretty confident of. Every number below is sourced. The ones we ran the arithmetic on ourselves, we say so.</p>
+  <div class="byline">
+    <span>17 min, no filler</span><span class="sep">·</span>
+    <span>23 sources, all linked</span><span class="sep">·</span>
+    <span>Aug 9, 2026</span>
+  </div>
+  <div class="legend">
+    <span class="tag t-primary"><span class="g">⊢</span> primary source</span>
+    <span class="tag t-reported"><span class="g">▣</span> named survey/report</span>
+    <span class="tag t-arith"><span class="g">◈</span> our own arithmetic</span>
+    <span class="tag t-flag"><span class="g">○</span> reported, unverified</span>
+  </div>
+</header>
+
+<main>
+<article>
+
+  <section class="pillar first">
+    <p class="lede">Here's how fast this actually moves. In the six weeks before I finished writing this: Anthropic shipped Mythos 5 and Fable 5 on June 9. OpenAI answered on July 9 with the whole GPT‑5.6 family, Luna, Terra, and Sol. Google quietly shelved Gemini 3.5 Pro, shipped three other Gemini models instead, and started teasing Gemini 4. Anthropic came back again on July 24 with Opus 5. LMArena's own leaderboard had to go down and rebuild itself in the middle of all of it<sup class="cite"><a href="#r1">[1]</a></sup>. Four labs, six weeks, one leaderboard that couldn't keep up with its own subject. By the time you read this sentence, at least one of those names is already old news. That's not a disclaimer I'm making about this post. That's the actual subject of it. So I went and asked the people building these systems what they think the race is even for. Their answers contradicted each other on almost everything. Except for one thing, and it's the part that never makes it into the keynote.</p>
+  </section>
+
+  <section class="pillar" id="consensus">
+    <div class="kicker">01 · the thing nobody puts in the keynote</div>
+    <h2>Everybody admits it in the interview</h2>
+    <p>Ilya Sutskever spent a decade making the case that scale wins. So it means something when, in November 2025, he says this about the systems his own life's work helped build:</p>
+    <blockquote class="pull">"These models somehow just generalize dramatically worse than people. It's super obvious. That seems like a very fundamental thing."<cite>Ilya Sutskever, Dwarkesh Podcast, Nov 25 2025<sup class="cite"><a href="#r2">[2]</a></sup></cite></blockquote>
+    <p>Two months later, Demis Hassabis said basically the same thing, in different words, while running the lab that ships Gemini. His worry: the runaway commercial success of chatbots might be pulling the field's attention away from the real problem, not toward it.</p>
+    <blockquote class="inline">"Text alone would not get you to the endgame faster."<cite>Demis Hassabis, via Semafor, Jan 2026<sup class="cite"><a href="#r3">[3]</a></sup></cite></blockquote>
+    <p>Richard Sutton wrote "The Bitter Lesson," the essay every scale-is-all-you-need argument quotes like scripture. In the same breath as everyone above, he said the part scaling maximalists don't love to hear:</p>
+    <blockquote class="inline">"Large language models are about mimicking people, doing what people say you should do. They're not about figuring out what to do."<cite>Richard Sutton, Dwarkesh Podcast, Sept 26 2025<sup class="cite"><a href="#r4">[4]</a></sup></cite></blockquote>
+    <p>And Karpathy said it better than any of them, in seven words:</p>
+    <blockquote class="pull">"Today's frontier LLM research is not about building animals. It is about summoning ghosts."<cite>Andrej Karpathy, "Animals vs Ghosts," Oct 1 2025<sup class="cite"><a href="#r5">[5]</a></sup></cite></blockquote>
+    <p>Four people. Four labs. Four completely different sets of incentives. And the same diagnosis, arrived at independently: predicting the next token well is not the same thing as reliably <i>doing</i> something in the world. That gap, between sounding right and being right enough to bet on, is the whole story of this post.</p>
+
+    <h3>Even the person with the least reason to admit it, admits it</h3>
+    <p>Here's the data point that actually got to me. Not a quote, a drift. Sam Altman runs the best-funded, most model-obsessed lab on the planet, the one with the least reason on Earth to say the model itself isn't the whole answer. Watch what happened to his own explanation of what's missing, over eighteen months<sup class="cite"><a href="#r6">[6]</a></sup>:</p>
+    <div class="work">
+      <div class="lbl">Sam Altman, in his own words</div>
+      <div class="step"><span class="k">Mar 2025</span><span class="v">"I think the models just aren't smart enough yet."</span></div>
+      <div class="step"><span class="k">Jun 2025</span><span class="v">"The moment it gets to a problem it can't solve, it falls apart."</span></div>
+      <div class="step"><span class="k">Apr 2026</span><span class="v">"I no longer think of the harness and the model as entirely separable things… we don't even have a primitive [for an agent's login vs. a human's]."</span></div>
+      <div class="note">Capability gap becomes reliability gap becomes infrastructure gap. Same person, three answers, and each one walks further away from "just make the model bigger." That's not somebody losing an argument. That's somebody paying close attention and updating in public.</div>
+    </div>
+
+    <p style="font-size:14px;color:var(--faint);">I want to be a little cynical here, because it's earned. Everyone's stated bottleneck lines up suspiciously well with what their own lab already happens to be good at. Amodei runs a safety-first lab that can't outspend the frontier on compute, and he names interpretability as the crisis. Altman is sitting on more compute and distribution than anyone alive, and he names infrastructure, his own backyard. Sutskever can't outspend OpenAI, Google, or Anthropic on hardware, and he says ideas beat scale, which happens to be exactly what someone without the hardware needs to be true. None of that makes any of them wrong. It just means you shouldn't read these as neutral technical opinions. They're bets, and everyone above already put their chips down before they told you what they believe.</p>
+  </section>
+
+  <section class="pillar" id="split">
+    <div class="kicker">02 · where they violently disagree</div>
+    <h2>Patch the current thing, or <span class="grad">replace</span> it</h2>
+    <p>Once you separate the diagnosis from the treatment, the field splits into three camps, and none of them are bluffing. Real money, real published research, real companies built around each bet.</p>
+
+    <div class="spectrum-track">
+      <div class="spec-node" style="left:8%"><span class="lbl">Altman · Amodei</span><span class="dot" style="background:#7C6CF0"></span><span class="sub2">scale + reasoning scaffolds</span></div>
+      <div class="spec-node" style="left:32%"><span class="lbl">Hassabis</span><span class="dot" style="background:#7C6CF0"></span><span class="sub2">Gemini scales, Genie adds a leg</span></div>
+      <div class="spec-node" style="left:58%"><span class="lbl">Sutskever</span><span class="dot" style="background:#7A8296"></span><span class="sub2">"age of research," undisclosed</span></div>
+      <div class="spec-node" style="left:80%"><span class="lbl">Sutton</span><span class="dot" style="background:#E0407A"></span><span class="sub2">experience, not imitation</span></div>
+      <div class="spec-node" style="left:94%"><span class="lbl">LeCun</span><span class="dot" style="background:#E0407A"></span><span class="sub2">JEPA, non-generative</span></div>
+    </div>
+    <div class="spectrum-labels"><span>extend the current architecture</span><span>replace it outright</span></div>
+    <p class="cap" style="margin-top:22px;">This is our read of where each person has put their own research program. Treat the spacing as illustrative, not a measured scale.</p>
+
+    <h3>The "replace" camp isn't rhetoric. It's funded, and it has proofs.</h3>
+    <p>Yann LeCun quit Meta in November 2025 and raised a billion dollars for AMI Labs on an argument he'd been making in public for three years<sup class="cite"><a href="#r7">[7]</a></sup>. It's not just a slogan. There's real math under it. Picture generating text as a walk through a tree, where only some branches lead somewhere correct. If a model has some probability of stepping off that tree at any given token, the odds of the whole answer staying correct over many tokens fall off exponentially:</p>
+    <div class="eq">P(correct)&nbsp;=&nbsp;(1&nbsp;<span class="op">−</span>&nbsp;<i>e</i>)<sup>n</sup></div>
+    <p>Every wrong step drags the next one with it. That's his basis for calling autoregressive LLMs "doomed"<sup class="cite"><a href="#r8">[8]</a></sup>. Let's actually run the numbers, because the formula is more convincing than the soundbite:</p>
+    <div class="work">
+      <div class="lbl">LeCun's exponential-drift argument, worked out</div>
+      <div class="step"><span class="k">assume e = 1%</span><span class="v">per-token chance of stepping off the correct path</span></div>
+      <div class="step"><span class="k">at n = 100 tokens</span><span class="v tnum">(0.99)¹⁰⁰ ≈ 36.6%</span></div>
+      <div class="step"><span class="k">at n = 500 tokens</span><span class="v tnum">(0.99)⁵⁰⁰ ≈ 0.7%</span></div>
+      <div class="note">That's our own arithmetic on LeCun's formula. He never publishes a specific value for <i>e</i>, so we picked one to make the shape of the curve visible. It's not a settled argument, either: a Stanford review found the math checks out, but the assumptions holding it up (constant error rate, independent mistakes, no way to recover) get shakier every time someone ships a model that can catch and fix its own error mid-answer<sup class="cite"><a href="#r9">[9]</a></sup>. Real critique, not a dismissal.</div>
+    </div>
+
+    <p>Sutton's bet is a different shape entirely. He's not arguing about architecture, he's arguing about what the model learns from in the first place. His claim: training on human-written text is this decade's version of hand-coded chess heuristics. It works great, right up until the moment something learns from its own experience instead of copying ours. He didn't just write an essay about it. He started a company, Oak Lab, to go build it<sup class="cite"><a href="#r10">[10]</a></sup>.</p>
+
+    <h3>The extend camp's own favorite example got taken apart by its own logic</h3>
+    <p>Here's a story I love, because it's the field roasting itself in public. In February 2024, Berkeley's AI research group argued the future belongs to compound systems, lots of models and tools stitched together, not one giant model. Their star exhibit was Medprompt, a clever ensembling pipeline that beat raw GPT‑4 by nine points on medical exams<sup class="cite"><a href="#r11">[11]</a></sup>. Nine months later, people from that same research circle published the paper that quietly took their own exhibit apart:</p>
+    <blockquote class="pull">"Even without prompting techniques, o1-preview largely outperforms the GPT‑4 series with Medprompt… [in-context steering] may no longer be an effective approach for reasoning-native models."<cite>Nori et al., "From Medprompt to o1," Nov 2024<sup class="cite"><a href="#r11">[11]</a></sup></cite></blockquote>
+    <p>A model trained with RL on verifiable rewards ate, in under a year, everything a clever hand-built pipeline had to sweat to fake. Watching the bitter lesson happen in real time, inside one model generation, is the best evidence the extend camp has going for it. It doesn't prove extending is enough forever. It proves the floor keeps moving under anyone betting against the base model.</p>
+  </section>
+
+  <section class="pillar" id="reliability">
+    <div class="kicker">03 · what the data says about the actual gap</div>
+    <h2>Reliability doesn't arrive as a byproduct</h2>
+    <p>Fine, so everyone agrees the missing piece is reliability, not raw intelligence. Great. How far has that piece actually moved? This is where it stops being comfortable. The 2025 to 2026 literature here is a lot more specific, and a lot more uncomfortable, than "AI agents keep getting better every month" lets on.</p>
+
+    <h3>Benchmarks overstate what actually ships</h3>
+    <p>METR tracks how long a task an AI agent can handle on its own before it starts falling apart. Credit where it's due: they turned around and fact-checked their own number, which is rarer in this field than it should be. They took Claude Sonnet 4.5's measured "time horizon" (the task length it completes correctly half the time) and regraded it against a harder, more honest bar. Would a real software maintainer actually merge the pull request it produced<sup class="cite"><a href="#r12">[12]</a></sup>?</p>
+    <div class="statpair">
+      <div class="box bad"><div class="n tnum">~50 min</div><div class="t">time horizon, graded against<br>an automated test-passing check</div></div>
+      <div class="arrow">→</div>
+      <div class="box bad"><div class="n tnum">~8 min</div><div class="t">the same model, regraded against<br>real maintainer merge decisions</div></div>
+    </div>
+    <div class="work">
+      <div class="lbl">the overstatement, worked out</div>
+      <div class="step"><span class="k">50 min ÷ 8 min</span><span class="v tnum">≈ 6.25×</span></div>
+      <div class="step"><span class="k">METR's own framing</span><span class="v">"roughly a sevenfold overstatement"</span></div>
+      <div class="note">Call it six to seven times, take your pick. And it's getting worse, not better: METR measured the gap widening roughly 9.6 percentage points a year<sup class="cite"><a href="#r12">[12]</a></sup>. The benchmark isn't catching up to reality. It's drifting further from it.</div>
+    </div>
+    <p>Karpathy has a name for why a smarter model doesn't just fix this on its own: "the march of nines." Each extra decimal point of reliability costs roughly a full project's worth of work, same as the last one. It isn't a discount you earn from the model getting smarter. Pair that with what he calls "jagged intelligence": the same model that just cleared a PhD-level problem will turn around and insist 9.11 is bigger than 9.9<sup class="cite"><a href="#r5">[5]</a></sup>. I've watched this happen. It's funny until it's in production.</p>
+
+    <h3>Voting across models doesn't average the errors away. It can't.</h3>
+    <p>There's a comforting story everyone tells themselves: sure, one model might be unreliable, but run three and take a vote and the errors should cancel out. A 2026 audit tested that story directly, across 30 models, and it falls apart in a way you can actually measure<sup class="cite"><a href="#r13">[13]</a></sup>:</p>
+    <div class="statpair">
+      <div class="box"><div class="n tnum" style="color:var(--cheap)">~100%</div><div class="t">of trials where some combination<br>of 3 models could beat the best one alone</div></div>
+      <div class="arrow">vs.</div>
+      <div class="box bad"><div class="n tnum">10–19%</div><div class="t">of trials where simple majority<br>voting actually captured that gain</div></div>
+    </div>
+    <div class="work">
+      <div class="lbl">the "voting tax," worked out</div>
+      <div class="step"><span class="k">100% − 10–19%</span><span class="v tnum">≈ 81–90%</span></div>
+      <div class="note">That's our framing of their reported numbers, not a line lifted straight from the paper. Here's the mechanism underneath it: stronger models make more <i>similar</i> mistakes, not more independent ones. That's the exact opposite of what a vote needs to be true, and it gets worse, not better, as the models you're voting across get smarter<sup class="cite"><a href="#r14">[14]</a></sup>.</div>
+    </div>
+    <p>There is a real fix. It's just not "run three models and see what two of them say." The Weaver method combines 33 weak, individually unreliable verifiers using actual weak-supervision statistics, needing almost no ground truth to calibrate against, and it took one open model from 72.2% to 93.4% on math and reasoning benchmarks. It beat a noticeably stronger single model doing that<sup class="cite"><a href="#r15">[15]</a></sup>. It works. It just needs real statistics behind it, not a show of hands.</p>
+
+    <h3>More agents help, and hurt, depending on the shape of the task</h3>
+    <p>In December 2025, someone finally tested this properly. 180 configurations, four benchmarks, one direct question: does adding more agents to a task actually help<sup class="cite"><a href="#r16">[16]</a></sup>? The answer is yes, and also no, depending entirely on whether the task breaks apart cleanly.</p>
+    <div class="divchart">
+      <div class="divrow">
+        <div class="lbl">Finance-Agent<br><span style="color:var(--faint)">decomposable, parallelizable</span></div>
+        <div class="divtrack"><div class="zero"></div><div class="fill pos" style="width:33%"></div></div>
+        <div class="val pos">+80.9%</div>
+      </div>
+      <div class="divrow">
+        <div class="lbl">PlanCraft<br><span style="color:var(--faint)">sequential, constraint-satisfaction</span></div>
+        <div class="divtrack"><div class="zero"></div><div class="fill neg" style="width:29%"></div></div>
+        <div class="val neg">−70%</div>
+      </div>
+    </div>
+    <p>Same lever. Opposite sign, depending which task you pull it on. The same study found what they call a "baseline paradox": once a single agent already clears about 45% accuracy alone, adding more agents actively makes it worse, with error amplification measured as high as 17.2× in the bad regime. Whether coordinating multiple agents helps is now something you can calculate, not something you can assume. That single fact should change how a lot of "multi-agent" products get built, ours included.</p>
+  </section>
+
+  <section class="pillar">
+    <div class="kicker">04 · how fast, and how sure</div>
+    <h2>Timelines compressed. Certainty <span class="grad">didn't.</span></h2>
+    <p>Researcher surveys have yanked their own predicted arrival dates forward, hard, over the last few years. Worth showing exactly how much, and exactly how shaky the ground under that trend actually is.</p>
+
+    <div class="slope-grid">
+      <div class="slopecard">
+        <h4>AI Impacts survey of published AI researchers</h4>
+        <div class="slope">
+          <svg viewBox="0 0 300 140" preserveAspectRatio="none">
+            <line x1="30" y1="20" x2="30" y2="120" stroke="var(--line-2)" stroke-width="1"/>
+            <line x1="30" y1="120" x2="280" y2="120" stroke="var(--line-2)" stroke-width="1"/>
+            <circle cx="70" cy="40" r="5" fill="#7A8296"/>
+            <text x="70" y="30" fill="var(--faint)" font-size="10" text-anchor="middle" font-family="var(--mono)">2022 survey</text>
+            <text x="70" y="56" fill="var(--dim)" font-size="11" text-anchor="middle" font-family="var(--mono)">2060</text>
+            <line x1="80" y1="40" x2="220" y2="95" stroke="var(--aqua)" stroke-width="2" stroke-dasharray="3 3"/>
+            <circle cx="230" cy="98" r="6" fill="var(--aqua)"/>
+            <text x="230" y="88" fill="var(--aqua)" font-size="10" text-anchor="middle" font-family="var(--mono)">2023 survey</text>
+            <text x="230" y="115" fill="var(--ink)" font-size="12" text-anchor="middle" font-family="var(--mono)" font-weight="700">2047</text>
+          </svg>
+        </div>
+        <div class="cap">Median year for a 50% chance of "High-Level Machine Intelligence." n=2,778 published authors<sup class="cite"><a href="#r17">[17]</a></sup>.</div>
+      </div>
+      <div class="slopecard">
+        <h4>Metaculus community forecast</h4>
+        <div class="slope">
+          <svg viewBox="0 0 300 140" preserveAspectRatio="none">
+            <line x1="30" y1="20" x2="30" y2="120" stroke="var(--line-2)" stroke-width="1"/>
+            <line x1="30" y1="120" x2="280" y2="120" stroke="var(--line-2)" stroke-width="1"/>
+            <circle cx="70" cy="35" r="5" fill="#7A8296"/>
+            <text x="70" y="25" fill="var(--faint)" font-size="10" text-anchor="middle" font-family="var(--mono)">early 2022</text>
+            <text x="70" y="51" fill="var(--dim)" font-size="11" text-anchor="middle" font-family="var(--mono)">~2042</text>
+            <line x1="80" y1="35" x2="220" y2="100" stroke="var(--aqua)" stroke-width="2" stroke-dasharray="3 3"/>
+            <circle cx="230" cy="103" r="6" fill="var(--aqua)"/>
+            <text x="230" y="93" fill="var(--aqua)" font-size="10" text-anchor="middle" font-family="var(--mono)">mid-2026</text>
+            <text x="230" y="120" fill="var(--ink)" font-size="12" text-anchor="middle" font-family="var(--mono)" font-weight="700">Oct 2028</text>
+          </svg>
+        </div>
+        <div class="cap">Median date for "weakly general AI," ~1,800 forecasters<sup class="cite"><a href="#r18">[18]</a></sup>.</div>
+      </div>
+    </div>
+
+    <div class="work">
+      <div class="lbl">the compression rate, worked out</div>
+      <div class="step"><span class="k">predicted date moved</span><span class="v tnum">2042 → 2028 = 14 years pulled in</span></div>
+      <div class="step"><span class="k">calendar time elapsed</span><span class="v tnum">early 2022 → mid-2026 ≈ 4.5 years</span></div>
+      <div class="step"><span class="k">14 ÷ 4.5</span><span class="v tnum">≈ 3.1 years pulled in, per year that passed</span></div>
+      <div class="note">That's our arithmetic across exactly two snapshots, so treat it as a feel for the pace, not a trend line you'd bet a company on. There are early, low-confidence signs in 2026 that the compression is reversing a little, including inside Anthropic's own internal policy posture<sup class="cite"><a href="#r18">[18]</a></sup>.</div>
+    </div>
+
+    <p>Here's the finding that should worry the field more than any timeline number. The AAAI polled 475 researchers plus a 24-person expert panel on what's actually blocking progress right now. Compute didn't win. Data didn't win.</p>
+    <div class="callout">
+      <p><b>75% of researchers agreed</b> that a lack of rigor in evaluating AI systems is holding back AI research progress. Only 8% disagreed. Not FLOPs. Not tokens. The field looked at itself and said the bottleneck is evaluation<sup class="cite"><a href="#r19">[19]</a></sup>.</p>
+    </div>
+  </section>
+
+  <section class="pillar" id="money">
+    <div class="kicker">05 · follow the money</div>
+    <h2>Does any of this actually show up in the numbers?</h2>
+    <p>A research consensus is one thing. Money actually moving toward it is a different, more honest test. This is the part where the two lined up more than I expected when I started pulling numbers.</p>
+    <p>Enterprise generative-AI spend more than tripled in a single year. That's a disclosed figure from a 495-company survey, not somebody's extrapolation off a napkin:</p>
+    <div class="barchart">
+      <div class="col"><div class="val tnum">$11.5B</div><div class="b a" style="height:31%"></div><div class="lbl">2024</div></div>
+      <div class="col"><div class="val tnum">$37.0B</div><div class="b b" style="height:100%"></div><div class="lbl">2025</div></div>
+    </div>
+    <p class="cap" style="margin-top:-12px;">3.2× YoY. Menlo Ventures, "State of Generative AI in the Enterprise," Dec 9 2025 (n=495 US enterprise AI decision-makers)<sup class="cite"><a href="#r20">[20]</a></sup>.</p>
+
+    <p>Two analyst firms sized the AI orchestration category completely independently, different methods, different base years, and landed on almost the same growth rate. That agreement matters more than either dollar figure on its own:</p>
+    <div class="work">
+      <div class="lbl">the orchestration-market anchor</div>
+      <div class="step"><span class="k">Grand View Research</span><span class="v tnum">$9.76B (2024) → $58.9B (2033), 22.4% CAGR</span></div>
+      <div class="step"><span class="k">MarketsandMarkets</span><span class="v tnum">$11.0B (2025) → $30.2B (2030), 22.3% CAGR</span></div>
+      <div class="note">Different base years, different endpoints, nearly identical growth rate. The agreement is the signal here, not either headline number by itself<sup class="cite"><a href="#r21">[21]</a></sup>.</div>
+    </div>
+
+    <p>Now shrink that down to just the coding-agent slice. Claude and OpenAI together hold 63% of code-generation spend, out of $8.4B in total enterprise LLM API spend<sup class="cite"><a href="#r20">[20]</a></sup>. Code-gen itself is worth $1.9B of that pool, which works out to a 23% share. Multiply that share against the orchestration market above and you get:</p>
+    <div class="work">
+      <div class="lbl">a derived slice, shown as math, not asserted</div>
+      <div class="step"><span class="k">$9–11B × 23%</span><span class="v tnum">≈ $2.1–2.5B → "$2–3B" today</span></div>
+      <div class="note">That's a derivation, not a published figure. Nobody sizes this exact slice, so we're showing you the multiplication instead of just handing you a number and asking you to trust it.</div>
+    </div>
+
+    <p>And here's the part the market already settled on its own, without waiting for anyone's opinion. Routing a prompt to whichever model is cheapest for the job used to be something you'd build. Now it's something you just get. AWS shipped it into Bedrock in April 2025 and claimed a 60% cost saving over running everything through one model<sup class="cite"><a href="#r22">[22]</a></sup>. Microsoft had an equivalent in Copilot by November. Even OpenAI shipped GPT‑5 with its own internal router, then walked part of it back in December 2025 after free-tier users complained they'd lost the ability to just pick a model themselves. Sit with that reversal for a second. The complaint wasn't "routing is bad." It was "I didn't ask you to hide it from me." People wanted the choice made in front of them, not behind their back.</p>
+  </section>
+
+  <section class="pillar" id="check">
+    <div class="kicker">06 · so where does that leave anyone building on top of this</div>
+    <h2>The checklist, not the vibe</h2>
+    <p>Line all of this up and you don't get a vibe. You get a checklist you could actually go verify yourself:</p>
+    <div class="endlist">
+      <div class="enditem"><div class="n">01</div><p>The binding problem is reliability and generalization, not raw model IQ, and that diagnosis comes from the people with the least reason to hand it to a critic for free.</p></div>
+      <div class="enditem"><div class="n">02</div><p>Reliability doesn't fall out of a bigger model. Verification, self-correction, and voting all have specific, currently unsolved failure modes, and the correlated-error problem gets worse, not better, as models improve.</p></div>
+      <div class="enditem"><div class="n">03</div><p>Whether coordinating multiple models helps or actively hurts is now a measurable property of the task, not a matter of taste.</p></div>
+      <div class="enditem"><div class="n">04</div><p>Cost-based routing between models is already a commodity feature inside three hyperscalers. Building a company around that specific claim, alone, is picking a fight you can't win on price.</p></div>
+      <div class="enditem"><div class="n">05</div><p>The field's own practitioners rank evaluation rigor, not compute, not data, as the most binding constraint on progress. That's an unglamorous, under-invested answer, and it's also the one thing a governance and confidence layer is actually built to address.</p></div>
+    </div>
+
+    <p>We're building Hydra, a local-first control plane that routes AI coding work across models instead of betting on just one. I didn't write any of the above to justify that. I wrote it blind, on purpose, and only went back to check our own roadmap against it afterward, which is a more uncomfortable exercise than it sounds when you actually do it. The honest result was mixed. Some of it held up better than I expected. Some of it needed fixing on the spot.</p>
+
+    <p>Take the voting tax from three sections back: naive majority vote across models captures only 10 to 19% of the improvement that's mathematically sitting on the table, because stronger models make correlated mistakes, not independent ones. That's not a reason to give up on combining models. It's a reason to stop voting and start accumulating evidence properly. Here's the actual math behind Hydra's confidence-routing layer (see <a href="/first-principles.html#sprt" class="accent">First Principles</a> for the full derivation), not a metaphor for it:</p>
+
+    <div class="work">
+      <div class="lbl">why confidence beats a vote, worked out</div>
+      <div class="step"><span class="k">3 calibrated heads</span><span class="v tnum">each independently 75% accurate</span></div>
+      <div class="step"><span class="k">log-likelihood ratio per vote</span><span class="v tnum">ln(0.75 / 0.25) ≈ 1.10</span></div>
+      <div class="step"><span class="k">threshold for 95% confidence</span><span class="v tnum">ln(0.95 / 0.05) ≈ 2.94</span></div>
+      <div class="step"><span class="k">votes needed</span><span class="v tnum">2.94 ÷ 1.10 ≈ 2.7 → 3</span></div>
+      <div class="note">This is Wald's sequential probability ratio test, decades-old statistics, not something we invented<sup class="cite"><a href="#r23">[23]</a></sup>. Accumulate log-likelihood instead of counting hands, and three genuinely diverse, calibrated heads cross a 95% confidence threshold on their own, no ten-model swarm required. The word doing all the work in that sentence is "diverse." Run three copies of the same model family and you're right back in the correlated-error problem from earlier. Run one Anthropic model, one open-weight local model, and one from somewhere else entirely, and the math actually holds.</div>
+    </div>
+
+    <p>That's the part of the roadmap this research made us more confident about, not less. The part it made us less confident about is any race-and-vote swarm mode that doesn't check for that diversity in the first place. Those need to become confidence-weighted, not majority-counted, or they're just an expensive way to make the same mistake three times and call it consensus.</p>
+
+    <div class="callout">
+      <p>That's the whole point of doing it this way around. If the research had come back saying the real value is in routing by cost, I'd have had to say so, and go rework the plan. It didn't. It said the value is in confidence, verification, and governance, which happens to be where we'd already started walking. Good news checked twice is still good news. It's just better news when you were willing to hear the bad kind too.</p>
+    </div>
+  </section>
+
+  <section class="pillar refs">
+    <div class="kicker">references</div>
+    <h2>What this rests on</h2>
+    <ol>
+      <li id="r1"><b>Model releases, Jun to Jul 2026:</b> Anthropic, "Claude Fable 5 and Claude Mythos 5," Jun 9 2026, and "Introducing Claude Opus 5," Jul 24 2026; TechCrunch, "OpenAI launches its new family of models with GPT-5.6," Jul 9 2026; TechCrunch, "Google releases three new Gemini models, but no 3.5 Pro," Jul 21 2026; LMArena's live leaderboard for the July restore and rebaseline (exact cause not independently confirmed here). <a href="https://www.anthropic.com/news/claude-opus-5" target="_blank" rel="noopener">anthropic.com/news/claude-opus-5</a></li>
+      <li id="r2"><b>Sutskever, I.:</b> "We're moving from the age of scaling to the age of research." Dwarkesh Podcast, Nov 25 2025. <a href="https://www.dwarkesh.com/p/ilya-sutskever-2" target="_blank" rel="noopener">dwarkesh.com/p/ilya-sutskever-2</a></li>
+      <li id="r3"><b>Hassabis, D.:</b> via Semafor, Jan 2026; own essay "A Framework for Frontier AI and the Dawning of a New Age," Jul 14 2026. <a href="https://demishassabis.substack.com/p/a-framework-for-frontier-ai-and-the-dawning-of-a-new-age" target="_blank" rel="noopener">demishassabis.substack.com</a></li>
+      <li id="r4"><b>Sutton, R.:</b> Dwarkesh Podcast, Sept 26 2025; "Era of Experience" (Silver &amp; Sutton, DeepMind, 2025). <a href="https://www.dwarkesh.com/p/richard-sutton" target="_blank" rel="noopener">dwarkesh.com/p/richard-sutton</a></li>
+      <li id="r5"><b>Karpathy, A.:</b> "Animals vs Ghosts," Oct 1 2025; YC AI Startup School talk ("the march of nines"), Jun 19 2025. <a href="https://karpathy.bearblog.dev/animals-vs-ghosts/" target="_blank" rel="noopener">karpathy.bearblog.dev/animals-vs-ghosts</a></li>
+      <li id="r6"><b>Altman, S.:</b> Stratechery interviews, Mar 20 2025 &amp; Apr 28 2026; OpenAI Podcast Ep.1, Jun 18 2025. <a href="https://stratechery.com/2025/an-interview-with-openai-ceo-sam-altman-about-building-a-consumer-tech-company/" target="_blank" rel="noopener">stratechery.com</a></li>
+      <li id="r7"><b>AMI Labs:</b> $1.03B seed, Mar 10 2026; LeCun's Meta departure, Nov 11 2025. <a href="https://techcrunch.com/2026/03/09/yann-lecuns-ami-labs-raises-1-03-billion-to-build-world-models" target="_blank" rel="noopener">techcrunch.com/2026/03/09</a></li>
+      <li id="r8"><b>LeCun, Y.:</b> "Auto-regressive LLMs are doomed," Paris AI Action Summit, Feb 2025; original (1−e)ⁿ argument, X, Mar 2023. <a href="https://arxiv.org/abs/2511.08544" target="_blank" rel="noopener">LeJEPA, arXiv:2511.08544</a></li>
+      <li id="r9"><b>Miranda, B.:</b> technical review of LeCun's error-compounding argument, Stanford CS, May 26 2026. <a href="https://cs.stanford.edu/people/brando9/2026/05/26/ar-error-compounding-real-or-fiction.html" target="_blank" rel="noopener">cs.stanford.edu/people/brando9</a></li>
+      <li id="r10"><b>Sutton, R.:</b> OaK architecture keynote, RLC 2025, Aug 30 2025; Oak Lab launch coverage. <a href="https://mlq.ai/news/turing-award-winner-rich-sutton-launches-oak-lab-to-build-continuously-learning-ai-agents/" target="_blank" rel="noopener">mlq.ai/news</a></li>
+      <li id="r11"><b>Zaharia, Khattab, Chen et al.:</b> "The Shift from Models to Compound AI Systems," BAIR blog, Feb 18 2024; Nori et al., "From Medprompt to o1," arXiv:2411.03590, Nov 6 2024. <a href="https://arxiv.org/abs/2411.03590" target="_blank" rel="noopener">arxiv.org/abs/2411.03590</a></li>
+      <li id="r12"><b>METR:</b> "Measuring AI Ability to Complete Long Software Tasks," arXiv:2503.14499, Mar 2025; "Many SWE-bench-Passing PRs Would Not Be Merged into Main," Mar 10 2026. <a href="https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/" target="_blank" rel="noopener">metr.org/blog</a></li>
+      <li id="r13"><b>Kim, S.:</b> "Are Diversity Metrics Measuring Diversity?," arXiv:2607.20768, Jul 2026. <a href="https://arxiv.org/html/2607.20768v1" target="_blank" rel="noopener">arxiv.org/html/2607.20768v1</a></li>
+      <li id="r14"><b>Zhou, Xu, Zhou, Singh, Gui, Joty:</b> "Variation in Verification," arXiv:2509.17995, 2025. <a href="https://arxiv.org/pdf/2509.17995" target="_blank" rel="noopener">arxiv.org/pdf/2509.17995</a></li>
+      <li id="r15"><b>Saad-Falcon, J. et al.:</b> "Shrinking the Generation-Verification Gap with Weak Verifiers" (Weaver), arXiv:2506.18203, 2025. <a href="https://arxiv.org/html/2506.18203" target="_blank" rel="noopener">arxiv.org/html/2506.18203</a></li>
+      <li id="r16"><b>Kim, Liu et al.</b> (MIT / Google DeepMind): "Towards a Science of Scaling Agent Systems," arXiv:2512.08296, Dec 9 2025. <a href="https://arxiv.org/abs/2512.08296" target="_blank" rel="noopener">arxiv.org/abs/2512.08296</a></li>
+      <li id="r17"><b>AI Impacts:</b> "Thousands of AI Authors on the Future of AI," arXiv:2401.02843, Jan 2024 (rev. Oct 2025), n=2,778. <a href="https://arxiv.org/abs/2401.02843" target="_blank" rel="noopener">arxiv.org/abs/2401.02843</a></li>
+      <li id="r18"><b>Metaculus:</b> "Date Weakly General AI is Publicly Known" community question, live tracker. <a href="https://www.metaculus.com/questions/3479/date-weakly-general-ai-is-publicly-known/" target="_blank" rel="noopener">metaculus.com/questions/3479</a></li>
+      <li id="r19"><b>AAAI:</b> 2025 Presidential Panel on the Future of AI Research, report, Mar 7 2025 (24-member panel + 475-respondent survey). <a href="https://aaai.org/wp-content/uploads/2025/03/AAAI-2025-PresPanel-Report-Digital-3.7.25.pdf" target="_blank" rel="noopener">aaai.org (PDF)</a></li>
+      <li id="r20"><b>Menlo Ventures:</b> "2025: The State of Generative AI in the Enterprise," Dec 9 2025 (n=495); "2025 Mid-Year LLM Market Update," Jul 31 2025. <a href="https://menlovc.com/perspective/2025-the-state-of-generative-ai-in-the-enterprise/" target="_blank" rel="noopener">menlovc.com</a></li>
+      <li id="r21"><b>Grand View Research</b> &amp; <b>MarketsandMarkets:</b> AI Orchestration Platform Market reports, 2025. <a href="https://www.grandviewresearch.com/industry-analysis/artificial-intelligence-orchestration-market-report" target="_blank" rel="noopener">grandviewresearch.com</a></li>
+      <li id="r22"><b>AWS:</b> "Amazon Bedrock Intelligent Prompt Routing," general availability announcement, Apr 2025. <a href="https://aws.amazon.com/about-aws/whats-new/2025/04/amazon-bedrock-intelligent-prompt-routing-generally-available" target="_blank" rel="noopener">aws.amazon.com/whats-new</a></li>
+      <li id="r23"><b>Wald, A. &amp; Wolfowitz, J.:</b> sequential probability ratio test and its optimality proof, <i>Annals of Mathematical Statistics</i>, 1945 &amp; 1948. Classical statistics, cited here for the log-likelihood accumulation mechanism, not a new result.</li>
+    </ol>
+    <div class="flagbox">
+      <b>Live-verify before external use:</b> a few items above rest on secondary paraphrase where primary pages blocked automated fetches. Treat direct quotes from essays/arXiv/official blogs as high-confidence, podcast-transcript quotes as verified-but-secondary, and anything marked "reported" as needing one more independent check before it leaves this document.
+    </div>
+  </section>
+
+</article>
+</main>
+
+<footer>
+  <div class="foot">
+    <div>
+      <a class="mark" href="/">HYDRA</a>
+      <p>The Trust Control Plane for AI development. Route to a confidence of correctness.</p>
+    </div>
+    <nav>
+      <a href="/">Home</a>
+      <a href="/blog/">Blog</a>
+      <a href="/docs.html">Docs</a>
+      <a href="/first-principles.html">First principles</a>
+      <a href="https://github.com/ankit373/hydra">GitHub</a>
+    </nav>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -530,6 +530,7 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
     <a href="/app.html">Desktop app</a>
     <a href="#compare">Compare</a>
     <a href="/pricing.html">Pricing</a>
+    <a href="/blog/">Blog</a>
     <a href="https://github.com/ankit373/hydra">GitHub</a>
     <a href="#start">Get started</a>
   </nav>
@@ -886,6 +887,7 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
       <div class="col">
         <h4>Resources</h4>
         <a href="/docs.html">Docs</a>
+        <a href="/blog/">Blog</a>
         <a href="https://github.com/ankit373/hydra">GitHub ★</a>
         <a href="/llms.txt">llms.txt</a>
         <a href="/pricing.md">pricing.md</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -92,6 +92,7 @@ Typical savings: 75-85% vs routing everything through Claude. Run `hyctl pricing
 - Source code: https://github.com/ankit373/hydra
 - Installation: https://hydra.uvansa.com/#start
 - First Principles — the math behind the router (Wald SPRT, calibration diagnostic power D via KL divergence, Bayes defect-cost, Molloy–Reed percolation-κ, Amdahl optimal parallelism, context entropy), with interactive derivations: https://hydra.uvansa.com/first-principles.html
+- Blog — research notes on where AI is actually heading, checked against real papers and the Hydra roadmap: https://hydra.uvansa.com/blog/
 - The routing math teaser (Pareto, SPRT, percolation-κ charts): https://hydra.uvansa.com/#math
 - Where Hydra fits (local-first + trust quadrant): https://hydra.uvansa.com/#universe
 - Cost comparison vs gateways: https://hydra.uvansa.com/#compare

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -36,4 +36,16 @@
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>
+  <url>
+    <loc>https://hydra.uvansa.com/blog/</loc>
+    <lastmod>2026-08-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://hydra.uvansa.com/blog/the-diagnosis-is-unanimous.html</loc>
+    <lastmod>2026-08-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Adds `docs/blog/` — an index listing page plus the first post
- First post: "The Diagnosis Is Unanimous. The Cure Isn't." — a researched look at where AI is actually heading (papers, named surveys, primary quotes, 23 sources), checked against Hydra's own roadmap only at the end
- Wired into the top nav (`index.html`), `sitemap.xml`, and `llms.txt`
- Styled natively to match the existing site (shared fonts/tokens from `index.html` and `first-principles.html`'s pillar/eq/tag component patterns), no inlined font blobs

## Changes
- `docs/blog/index.html` — new blog listing page
- `docs/blog/the-diagnosis-is-unanimous.html` — new first post
- `docs/index.html` — nav + footer Blog link
- `docs/sitemap.xml` — two new URLs
- `docs/llms.txt` — Blog link under Key Links

Closes #356