### PR TITLE
feat(capabilities): model-provenance visibility (managed vs runtime-added)

### DIFF
--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -111,6 +111,33 @@ func (db *DB) Name(id string) string {
 	return id
 }
 
+// Source returns id's capability entry's provenance — "builtin" for the
+// embedded, curated catalog, "user" for one added via the runtime overlay
+// (`hyctl models add`), or "" if id matched neither and fell to DefaultScore.
+// This is the "managed vs. discovered" distinction AI-BOM tooling is built
+// around — a user-added model isn't malicious, it just wasn't vetted by
+// whoever curated the embedded catalog, and that's worth being able to see.
+func (db *DB) Source(id string) string {
+	if m, ok := db.index[id]; ok {
+		return m.Source
+	}
+	return ""
+}
+
+// SourceOllama returns "builtin" when modelName matched a curated family
+// pattern, or "" when it fell to DefaultScore (an unrecognized local model) —
+// the ScoreOllama analog of Source, since family-pattern matching has no
+// per-model Entry to look up.
+func (db *DB) SourceOllama(modelName string) string {
+	lower := strings.ToLower(modelName)
+	for _, f := range db.d.OllamaFamilies {
+		if strings.Contains(lower, f.Pattern) {
+			return "builtin"
+		}
+	}
+	return ""
+}
+
 // Entries returns all models (built-in ⊕ user), sorted by capScore descending.
 func (db *DB) Entries() []Entry {
 	out := append([]Entry(nil), db.d.Known...)

--- a/internal/capabilities/capabilities_test.go
+++ b/internal/capabilities/capabilities_test.go
@@ -100,6 +100,42 @@ func TestEntries_MarksSourceAndSorts(t *testing.T) {
 	}
 }
 
+// Source is the "managed vs. discovered" signal a security dashboard reports
+// on — a user-added model must be distinguishable from an embedded one.
+func TestSource_DistinguishesUserFromBuiltin(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "models.json")
+	if _, err := AddModel(path, Entry{ID: "kimi-k2", Name: "Kimi K2", CapScore: 82}); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := db.Source("kimi-k2"); got != "user" {
+		t.Errorf("Source(kimi-k2) = %q, want user", got)
+	}
+	if got := db.Source("claude"); got != "builtin" {
+		t.Errorf("Source(claude) = %q, want builtin", got)
+	}
+	if got := db.Source("never-heard-of-it"); got != "" {
+		t.Errorf("Source(unknown) = %q, want empty", got)
+	}
+}
+
+func TestSourceOllama_MatchesFamilyPatternsAsBuiltin(t *testing.T) {
+	db, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := db.SourceOllama("qwen2.5-coder:7b"); got != "builtin" {
+		t.Errorf("SourceOllama(known family) = %q, want builtin", got)
+	}
+	if got := db.SourceOllama("some-totally-unrecognized-model:1b"); got != "" {
+		t.Errorf("SourceOllama(unrecognized) = %q, want empty", got)
+	}
+}
+
 func TestHeuristicCapScore(t *testing.T) {
 	cases := map[string]int{
 		"anthropic/claude-opus-4": 92,

--- a/internal/provider/cli/provider.go
+++ b/internal/provider/cli/provider.go
@@ -39,6 +39,7 @@ func (p *Provider) Discover(_ context.Context) ([]provider.Head, error) {
 			CapScore:   caps.Score(c.binary),
 			LocalOnly:  c.local,
 			AuthReady:  true,
+			Meta:       map[string]string{"model_source": caps.Source(c.binary)},
 		})
 	}
 	return heads, nil

--- a/internal/provider/cli/provider_test.go
+++ b/internal/provider/cli/provider_test.go
@@ -58,6 +58,26 @@ func TestDiscover_FindsPlantedBinaryOnEveryOS(t *testing.T) {
 	}
 }
 
