### PR TITLE
feat(ledger): hash-chained ledger integrity (tamper-evidence)

### DIFF
--- a/cmd/hydra/cli_data_test.go
+++ b/cmd/hydra/cli_data_test.go
@@ -109,6 +109,28 @@ func TestCLI_MCPLogAndReport_SurfaceFlaggedEvents(t *testing.T) {
 	}
 }
 
+// `hyctl mcp verify-chain` is the tamper-evidence check over the ledger —
+// it must report intact after ordinary recording and confirm gate-ability
+// (a non-zero exit) when it isn't, matching the other ledger verify commands.
+func TestCLI_MCPVerifyChain_ReportsIntactAfterOrdinaryRecording(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	for i := 0; i < 3; i++ {
+		if _, cobraOut, err := run(t, "mcp", "record", "--agent", "a", "--tool", "t", "--decision", "allow"); err != nil {
+			t.Fatalf("`hyctl mcp record` failed: %v (%s)", err, cobraOut)
+		}
+	}
+
+	out, cobraOut, err := run(t, "mcp", "verify-chain")
+	if err != nil {
+		t.Fatalf("`hyctl mcp verify-chain` failed on an untampered ledger: %v", err)
+	}
+	combined := out + cobraOut
+	if !strings.Contains(strings.ToLower(combined), "intact") {
+		t.Errorf("verify-chain did not report intact:\n%s", combined)
+	}
+}
+
 // ── trust ─────────────────────────────────────────────────────────────────────
 
 // `hyctl trust explain` is the audit trail behind a confidence number: it must

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -972,7 +972,33 @@ func cmdMCP() *cobra.Command {
 	}
 	report.Flags().BoolVar(&repJSON, "json", false, "machine-readable JSON output")
 
-	cmd.AddCommand(check, record, verify, logCmd, report)
+	// verify-chain: confirm the ledger's hash chain hasn't been tampered with.
+	var chainJSON bool
+	verifyChain := &cobra.Command{
+		Use:   "verify-chain",
+		Short: "Confirm the ledger's hash chain is intact (tamper-evidence)",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			res, err := ledger.VerifyChain(ledger.DefaultPath())
+			if err != nil {
+				return err
+			}
+			if chainJSON {
+				return json.NewEncoder(os.Stdout).Encode(res)
+			}
+			if res.Intact {
+				fmt.Printf("  %s  chain intact — %d chained event(s), %d unchained (pre-dates this feature)\n",
+					okStyle.Render("OK"), res.Chained, res.Unchained)
+				return nil
+			}
+			fmt.Printf("  %s  chain broken at event index %d — the ledger was modified after recording\n",
+				strings.ToUpper(string(ledger.Deny)), res.BrokenAt)
+			os.Exit(3) // non-zero so callers can gate on it
+			return nil
+		},
+	}
+	verifyChain.Flags().BoolVar(&chainJSON, "json", false, "machine-readable JSON output")
+
+	cmd.AddCommand(check, record, verify, logCmd, report, verifyChain)
 	return cmd
 }
 
@@ -2333,6 +2359,7 @@ var (
 	cortexStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("205"))
 	dimStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	warnStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+	okStyle     = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("42"))
 )
 
 // promptPreview shortens a prompt for a log Detail field. Run events carry a

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -103,6 +103,13 @@ type Event struct {
 	// FlagReason is the specific heuristic that matched, when Flagged is true.
 	FlagReason string `json:"flag_reason,omitempty"`
 
+	// PrevHash is the previous event's Hash, and Hash is sha256 of this event
+	// (PrevHash set, Hash cleared) — a local hash chain, so an edited or
+	// deleted line breaks the link and VerifyChain can detect it. Both empty
+	// means this event predates the feature ("unchained"), not tampered.
+	PrevHash string `json:"prev_hash,omitempty"`
+	Hash     string `json:"hash,omitempty"`
+
 	// Config is the deployment-identity breadcrumb (config.Breadcrumb) in
 	// effect when this event was recorded, ties the event to the exact
 	// routing rules that were live.
@@ -195,6 +202,11 @@ func Record(path string, e Event) error {
 			e.Config = bc
 		}
 	}
