### PR TITLE
feat(desktop): redesign Fleet as a dynamic workflow graph

### DIFF
--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -346,6 +346,30 @@ body {
 .agent__meta { margin-left: auto; color: var(--hy-dim); font-size: 12px; font-variant-numeric: tabular-nums; }
 .agent__detail { color: var(--hy-dim); font-size: 12px; }
 
+/* Fleet's inline run graph (RunGraph) reuses .graph/.edge/.gnode from the
+   Session graph below — this modifier only trims the chrome that doesn't fit
+   inside a run card: no legend, tighter margin/padding. */
+.graph--compact { margin-top: 10px; padding: 8px; }
+
+/* Fleet's state heatmap for a run at/above GroupThreshold — one chip per
+   agent, grouped by depth, colored the same as .state-dot/.gnode so "shape of
+   a run" always means the same colours everywhere in the app. */
+.agrid { display: flex; flex-direction: column; gap: 6px; margin-top: 12px; }
+.agrid__row { display: flex; align-items: flex-start; gap: 8px; }
+.agrid__depth {
+  flex: 0 0 22px;
+  padding-top: 2px;
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  color: var(--hy-dim);
+}
+.agrid__chips { display: flex; flex-wrap: wrap; gap: 3px; }
+
+.chip { width: 12px; height: 12px; border-radius: 3px; background: var(--hy-line); flex: 0 0 auto; }
+.chip--running { background: var(--hy-aqua); }
+.chip--ok      { background: var(--hy-cheap); }
+.chip--failed  { background: var(--hy-expensive); }
+
 /* ── Session ───────────────────────────────────────────────────────────── */
 
 .back {

--- a/desktop/frontend/src/dagreLayout.ts
+++ b/desktop/frontend/src/dagreLayout.ts
@@ -1,0 +1,116 @@
+import dagre from '@dagrejs/dagre'
+
+/**
+ * Layered (Sugiyama) layout via dagre.
+ *
+ * Deterministic and near-linear per relayout, and it has a notion of
+ * direction — which matches the causal semantics of a run. A force-directed
+ * or stress-majorization model has neither: it treats edges as springs, so
+ * the same run lays out differently frame to frame and "downstream" means
+ * nothing.
+ *
+ * The layout maths is bought, not hand-rolled. Crossing minimisation is
+ * NP-hard and dagre already implements the standard heuristic chain
+ * (Brandes-Köpf coordinate assignment included).
+ *
+ * Shared by SessionGraph (a run's detail view) and Fleet's inline run graph
+ * so both surfaces agree on what a run's shape looks like — only node size
+ * and label content differ per caller.
+ */
+
+export interface LayoutNodeInput {
+  id: string
+  /** Ownership edge: parent -> id. Absent or unknown parents are ignored. */
+  parent?: string
+}
+
+export interface LayoutEdgeInput {
+  from: string
+  to: string
+  /** True for a collaboration/handoff edge, distinct from ownership. */
+  a2a?: boolean
+}
+
+export interface PlacedNode {
+  id: string
+  x: number
+  y: number
+}
+
+export interface PlacedEdge {
+  points: string
+  a2a: boolean
+}
+
+export interface LayoutResult {
+  nodes: PlacedNode[]
+  edges: PlacedEdge[]
+  width: number
+  height: number
+}
+
+export interface LayoutSize {
+  nodeW: number
+  nodeH: number
+  nodesep?: number
+  ranksep?: number
+  /** Floor for the returned width/height, so a tiny graph still gets a frame. */
+  minWidth?: number
+  minHeight?: number
+}
+
+export function layoutDag(
+  nodes: LayoutNodeInput[],
+  edges: LayoutEdgeInput[],
+  size: LayoutSize,
+): LayoutResult {
+  const g = new dagre.graphlib.Graph()
+  // Top-to-bottom: a run reads as time flowing downward.
+  g.setGraph({
+    rankdir: 'TB',
+    nodesep: size.nodesep ?? 26,
+    ranksep: size.ranksep ?? 42,
+    marginx: 16,
+    marginy: 16,
+  })
+  g.setDefaultEdgeLabel(() => ({}))
+
+  for (const n of nodes) {
+    g.setNode(n.id, { width: size.nodeW, height: size.nodeH })
+  }
+  for (const n of nodes) {
+    if (n.parent && g.hasNode(n.parent)) g.setEdge(n.parent, n.id, { a2a: false })
+  }
+  // Non-ownership edges (e.g. A2A handoffs) are laid out too, so a target is
+  // placed sensibly rather than floating — but they stay visually distinct.
+  for (const e of edges) {
+    if (g.hasNode(e.from) && g.hasNode(e.to)) g.setEdge(e.from, e.to, { a2a: Boolean(e.a2a) })
+  }
+
+  dagre.layout(g)
+
+  const placed: PlacedNode[] = []
+  for (const id of g.nodes()) {
+    const p = g.node(id)
+    if (!p) continue
+    placed.push({ id, x: p.x, y: p.y })
+  }
+
+  const lines: PlacedEdge[] = []
+  for (const e of g.edges()) {
+    const pts = g.edge(e)?.points ?? []
+    if (pts.length === 0) continue
+    lines.push({
+      points: pts.map((pt: { x: number; y: number }) => `${pt.x},${pt.y}`).join(' '),
+      a2a: Boolean(g.edge(e)?.a2a),
+    })
+  }
+
+  const graph = g.graph()
+  return {
+    nodes: placed,
+    edges: lines,
+    width: Math.max(graph.width ?? 0, size.minWidth ?? 320),
+    height: Math.max(graph.height ?? 0, size.minHeight ?? 120),
+  }
+}

--- a/desktop/frontend/src/views/Fleet.tsx
+++ b/desktop/frontend/src/views/Fleet.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import type { Agent, Fleet as FleetData, Run } from '../types'
 import { ms, pct, usdExact } from '../format'
+import { RunGraph } from './RunGraph'
 
 export function Fleet({ data, onOpen }: { data: FleetData; onOpen: (runID: string) => void }) {
   return (
@@ -41,9 +42,10 @@ function RunCard({
   groupThreshold: number
   onOpen: (runID: string) => void
 }) {
-  // Past the threshold a fan-out stops being readable as cards, so it collapses
-  // to its state counts until asked to expand. A live run starts expanded —
-  // it is the one you opened the app to watch.
+  // Past the threshold a node-link graph is a hairball, not a picture (mirrors
+  // Airflow's separate Grid view for large DAGs), so it collapses to a state
+  // heatmap until asked to expand. A live run starts expanded — it is the one
+  // you opened the app to watch.
   const large = run.allCount > groupThreshold
   const [expanded, setExpanded] = useState(!large)
 
@@ -80,17 +82,31 @@ function RunCard({
             </button>
           )}
 
-          {expanded && run.agents.length > 0 && (
-            <ul className="agents">
-              {run.agents.map((a) => (
-                <AgentRow key={a.id} agent={a} />
-              ))}
-            </ul>
-          )}
+          {/* Below the threshold: a single agent needs no graph, and 2..N draw
+              the same dagre DAG SessionGraph uses, just smaller. At/above the
+              threshold the toggle above reveals a heatmap grid instead. */}
+          {!large && <RunShape agents={run.agents} />}
+          {large && expanded && run.agents.length > 0 && <AgentGrid agents={run.agents} />}
         </>
       )}
     </section>
   )
+}
+
+/** The 0/1/2..N shape for a run below GroupThreshold. */
+function RunShape({ agents }: { agents: Agent[] }) {
+  if (agents.length === 0) return null
+  // A single node is trivially linear — the same reasoning Session.tsx uses
+  // to decide nonLinear (isNonLinear is false whenever there's nothing to
+  // branch from). Drawing a graph of one box is worse than a line of text.
+  if (agents.length === 1) {
+    return (
+      <ul className="agents">
+        <AgentRow agent={agents[0]} />
+      </ul>
+    )
+  }
+  return <RunGraph agents={agents} />
 }
 
 function StateBar({ run }: { run: Run }) {
@@ -127,4 +143,51 @@ function AgentRow({ agent }: { agent: Agent }) {
       {agent.detail && <span className="agent__detail">{agent.detail}</span>}
     </li>
   )
+}
+
+/**
+ * At/above GroupThreshold a node-link graph is a hairball, not a picture —
+ * Airflow ships a separate Grid view for exactly this reason instead of
+ * scaling its Graph view. One chip per agent, colored by state, grouped by
+ * depth: "mostly green with a cluster of red" has to read in under a second.
+ */
+function AgentGrid({ agents }: { agents: Agent[] }) {
+  const byDepth = new Map<number, Agent[]>()
+  for (const a of agents) {
+    const row = byDepth.get(a.depth)
+    if (row) row.push(a)
+    else byDepth.set(a.depth, [a])
+  }
+  const depths = [...byDepth.keys()].sort((x, y) => x - y)
+
+  return (
+    <div className="agrid">
+      {depths.map((d) => (
+        <div className="agrid__row" key={d}>
+          <span className="agrid__depth">D{d}</span>
+          <div className="agrid__chips">
+            {byDepth.get(d)!.map((a) => (
+              <span
+                key={a.id}
+                className={`chip chip--${a.state || 'pending'}`}
+                title={chipTitle(a)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function chipTitle(a: Agent): string {
+  return [
+    a.model || a.head || a.id,
+    a.tier > 0 ? `T${a.tier}` : null,
+    a.state,
+    a.durationMs > 0 ? ms(a.durationMs) : null,
+    a.costUsd > 0 ? usdExact(a.costUsd) : null,
+  ]
+    .filter(Boolean)
+    .join(' · ')
 }

--- a/desktop/frontend/src/views/RunGraph.tsx
+++ b/desktop/frontend/src/views/RunGraph.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from 'react'
+import type { Agent } from '../types'
+import { layoutDag } from '../dagreLayout'
+
+// Deliberately smaller than SessionGraph's NODE_W/H (168x46): Fleet shows one
+// of these per run, several runs per screen, so a node here carries only a
+// short label — no tier/duration subtext. Same .gnode--* state classes as
+// SessionGraph though, so a run's shape reads identically in both views.
+const NODE_W = 92
+const NODE_H = 26
+const LABEL_MAX = 12
+
+interface Placed {
+  id: string
+  x: number
+  y: number
+  label: string
+  state: string
+}
+
+/** Compact inline DAG for a run's agents — Fleet's 2..GroupThreshold tier. */
+export function RunGraph({ agents }: { agents: Agent[] }) {
+  const { nodes, lines, width, height } = useMemo(() => layout(agents), [agents])
+
+  if (nodes.length === 0) return null
+
+  return (
+    <div className="graph graph--compact">
+      <svg width={width} height={height} role="img" aria-label="Run graph">
+        {lines.map((l, i) => (
+          <polyline key={i} points={l.points} className="edge" fill="none" />
+        ))}
+        {nodes.map((n) => (
+          <g key={n.id} transform={`translate(${n.x - NODE_W / 2},${n.y - NODE_H / 2})`}>
+            <rect
+              width={NODE_W}
+              height={NODE_H}
+              rx={7}
+              className={`gnode gnode--${n.state || 'pending'}`}
+            />
+            <text x={8} y={17} className="gnode__label">
+              {n.label}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  )
+}
+
+function shortLabel(a: Agent): string {
+  const s = a.model || a.head || a.id
+  return s.length > LABEL_MAX ? `${s.slice(0, LABEL_MAX - 1)}…` : s
+}
+
+function layout(agents: Agent[]) {
+  const { nodes: placed, edges: lines, width, height } = layoutDag(
+    agents.map((a) => ({ id: a.id, parent: a.parent })),
+    [],
+    { nodeW: NODE_W, nodeH: NODE_H, nodesep: 14, ranksep: 26, minWidth: 0, minHeight: 0 },
+  )
+
+  const byID = new Map(agents.map((a) => [a.id, a]))
+  const nodes: Placed[] = []
+  for (const p of placed) {
+    const a = byID.get(p.id)
+    if (!a) continue
+    nodes.push({ id: p.id, x: p.x, y: p.y, label: shortLabel(a), state: a.state })
+  }
+
+  return { nodes, lines, width, height }
+}

--- a/desktop/frontend/src/views/SessionGraph.tsx
+++ b/desktop/frontend/src/views/SessionGraph.tsx
@@ -1,19 +1,9 @@
 import { useMemo } from 'react'
-import dagre from '@dagrejs/dagre'
 import type { Session } from '../types'
+import { layoutDag } from '../dagreLayout'
 
-/**
- * Layered (Sugiyama) layout via dagre.
- *
- * Deterministic and near-linear per relayout, and it has a notion of direction —
- * which matches the causal semantics of a run. A force-directed or
- * stress-majorization model has neither: it treats edges as springs, so the same
- * run lays out differently frame to frame and "downstream" means nothing.
- *
- * The layout maths is bought, not hand-rolled. Crossing minimisation is NP-hard
- * and dagre already implements the standard heuristic chain (Brandes-Köpf
- * coordinate assignment included).
- */
+// Sugiyama/dagre layout mechanics live in dagreLayout.ts, shared with Fleet's
+// inline run graph — see that file for why dagre over a force-directed layout.
 const NODE_W = 168
 const NODE_H = 46
 
@@ -24,11 +14,6 @@ interface Placed {
   label: string
   sub: string
   state: string
-}
-
-interface Line {
-  points: string
-  a2a: boolean
 }
 
 export function SessionGraph({ session }: { session: Session }) {
@@ -72,34 +57,19 @@ export function SessionGraph({ session }: { session: Session }) {
 }
 
 function layout(session: Session) {
-  const g = new dagre.graphlib.Graph()
-  // Top-to-bottom: a run reads as time flowing downward, and that matches the
-  // timeline it sits next to.
-  g.setGraph({ rankdir: 'TB', nodesep: 26, ranksep: 42, marginx: 16, marginy: 16 })
-  g.setDefaultEdgeLabel(() => ({}))
-
-  for (const a of session.agents) {
-    g.setNode(a.id, { width: NODE_W, height: NODE_H })
-  }
-  for (const a of session.agents) {
-    if (a.parent && g.hasNode(a.parent)) g.setEdge(a.parent, a.id, { a2a: false })
-  }
-  // A2A edges are laid out too, so a handoff target is placed sensibly rather
-  // than floating — but they stay visually distinct from ownership.
-  for (const e of session.edges) {
-    if (g.hasNode(e.from) && g.hasNode(e.to)) g.setEdge(e.from, e.to, { a2a: true })
-  }
-
-  dagre.layout(g)
+  const { nodes: placed, edges: lines, width, height } = layoutDag(
+    session.agents.map((a) => ({ id: a.id, parent: a.parent })),
+    session.edges.map((e) => ({ from: e.from, to: e.to, a2a: true })),
+    { nodeW: NODE_W, nodeH: NODE_H },
+  )
 
   const byID = new Map(session.agents.map((a) => [a.id, a]))
   const nodes: Placed[] = []
-  for (const id of g.nodes()) {
-    const p = g.node(id)
-    const a = byID.get(id)
-    if (!p || !a) continue
+  for (const p of placed) {
+    const a = byID.get(p.id)
+    if (!a) continue
     nodes.push({
-      id,
+      id: p.id,
       x: p.x,
       y: p.y,
       label: a.model || a.head || a.id,
@@ -111,21 +81,5 @@ function layout(session: Session) {
     })
   }
 
-  const lines: Line[] = []
-  for (const e of g.edges()) {
-    const pts = g.edge(e)?.points ?? []
-    if (pts.length === 0) continue
-    lines.push({
-      points: pts.map((pt: { x: number; y: number }) => `${pt.x},${pt.y}`).join(' '),
-      a2a: Boolean(g.edge(e)?.a2a),
-    })
-  }
-
-  const graph = g.graph()
-  return {
-    nodes,
-    lines,
-    width: Math.max(graph.width ?? 0, 320),
-    height: Math.max(graph.height ?? 0, 120),
-  }
+  return { nodes, lines, width, height }
 }


### PR DESCRIPTION
## Summary
Replaces Fleet's flat indented `<ul>` of `AgentRow`s with a three-tier rendering strategy driven by agent count, reusing `SessionGraph.tsx`'s dagre (Sugiyama) layout engine so a run's shape reads identically in Fleet and Session:

- **1 agent** — no graph at all: a single compact stat line (the existing `AgentRow`). Same reasoning `Session.tsx` already applies for `nonLinear` — a single-node run is trivially linear, so a graph of one box is worse than a line of text.
- **2..GroupThreshold (16) agents** — a compact inline DAG (new `RunGraph.tsx`), built on the same `.gnode--*`/`.edge` CSS classes and dagre layout `SessionGraph.tsx` already defines, just smaller (92x26 vs 168x46) with a short id/model label instead of verbose tier/state/duration subtext.
- **16+ agents** — a CSS-grid state heatmap (new `AgentGrid` in `Fleet.tsx`): one small chip per agent, grouped by `Depth`, colored the same as `.state-dot`/`.gnode` (aqua/cheap/expensive). This mirrors why Apache Airflow ships a separate Grid view instead of forcing its Graph view to scale past a hairball. The existing "Show all N agents" toggle now reveals this grid instead of a list.

### Shared layout extraction
Pulled the dagre layout maths out of `SessionGraph.tsx` into `desktop/frontend/src/dagreLayout.ts` (`layoutDag`), parameterized by node size. `SessionGraph.tsx` now calls it — refactor only, no behavior change (verified node/edge output is identical). This is what makes Fleet and Session visually agree about what one run's agent tree looks like: they share the same layout code, not a re-implementation.

### Untouched, as specified
- `StateBar`'s aggregate running/ok/failed/pending counts stay visible regardless of tier.
- `run.error` (unreadable run) and `run.skipped` (unattributed events) handling is unchanged.

### Go changes
None needed. `desktop/api/fleet.go`'s `GetFleet`/`Run`/`Agent` already return `Parent`/`Depth`/`State`/`DurationMS`/`CostUSD`/`Confidence` and `GroupThreshold` — everything the frontend needed was already on the wire.

## Verification
- `cd desktop && go test ./...` — passes (no Go changes; confirms the DTO already carries what's needed)
- `cd desktop/frontend && npm run build` (`tsc -b && vite build`) — compiles clean
- No display server in this sandbox to drive `wails dev`, so relied on careful static review plus a throwaway trace script (not committed) that ran the actual dagre layout function against a 1-agent, a 5-agent fan-out, an orphan-parent edge case, and a 20-agent flat-swarm fixture, and the `AgentGrid` depth-grouping logic against a mixed-depth/mixed-state fixture — checked finite coordinates, correct node/edge counts, and that every agent appears exactly once across grid rows.

## Test plan
- [ ] Visually confirm in `wails dev`: a 1-agent run shows a stat line, no graph
- [ ] A 3-10 agent swarm shows the compact inline DAG with correct parent/child edges and state colors
- [ ] A 16+ agent run collapses behind "Show all N agents" and reveals the heatmap grid on click, matching StateBar's counts by color

Closes #381