### PR TITLE
feat(ledger): lightweight MITRE ATLAS / OWASP LLM Top-10 tagging on rules

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -266,6 +266,13 @@ type Rule struct {
 	Action         Action   `json:"action,omitempty"`
 	Classification string   `json:"classification,omitempty"`
 	Decision       Decision `json:"decision"`
+
+	// Framework optionally tags which recognized security framework category
+	// this rule covers (e.g. "owasp:llm06", "atlas:ai-ml-attack-staging") —
+	// freeform, normalized like Classification. Purely a label for
+	// FrameworksCovered's coverage report: it plays no part in Decide's
+	// matching, since an access attempt carries no "framework" of its own.
+	Framework string `json:"framework,omitempty"`
 }
 
 // Policy is an ordered rule set with a default decision. First matching rule wins.
@@ -380,8 +387,29 @@ func (p *Policy) validate() error {
 			return fmt.Errorf("rule %d: invalid resource pattern %q: %w", i, r.Resource, err)
 		}
 		r.Classification = NormalizeClassification(r.Classification)
+		r.Framework = NormalizeClassification(r.Framework)
 	}
 	return nil
+}
+
+// FrameworksCovered returns the distinct, non-empty Framework tags present
+// across p's rules, sorted — hyctl security's coverage list: which
+// recognized categories (e.g. "owasp:llm06", "atlas:ai-ml-attack-staging")
+// have at least one rule, versus which don't. Never a manufactured score —
+// only what a user has actually tagged and configured.
+func (p Policy) FrameworksCovered() []string {
+	seen := map[string]bool{}
+	for _, r := range p.Rules {
+		if r.Framework != "" {
+			seen[r.Framework] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for f := range seen {
+		out = append(out, f)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // CheckRequest describes one access-check request: what's being accessed, by

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -112,6 +112,53 @@ func TestPolicy_Decide_MatchesOnClassification(t *testing.T) {
 	}
 }
 
+func TestFrameworksCovered_ReturnsDistinctSortedNonEmptyTags(t *testing.T) {
+	// Rules built directly (not through LoadPolicy) already carry normalized
+	// tags here — case normalization is validate()'s job, covered separately
+	// by TestLoadPolicy_NormalizesFramework.
+	p := Policy{Rules: []Rule{
+		{Tool: "a", Framework: "owasp:llm06", Decision: Deny},
+		{Tool: "b", Framework: "owasp:llm06", Decision: Deny}, // duplicate
+		{Tool: "c", Framework: "atlas:ai-ml-attack-staging", Decision: Allow},
+		{Tool: "d", Decision: Allow}, // untagged, must not appear
+	}}
+	got := p.FrameworksCovered()
+	want := []string{"atlas:ai-ml-attack-staging", "owasp:llm06"}
+	if len(got) != len(want) {
+		t.Fatalf("FrameworksCovered = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("FrameworksCovered[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFrameworksCovered_EmptyWhenNoRuleIsTagged(t *testing.T) {
+	p := Policy{Rules: []Rule{{Tool: "a", Decision: Allow}}}
+	if got := p.FrameworksCovered(); len(got) != 0 {
+		t.Errorf("FrameworksCovered = %v, want empty", got)
+	}
+}
+
+// LoadPolicy must normalize Framework the same way it normalizes
+// Classification — a rule authored as "OWASP:LLM06" and one authored as
+// "owasp:llm06" are the same tag.
+func TestLoadPolicy_NormalizesFramework(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	body := `{"rules":[{"tool":"a","framework":"OWASP:LLM06","decision":"deny"}],"default":"allow"}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pol, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := pol.FrameworksCovered(); len(got) != 1 || got[0] != "owasp:llm06" {
+		t.Errorf("FrameworksCovered = %v, want [owasp:llm06]", got)
+	}
+}
+
 func TestCheck_RecordsDecision(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
 	p := Policy{Rules: []Rule{{Tool: "fs", Resource: "/etc/*", Decision: Deny}}, Default: Allow}


### PR DESCRIPTION
## Summary
- `ledger.Rule` gains an optional `Framework string` (freeform, e.g. `"owasp:llm06"`, `"atlas:ai-ml-attack-staging"`) — mirrors `Classification`'s shape: optional, normalized at load.
- Plays no part in `Decide`'s matching — an access attempt carries no "framework" of its own, so unlike `Classification` this is pure metadata on the rule, not a new matching dimension.
- New `Policy.FrameworksCovered()` returns the distinct, non-empty tags present across a policy's rules, sorted — an honest coverage list, never a manufactured score.
- No `--framework` CLI flag: there's no existing command for authoring policy *rules* at all (`mcp_policy.json` is hand-edited), so adding one here would be inconsistent with every other `Rule` field.

## Changes
- `internal/ledger/ledger.go` — `Rule.Framework`, normalization in `validate()`, `Policy.FrameworksCovered()`

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` — full repo, clean
- [x] `FrameworksCovered` returns distinct, sorted, non-empty tags
- [x] `LoadPolicy` normalizes `Framework` the same way it normalizes `Classification`

Closes #373