+	if e.PrevHash == "" {
+		e.PrevHash = readChainHash(chainHashPath(path))
+	}
+	e.Hash = hashEvent(e)
+
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
@@ -207,8 +219,84 @@ func Record(path string, e Event) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintln(f, string(raw))
-	return err
+	if _, err := fmt.Fprintln(f, string(raw)); err != nil {
+		return err
+	}
+	// Best-effort: a failed chainhash write costs the next Record a fresh
+	// chain start (reported as a false break at verify time, never a false
+	// all-clear) rather than failing the access decision it was recording.
+	_ = writeChainHash(chainHashPath(path), e.Hash)
+	return nil
+}
+
+// hashEvent computes e's chain hash: sha256 of e's canonical JSON with Hash
+// cleared (PrevHash, being an ordinary field, is covered by the same hash —
+// no separate prefix needed). Event holds only strings and typed strings, so
+// json.Marshal cannot fail here.
+func hashEvent(e Event) string {
+	e.Hash = ""
+	raw, _ := json.Marshal(e)
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func chainHashPath(ledgerPath string) string { return ledgerPath + ".chainhash" }
+
+func readChainHash(path string) string {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func writeChainHash(path, hash string) error {
+	return os.WriteFile(path, []byte(hash+"\n"), 0o600)
+}
+
+// ChainResult is VerifyChain's report.
+type ChainResult struct {
+	// Chained is the number of events that carry a hash (post-migration).
+	Chained int `json:"chained"`
+	// Unchained is the number of events with no hash — they predate this
+	// feature, not tampered.
+	Unchained int  `json:"unchained"`
+	Intact    bool `json:"intact"`
+	// BrokenAt is the index into the events slice VerifyChain read, of the
+	// first event whose hash doesn't match — 0 when Intact.
+	BrokenAt int `json:"broken_at,omitempty"`
+}
+
+// VerifyChain walks path's events in order, recomputing each chained event's
+// hash and confirming it links to the one before it. An event with no Hash is
+// treated as pre-migration and excluded from verification, not flagged
+// broken — the chain only covers events recorded since this feature shipped.
+func VerifyChain(path string) (ChainResult, error) {
+	events, _, err := LoadCounted(path)
+	if err != nil {
+		return ChainResult{}, err
+	}
+	res := ChainResult{Intact: true}
+	prevHash := ""
+	chainStarted := false
+	for i, e := range events {
+		if e.Hash == "" {
+			res.Unchained++
+			continue
+		}
+		res.Chained++
+		broken := hashEvent(e) != e.Hash
+		if chainStarted && e.PrevHash != prevHash {
+			broken = true
+		}
+		if broken && res.Intact {
+			res.Intact = false
+			res.BrokenAt = i
+		}
+		prevHash = e.Hash
+		chainStarted = true
+	}
+	return res, nil
 }
 
 // Load reads all events; a missing ledger yields no events. Unparseable lines

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -526,3 +526,115 @@ func TestFilter(t *testing.T) {
 		t.Errorf("Filter(agent=a, denied) = %d, want 1", len(got))
 	}
 }
+
+func TestVerifyChain_RoundTripIsIntact(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	for i := 0; i < 5; i++ {
+		if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Intact || res.Chained != 5 || res.Unchained != 0 {
+		t.Errorf("ChainResult = %+v, want intact with 5 chained events", res)
+	}
+}
+
+// Editing a line after the fact must be detectable — the entire point of a
+// hash chain over a plain append-only file.
+func TestVerifyChain_DetectsATamperedLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	for i := 0; i < 3; i++ {
+		if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	var e Event
+	if err := json.Unmarshal([]byte(lines[1]), &e); err != nil {
+		t.Fatal(err)
+	}
+	e.Decision = Deny // tamper: flip an already-recorded decision
+	tampered, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines[1] = string(tampered)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Intact {
+		t.Fatal("VerifyChain reported intact after a line was hand-edited")
+	}
+	if res.BrokenAt != 1 {
+		t.Errorf("BrokenAt = %d, want 1 (the tampered line's index)", res.BrokenAt)
+	}
+}
+
+// A ledger written before this feature has no Hash on any event — that must
+// report as fully unchained, not as a broken chain.
+func TestVerifyChain_PreExistingLedgerIsUnchainedNotBroken(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	old := []Event{
+		{Agent: "a", Tool: "t", Decision: Allow},
+		{Agent: "a", Tool: "t", Decision: Deny},
+	}
+	var lines []string
+	for _, e := range old {
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, string(raw))
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Intact || res.Chained != 0 || res.Unchained != 2 {
+		t.Errorf("ChainResult = %+v, want intact with 0 chained, 2 unchained", res)
+	}
+}
+
+// A ledger that mixes pre-feature (unchained) events with new (chained) ones
+// — the real-world shape every existing installation will have — must verify
+// the chained tail without complaining about the unchained head.
+func TestVerifyChain_MixedUnchainedThenChainedIsIntact(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	old, err := json.Marshal(Event{Agent: "a", Tool: "t", Decision: Allow})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(old, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Intact || res.Chained != 3 || res.Unchained != 1 {
+		t.Errorf("ChainResult = %+v, want intact with 3 chained, 1 unchained", res)
+	}
+}


### PR DESCRIPTION
## Summary
- `mcp_ledger.jsonl` was append-only but had no tamper-evidence beyond file permissions — a line could be silently edited or deleted with no way to detect it after the fact.
- `Event` gains `PrevHash`/`Hash` (both `omitempty`). `Record` computes `Hash = sha256(event JSON, PrevHash set, Hash cleared)`.
- The last hash is tracked in a one-line sidecar (`mcp_ledger.jsonl.chainhash`), not by replaying the whole log per append — avoiding the exact perf mistake #350 already fixed once.
- New `ledger.VerifyChain` walks events recomputing/comparing hashes; a pre-migration event (no `Hash`) is excluded from verification, not flagged broken.
- New `hyctl mcp verify-chain` surfaces this for scripting/CI.

## Changes
- `internal/ledger/ledger.go` — `PrevHash`/`Hash` fields, chain computation in `Record`, `VerifyChain`
- `cmd/hydra/main.go` — `hyctl mcp verify-chain` command, `okStyle`

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` — full repo, clean
- [x] Round-trip: `Record` → `VerifyChain` reports intact
- [x] Tamper test: hand-edit one line, `VerifyChain` reports the exact broken index
- [x] Back-compat: a pre-hash-chain ledger reports "N unchained, 0 chained," not an error
- [x] Mixed pre-migration + post-migration ledger verifies the chained tail correctly
- [x] CLI test: `hyctl mcp verify-chain` reports intact after ordinary `hyctl mcp record` calls

Closes #370