### PR TITLE
feat(ledger,dispatch): give the ledger's resource field real content

### DIFF
--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -240,6 +240,28 @@ func TestDispatch_DefaultLedgerPolicyRecordsButNeverBlocks(t *testing.T) {
 	}
 }
 
+// A ledger rule keyed on Resource must scope by the file a dispatch acts on,
+// not just by head — the concrete "excessive agency" containment: a head may
+// be trusted in general but still denied write access to a specific path.
+func TestDispatch_LedgerResourceScopingBlocksOnlyMatchingFiles(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	writeLedgerPolicy(t, ledger.Policy{Rules: []ledger.Rule{{Resource: "internal/auth/*", Decision: ledger.Deny}}})
+
+	if _, err := liveDispatcher(echoHead(t, s, "h1", 90)).
+		Dispatch(context.Background(), "go", Options{Resource: "internal/auth/token.go"}); err == nil {
+		t.Error("dispatch touching internal/auth/token.go should have been denied by the resource rule")
+	}
+
+	res, err := liveDispatcher(echoHead(t, s, "h1", 90)).
+		Dispatch(context.Background(), "go", Options{Resource: "internal/api/handler.go"})
+	if err != nil {
+		t.Fatalf("dispatch touching a non-matching resource should succeed: %v", err)
+	}
+	if res.Head.ID != "h1" {
+		t.Errorf("Head = %q, want h1", res.Head.ID)
+	}
+}
+
 func writeLedgerPolicy(t *testing.T, p ledger.Policy) {
 	t.Helper()
 	raw, err := json.Marshal(p)

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -42,6 +42,13 @@ type Options struct {
 	A2AFile   string // path to A2A handoff JSON; prepends structured context to prompt
 	Enum      string // enum key (e.g. "SIMPLE") for cost logging
 
+	// Resource is the file (or other resource) this dispatch acts on, if any —
+	// e.g. the path editor.Edit is about to write. Passed to the ledger so a
+	// policy rule can express least-privilege file scoping ("deny writes under
+	// internal/auth/**"), not just per-head rules. Empty means no resource
+	// concept applies (e.g. a plain text dispatch with no target file).
+	Resource string
+
 	// RunID groups every log row produced by one user-facing invocation;
 	// TaskID groups the rows for one logical task inside it. Empty means
 	// "derive one" (see runid.ResolveRun/ResolveTask) — pass them explicitly
@@ -180,7 +187,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 			Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
 			Detail: fmt.Sprintf("candidate %d of %d", i+1, len(candidates)),
 		})
