### PR TITLE
feat(dispatch): denial-of-wallet protection for ordinary dispatch (--max-cost)

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -438,6 +438,7 @@ func cmdDispatch() *cobra.Command {
 		system    string
 		a2aFile   string
 		enumKey   string
+		maxCost   float64
 		// swarm flags
 		doSwarm       bool
 		swarmMode     string
@@ -624,14 +625,15 @@ func cmdDispatch() *cobra.Command {
 				tierHint = dispatch.EnumToTier(enumKey)
 			}
 			opts := dispatch.Options{
-				TierHint:  tierHint,
-				LocalOnly: localOnly,
-				DryRun:    dryRun,
-				System:    system,
-				A2AFile:   a2aFile,
-				Enum:      enumKey,
-				RunID:     runID,
-				TaskID:    taskID,
+				TierHint:   tierHint,
+				LocalOnly:  localOnly,
+				DryRun:     dryRun,
+				System:     system,
+				A2AFile:    a2aFile,
+				Enum:       enumKey,
+				RunID:      runID,
+				TaskID:     taskID,
+				MaxCostUSD: maxCost,
 			}
 
 			result, err := d.Dispatch(ctx, prompt, opts)
@@ -674,6 +676,7 @@ func cmdDispatch() *cobra.Command {
 	cmd.Flags().StringVarP(&system, "system", "s", "", "system prompt")
 	cmd.Flags().StringVar(&a2aFile, "a2a", "", "path to A2A handoff JSON (prepends structured context to prompt)")
 	cmd.Flags().StringVar(&enumKey, "enum", "", "routing enum key, e.g. SIMPLE — selects the tier when --tier is unset")
+	cmd.Flags().Float64Var(&maxCost, "max-cost", 0, "refuse a candidate head if its estimated cost exceeds this USD (denial-of-wallet guard)")
 	// swarm flags
 	cmd.Flags().BoolVar(&doSwarm, "swarm", false, "fan prompt out to multiple heads simultaneously")
 	cmd.Flags().StringVar(&swarmMode, "swarm-mode", "best", "response strategy: best|race|all")

--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -262,6 +262,53 @@ func TestDispatch_LedgerResourceScopingBlocksOnlyMatchingFiles(t *testing.T) {
 	}
 }
 
+// A denial-of-wallet guard: a candidate head whose estimated cost exceeds
+// MaxCostUSD must never execute — mirrors swarm's own preflight-cost pattern,
+// extended to ordinary dispatch (which had no ceiling at all before this).
+func TestDispatch_MaxCostUSDRefusesAnExpensiveHead(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	dd := liveDispatcher(echoHead(t, s, "expensive", 95))
+	dd.pricing = pricing.Load()
+
+	// A prompt with real length, so the char-count/4 token estimate is
+	// nonzero — tier 1's $15/$75-per-million rate then prices well above the
+	// ceiling below.
+	prompt := strings.Repeat("x", 400)
+	if _, err := dd.Dispatch(context.Background(), prompt, Options{MaxCostUSD: 0.0000001}); err == nil {
+		t.Error("dispatch should have been refused: the only head's estimated cost exceeds the ceiling")
+	}
+
+	events, err := ledger.Load(ledger.DefaultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawCostDenial bool
+	for _, e := range events {
+		if e.Decision == ledger.Deny && strings.Contains(e.Reason, "cost ceiling") {
+			sawCostDenial = true
+		}
+	}
+	if !sawCostDenial {
+		t.Errorf("no cost-ceiling denial recorded in the ledger: %+v", events)
+	}
+}
+
+// MaxCostUSD: 0 (the default) must change nothing — a ceiling that silently
+// activates itself would refuse dispatches nobody asked to bound.
+func TestDispatch_ZeroMaxCostUSDIsNoLimit(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	dd := liveDispatcher(echoHead(t, s, "h1", 95))
+	dd.pricing = pricing.Load()
+
+	res, err := dd.Dispatch(context.Background(), "go", Options{MaxCostUSD: 0})
+	if err != nil {
+		t.Fatalf("MaxCostUSD: 0 should not refuse anything: %v", err)
+	}
+	if res.Head.ID != "h1" {
+		t.Errorf("Head = %q, want h1", res.Head.ID)
+	}
+}
+
 func writeLedgerPolicy(t *testing.T, p ledger.Policy) {
 	t.Helper()
 	raw, err := json.Marshal(p)

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -49,6 +49,11 @@ type Options struct {
 	// concept applies (e.g. a plain text dispatch with no target file).
 	Resource string
 
+	// MaxCostUSD refuses a candidate whose estimated cost exceeds it before
+	// executing — the same preflight guard swarm.Options.MaxEstCostUSD already
+	// gives fan-out mode, extended to ordinary dispatch. 0 = no limit.
+	MaxCostUSD float64
+
 	// RunID groups every log row produced by one user-facing invocation;
 	// TaskID groups the rows for one logical task inside it. Empty means
 	// "derive one" (see runid.ResolveRun/ResolveTask) — pass them explicitly
@@ -195,6 +200,26 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 				Status: "denied", Detail: "denied by ledger policy",
 			})
 			continue
+		}
+		if opts.MaxCostUSD > 0 {
+			estInputTokens := len(prompt) / 4
+			estCost := d.estimateCost(rank.UITier(h), estInputTokens, estInputTokens/2)
+			if estCost > opts.MaxCostUSD {
+				lastErr = fmt.Errorf("estimated cost $%.4f for head %s exceeds limit $%.4f", estCost, h.ID, opts.MaxCostUSD)
+				_ = rl.Append(runlog.Event{
+					Kind: runlog.KindError, TaskID: taskID,
+					Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
+					Status: "denied", Detail: "exceeds cost ceiling",
+				})
+				// Shares the ledger's accountability trail with policy denials
+				// (Reason distinguishes them) so `hyctl security` has one place
+				// to find every kind of refused access, cost or policy.
+				_ = ledger.Record(ledger.DefaultPath(), ledger.Event{
+					Agent: "hydra-dispatch", Tool: h.ID, Decision: ledger.Deny,
+					Reason: fmt.Sprintf("exceeds cost ceiling: estimated $%.4f > limit $%.4f", estCost, opts.MaxCostUSD),
+				})
+				continue
+			}
 		}
 		started := time.Now()
 		exec := executor.For(h)


### PR DESCRIPTION
## Summary
- `--swarm-max-cost` was the only USD spend ceiling anywhere in Hydra, scoped to `hyctl dispatch --swarm`. Ordinary `hyctl dispatch` — the common path — had zero cost ceiling.
- `dispatch.Options` gains `MaxCostUSD` (0 = no limit, matching `swarm.Options.MaxEstCostUSD`'s exact semantics).
- `Dispatcher.Dispatch` estimates cost for the selected head before executing and refuses if it exceeds the ceiling — preflight, same shape as swarm's guard.
- A refusal also writes a ledger event (`Reason` mentions "cost ceiling"), sharing the accountability trail with policy denials.
- `hyctl dispatch --max-cost <usd>` wires it in. Flag-only, no persistent config default — matches `--swarm-max-cost`'s own precedent.

## Changes
- `internal/dispatch/dispatch.go` — `Options.MaxCostUSD`, preflight check + ledger record in the fallback loop
- `cmd/hydra/main.go` — `--max-cost` flag

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` — full repo, clean
- [x] A candidate head whose estimated cost exceeds `MaxCostUSD` is refused before `executor.Execute` runs, and a cost-ceiling ledger denial is recorded
- [x] `MaxCostUSD: 0` changes nothing (default-safe)

Closes #371