### PR TITLE
feat(desktop): redesign Dashboard with SVG charts

### DIFF
--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -200,6 +200,121 @@ body {
 .cost--mid       { color: var(--hy-mid); }
 .cost--expensive { color: var(--hy-expensive); }
 
+/* ── Dashboard: hero spend chart ──────────────────────────────────────── */
+
+.spend-chart {
+  background: var(--hy-panel);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius);
+  padding: 16px 17px 12px;
+  overflow-x: auto;
+}
+
+.spend-bar { cursor: default; }
+.spend-bar:focus-visible { outline: none; }
+
+.spend-bar__rect { opacity: .82; transition: opacity .12s; }
+.spend-bar:hover .spend-bar__rect,
+.spend-bar:focus-visible .spend-bar__rect { opacity: 1; }
+
+.spend-bar__rect--free      { fill: var(--hy-dim); }
+.spend-bar__rect--cheap     { fill: var(--hy-cheap); }
+.spend-bar__rect--mid       { fill: var(--hy-mid); }
+.spend-bar__rect--expensive { fill: var(--hy-expensive); }
+
+.spend-tip { pointer-events: none; }
+.spend-tip__bg { fill: var(--hy-bg-2); stroke: var(--hy-line); }
+.spend-tip__value {
+  fill: var(--hy-ink);
+  font-family: var(--hy-font-mono);
+  font-size: 11px;
+  font-weight: 700;
+}
+.spend-tip__meta { fill: var(--hy-dim); font-family: var(--hy-font-mono); font-size: 10px; }
+
+.spend-chart__range {
+  margin-top: 8px;
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  color: var(--hy-dim);
+}
+
+/* ── Dashboard: inline sparkline (spend stat card) ────────────────────── */
+
+.spend-spark { display: block; margin-top: 9px; }
+.spend-spark__line { stroke: var(--hy-dim); stroke-width: 1.5; }
+.spend-spark__dot  { fill: var(--hy-aqua); }
+
+/* ── Dashboard: ranked bar lists (by model / by tier) ─────────────────── */
+
+.rank { display: flex; flex-direction: column; gap: 9px; }
+
+.rank__row {
+  display: grid;
+  grid-template-columns: minmax(64px, 130px) 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.rank__name {
+  font-family: var(--hy-font-mono);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rank__track {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--hy-line);
+  overflow: hidden;
+}
+.rank__fill { display: block; height: 100%; border-radius: 4px; }
+.rank__fill--free      { background: var(--hy-dim); }
+.rank__fill--cheap     { background: var(--hy-cheap); }
+.rank__fill--mid       { background: var(--hy-mid); }
+.rank__fill--expensive { background: var(--hy-expensive); }
+
+.rank__value { font-size: 12px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+/* ── Dashboard: trust comparison bars ──────────────────────────────────── */
+
+.trust-cmp { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; }
+
+.trust-cmp__row {
+  display: grid;
+  grid-template-columns: 58px 1fr auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.trust-cmp__label {
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--hy-dim);
+}
+
+.trust-cmp__track {
+  height: 8px;
+  border-radius: 4px;
+  background: var(--hy-line);
+  overflow: hidden;
+}
+.trust-cmp__fill { display: block; height: 100%; border-radius: 4px; }
+.trust-cmp__fill--actual   { background: var(--hy-aqua); }
+.trust-cmp__fill--baseline { background: var(--hy-dim); }
+
+.trust-cmp__value { font-size: 12px; font-variant-numeric: tabular-nums; }
+
+.trust-cmp__delta { margin-top: 3px; font-size: 12px; }
+.trust-cmp__delta--good { color: var(--hy-cheap); }
+.trust-cmp__delta--bad  { color: var(--hy-expensive); }
+
 /* ── Empty / error states ──────────────────────────────────────────────── */
 
 .empty {

--- a/desktop/frontend/src/views/Dashboard.tsx
+++ b/desktop/frontend/src/views/Dashboard.tsx
@@ -1,5 +1,6 @@
-import type { Breakdown, Dashboard as DashboardData } from '../types'
-import { clockTime, costBand, govBand, ms, pct, tokens, usd, usdExact } from '../format'
+import type { Breakdown, Dashboard as DashboardData, TrustPanel } from '../types'
+import { clockTime, costBand, govBand, ms, pct, usd, usdExact } from '../format'
+import { Sparkline, SpendTrend } from './DashboardCharts'
 
 export function Dashboard({ data }: { data: DashboardData }) {
   return (
@@ -21,7 +22,7 @@ export function Dashboard({ data }: { data: DashboardData }) {
 }
 
 function SpendCard({ data }: { data: DashboardData }) {
-  const { spend, hasData } = data
+  const { spend, hasData, byDay } = data
   if (!hasData) {
     return (
       <div className="card">
@@ -42,6 +43,7 @@ function SpendCard({ data }: { data: DashboardData }) {
             number is measured rather than estimated from char/4. */}
         {pct(spend.tokensActualPct)} of tokens provider-reported
       </div>
+      {byDay && <Sparkline days={byDay} />}
     </div>
   )
 }
@@ -88,9 +90,45 @@ function TrustCard({ data }: { data: DashboardData }) {
     <div className="card">
       <div className="card__label">Trust ensemble</div>
       <div className="card__value">{trust.meanSamples.toFixed(2)}</div>
+      <TrustCompare trust={trust} />
       <div className="card__note">
-        mean samples vs fixed-{trust.fixedSwarmN} swarm · {pct(trust.samplesSavedPct)} saved ·{' '}
         {trust.runs} run{trust.runs === 1 ? '' : 's'}
+      </div>
+    </div>
+  )
+}
+
+/** SPRT mean samples vs. a fixed-N swarm, same axis, so the saving reads at a
+ * glance instead of as a sentence to parse. */
+function TrustCompare({ trust }: { trust: TrustPanel }) {
+  const max = Math.max(trust.meanSamples, trust.fixedSwarmN, 1)
+  const saved = trust.samplesSavedPct >= 0
+  return (
+    <div className="trust-cmp">
+      <div className="trust-cmp__row">
+        <span className="trust-cmp__label">SPRT</span>
+        <span className="trust-cmp__track">
+          <span
+            className="trust-cmp__fill trust-cmp__fill--actual"
+            style={{ width: `${(trust.meanSamples / max) * 100}%` }}
+          />
+        </span>
+        <span className="trust-cmp__value">{trust.meanSamples.toFixed(2)}</span>
+      </div>
+      <div className="trust-cmp__row">
+        <span className="trust-cmp__label">Fixed-{trust.fixedSwarmN}</span>
+        <span className="trust-cmp__track">
+          <span
+            className="trust-cmp__fill trust-cmp__fill--baseline"
+            style={{ width: `${(trust.fixedSwarmN / max) * 100}%` }}
+          />
+        </span>
+        <span className="trust-cmp__value">{trust.fixedSwarmN}</span>
+      </div>
+      <div className={`trust-cmp__delta ${saved ? 'trust-cmp__delta--good' : 'trust-cmp__delta--bad'}`}>
+        {saved
+          ? `${pct(trust.samplesSavedPct)} fewer samples than a fixed swarm`
+          : `${pct(Math.abs(trust.samplesSavedPct))} more samples than a fixed swarm`}
       </div>
     </div>
   )
@@ -99,53 +137,52 @@ function TrustCard({ data }: { data: DashboardData }) {
 function Breakdowns({ data }: { data: DashboardData }) {
   return (
     <>
+      {data.byDay && data.byDay.length > 0 && (
+        <section>
+          <h2 className="section__title">Spend by day</h2>
+          <SpendTrend days={data.byDay} />
+        </section>
+      )}
       <div className="grid-2">
-        <BreakdownTable title="By model" heading="Model" rows={data.byModel} />
-        <BreakdownTable title="By tier" heading="Tier" rows={data.byTier} />
+        <RankedBars title="By model" rows={data.byModel} />
+        <RankedBars title="By tier" rows={data.byTier} />
       </div>
-      <BreakdownTable title="By day" heading="Day" rows={data.byDay} />
       <RecentTable data={data} />
     </>
   )
 }
 
-function BreakdownTable({
-  title,
-  heading,
-  rows,
-}: {
-  title: string
-  heading: string
-  rows: Breakdown[] | null
-}) {
+/** A ranked horizontal bar list: name, a proportional bar, and the exact
+ * dollar amount — replaces the plain by-model/by-tier tables. */
+function RankedBars({ title, rows }: { title: string; rows: Breakdown[] | null }) {
   if (!rows || rows.length === 0) return null
   const max = Math.max(...rows.map((r) => r.costUsd))
   return (
     <section>
       <h2 className="section__title">{title}</h2>
       <div className="table__wrap">
-        <table className="table">
-          <thead>
-            <tr>
-              <th>{heading}</th>
-              <th className="num">Calls</th>
-              <th className="num">Tokens</th>
-              <th className="num">Wall</th>
-              <th className="num">Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((r) => (
-              <tr key={r.key}>
-                <td className="mono">{r.key}</td>
-                <td className="num">{r.calls}</td>
-                <td className="num">{tokens(r.promptTokens + r.responseTokens)}</td>
-                <td className="num">{ms(r.wallMs)}</td>
-                <td className={`num cost--${costBand(r.costUsd, max)}`}>{usdExact(r.costUsd)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <div className="rank">
+          {rows.map((r) => {
+            const band = costBand(r.costUsd, max)
+            // A day with only free/local calls still gets a sliver: present,
+            // just not comparable to anything on this ramp.
+            const widthPct = max > 0 ? (r.costUsd / max) * 100 : r.calls > 0 ? 4 : 0
+            return (
+              <div className="rank__row" key={r.key}>
+                <span className="rank__name" title={r.key}>
+                  {r.key}
+                </span>
+                <span className="rank__track">
+                  <span
+                    className={`rank__fill rank__fill--${band}`}
+                    style={{ width: `${widthPct}%` }}
+                  />
+                </span>
+                <span className={`rank__value cost--${band}`}>{usdExact(r.costUsd)}</span>
+              </div>
+            )
+          })}
+        </div>
       </div>
     </section>
   )

--- a/desktop/frontend/src/views/DashboardCharts.tsx
+++ b/desktop/frontend/src/views/DashboardCharts.tsx
@@ -1,0 +1,143 @@
+import { useMemo, useState } from 'react'
+import type { Breakdown } from '../types'
+import { costBand, usd } from '../format'
+
+const BAR_W = 16
+const GAP = 8
+const CHART_H = 160
+// Reserves room above the tallest bar for the hover tooltip, so it never
+// clips off the top of the chart.
+const TOP_PAD = 34
+
+interface Bar {
+  key: string
+  x: number
+  barH: number
+  costUsd: number
+  calls: number
+  band: ReturnType<typeof costBand>
+}
+
+/**
+ * The dashboard's hero chart: one bar per day, height proportional to spend.
+ * Same pattern as SessionGraph — a useMemo layout pass produces positions,
+ * then plain SVG primitives render them, styled via tokens.css. Bars pick up
+ * the existing cost ramp (free/cheap/mid/expensive) so an expensive day reads
+ * as red without a legend.
+ */
+export function SpendTrend({ days }: { days: Breakdown[] }) {
+  const [hover, setHover] = useState<number | null>(null)
+  const { bars, width } = useMemo(() => layout(days), [days])
+
+  if (bars.length === 0) return null
+
+  const hovered = hover !== null ? bars[hover] : null
+
+  return (
+    <div className="spend-chart">
+      <svg width={width} height={CHART_H} role="img" aria-label="Daily spend, most recent last">
+        {bars.map((b, i) => (
+          <g
+            key={b.key}
+            className="spend-bar"
+            tabIndex={0}
+            role="img"
+            aria-label={`${b.key}: ${usd(b.costUsd)}, ${b.calls} call${b.calls === 1 ? '' : 's'}`}
+            onMouseEnter={() => setHover(i)}
+            onMouseLeave={() => setHover(null)}
+            onFocus={() => setHover(i)}
+            onBlur={() => setHover(null)}
+          >
+            <rect
+              x={b.x}
+              y={CHART_H - b.barH}
+              width={BAR_W}
+              height={b.barH}
+              rx={2}
+              className={`spend-bar__rect spend-bar__rect--${b.band}`}
+            />
+          </g>
+        ))}
+        {hovered && <Tooltip bar={hovered} chartWidth={width} />}
+      </svg>
+      <div className="spend-chart__range">
+        <span>{bars[0].key}</span>
+        {bars.length > 1 && <span>{bars[bars.length - 1].key}</span>}
+      </div>
+    </div>
+  )
+}
+
+function Tooltip({ bar, chartWidth }: { bar: Bar; chartWidth: number }) {
+  const w = 100
+  const h = 32
+  const x = Math.max(2, Math.min(bar.x + BAR_W / 2 - w / 2, chartWidth - w - 2))
+  const y = Math.max(CHART_H - bar.barH - h - 6, 2)
+  return (
+    <g className="spend-tip">
+      <rect x={x} y={y} width={w} height={h} rx={6} className="spend-tip__bg" />
+      <text x={x + 9} y={y + 14} className="spend-tip__value">
+        {usd(bar.costUsd)}
+      </text>
+      <text x={x + 9} y={y + 26} className="spend-tip__meta">
+        {bar.calls} call{bar.calls === 1 ? '' : 's'}
+      </text>
+    </g>
+  )
+}
+
+function layout(days: Breakdown[]): { bars: Bar[]; width: number } {
+  if (days.length === 0) return { bars: [], width: 0 }
+  const max = Math.max(...days.map((d) => d.costUsd))
+  const scale = max > 0 ? (CHART_H - TOP_PAD) / max : 0
+  const bars = days.map((d, i) => ({
+    key: d.key,
+    x: i * (BAR_W + GAP),
+    // A zero-cost day (all local/free heads) still gets a visible nub rather
+    // than vanishing — the day itself is real, even if it cost nothing.
+    barH: max > 0 ? Math.max(2, d.costUsd * scale) : 2,
+    costUsd: d.costUsd,
+    calls: d.calls,
+    band: costBand(d.costUsd, max),
+  }))
+  return { bars, width: days.length * (BAR_W + GAP) - GAP }
+}
+
+const SPARK_W = 96
+const SPARK_H = 26
+
+/**
+ * Inline trend inside the spend stat card: the tail of byDay, so "is this
+ * normal" is visible without scrolling down to the hero chart. Follows the
+ * sparkline figure spec — the line stays in the de-emphasis hue, only the
+ * current (latest) point picks up the accent.
+ */
+export function Sparkline({ days }: { days: Breakdown[] }) {
+  const tail = days.slice(-14)
+  if (tail.length < 2) return null
+
+  const max = Math.max(...tail.map((d) => d.costUsd), 0)
+  const points = tail.map((d, i) => {
+    const x = (i / (tail.length - 1)) * SPARK_W
+    const y = max > 0 ? SPARK_H - (d.costUsd / max) * SPARK_H : SPARK_H
+    return [x, y] as const
+  })
+  const last = points[points.length - 1]
+
+  return (
+    <svg
+      className="spend-spark"
+      width={SPARK_W}
+      height={SPARK_H}
+      role="img"
+      aria-label={`Spend trend over the last ${tail.length} days`}
+    >
+      <polyline
+        className="spend-spark__line"
+        points={points.map(([x, y]) => `${x},${y}`).join(' ')}
+        fill="none"
+      />
+      <circle className="spend-spark__dot" cx={last[0]} cy={last[1]} r={2.5} />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
Replaces the stat-cards-plus-tables Dashboard with hand-rolled SVG/CSS charts, following the `SessionGraph.tsx` pattern (`useMemo` layout -> plain SVG primitives styled via `tokens.css`) instead of adding a chart library — the research pass on #380 found no library buys anything at this app's data volume (one local machine, dozens of days, a handful of models/tiers) and it would fight the existing theming system.

## Changes
- **`DashboardCharts.tsx` (new)**: `SpendTrend` (hero daily-spend bar chart from `byDay`, colored by the existing cost ramp) and `Sparkline` (7-14 day inline trend in the spend stat card).
- **`Dashboard.tsx`**: `RankedBars` (horizontal proportional bar lists replacing the `byModel`/`byTier` tables) and `TrustCompare` (meanSamples vs fixedSwarmN as two bars with `samplesSavedPct` as a colored delta, replacing the prose sentence).
- `Recent` stays a plain table — row-shaped data, not chart-shaped, an intentional call from the research pass.
- Every new component guards its empty/zero-cost path so `hasData=false` (first-run, no `~/.hydra`) is untouched.

## Test plan
- [x] `go test ./desktop/...` — first-run/empty-state tests pass
- [x] `cd desktop/frontend && npm run build` — TypeScript compiles clean

Closes #380