### PR TITLE
feat(security): internal/security package + hyctl security dashboard

### DIFF
--- a/cmd/hydra/cli_data_test.go
+++ b/cmd/hydra/cli_data_test.go
@@ -131,6 +131,48 @@ func TestCLI_MCPVerifyChain_ReportsIntactAfterOrdinaryRecording(t *testing.T) {
 	}
 }
 
+// `hyctl security` is the security posture dashboard — it must run clean on
+// an empty machine (no ledger yet) and surface real data once the ledger has
+// events, never panicking on either state.
+func TestCLI_Security_HandlesEmptyAndSeededLedger(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	emptyOut, emptyCobraOut, err := run(t, "security")
+	if err != nil {
+		t.Fatalf("`hyctl security` failed on an empty machine: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(emptyOut+emptyCobraOut), "no ledger events") {
+		t.Errorf("`security` on an empty machine should say so plainly:\n%s", emptyOut+emptyCobraOut)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	seed(t, "mcp_ledger.jsonl", strings.Join([]string{
+		`{"ts":"` + now + `","agent":"hydra-dispatch","tool":"claude","resource":"","action":"exec","decision":"allow"}`,
+		`{"ts":"` + now + `","agent":"hydra-dispatch","tool":"sketchy","resource":"","action":"exec","decision":"deny","reason":"denied by ledger policy"}`,
+	}, "\n")+"\n")
+
+	out, cobraOut, err := run(t, "security", "--json")
+	if err != nil {
+		t.Fatalf("`hyctl security --json` failed: %v", err)
+	}
+	var rep struct {
+		Ledger struct{ Total, Denied int } `json:"ledger"`
+		ByHead []struct {
+			Head   string `json:"head"`
+			Denied int    `json:"denied"`
+		} `json:"byHead"`
+	}
+	if err := json.Unmarshal([]byte(out+cobraOut), &rep); err != nil {
+		t.Fatalf("security --json did not parse: %v\n%s", err, out+cobraOut)
+	}
+	if rep.Ledger.Total != 2 || rep.Ledger.Denied != 1 {
+		t.Errorf("Ledger = %+v, want Total=2 Denied=1", rep.Ledger)
+	}
+	if len(rep.ByHead) != 1 || rep.ByHead[0].Head != "sketchy" {
+		t.Errorf("ByHead = %+v, want exactly the denied head", rep.ByHead)
+	}
+}
+
 // ── trust ─────────────────────────────────────────────────────────────────────
 
 // `hyctl trust explain` is the audit trail behind a confidence number: it must

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ankit373/hydra/internal/review"
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/security"
 	"github.com/ankit373/hydra/internal/swarm"
 	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/tui"
@@ -91,7 +92,7 @@ func rootCmd() *cobra.Command {
 		cmdInit(), cmdProbe(), cmdStatus(), cmdTui(), cmdDispatch(),
 		cmdEdit(), cmdReview(), cmdParallel(), cmdCost(), cmdStats(),
 		cmdPricing(), cmdTrust(), cmdGraph(), cmdContext(), cmdMCP(), cmdOracle(), cmdModels(),
-		cmdVersion(),
+		cmdSecurity(), cmdVersion(),
 	)
 	return root
 }
@@ -1003,6 +1004,66 @@ func cmdMCP() *cobra.Command {
 
 	cmd.AddCommand(check, record, verify, logCmd, report, verifyChain)
 	return cmd
+}
+
+// cmdSecurity is the security posture dashboard: ledger accountability,
+// per-head risk, and a short list of honest checks — never a manufactured
+// score, only what's actually configured and observed.
+func cmdSecurity() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "security",
+		Short: "Security posture dashboard: ledger accountability, risk by head, and honest checks",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			heads := probe.Run(context.Background()).Heads
+			rep, err := security.Build(heads)
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(rep)
+			}
+			printSecurityReport(rep)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
+	return cmd
+}
+
+func printSecurityReport(r *security.Report) {
+	fmt.Println()
+	if !r.HasData {
+		fmt.Println(dimStyle.Render("  no ledger events yet — nothing has dispatched through hyctl on this machine"))
+	} else {
+		fmt.Printf("  %s  %d  (%d allowed · %d denied · %d flagged)\n",
+			cortexStyle.Render("ledger events"), r.Ledger.Total, r.Ledger.Allowed, r.Ledger.Denied, r.Ledger.Flagged)
+	}
+
+	if len(r.ByHead) > 0 {
+		fmt.Println()
+		fmt.Println(dimStyle.Render("  " + strings.Repeat("─", 48)))
+		fmt.Printf("  %-24s %8s %8s\n", "HEAD", "DENIED", "FLAGGED")
+		fmt.Println(dimStyle.Render("  " + strings.Repeat("─", 48)))
+		for _, h := range r.ByHead {
+			fmt.Printf("  %-24.24s %8d %8d\n", h.Head, h.Denied, h.Flagged)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println(dimStyle.Render("  " + strings.Repeat("─", 48)))
+	fmt.Println("  checks:")
+	for _, c := range r.Checks {
+		status := c.Status
+		if strings.Contains(strings.ToLower(status), "broken") {
+			status = warnStyle.Render(status)
+		} else if status == "intact" || strings.HasSuffix(status, "refusal(s)") {
+			status = okStyle.Render(status)
+		}
+		fmt.Printf("    %-26s %s\n", c.Name, status)
+		fmt.Println(dimStyle.Render("      " + c.Detail))
+	}
+	fmt.Println()
 }
 
 // cmdModels manages the runtime-extensible model capability registry.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,7 +30,8 @@
 - `hyctl trust` — confidence layer: `calibration`, `record`, `defect`, `stats`, `explain`
 - `hyctl graph` — code dependency graph: `blast` (blast radius + percolation-κ), `parallel` (optimal agent count)
 - `hyctl context` — context signal density / entropy governor: `entropy`
-- `hyctl mcp` — local MCP accountability ledger: `check`, `record`, `verify`, `log`, `report`. Access checks can be classification-aware (PII auto-detected from content) and bind a SHA256 hash of the invocation parameters, so `verify` can later prove the executed parameters match the ones that were approved
+- `hyctl mcp` — local MCP accountability ledger: `check`, `record`, `verify`, `log`, `report`, `verify-chain`. Access checks can be classification-aware (PII/prompt-injection-marker auto-detected from content) and bind a SHA256 hash of the invocation parameters, so `verify` can later prove the executed parameters match the ones that were approved. Every event is hash-chained (`verify-chain` detects post-hoc tampering) and can carry an optional MITRE ATLAS/OWASP LLM Top-10 `Framework` tag
+- `hyctl security` — security posture dashboard: ledger accountability totals, per-head risk (denied/flagged), and honest checks (ledger chain integrity, denial-of-wallet refusals, model provenance, framework-tag coverage) — never a manufactured score
 - `hyctl oracle` — verification oracles (tests/compile/lint) as calibrated evidence: `verify`
 - `hyctl models` — model capability registry: `list`, `add`, `remove`, `sync`
 - `hyctl parallel` — fan N independent tasks out to N heads at once, from a task JSON file

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -632,6 +632,50 @@ func Filter(events []Event, agent string, deniedOnly bool) []Event {
 	return out
 }
 
+// HeadRisk is one head's denied/flagged activity — the "top-N riskiest
+// entity" panel a security dashboard reports on.
+type HeadRisk struct {
+	Head    string `json:"head"`
+	Denied  int    `json:"denied"`
+	Flagged int    `json:"flagged"`
+}
+
+// ByHeadRisk groups denied and flagged counts by Tool (head), sorted by
+// denied+flagged descending then Head ascending. Heads with neither are
+// omitted — this is a risk list, not a full inventory.
+func ByHeadRisk(events []Event) []HeadRisk {
+	type acc struct{ denied, flagged int }
+	byHead := map[string]*acc{}
+	for _, e := range events {
+		if e.Decision != Deny && !e.Flagged {
+			continue
+		}
+		a, ok := byHead[e.Tool]
+		if !ok {
+			a = &acc{}
+			byHead[e.Tool] = a
+		}
+		if e.Decision == Deny {
+			a.denied++
+		}
+		if e.Flagged {
+			a.flagged++
+		}
+	}
+	out := make([]HeadRisk, 0, len(byHead))
+	for head, a := range byHead {
+		out = append(out, HeadRisk{Head: head, Denied: a.denied, Flagged: a.flagged})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		ri, rj := out[i].Denied+out[i].Flagged, out[j].Denied+out[j].Flagged
+		if ri != rj {
+			return ri > rj
+		}
+		return out[i].Head < out[j].Head
+	})
+	return out
+}
+
 // SortedCounts returns key/count pairs sorted by count descending, for stable
 // report rendering.
 func SortedCounts(m map[string]int) []struct {

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -159,6 +159,26 @@ func TestLoadPolicy_NormalizesFramework(t *testing.T) {
 	}
 }
 
+func TestByHeadRisk_GroupsSortsAndOmitsHeadsWithNoRisk(t *testing.T) {
+	events := []Event{
+		{Tool: "quiet", Decision: Allow},
+		{Tool: "risky", Decision: Deny},
+		{Tool: "risky", Decision: Deny},
+		{Tool: "risky", Flagged: true, Decision: Allow},
+		{Tool: "flagged-only", Flagged: true, Decision: Allow},
+	}
+	got := ByHeadRisk(events)
+	if len(got) != 2 {
+		t.Fatalf("ByHeadRisk = %+v, want 2 entries (quiet must be omitted)", got)
+	}
+	if got[0].Head != "risky" || got[0].Denied != 2 || got[0].Flagged != 1 {
+		t.Errorf("got[0] = %+v, want risky with 2 denied, 1 flagged (the riskiest first)", got[0])
+	}
+	if got[1].Head != "flagged-only" || got[1].Denied != 0 || got[1].Flagged != 1 {
+		t.Errorf("got[1] = %+v, want flagged-only with 0 denied, 1 flagged", got[1])
+	}
+}
+
 func TestCheck_RecordsDecision(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
 	p := Policy{Rules: []Rule{{Tool: "fs", Resource: "/etc/*", Decision: Deny}}, Default: Allow}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+
+// Package security aggregates Hydra's security-relevant data — the ledger's
+// accountability trail, per-head risk, and a short list of honest checks —
+// into one report. It reuses ledger.Summarize/ByHeadRisk/VerifyChain and
+// ledger.Policy.FrameworksCovered rather than reimplementing any of them, the
+// same discipline desktop/api/dashboard.go already applies to cost/trust.
+package security
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ankit373/hydra/internal/ledger"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// LedgerPanel is the headline accountability figures.
+type LedgerPanel struct {
+	Total   int `json:"total"`
+	Allowed int `json:"allowed"`
+	Denied  int `json:"denied"`
+	Flagged int `json:"flagged"`
+}
+
+// Check is one honest fact about the current security posture — never a
+// manufactured score. Status is a short human-readable summary; Detail
+// explains it.
+type Check struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+// Report is everything `hyctl security` renders.
+type Report struct {
+	// HasData is false when the ledger has never recorded an event — the
+	// view must render "no data yet", not a wall of zeros indistinguishable
+	// from a clean bill of health.
+	HasData bool `json:"hasData"`
+
+	Ledger LedgerPanel       `json:"ledger"`
+	ByHead []ledger.HeadRisk `json:"byHead"`
+	Checks []Check           `json:"checks"`
+}
+
+// Build assembles the report from the ledger, the loaded access policy, and
+// heads is the currently-discovered head list (e.g. probe.Run's result) —
+// passed in rather than probed here, so this package stays free of any
+// network/subprocess dependency and is testable on plain data.
+func Build(heads []provider.Head) (*Report, error) {
+	events, err := ledger.Load(ledger.DefaultPath())
+	if err != nil {
+		return nil, err
+	}
+
+	s := ledger.Summarize(events)
+	r := &Report{
+		HasData: len(events) > 0,
+		Ledger:  LedgerPanel{Total: s.Total, Allowed: s.Allowed, Denied: s.Denied, Flagged: s.Flagged},
+		ByHead:  ledger.ByHeadRisk(events),
+	}
+
+	pol, err := ledger.LoadPolicy(ledger.DefaultPolicyPath())
+	if err != nil {
+		return nil, err
+	}
+
+	r.Checks = []Check{
+		chainCheck(),
+		costCeilingCheck(events),
+		provenanceCheck(heads),
+		frameworkCheck(pol),
+	}
+	return r, nil
+}
+
+func chainCheck() Check {
+	const name = "Ledger chain integrity"
+	res, err := ledger.VerifyChain(ledger.DefaultPath())
+	if err != nil {
+		return Check{Name: name, Status: "error", Detail: err.Error()}
+	}
+	if res.Chained == 0 {
+		return Check{Name: name, Status: "no chained events",
+			Detail: fmt.Sprintf("%d unchained event(s) predate this feature", res.Unchained)}
+	}
+	if !res.Intact {
+		return Check{Name: name, Status: "BROKEN",
+			Detail: fmt.Sprintf("tampering detected at event index %d", res.BrokenAt)}
+	}
+	return Check{Name: name, Status: "intact",
+		Detail: fmt.Sprintf("%d chained event(s), %d unchained", res.Chained, res.Unchained)}
+}
+
+func costCeilingCheck(events []ledger.Event) Check {
+	const name = "Denial-of-wallet guard"
+	n := 0
+	for _, e := range events {
+		if e.Decision == ledger.Deny && strings.Contains(e.Reason, "cost ceiling") {
+			n++
+		}
+	}
+	if n == 0 {
+		return Check{Name: name, Status: "0 refusals",
+			Detail: "no dispatch has been refused for exceeding a cost ceiling — set one with --max-cost"}
+	}
+	return Check{Name: name, Status: fmt.Sprintf("%d refusal(s)", n),
+		Detail: "at least one dispatch was refused for exceeding its --max-cost ceiling"}
+}
+
+func provenanceCheck(heads []provider.Head) Check {
+	const name = "Model provenance"
+	var builtin, user, unknown int
+	for _, h := range heads {
+		switch h.Meta["model_source"] {
+		case "builtin":
+			builtin++
+		case "user":
+			user++
+		default:
+			unknown++
+		}
+	}
+	return Check{Name: name,
+		Status: fmt.Sprintf("%d builtin, %d user-added, %d unclassified", builtin, user, unknown),
+		Detail: "a user-added model isn't vetted by the curated catalog — not malicious, just worth knowing about"}
+}
+
+func frameworkCheck(pol ledger.Policy) Check {
+	const name = "Framework tag coverage"
+	covered := pol.FrameworksCovered()
+	if len(covered) == 0 {
+		return Check{Name: name, Status: "0 tagged",
+			Detail: "no policy rule carries a Framework tag (e.g. owasp:llm06)"}
+	}
+	return Check{Name: name, Status: fmt.Sprintf("%d tagged", len(covered)),
+		Detail: strings.Join(covered, ", ")}
+}

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/ledger"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+func TestBuild_NoDataOnAnEmptyMachine(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	r, err := Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.HasData {
+		t.Error("HasData = true with no ledger on disk")
+	}
+	if r.Ledger.Total != 0 {
+		t.Errorf("Ledger.Total = %d, want 0", r.Ledger.Total)
+	}
+	// Checks must still run and say something concrete even with no data.
+	for _, c := range r.Checks {
+		if c.Name == "" || c.Status == "" {
+			t.Errorf("check %+v is missing a Name/Status", c)
+		}
+	}
+}
+
+// Panel numbers must come straight from ledger.Summarize/ByHeadRisk — no
+// reimplemented math to drift from the ledger package's own truth.
+func TestBuild_PanelNumbersMatchLedgerSummarize(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if err := ledger.Record(ledger.DefaultPath(), ledger.Event{Agent: "a", Tool: "h1", Decision: ledger.Allow}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.Record(ledger.DefaultPath(), ledger.Event{Agent: "a", Tool: "h1", Decision: ledger.Deny}); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.HasData {
+		t.Error("HasData = false with events on disk")
+	}
+	if r.Ledger.Total != 2 || r.Ledger.Allowed != 1 || r.Ledger.Denied != 1 {
+		t.Errorf("Ledger = %+v, want Total=2 Allowed=1 Denied=1", r.Ledger)
+	}
+	if len(r.ByHead) != 1 || r.ByHead[0].Head != "h1" || r.ByHead[0].Denied != 1 {
+		t.Errorf("ByHead = %+v, want one entry for h1 with 1 denied", r.ByHead)
+	}
+}
+
+func TestBuild_ChainCheckReflectsRealVerifyChain(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if err := ledger.Record(ledger.DefaultPath(), ledger.Event{Agent: "a", Tool: "h1", Decision: ledger.Allow}); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := findCheck(t, r, "Ledger chain integrity")
+	if chain.Status != "intact" {
+		t.Errorf("chain check Status = %q, want intact", chain.Status)
+	}
+
+	// Tamper with the one line on disk.
+	raw, err := os.ReadFile(ledger.DefaultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered := strings.Replace(string(raw), `"allow"`, `"deny"`, 1)
+	if err := os.WriteFile(ledger.DefaultPath(), []byte(tampered), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err = Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain = findCheck(t, r, "Ledger chain integrity")
+	if chain.Status != "BROKEN" {
+		t.Errorf("chain check Status = %q, want BROKEN after tampering", chain.Status)
+	}
+}
+
+func TestBuild_CostCeilingCheckCountsCostDenials(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	if err := ledger.Record(ledger.DefaultPath(), ledger.Event{
+		Agent: "hydra-dispatch", Tool: "h1", Decision: ledger.Deny,
+		Reason: "exceeds cost ceiling: estimated $1.00 > limit $0.50",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ledger.Record(ledger.DefaultPath(), ledger.Event{
+		Agent: "hydra-dispatch", Tool: "h2", Decision: ledger.Deny, Reason: "denied by ledger policy",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findCheck(t, r, "Denial-of-wallet guard").Status; got != "1 refusal(s)" {
+		t.Errorf("cost-ceiling check Status = %q, want exactly 1 counted (not the unrelated policy denial)", got)
+	}
+}
+
+func TestBuild_ProvenanceCheckCountsHeadsBySource(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	heads := []provider.Head{
+		{ID: "a", Meta: map[string]string{"model_source": "builtin"}},
+		{ID: "b", Meta: map[string]string{"model_source": "user"}},
+		{ID: "c", Meta: map[string]string{}},
+	}
+	r, err := Build(heads)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findCheck(t, r, "Model provenance").Status; got != "1 builtin, 1 user-added, 1 unclassified" {
+		t.Errorf("provenance check Status = %q", got)
+	}
+}
+
+func TestBuild_FrameworkCheckReflectsPolicyTags(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	raw := `{"rules":[{"tool":"a","framework":"owasp:llm06","decision":"deny"}],"default":"allow"}`
+	if err := os.MkdirAll(filepath.Dir(ledger.DefaultPolicyPath()), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ledger.DefaultPolicyPath(), []byte(raw), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := findCheck(t, r, "Framework tag coverage")
+	if got.Status != "1 tagged" || !strings.Contains(got.Detail, "owasp:llm06") {
+		t.Errorf("framework check = %+v", got)
+	}
+}
+
+func findCheck(t *testing.T, r *Report, name string) Check {
+	t.Helper()
+	for _, c := range r.Checks {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("no check named %q in %+v", name, r.Checks)
+	return Check{}
+}


### PR DESCRIPTION
## Summary
- New `internal/security` package assembles a `Report` from data already shipped in #370-#373: `ledger.Summarize` (headline totals), new `ledger.ByHeadRisk` (denied+flagged grouped by head, sorted — the top-N riskiest-entity panel), and four honest `Checks`: ledger chain integrity, denial-of-wallet refusals, model provenance (builtin/user-added/unclassified), and framework-tag coverage.
- Every number traces back to an existing package function — nothing reimplemented that could drift from `ledger`'s own truth.
- Heads are passed into `Build()` rather than probed inside it, keeping the package free of network/subprocess dependencies and fully testable on plain data.
- `hyctl security` (+ `--json`) renders it in the same terminal-dashboard style as `hyctl status`/`cost`.
- Updated `docs/llms.txt` for the new command and the `mcp verify-chain`/`Framework` additions from earlier PRs in this batch.

## Changes
- `internal/security/security.go` — new package
- `internal/ledger/ledger.go` — `HeadRisk`/`ByHeadRisk`
- `cmd/hydra/main.go` — `hyctl security` command
- `docs/llms.txt` — CLI command list

## Not in this PR
TUI cockpit view and desktop app "Security" nav tab — a deliberate, separate follow-up once this data model has shipped and been used for a while, per the approved plan.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test -race ./...` — full repo, clean
- [x] `security.Report` panel numbers match `ledger.Summarize`/`ByHeadRisk` exactly against seeded data
- [x] `hyctl security` runs clean on an empty machine (`HasData=false`) and against seeded data
- [x] Manually smoke-tested against both an empty machine and a seeded ledger

Closes #374