### PR TITLE
fix(oracle): argument-injection via unsplit {answer} substitution in CommandOracle

### DIFF
--- a/internal/oracle/coverage_test.go
+++ b/internal/oracle/coverage_test.go
@@ -176,6 +176,62 @@ func TestBuildArgs_SubstitutionAndSpacing(t *testing.T) {
 	}
 }
 
+// A candidate answer containing whitespace or flag-like tokens must land as
+// ONE atomic argv element, never re-split — otherwise it can inject extra
+// argv entries into whatever binary the template names (CWE-88 argument
+// injection). This is the regression test for the bug: {answer} used to be
+// substituted via raw string-replace before Fields-splitting, so whitespace
+// in the candidate fragmented into multiple argv tokens.
+func TestBuildArgs_AnswerWithWhitespaceIsOneAtomicArg(t *testing.T) {
+	o := &CommandOracle{Template: "grep {answer} file.txt", Source: "v"}
+	malicious := "ok --exec=rm -rf /"
+
+	parts, cleanup, err := o.buildArgs(malicious)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+	want := []string{"grep", malicious, "file.txt"}
+	if len(parts) != len(want) {
+		t.Fatalf("buildArgs = %q, want %q — the candidate was fragmented into %d argv tokens instead of 1",
+			parts, want, len(parts)-2)
+	}
+	for i := range want {
+		if parts[i] != want[i] {
+			t.Errorf("parts[%d] = %q, want %q", i, parts[i], want[i])
+		}
+	}
+}
+
+// The same guarantee must hold when {answer} and {file} share a template,
+// each substituting atomically regardless of order.
+func TestBuildArgs_AnswerAndFileBothAtomicRegardlessOfOrder(t *testing.T) {
+	malicious := "ok --exec=rm -rf /"
+	o := &CommandOracle{
+		Template:  "diff {answer} {file}",
+		Source:    "v",
+		writeTemp: func(string) (string, func(), error) { return "/tmp/expected.txt", func() {}, nil },
+	}
+	parts, cleanup, err := o.buildArgs(malicious)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+	want := []string{"diff", malicious, "/tmp/expected.txt"}
+	if len(parts) != len(want) {
+		t.Fatalf("buildArgs = %q, want %q", parts, want)
+	}
+	for i := range want {
+		if parts[i] != want[i] {
+			t.Errorf("parts[%d] = %q, want %q", i, parts[i], want[i])
+		}
+	}
+}
+
 // A cancelled context must stop the oracle rather than let it run to its own
 // timeout — the SPRT loop relies on this to bound a run.
 func TestVerify_HonoursContextCancellation(t *testing.T) {

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -92,11 +92,15 @@ func (o *CommandOracle) Verify(ctx context.Context, candidate string, _ trust.Ta
 	return Verdict{Passed: true}, nil
 }
 
-// buildArgs splits the template, substituting {answer} inline and materializing
-// {file} to a temp path. It mirrors editor.runValidatorCmd's safe splitting so
-// paths with spaces are never fragmented.
+// buildArgs splits the template into argv, substituting {answer} inline and
+// materializing {file} to a temp path. Both substitute as exactly one atomic
+// argv element via splitTemplate — never re-split by whitespace inside the
+// substituted value, so a candidate answer containing whitespace or flag-like
+// tokens cannot inject extra argv entries into whatever binary the template
+// names (CWE-88 argument injection).
 func (o *CommandOracle) buildArgs(candidate string) (parts []string, cleanup func(), err error) {
 	tmpl := o.Template
+	var filePath string
 	if strings.Contains(tmpl, "{file}") {
 		writer := o.writeTemp
 		if writer == nil {
@@ -107,16 +111,34 @@ func (o *CommandOracle) buildArgs(candidate string) (parts []string, cleanup fun
 			return nil, nil, werr
 		}
 		cleanup = cl
-		idx := strings.Index(tmpl, "{file}")
-		parts = append(strings.Fields(subAnswer(tmpl[:idx], candidate)), path)
-		parts = append(parts, strings.Fields(subAnswer(tmpl[idx+len("{file}"):], candidate))...)
-		return parts, cleanup, nil
+		filePath = path
 	}
-	return strings.Fields(subAnswer(tmpl, candidate)), nil, nil
+	return splitTemplate(tmpl, candidate, filePath), cleanup, nil
 }
 
-func subAnswer(s, candidate string) string {
-	return strings.ReplaceAll(s, "{answer}", candidate)
+// splitTemplate tokenizes tmpl into argv. Each {answer}/{file} placeholder
+// substitutes as exactly one atomic argv element, in whatever order and
+// however many times they appear; literal text around them is split on
+// whitespace normally, mirroring editor.runValidatorCmd's handling of {file}.
+func splitTemplate(tmpl, answer, file string) []string {
+	var parts []string
+	for {
+		ai := strings.Index(tmpl, "{answer}")
+		fi := strings.Index(tmpl, "{file}")
+		var idx int
+		var token, value string
+		switch {
+		case ai < 0 && fi < 0:
+			return append(parts, strings.Fields(tmpl)...)
+		case fi < 0 || (ai >= 0 && ai < fi):
+			idx, token, value = ai, "{answer}", answer
+		default:
+			idx, token, value = fi, "{file}", file
+		}
+		parts = append(parts, strings.Fields(tmpl[:idx])...)
+		parts = append(parts, value)
+		tmpl = tmpl[idx+len(token):]
+	}
 }
 
 // LLR maps a verdict to the calibrated log-likelihood-ratio contribution of this


### PR DESCRIPTION
## Steps to Reproduce
`CommandOracle.buildArgs`/`subAnswer` did `strings.ReplaceAll(tmpl, "{answer}", candidate)` on the raw template string *before* `strings.Fields` split it into argv. A candidate containing whitespace injects extra argv tokens into whatever binary the template names — e.g. template `"grep {answer} file.txt"` plus a candidate containing spaces/flags restructures the argv unexpectedly.

Found while auditing Hydra's own prompt/argument-construction sites for GenAI-security-shaped issues — independent bug, CWE-88 argument injection (no shell involved, so this is argv-splitting corruption, not shell RCE).

## Expected
`{answer}` substitutes as one atomic argv element, the same way `{file}` already correctly does.

## Actual
`{answer}` was substituted via raw string-replace before any splitting, so whitespace in `candidate` fragmented into multiple argv tokens. The doc comment claimed it "mirrors editor.runValidatorCmd's safe splitting" — true only for `{file}`.

## Fix
Replaces the ad-hoc `{file}`-only splitting with `splitTemplate`, a general tokenizer that substitutes both `{answer}` and `{file}` as exactly one atomic argv element each, in whatever order/count they appear. Removes the now-dead `subAnswer` helper.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` — full repo, clean
- [x] New regression test: a candidate containing whitespace/flag-like tokens lands as one atomic argv element
- [x] New test: `{answer}` and `{file}` both substitute atomically regardless of order in the same template
- [x] Existing `buildArgs`/oracle tests unchanged and passing

Closes #365