-		if decision, lerr := ledger.CheckAndRecordDispatch("hydra-dispatch", h.ID, "", prompt); lerr == nil && decision == ledger.Deny {
+		if decision, lerr := ledger.CheckAndRecordDispatch("hydra-dispatch", h.ID, opts.Resource, prompt); lerr == nil && decision == ledger.Deny {
 			lastErr = fmt.Errorf("denied by ledger policy: head %s", h.ID)
 			_ = rl.Append(runlog.Event{
 				Kind: runlog.KindError, TaskID: taskID,

--- a/internal/editor/edit_test.go
+++ b/internal/editor/edit_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/testutil"
 	"github.com/ankit373/hydra/internal/trust"
@@ -135,6 +136,58 @@ func TestEdit_WritesTheContentAndRecordsTheEdit(t *testing.T) {
 	}
 	if !sawEdit {
 		t.Errorf("no edit event in the run log: %+v", events)
+	}
+}
+
+// A ledger rule keyed on a file glob must block an edit to a matching path —
+// the concrete "excessive agency" containment: a head may be trusted in
+// general but still denied write access to a specific subtree.
+func TestEdit_LedgerResourceRuleBlocksAMatchingFile(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}"))
+	writeLedgerPolicy(t, ledger.Policy{Rules: []ledger.Rule{{Resource: "**/secrets/**", Decision: ledger.Deny}}})
+
+	blocked := filepath.Join(repo, "secrets", "key.go")
+	if err := os.MkdirAll(filepath.Dir(blocked), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blocked, []byte("package secrets\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{
+		File: blocked, Enum: "MODERATE", Prompt: "add a helper",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" {
+		t.Errorf("status = %q, want fail — the resource rule should have blocked this edit", res.Status)
+	}
+
+	allowed := filepath.Join(repo, "main.go")
+	res, err = Edit(context.Background(), Request{
+		File: allowed, Enum: "MODERATE", Prompt: "add an empty main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "ok" {
+		t.Errorf("status = %q, want ok — a non-matching path must not be blocked: %q", res.Status, res.Error)
+	}
+}
+
+func writeLedgerPolicy(t *testing.T, p ledger.Policy) {
+	t.Helper()
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := ledger.DefaultPolicyPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -149,6 +149,7 @@ snippet) between these exact markers and nothing else:
 		TierHint: tierHint,
 		RunID:    req.RunID,
 		TaskID:   req.TaskID,
+		Resource: req.File,
 	})
 	if err != nil {
 		cleanupBackup()

--- a/internal/parallel/edit_test.go
+++ b/internal/parallel/edit_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/testutil"
 
 	// Providers register themselves in init(), and this package does not import
@@ -126,6 +127,51 @@ func TestEdit_WritesTheModelsContentAndReportsTheDiff(t *testing.T) {
 		if strings.HasPrefix(e.Name(), ".hydra-tmp") || strings.HasSuffix(e.Name(), ".hydra-bak") {
 			t.Errorf("%s was left behind after a successful edit", e.Name())
 		}
+	}
+}
+
+// A ledger rule keyed on a file glob must block runEditTask against a
+// matching path — mirrors editor.Edit's own resource-scoping test, since
+// parallel.runEditTask duplicates that flow.
+func TestEdit_LedgerResourceRuleBlocksAMatchingFile(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}"))
+	writeLedgerPolicy(t, ledger.Policy{Rules: []ledger.Rule{{Resource: "**/secrets/**", Decision: ledger.Deny}}})
+
+	blocked := filepath.Join(repo, "secrets", "key.go")
+	if err := os.MkdirAll(filepath.Dir(blocked), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(blocked, []byte("package secrets\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{Label: "edit", Enum: "MODERATE", File: blocked, Prompt: "add a helper", Validate: boolPtr(false)})
+	if got.Status != "fail" {
+		t.Errorf("status = %q, want fail — the resource rule should have blocked this edit", got.Status)
+	}
+
+	allowed := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(allowed, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got = runEdit(t, Task{Label: "edit", Enum: "MODERATE", File: allowed, Prompt: "add an empty main", Validate: boolPtr(false)})
+	if got.Status != "ok" {
+		t.Errorf("status = %q, want ok — a non-matching path must not be blocked: %q", got.Status, got.Error)
+	}
+}
+
+func writeLedgerPolicy(t *testing.T, p ledger.Policy) {
+	t.Helper()
+	raw, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := ledger.DefaultPolicyPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -199,6 +199,7 @@ func runTextTask(ctx context.Context, task Task, runID, taskID string) json.RawM
 		TierHint: enumToTier(task.Enum),
 		RunID:    runID,
 		TaskID:   taskID,
+		Resource: task.Context,
 	})
 	if err != nil {
 		return failText(task, err.Error())
@@ -300,6 +301,7 @@ snippet) between these exact markers and nothing else:
 		TierHint: enumToTier(task.Enum),
 		RunID:    runID,
 		TaskID:   taskID,
+		Resource: file,
 	})
 	if err != nil {
 		cleanupBackup()


### PR DESCRIPTION
## Summary
- `ledger.CheckAndRecordDispatch`'s `resource` argument was always `""` at both real call sites — the ledger could log which head ran, but a policy rule had no way to express "this head may only touch these files."
- Adds `Resource` to `dispatch.Options`, threaded from `editor.Edit` (`req.File`), `parallel.runTextTask` (`task.Context`), and `parallel.runEditTask` (its target file) into `dispatch.go`'s existing ledger check.
- Explicit, caller-set data — not sniffed from the flattened prompt text (which would be fragile and itself an injection target).
- `swarm.executeHead` has no analogous file concept — correctly stays `resource=""`.

## Changes
- `internal/dispatch/dispatch.go` — new `Options.Resource`, used in the ledger call
- `internal/editor/editor.go` — sets `Resource: req.File`
- `internal/parallel/parallel.go` — sets `Resource` in both `runTextTask` and `runEditTask`

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` — full repo, clean
- [x] A `ledger.Rule` keyed on a file-glob `Resource` blocks `dispatch.Dispatch`/`editor.Edit`/`parallel.runEditTask` against a matching path, and does not block a non-matching one

Closes #364