### PR TITLE
fix(docs): make the website's app preview interactive

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -110,8 +110,11 @@ a:hover{text-decoration:underline;}
 .side{border-right:1px solid var(--line);padding:14px 10px;background:rgba(6,7,15,.5);}
 .side .lbl{font-family:var(--mono);font-size:9.5px;letter-spacing:1.6px;color:var(--faint);
   text-transform:uppercase;padding:0 8px 10px;}
-.nav-item{display:flex;align-items:center;gap:8px;padding:7px 9px;border-radius:6px;
-  font-family:var(--mono);font-size:12px;color:var(--dim);margin-bottom:2px;}
+.nav-item{display:flex;align-items:center;gap:8px;width:100%;padding:7px 9px;border-radius:6px;
+  font:inherit;font-family:var(--mono);font-size:12px;color:var(--dim);margin-bottom:2px;
+  background:none;border:none;text-align:left;cursor:pointer;-webkit-appearance:none;appearance:none;}
+.nav-item:hover{background:var(--line);color:var(--ink);}
+.nav-item:focus-visible{outline:2px solid var(--aqua);outline-offset:1px;}
 .nav-item i{width:5px;height:5px;border-radius:50%;background:currentColor;opacity:.5;font-style:normal;}
 .pane{padding:18px 20px;position:relative;}
 
@@ -137,6 +140,12 @@ a:hover{text-decoration:underline;}
   3%,23%  {background:rgba(0,230,195,.10);color:var(--aqua);}
   25%,100%{background:transparent;color:var(--dim);}
 }
+/* Once nav.js confirms click handling is wired, it swaps the autoplay loop
+   above for direct control: exactly one view/nav-item active, no timer. */
+.win-body.js-active .view{animation:none;}
+.win-body.js-active .view.active{opacity:1;}
+.win-body.js-active .nav-item{animation:none;}
+.win-body.js-active .nav-item.active{background:rgba(0,230,195,.10);color:var(--aqua);}
 /* Anyone who has asked the OS to stop moving things gets a static first view. */
 @media(prefers-reduced-motion:reduce){
   .view,.nav-item{animation:none;}
@@ -277,10 +286,10 @@ footer a{color:var(--dim);}
       <div class="win-body">
         <div class="side">
           <div class="lbl">Views</div>
-          <div class="nav-item"><i></i>Dashboard</div>
-          <div class="nav-item"><i></i>Fleet</div>
-          <div class="nav-item"><i></i>Session</div>
-          <div class="nav-item"><i></i>Code</div>
+          <button type="button" class="nav-item"><i></i>Dashboard</button>
+          <button type="button" class="nav-item"><i></i>Fleet</button>
+          <button type="button" class="nav-item"><i></i>Session</button>
+          <button type="button" class="nav-item"><i></i>Code</button>
         </div>
 
         <div class="pane">
@@ -565,6 +574,36 @@ footer a{color:var(--dim);}
     el.addEventListener('click',fire);
     el.addEventListener('keydown',function(e){if(e.key==='Enter'||e.key===' '){e.preventDefault();fire();}});
   });
+})();
+
+// The app preview sidebar: click a view name, see that view — matched by
+// position, since the nav-items and .view panes share the same markup order.
+(function(){
+  var winBody=document.querySelector('.stage .win-body');
+  if(!winBody)return;
+  var navItems=winBody.querySelectorAll('.nav-item');
+  var views=winBody.querySelectorAll('.view');
+  if(!navItems.length||navItems.length!==views.length)return;
+
+  function activate(index){
+    Array.prototype.forEach.call(navItems,function(item,i){
+      var on=i===index;
+      item.classList.toggle('active',on);
+      item.setAttribute('aria-pressed',on?'true':'false');
+    });
+    Array.prototype.forEach.call(views,function(view,i){
+      var on=i===index;
+      view.classList.toggle('active',on);
+      view.setAttribute('aria-hidden',on?'false':'true');
+    });
+  }
+
+  Array.prototype.forEach.call(navItems,function(item,i){
+    item.addEventListener('click',function(){activate(i);});
+  });
+
+  winBody.classList.add('js-active');
+  activate(0);
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- The desktop app preview on `docs/app.html` only auto-cycled its four views (Dashboard/Fleet/Session/Code) on a fixed 24s CSS loop — clicking a sidebar nav-item did nothing.
- Converts the four `.nav-item` sidebar entries from `<div>` to real `<button>` elements (native keyboard support, no ARIA hacks needed) and adds a small vanilla-JS click handler that shows the matching `.view` (matched by position) and marks the clicked nav-item active.
- The CSS autoplay animation is disabled once JS confirms the click handling is wired (`.win-body.js-active`), and remains as the fallback for no-JS/`prefers-reduced-motion` visitors otherwise.
- Adds a hover/focus-visible state and pointer cursor to `.nav-item` using the page's existing tokens (`--line`, `--aqua`) so the sidebar reads as clickable even before interacting.
- No sample data/content changed inside any `.view` — this is scoped entirely to show/hide/active-state behavior and accessibility affordances.
- Side effect: switching `<div>`→`<button>` also fixes a pre-existing `nth-of-type` miscount (the `.lbl` div shared the same tag type as the old `.nav-item` divs and threw off the count), which had the old CSS-only autoplay highlight one slot out of sync with the view actually showing.

## Test plan
- [x] Read the entire file (572 lines) including the full `<style>` block before editing, to reuse existing tokens/classes.
- [x] `node --check` on the extracted inline script — no syntax errors.
- [x] Verified button/tag balance (4 `<button class="nav-item">`, 4 `</button>`, 4 `.view` divs, 0 leftover `<div class="nav-item">`).
- [x] Read the full diff for well-formed HTML and correct class/id references.
- [ ] Visual browser click-through — Chrome MCP could not connect in this sandbox (no debugging bridge available), so this was static-review only; a manual click-through in a real browser is recommended before merge.

Closes #382