### PR TITLE
fix(desktop): dry-run dispatches were polluting Fleet with empty ghost runs

### DIFF
--- a/cmd/hydra/cli_contract_test.go
+++ b/cmd/hydra/cli_contract_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/testutil"
 )
 
@@ -237,6 +238,19 @@ func TestCLI_DryRunExecutesNothing(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(config.Dir(), "logs", "last_handoff.json")); err == nil {
 		t.Error("a dry run wrote a handoff")
+	}
+
+	// A dry run chooses a head but never calls one, so it has no place in a
+	// log of runs either. Before #379 it wrote run_started/run_finished
+	// unconditionally, leaving a permanent, contentless card in the desktop
+	// app's Fleet view for every preview — 0ms, $0.00, no agents, nothing to
+	// say why, indistinguishable from a broken reconstruction.
+	ids, err := runlog.Runs()
+	if err != nil {
+		t.Fatalf("runlog.Runs(): %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("a dry run left %d entries in the run log: %v", len(ids), ids)
 	}
 }
 

--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/testutil"
 )
 
@@ -178,6 +179,9 @@ func TestCLI_Dispatch_SwarmDryRunFiresNothing(t *testing.T) {
 	if _, statErr := os.Stat(filepath.Join(config.Dir(), "logs", "cost.jsonl")); statErr == nil {
 		t.Error("a swarm dry run wrote cost rows")
 	}
+	if ids, runErr := runlog.Runs(); runErr != nil || len(ids) != 0 {
+		t.Errorf("a swarm dry run left run log entries: ids=%v err=%v", ids, runErr)
+	}
 }
 
 // A real risk signal — PII in the prompt, or --irreversible/--production —
@@ -227,6 +231,9 @@ func TestCLI_Dispatch_ConfidenceDryRunFiresNothing(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(config.Dir(), "logs", "cost.jsonl")); statErr == nil {
 		t.Error("an SPRT dry run wrote cost rows")
+	}
+	if ids, runErr := runlog.Runs(); runErr != nil || len(ids) != 0 {
+		t.Errorf("an SPRT dry run left run log entries: ids=%v err=%v", ids, runErr)
 	}
 }
 

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -476,14 +476,22 @@ func cmdDispatch() *cobra.Command {
 			// Mark the run live for its whole duration. Without this
 			// runlog.LiveRuns() is always empty and nothing — cockpit or desktop
 			// Fleet — can distinguish a running agent from a finished one.
-			hb := runlog.StartHeartbeat(ctx, runID, runlog.HeartbeatInterval)
-			defer hb.Stop()
+			//
+			// --dry-run executes nothing in every mode it combines with (plain,
+			// --swarm, --confidence): no head is chosen, no output produced.
+			// Logging one anyway leaves a permanent, contentless Fleet card
+			// behind on every preview — 0ms elapsed, $0.00, no agents, nothing
+			// to say why — indistinguishable from a broken reconstruction (#379).
+			if !dryRun {
+				hb := runlog.StartHeartbeat(ctx, runID, runlog.HeartbeatInterval)
+				defer hb.Stop()
 
-			rl := runlog.New(runID)
-			_ = rl.Append(runlog.Event{Kind: runlog.KindRunStarted, TaskID: taskID, Detail: promptPreview(prompt)})
-			defer func() {
-				_ = rl.Append(runlog.Event{Kind: runlog.KindRunFinished, TaskID: taskID})
-			}()
+				rl := runlog.New(runID)
+				_ = rl.Append(runlog.Event{Kind: runlog.KindRunStarted, TaskID: taskID, Detail: promptPreview(prompt)})
+				defer func() {
+					_ = rl.Append(runlog.Event{Kind: runlog.KindRunFinished, TaskID: taskID})
+				}()
+			}
 
 			d, err := dispatch.New(ctx)
 			if err != nil {


### PR DESCRIPTION
## Problem

`hyctl dispatch --dry-run` (in every mode it combines with — plain,
`--swarm`, `--confidence`) never selects or calls a head. It only prints a
preview of the routing chain / ensemble plan and returns.

`cmdDispatch` in `cmd/hydra/main.go`, however, wrote `run_started` and
(deferred) `run_finished` to the runlog *before* the `--dry-run` check —
unconditionally, on every invocation. The result: every dry run left
behind a permanent entry in `~/.hydra/logs/runs/`, which the desktop app's
Fleet view (`desktop/api/fleet.go`) faithfully lists as a run — with
`elapsedMs: 0`, `costUsd: 0`, zero agents, and nothing to explain why.
`Fleet.tsx`'s `RunCard` renders that as a bare header and an empty body:
no state bar, no agent list, no error message. To a user it looks exactly
like the feature silently doing nothing.

This is not a corner case: `hyctl dispatch --dry-run` is CLAUDE.md's own
documented way to "preview the routing/fallback chain without executing"
(Quick Reference, Step 3 of the Orchestration Protocol). On the machine I
investigated this on, the real run log was overwhelmingly these ghost
entries — ordinary, encouraged usage reproduces it every time.

## Investigation

- `go test ./desktop/api/... -run Fleet -v` and the full `go test
  ./desktop/... -v` pass — `buildRun`/`tree.Reconstruct` are not the
  problem for well-formed data (verified against a real run with agents:
  it renders correctly, with cost, tier, and agent list intact).
- `internal/runlog` resolves through `config.Dir()` (`~/.hydra`) for both
  the CLI writer and the desktop reader — no path mismatch.
- Built `hyctl` from source and ran `dispatch --dry-run "..."` directly:
  reproduced instantly. The resulting `.jsonl` file contains only
  `run_started`/`run_finished`, confirmed by reading `internal/dispatch`'s
  `Dispatch()`, which returns before ever touching its own runlog logger
  when `opts.DryRun` is true — but the outer wrapper in `main.go` had
  already committed to logging a run regardless.

## Fix

Skip the heartbeat and the `run_started`/`run_finished` writes entirely
when `--dry-run` is set, so a preview leaves nothing behind for Fleet to
show.

## Tests

- Extended `TestCLI_DryRunExecutesNothing` to assert `runlog.Runs()` is
  empty after a plain dry run (previously only checked `cost.jsonl` /
  `last_handoff.json`).
- Added the same assertion to `TestCLI_Dispatch_SwarmDryRunFiresNothing`
  and `TestCLI_Dispatch_ConfidenceDryRunFiresNothing`, covering all three
  dry-run modes.
- `go test -race ./cmd/hydra/... ./internal/runlog/... ./internal/dispatch/... ./internal/swarm/...`
  and the full `go test ./...` (root and `desktop` modules) pass.

Closes #379