+// A discovered head must carry whether its capability entry is embedded or
+// user-added (Meta["model_source"]) — the "managed vs. discovered" split a
+// security dashboard reports on, otherwise invisible once discovery discards
+// the capabilities.Entry it came from.
+func TestDiscover_StampsModelSource(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	s.FakeBinary(t, "claude")
+
+	heads, err := (&Provider{}).Discover(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 1 {
+		t.Fatalf("got %d heads, want 1: %+v", len(heads), heads)
+	}
+	if got := heads[0].Meta["model_source"]; got != "builtin" {
+		t.Errorf("Meta[model_source] = %q, want builtin — claude is in the embedded catalog", got)
+	}
+}
+
 // LocalOnly drives tier-10 placement in rank.UITier (#248) and the --local
 // routing gate. Getting it wrong sends work that must stay local to a paid API.
 func TestDiscover_LocalOnlyMatchesTheTable(t *testing.T) {

--- a/internal/provider/env/provider.go
+++ b/internal/provider/env/provider.go
@@ -37,6 +37,7 @@ func (p *Provider) Discover(_ context.Context) ([]provider.Head, error) {
 			Source:    "env",
 			CapScore:  caps.Score(id),
 			AuthReady: true,
+			Meta:      map[string]string{"model_source": caps.Source(id)},
 		})
 	}
 	return heads, nil

--- a/internal/provider/env/provider_test.go
+++ b/internal/provider/env/provider_test.go
@@ -53,6 +53,9 @@ func TestDiscover_OneKeyYieldsOneHead(t *testing.T) {
 	if h.LocalOnly {
 		t.Error("LocalOnly = true for an API head — --local would route paid work as if it were free")
 	}
+	if got := h.Meta["model_source"]; got != "builtin" {
+		t.Errorf("Meta[model_source] = %q, want builtin — env/anthropic is in the embedded catalog", got)
+	}
 }
 
 // anyOf: either variable alone is enough. Requiring both would silently hide a

--- a/internal/provider/port/provider.go
+++ b/internal/provider/port/provider.go
@@ -139,6 +139,7 @@ func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]pro
 			CapScore:  caps.ScoreOllama(m.Name),
 			LocalOnly: true,
 			AuthReady: true,
+			Meta:      map[string]string{"model_source": caps.SourceOllama(m.Name)},
 		})
 	}
 	return heads, nil
@@ -190,6 +191,7 @@ func (s *lmStudioService) probe(ctx context.Context, caps *capabilities.DB) ([]p
 			CapScore:  caps.ScoreOllama(m.ID),
 			LocalOnly: true,
 			AuthReady: true,
+			Meta:      map[string]string{"model_source": caps.SourceOllama(m.ID)},
 		})
 	}
 	return heads, nil

--- a/internal/provider/port/provider_test.go
+++ b/internal/provider/port/provider_test.go
@@ -284,6 +284,9 @@ func TestDiscover_FindsAListeningOllama(t *testing.T) {
 	if heads[0].Endpoint != srv.URL {
 		t.Errorf("Endpoint = %q, want the address it was found at", heads[0].Endpoint)
 	}
+	if got := heads[0].Meta["model_source"]; got != "builtin" {
+		t.Errorf("Meta[model_source] = %q, want builtin — qwen matches a curated family pattern", got)
+	}
 }
 
 // Each service's dial address is derived from the base it will probe, for both


### PR DESCRIPTION
## Summary
- `internal/capabilities` already tags each model entry with `Source` ("builtin"/"user") — the exact "managed vs. discovered" split AI-BOM tooling (Wiz AI-SPM, Lasso Security) is built around — but discovery discarded it, pulling only `CapScore`/`Name` out of the matched entry.
- Adds `DB.Source(id)` and `DB.SourceOllama(modelName)` (the family-pattern-match analog).
- Stamps `Meta["model_source"]` onto every discovered `Head` in all three providers (`cli`, `env`, `port`).

## Changes
- `internal/capabilities/capabilities.go` — `Source`/`SourceOllama` methods
- `internal/provider/{cli,env,port}/provider.go` — stamp `Meta["model_source"]`

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` — full repo, clean
- [x] `Source`/`SourceOllama` distinguish user-added from embedded from unknown
- [x] Each of the 3 discovery providers stamps `model_source` correctly on a real discovered head

Closes #372