### PR TITLE
feat(trust): empirical family-correlation coupling (replace sprt.correlationDiscount magic 0.5)

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -2171,6 +2171,15 @@ func cmdTrustCalibration() *cobra.Command {
 				fmt.Printf("  %-28.28s %-10.10s %6.0f %7.3f %7.3f %8.3f\n",
 					s.Source, s.Domain, s.N, s.Se, s.Sp, s.D)
 			}
+			// A family whose members have converged on effectively one vote is a
+			// coordination risk the se/sp table above cannot show — two "sources"
+			// that always agree are one opinion, not confirming evidence.
+			for _, fam := range trust.KnownFamilies(trust.DefaultCoAgreementPath()) {
+				if j, warn := trust.FalseConsensusWarning(trust.DefaultCoAgreementPath(), fam); warn {
+					fmt.Printf("\n  %s\n", warnStyle.Render(fmt.Sprintf(
+						"false-consensus warning: %q's members measured J=%.2f — effectively one vote, not independent confirmation", fam, j)))
+				}
+			}
 			fmt.Println()
 			return nil
 		},

--- a/internal/swarm/calibrated_judge.go
+++ b/internal/swarm/calibrated_judge.go
@@ -54,6 +54,8 @@ func (j *CalibratedJudge) Judge(_ context.Context, _ string, attempts []Attempt)
 	}
 
 	groups := clusterByAgreement(attempts, successful, j.equiv)
+	recordSwarmCoAgreement(j.domain, successful, attempts, j.equiv)
+
 	lambda := make([]float64, len(groups))
 	for k := range groups {
 		lambda[k] = j.lambdaFor(groups[k], successful, attempts)
@@ -103,7 +105,7 @@ func (j *CalibratedJudge) lambdaFor(hypothesis agreementGroup, successful []int,
 		llr := j.cal.LLR(attempts[idx].Head.ID, j.domain, inGroup[idx])
 		if fam := attempts[idx].Head.Provider; fam != "" {
 			if seenFamily[fam] {
-				llr *= trust.CorrelationDiscount
+				llr *= trust.FamilyDiscount(trust.DefaultCoAgreementPath(), fam)
 			}
 			seenFamily[fam] = true
 		}
@@ -128,22 +130,34 @@ func representative(g agreementGroup, attempts []Attempt, cal *trust.Calibrator,
 
 // clusterByAgreement greedily groups attempts whose outputs equiv treats as the same answer.
 func clusterByAgreement(attempts []Attempt, successful []int, equiv trust.AnswerEquivalence) []agreementGroup {
-	var groups []agreementGroup
-	for _, idx := range successful {
-		placed := false
-		for gi := range groups {
-			rep := groups[gi].members[0]
-			if equiv(attempts[rep].Output, attempts[idx].Output) {
-				groups[gi].members = append(groups[gi].members, idx)
-				placed = true
-				break
-			}
+	texts := make([]string, len(successful))
+	for i, idx := range successful {
+		texts[i] = attempts[idx].Output
+	}
+	groups := make([]agreementGroup, 0, len(texts))
+	for _, g := range trust.ClusterByAgreement(texts, equiv) {
+		members := make([]int, len(g))
+		for i, localIdx := range g {
+			members[i] = successful[localIdx]
 		}
-		if !placed {
-			groups = append(groups, agreementGroup{members: []int{idx}})
-		}
+		groups = append(groups, agreementGroup{members: members})
 	}
 	return groups
+}
+
+// recordSwarmCoAgreement feeds ModeBest's own agreement structure into the
+// same coupling measurement trust.Run's SPRT path feeds, so a family's
+// FamilyDiscount improves from every ensembling path, not just --confidence.
+func recordSwarmCoAgreement(domain string, successful []int, attempts []Attempt, equiv trust.AnswerEquivalence) {
+	ids := make([]string, len(successful))
+	families := make([]string, len(successful))
+	texts := make([]string, len(successful))
+	for i, idx := range successful {
+		ids[i] = attempts[idx].Head.ID
+		families[i] = attempts[idx].Head.Provider
+		texts[i] = attempts[idx].Output
+	}
+	trust.RecordCoAgreement(trust.DefaultCoAgreementPath(), domain, ids, families, texts, equiv)
 }
 
 func allZero(xs []float64) bool {

--- a/internal/trust/coupling.go
+++ b/internal/trust/coupling.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: MIT
+
+package trust
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// defaultCorrelationDiscount is FamilyDiscount's fallback below minCoAgreementSamples.
+const defaultCorrelationDiscount = 0.5
+
+// minCoAgreementSamples: below this many same-family pairs, trust the flat default.
+const minCoAgreementSamples = 20
+
+// criticalCoupling: past this measured excess agreement, a family is flagged
+// as effectively one vote. A practical threshold, not one derived from an
+// Ising phase-transition calculation.
+const criticalCoupling = 0.7
+
+// ClusterByAgreement greedily groups indices into texts whose entries equiv
+// treats as the same answer — shared by Run's own co-agreement recording and
+// any ensembling caller (e.g. swarm.CalibratedJudge) that needs the same grouping.
+func ClusterByAgreement(texts []string, equiv AnswerEquivalence) [][]int {
+	if equiv == nil {
+		equiv = TextEquivalence
+	}
+	var groups [][]int
+	for i, t := range texts {
+		placed := false
+		for gi, g := range groups {
+			if equiv(texts[g[0]], t) {
+				groups[gi] = append(g, i)
+				placed = true
+				break
+			}
+		}
+		if !placed {
+			groups = append(groups, []int{i})
+		}
+	}
+	return groups
+}
+
+type coAgreementSource struct {
+	ID      string `json:"id"`
+	Family  string `json:"family"`
+	Cluster int    `json:"cluster"`
+}
+
+// coAgreementRecord is one task's participants, grouped by agreement.
+type coAgreementRecord struct {
+	TS      string              `json:"ts"`
+	Domain  string              `json:"domain"`
+	Sources []coAgreementSource `json:"sources"`
+}
+
+// DefaultCoAgreementPath is where co-agreement observations are persisted.
+func DefaultCoAgreementPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".hydra", "coagreement.jsonl")
+}
+
+// RecordCoAgreement clusters one task's answers by agreement and appends the
+// observation — best-effort, since a logging failure must never affect the
+// ensemble it observes. Sources with an empty Family are dropped: a repeat
+// vote is only ever discounted when a family is known, so an unfamilied
+// source carries no correlation signal to record.
+func RecordCoAgreement(path, domain string, ids, families, texts []string, equiv AnswerEquivalence) {
+	if path == "" || len(ids) < 2 {
+		return
+	}
+	groups := ClusterByAgreement(texts, equiv)
+	clusterOf := make([]int, len(texts))
+	for gi, g := range groups {
+		for _, idx := range g {
+			clusterOf[idx] = gi
+		}
+	}
+	rec := coAgreementRecord{TS: time.Now().UTC().Format(time.RFC3339), Domain: domain}
+	for i := range ids {
+		if families[i] == "" {
+			continue
+		}
+		rec.Sources = append(rec.Sources, coAgreementSource{ID: ids[i], Family: families[i], Cluster: clusterOf[i]})
+	}
+	if len(rec.Sources) < 2 {
+		return
+	}
+	raw, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.WriteString(string(raw) + "\n")
+}
+
+func loadCoAgreement(path string) []coAgreementRecord {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var out []coAgreementRecord
+	for _, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var r coAgreementRecord
+		if json.Unmarshal([]byte(line), &r) != nil {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// FamilyCoupling reports family's measured excess same-family agreement: the
+// empirical rate at which two DIFFERENT same-family sources agree, minus the
+// rate at which two different-family sources agree — the measurable
+// definition of "these are correlated, not independently confirming." ok is
+// false below minCoAgreementSamples same-family pairs.
+func FamilyCoupling(path, family string) (j float64, ok bool) {
+	var sameAgree, sameTotal, diffAgree, diffTotal int
+	for _, r := range loadCoAgreement(path) {
+		for i := 0; i < len(r.Sources); i++ {
+			for k := i + 1; k < len(r.Sources); k++ {
+				a, b := r.Sources[i], r.Sources[k]
+				agreed := a.Cluster == b.Cluster
+				if a.Family == family && b.Family == family {
+					sameTotal++
+					if agreed {
+						sameAgree++
+					}
+				} else {
+					diffTotal++
+					if agreed {
+						diffAgree++
+					}
+				}
+			}
+		}
+	}
+	if sameTotal < minCoAgreementSamples {
+		return 0, false
+	}
+	sameRate := float64(sameAgree) / float64(sameTotal)
+	diffRate := 0.0
+	if diffTotal > 0 {
+		diffRate = float64(diffAgree) / float64(diffTotal)
+	}
+	j = sameRate - diffRate
+	switch {
+	case j < 0:
+		j = 0
+	case j > 1:
+		j = 1
+	}
+	return j, true
+}
+
+// FamilyDiscount replaces the flat correlation constant: 1-J, so a family
+// with no measured excess correlation (J=0) is not discounted at all, and a
+// family whose members are nearly always identical (J→1) contributes almost
+// nothing on a repeat vote. Falls back to defaultCorrelationDiscount below
+// minCoAgreementSamples.
+func FamilyDiscount(path, family string) float64 {
+	j, ok := FamilyCoupling(path, family)
+	if !ok {
+		return defaultCorrelationDiscount
+	}
+	return 1 - j
+}
+
+// FalseConsensusWarning reports whether family's measured coupling has
+// crossed criticalCoupling — its members are effectively one vote.
+func FalseConsensusWarning(path, family string) (j float64, warn bool) {
+	j, ok := FamilyCoupling(path, family)
+	return j, ok && j >= criticalCoupling
+}
+
+// KnownFamilies returns the distinct families observed in the co-agreement
+// log, sorted — for a caller (e.g. `hyctl trust calibration`) that wants to
+// check every family's FalseConsensusWarning without knowing names up front.
+func KnownFamilies(path string) []string {
+	seen := map[string]bool{}
+	for _, r := range loadCoAgreement(path) {
+		for _, s := range r.Sources {
+			seen[s.Family] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for f := range seen {
+		out = append(out, f)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/trust/coupling_test.go
+++ b/internal/trust/coupling_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+
+package trust
+
+import (
+	"math"
+	"path/filepath"
+	"testing"
+)
+
+func TestClusterByAgreement_GroupsByEquivalence(t *testing.T) {
+	got := ClusterByAgreement([]string{"a", "a", "b", "a"}, TextEquivalence)
+	if len(got) != 2 {
+		t.Fatalf("got %d groups, want 2: %+v", len(got), got)
+	}
+	if len(got[0]) != 3 || len(got[1]) != 1 {
+		t.Errorf("group sizes = %v, want [3 1]", []int{len(got[0]), len(got[1])})
+	}
+}
+
+func TestClusterByAgreement_NilEquivDefaultsToText(t *testing.T) {
+	got := ClusterByAgreement([]string{"same", "SAME"}, nil)
+	if len(got) != 1 {
+		t.Errorf("got %d groups, want 1 (case-insensitive default)", len(got))
+	}
+}
+
+// A run with fewer than two familied sources carries no correlation signal
+// and must not be recorded — an empty Family means "independent, nothing to
+// discount," so there is nothing to measure.
+func TestRecordCoAgreement_SkipsUnfamiliedSourcesAndTinyRuns(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coagreement.jsonl")
+
+	RecordCoAgreement(path, "go", []string{"a"}, []string{"fam"}, []string{"x"}, TextEquivalence)
+	if got := loadCoAgreement(path); len(got) != 0 {
+		t.Errorf("a single-source run was recorded: %+v", got)
+	}
+
+	RecordCoAgreement(path, "go", []string{"a", "b"}, []string{"", ""}, []string{"x", "y"}, TextEquivalence)
+	if got := loadCoAgreement(path); len(got) != 0 {
+		t.Errorf("a run with no familied sources was recorded: %+v", got)
+	}
+
+	RecordCoAgreement(path, "go", []string{"a", "b"}, []string{"famA", "famA"}, []string{"x", "x"}, TextEquivalence)
+	if got := loadCoAgreement(path); len(got) != 1 {
+		t.Errorf("a real two-familied-source run was not recorded: %+v", got)
+	}
+}
+
+func TestFamilyCoupling_BelowThresholdIsNotOK(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coagreement.jsonl")
+	for i := 0; i < minCoAgreementSamples-1; i++ {
+		RecordCoAgreement(path, "go", []string{"a", "b"}, []string{"fam", "fam"}, []string{"x", "x"}, TextEquivalence)
+	}
+	if _, ok := FamilyCoupling(path, "fam"); ok {
+		t.Error("FamilyCoupling reported ok below minCoAgreementSamples")
+	}
+	if got := FamilyDiscount(path, "fam"); got != defaultCorrelationDiscount {
+		t.Errorf("FamilyDiscount = %v below threshold, want the flat default %v", got, defaultCorrelationDiscount)
+	}
+}
+
+// Two same-family sources that always echo each other, alongside a
+// different-family source that never agrees with either, is the textbook
+// "these two are one vote" case — J must measure close to 1.
+func TestFamilyCoupling_HighExcessAgreementMeasuresNearOne(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coagreement.jsonl")
+	for i := 0; i < minCoAgreementSamples; i++ {
+		RecordCoAgreement(path, "go",
+			[]string{"a", "b", "c"},
+			[]string{"famX", "famX", "famY"},
+			[]string{"same-answer", "same-answer", "different-answer"},
+			TextEquivalence)
+	}
+	j, ok := FamilyCoupling(path, "famX")
+	if !ok {
+		t.Fatal("FamilyCoupling reported not-ok with plenty of samples")
+	}
+	if j < 0.9 {
+		t.Errorf("J = %.3f, want close to 1 for a family that always agrees while cross-family never does", j)
+	}
+	if discount := FamilyDiscount(path, "famX"); discount > 0.15 {
+		t.Errorf("FamilyDiscount = %.3f, want close to 0 for a near-perfectly-coupled family", discount)
+	}
+	if _, warn := FalseConsensusWarning(path, "famX"); !warn {
+		t.Error("a family measured at J≈1 did not trigger the false-consensus warning")
+	}
+}
+
+// Same-family and cross-family pairs agreeing at the same rate is the
+// textbook "not actually correlated" case — J must measure close to 0, and
+// the discount must be close to 1 (no discount).
+func TestFamilyCoupling_NoExcessAgreementMeasuresNearZero(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coagreement.jsonl")
+	// Half of each round's same-family pair agrees, matching the rate at
+	// which the third (different-family) source also happens to agree.
+	for i := 0; i < minCoAgreementSamples; i++ {
+		bAnswer := "x"
+		if i%2 == 0 {
+			bAnswer = "y" // disagrees with a half the time
+		}
+		cAnswer := "x"
+		if i%2 == 0 {
+			cAnswer = "y" // the cross-family source tracks the same rate
+		}
+		RecordCoAgreement(path, "go",
+			[]string{"a", "b", "c"},
+			[]string{"famX", "famX", "famY"},
+			[]string{"x", bAnswer, cAnswer},
+			TextEquivalence)
+	}
+	j, ok := FamilyCoupling(path, "famX")
+	if !ok {
+		t.Fatal("FamilyCoupling reported not-ok with plenty of samples")
+	}
+	if j > 0.1 {
+		t.Errorf("J = %.3f, want close to 0 when same-family agreement matches cross-family baseline", j)
+	}
+	if discount := FamilyDiscount(path, "famX"); discount < 0.9 {
+		t.Errorf("FamilyDiscount = %.3f, want close to 1 (no discount) for an uncorrelated family", discount)
+	}
+	if _, warn := FalseConsensusWarning(path, "famX"); warn {
+		t.Error("an uncorrelated family triggered the false-consensus warning")
+	}
+}
+
+func TestKnownFamilies_ReturnsDistinctSortedNames(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coagreement.jsonl")
+	RecordCoAgreement(path, "go", []string{"a", "b"}, []string{"zeta", "alpha"}, []string{"x", "y"}, TextEquivalence)
+	RecordCoAgreement(path, "go", []string{"a", "b"}, []string{"zeta", "alpha"}, []string{"x", "y"}, TextEquivalence)
+
+	got := KnownFamilies(path)
+	if len(got) != 2 || got[0] != "alpha" || got[1] != "zeta" {
+		t.Errorf("KnownFamilies = %v, want [alpha zeta]", got)
+	}
+}
+
+// A missing log must degrade to "not enough data," never a panic or error.
+func TestFamilyCoupling_MissingLogIsGracefullyNotOK(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.jsonl")
+	if _, ok := FamilyCoupling(path, "anything"); ok {
+		t.Error("a missing co-agreement log reported ok")
+	}
+	if got := FamilyDiscount(path, "anything"); math.Abs(got-defaultCorrelationDiscount) > 1e-9 {
+		t.Errorf("FamilyDiscount = %v, want the flat default with no log at all", got)
+	}
+}

--- a/internal/trust/sprt.go
+++ b/internal/trust/sprt.go
@@ -10,10 +10,6 @@ import (
 	"strings"
 )
 
-// CorrelationDiscount halves a repeat vote from an already-seen model family.
-// Exported so internal/swarm's CalibratedJudge shares this one constant too.
-const CorrelationDiscount = 0.5
-
 // Target configures an SPRT run. The domain used for calibration lookups comes
 // from the Task, not here, so there is exactly one source of truth for it.
 type Target struct {
@@ -122,6 +118,7 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 	var lambda float64
 	candidate := ""
 	familySeen := map[string]bool{}
+	var seenIDs, seenFamilies, seenTexts []string
 
 	for _, src := range order {
 		cost := src.EstCostUSD
@@ -137,6 +134,9 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 		}
 		res.SpentUSD += cost
 		res.Samples++
+		seenIDs = append(seenIDs, src.ID)
+		seenFamilies = append(seenFamilies, src.Family)
+		seenTexts = append(seenTexts, ans.Text)
 
 		if candidate == "" {
 			candidate = ans.Text // first answer seeds the candidate
@@ -145,7 +145,7 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 
 		llr := cal.LLR(src.ID, task.Domain, agreed)
 		if src.Family != "" && familySeen[src.Family] {
-			llr *= CorrelationDiscount
+			llr *= FamilyDiscount(DefaultCoAgreementPath(), src.Family)
 		}
 		familySeen[src.Family] = true
 
@@ -170,6 +170,8 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 			res.Ledger[len(res.Ledger)-1].LambdaAfter = lambda
 		}
 	}
+
+	RecordCoAgreement(DefaultCoAgreementPath(), task.Domain, seenIDs, seenFamilies, seenTexts, cfg.equiv)
 
 	res.Candidate = candidate
 	res.Lambda = lambda


### PR DESCRIPTION
## Summary
`sprt.correlationDiscount = 0.5` was a hardcoded guess: any second vote from an already-seen model
family got its LLR halved, flat, regardless of how correlated that family actually is — a
zeroth-order mean-field approximation with the coupling constant guessed, not measured.

## Changes
- New `internal/trust/coupling.go`: records per-task co-agreement (which sources answered a task,
  grouped by which cluster of equivalent answers they landed in) to `~/.hydra/coagreement.jsonl`.
  `FamilyCoupling` measures a family's excess same-family agreement rate over the empirical
  cross-family baseline — the measurable definition of "these are correlated, not independently
  confirming." `FamilyDiscount` (`1-J`) replaces the flat constant, falling back to the same `0.5`
  default below 20 same-family samples — no behavior change for any install without enough data yet.
- `trust.Run` (SPRT) and `swarm.CalibratedJudge` both now call `FamilyDiscount` instead of the flat
  constant, and both feed `RecordCoAgreement` — every ensembling path improves the same
  measurement, not just `--confidence`. `CalibratedJudge`'s own `clusterByAgreement` is now a thin
  wrapper over the shared `trust.ClusterByAgreement`, removing a duplicate clustering algorithm.
- `hyctl trust calibration` surfaces a false-consensus warning when a family's measured coupling
  crosses a practical threshold (`J≥0.7`) — "these N heads are effectively one vote." Named
  explicitly as a practical threshold, not a claimed Ising phase-transition derivation.

Per the issue's own non-goal: no full pairwise Ising inference, a per-family scalar coupling only.

## Test plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./...` — whole repo green
- [x] New tests: clustering correctness; tiny/unfamilied runs are never recorded; below-threshold
      coupling reports not-ok and falls back to the flat default; a family that always agrees with
      itself while a cross-family source never does measures `J≈1` and triggers the warning; a
      family whose agreement rate matches the cross-family baseline measures `J≈0` and does not
      warn; a missing log degrades gracefully

Closes #118