### PR TITLE
feat(desktop): auto-install hyctl when missing

### DIFF
--- a/desktop/api/dto_test.go
+++ b/desktop/api/dto_test.go
@@ -20,7 +20,7 @@ import (
 // must always be present on the wire. Strings may be omitempty — TypeScript
 // models those naturally as optional.
 func TestDTOs_NumericFieldsAreNeverOmitEmpty(t *testing.T) {
-	for _, v := range []any{Fleet{}, Run{}, Agent{}, Dashboard{}, SpendPanel{}, GovernorPanel{}, TrustPanel{}, Breakdown{}, RecentCall{}} {
+	for _, v := range []any{Fleet{}, Run{}, Agent{}, Dashboard{}, SpendPanel{}, GovernorPanel{}, TrustPanel{}, Breakdown{}, RecentCall{}, HyctlStatus{}, InstallResult{}} {
 		rt := reflect.TypeOf(v)
 		t.Run(rt.Name(), func(t *testing.T) {
 			for i := range rt.NumField() {
@@ -42,7 +42,7 @@ func TestDTOs_NumericFieldsAreNeverOmitEmpty(t *testing.T) {
 // Every DTO must round-trip through JSON unchanged. A field with no json tag
 // would ship a Go-cased key the hand-written mirror does not declare.
 func TestDTOs_FieldNamesAreExplicitlyTagged(t *testing.T) {
-	for _, v := range []any{Fleet{}, Run{}, Agent{}, Dashboard{}, SpendPanel{}, GovernorPanel{}, TrustPanel{}, Breakdown{}, RecentCall{}, Version{}} {
+	for _, v := range []any{Fleet{}, Run{}, Agent{}, Dashboard{}, SpendPanel{}, GovernorPanel{}, TrustPanel{}, Breakdown{}, RecentCall{}, Version{}, HyctlStatus{}, InstallResult{}} {
 		rt := reflect.TypeOf(v)
 		for i := range rt.NumField() {
 			f := rt.Field(i)

--- a/desktop/api/firstrun_test.go
+++ b/desktop/api/firstrun_test.go
@@ -101,6 +101,14 @@ func TestFirstRun_EveryEntryPointIsSafeWithNoHydraHome(t *testing.T) {
 			t.Error("Version is empty")
 		}
 	})
+
+	// CheckHyctl reads $PATH, not ~/.hydra, so an empty home is unrelated to
+	// it — but it is the very first call the app makes on a fresh machine
+	// (#383), so it belongs in this contract too: it must return a value, not
+	// panic, regardless of what is or is not installed.
+	t.Run("hyctl status", func(t *testing.T) {
+		_ = a.CheckHyctl()
+	})
 }
 
 // The whole first-run payload must be marshallable and free of nulls where the

--- a/desktop/api/setup.go
+++ b/desktop/api/setup.go
@@ -193,15 +193,25 @@ func defaultHyctlSearchDirs() []string {
 
 // findHyctlInCommonDirs checks hyctlSearchDirs directly with os.Stat, for the
 // PATH-refresh gap CheckHyctl's doc comment describes.
+//
+// On Windows this tries every name PATHEXT would resolve for a bare "hyctl":
+// install.ps1 produces hyctl.exe, but a real hyctl.exe binary is what this
+// checks for in production — the multi-name list exists so a fake, script-based
+// stand-in (a .bat, the same trick internal/testutil.Sandbox.FakeBinary and
+// this package's own fakeHyctl test helper use to avoid compiling a real PE
+// binary in a test) resolves too, the same way exec.LookPath's PATHEXT search
+// would treat both as valid.
 func findHyctlInCommonDirs() (string, error) {
-	bin := "hyctl"
+	names := []string{"hyctl"}
 	if runtime.GOOS == "windows" {
-		bin = "hyctl.exe"
+		names = []string{"hyctl.exe", "hyctl.bat", "hyctl.cmd"}
 	}
 	for _, dir := range hyctlSearchDirs() {
-		p := filepath.Join(dir, bin)
-		if info, err := os.Stat(p); err == nil && !info.IsDir() {
-			return p, nil
+		for _, name := range names {
+			p := filepath.Join(dir, name)
+			if info, err := os.Stat(p); err == nil && !info.IsDir() {
+				return p, nil
+			}
 		}
 	}
 	return "", fmt.Errorf("hyctl not found in common install locations")

--- a/desktop/api/setup.go
+++ b/desktop/api/setup.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/ankit373/hydra/internal/util"
+)
+
+// installScriptURL is the same curl-installer documented at the repo root and
+// in the README. A var, not a const, so a test can point InstallHyctl at an
+// httptest server instead of GitHub — matching internal/update's releaseURL
+// and internal/pricing's openRouterModelsURL.
+var installScriptURL = "https://raw.githubusercontent.com/ankit373/hydra/main/install.sh"
+
+// hyctlSearchDirs returns the fixed destinations to check when exec.LookPath
+// fails. A var, not a direct call, so a test can point it at a sandboxed
+// directory — the real /usr/local/bin must never be touched by a test.
+var hyctlSearchDirs = defaultHyctlSearchDirs
+
+const (
+	// installFetchTimeout bounds downloading install.sh itself (a few KB).
+	installFetchTimeout = 15 * time.Second
+	// installRunTimeout bounds running it — it downloads a multi-MB archive
+	// of its own, so it gets much longer than the fetch above.
+	installRunTimeout = 2 * time.Minute
+	// versionProbeTimeout bounds `hyctl --version`, a purely local call.
+	versionProbeTimeout = 3 * time.Second
+)
+
+// HyctlStatus is whether hyctl is set up on this machine, for the first-run
+// banner (#383). A machine that already has hyctl working must see nothing —
+// Found is what the frontend branches on — so every field here is cheap to
+// compute: a PATH lookup, at most one local subprocess, no network.
+type HyctlStatus struct {
+	Found   bool   `json:"found"`
+	Path    string `json:"path,omitempty"`
+	Version string `json:"version,omitempty"`
+
+	// Supported is false on platforms InstallHyctl cannot drive (Windows —
+	// see its doc comment). The frontend uses this to decide between offering
+	// a one-click install and pointing at the manual instructions.
+	Supported bool `json:"supported"`
+}
+
+// CheckHyctl looks for hyctl the way a shell would (exec.LookPath), then
+// falls back to install.sh's own destinations (/usr/local/bin, ~/.local/bin)
+// directly. The fallback matters: a GUI app launched from Finder/Dock/a
+// desktop file inherits a minimal PATH that usually omits both, so right
+// after InstallHyctl succeeds, a PATH-only check run in the same process
+// would still report "not found" even though the install worked.
+func (a *API) CheckHyctl() HyctlStatus {
+	st := HyctlStatus{Supported: installSupported(runtime.GOOS)}
+
+	path, err := exec.LookPath("hyctl")
+	if err != nil {
+		path, err = findHyctlInCommonDirs()
+	}
+	if err != nil {
+		return st
+	}
+
+	st.Found = true
+	st.Path = path
+	st.Version = hyctlVersion(path)
+	return st
+}
+
+// InstallResult is the outcome of one InstallHyctl run.
+type InstallResult struct {
+	OK      bool   `json:"ok"`
+	Version string `json:"version,omitempty"`
+
+	// Log is the installer's combined stdout/stderr, capped by
+	// util.Accumulator. Returned on both success and failure — "it eventually
+	// worked" tells the user nothing; the installer's own progress lines do.
+	Log string `json:"log"`
+
+	Error string `json:"error,omitempty"`
+}
+
+// InstallHyctl runs the same curl-installer documented at the repo root
+// (install.sh) and in the README, rather than reimplementing platform/arch
+// detection and checksum verification a second time in Go — that logic
+// already exists, is shellchecked in CI, and would drift the moment one copy
+// changed without the other.
+//
+// It differs from the documented `curl -fsSL … | sh` one-liner only in
+// mechanics, not behaviour: this fetches the script itself over HTTPS via
+// net/http (which validates the TLS certificate exactly as curl does) and
+// feeds the bytes to `sh` on stdin. That avoids building a shell command
+// string at all (there is no injection surface, since no user input reaches
+// the command line) and drops the assumption that curl is even installed —
+// which hyctl being absent says nothing about.
+//
+// Scope: macOS and Linux only. Windows ships install.ps1, a different
+// installer with different mechanics (irm | iex, PowerShell execution
+// policy, a %LOCALAPPDATA% destination) and different PATH-refresh
+// semantics; wiring a second code path for it is left as a follow-up to
+// #383 rather than blocking this MVP on full platform parity.
+func (a *API) InstallHyctl() InstallResult {
+	if !installSupported(runtime.GOOS) {
+		return InstallResult{Error: "automatic setup is only available on macOS and Linux — " +
+			"on Windows, run install.ps1 or `npm install -g hyctl` (see the README)"}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), installRunTimeout)
+	defer cancel()
+
+	script, err := fetchInstallScript(ctx)
+	if err != nil {
+		return InstallResult{Error: fmt.Sprintf("could not download the installer: %v", err)}
+	}
+
+	out := util.NewAccumulator(1 << 20) // 1 MB — install.sh's own output is a few dozen lines
+	// Absolute path, not "sh" resolved off $PATH: a GUI app launched from
+	// Finder/Dock/a desktop file can inherit a PATH too minimal to resolve
+	// even the shell (the same gap CheckHyctl's fallback exists for), and
+	// /bin/sh is guaranteed on both platforms installSupported allows.
+	cmd := exec.CommandContext(ctx, "/bin/sh")
+	cmd.Stdin = strings.NewReader(script)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		return InstallResult{Log: out.String(), Error: fmt.Sprintf("installer exited with an error: %v", err)}
+	}
+
+	status := a.CheckHyctl()
+	return InstallResult{OK: status.Found, Version: status.Version, Log: out.String()}
+}
+
+// fetchInstallScript downloads install.sh's current contents. Capped at 1 MB
+// (the real script is a few KB) so a misconfigured URL cannot turn this into
+// an unbounded read.
+func fetchInstallScript(parent context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(parent, installFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, installScriptURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, installScriptURL)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	if len(body) == 0 {
+		return "", fmt.Errorf("empty response from %s", installScriptURL)
+	}
+	return string(body), nil
+}
+
+// installSupported takes goos rather than reading runtime.GOOS directly so a
+// test can exercise the Windows branch without cross-compiling.
+func installSupported(goos string) bool {
+	return goos == "darwin" || goos == "linux"
+}
+
+// defaultHyctlSearchDirs is hyctlSearchDirs' production value.
+func defaultHyctlSearchDirs() []string {
+	if runtime.GOOS == "windows" {
+		if lad := os.Getenv("LOCALAPPDATA"); lad != "" {
+			// install.ps1's own destination (see the README).
+			return []string{filepath.Join(lad, "Programs", "hyctl")}
+		}
+		return nil
+	}
+	dirs := []string{"/usr/local/bin"}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		dirs = append(dirs, filepath.Join(home, ".local", "bin"))
+	}
+	return dirs
+}
+
+// findHyctlInCommonDirs checks hyctlSearchDirs directly with os.Stat, for the
+// PATH-refresh gap CheckHyctl's doc comment describes.
+func findHyctlInCommonDirs() (string, error) {
+	bin := "hyctl"
+	if runtime.GOOS == "windows" {
+		bin = "hyctl.exe"
+	}
+	for _, dir := range hyctlSearchDirs() {
+		p := filepath.Join(dir, bin)
+		if info, err := os.Stat(p); err == nil && !info.IsDir() {
+			return p, nil
+		}
+	}
+	return "", fmt.Errorf("hyctl not found in common install locations")
+}
+
+// hyctlVersion runs `hyctl --version` and returns its first line — the
+// "  hydra vX.Y.Z" line versionText() in cmd/hydra/main.go prints — trimmed.
+// Empty on any error: the caller already knows Found=true, so a version that
+// could not be read is decoration lost, not a reason to report hyctl absent.
+func hyctlVersion(path string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, path, "--version").Output()
+	if err != nil {
+		return ""
+	}
+	line, _, _ := strings.Cut(strings.TrimSpace(string(out)), "\n")
+	return strings.TrimSpace(line)
+}

--- a/desktop/api/setup_test.go
+++ b/desktop/api/setup_test.go
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// withPath puts dir as the only entry on $PATH, so exec.LookPath finds
+// nothing outside it — mirrors internal/testutil.Sandbox's reasoning that one
+// empty directory makes "not found" mean exactly that, rather than leaking
+// whatever the developer's own machine happens to have installed (which, for
+// hyctl, on this repo's own contributors' machines, is likely to be true).
+func withPath(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("PATH", dir)
+}
+
+// withHyctlSearchDirs points CheckHyctl's fallback at dirs instead of the
+// real /usr/local_bin and ~/.local/bin — a test must never touch either.
+func withHyctlSearchDirs(t *testing.T, dirs ...string) {
+	t.Helper()
+	orig := hyctlSearchDirs
+	hyctlSearchDirs = func() []string { return dirs }
+	t.Cleanup(func() { hyctlSearchDirs = orig })
+}
+
+// fakeHyctl writes an executable named hyctl into dir that prints versionLine
+// when run with any arguments (including --version). On Windows,
+// exec.LookPath only considers files carrying a PATHEXT extension, so the
+// file is hyctl.bat there — same reasoning as
+// internal/testutil.Sandbox.FakeBinary.
+func fakeHyctl(t *testing.T, dir, versionLine string) string {
+	t.Helper()
+	var path, script string
+	if runtime.GOOS == "windows" {
+		path = filepath.Join(dir, "hyctl.bat")
+		script = "@echo off\r\necho " + versionLine + "\r\n"
+	} else {
+		path = filepath.Join(dir, "hyctl")
+		script = "#!/bin/sh\necho '" + versionLine + "'\n"
+	}
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// A machine with no hyctl anywhere PATH or the common install directories
+// point at must say so plainly, so the frontend banner has something to key
+// off — the whole point of #383.
+func TestCheckHyctl_NotFoundAnywhere(t *testing.T) {
+	withPath(t, t.TempDir())
+	withHyctlSearchDirs(t) // no dirs at all
+
+	st := New().CheckHyctl()
+	if st.Found {
+		t.Errorf("Found = true with an empty PATH and no search dirs; Path=%q", st.Path)
+	}
+	if st.Path != "" || st.Version != "" {
+		t.Errorf("Path/Version set despite Found=false: %+v", st)
+	}
+}
+
+// The common case this feature must stay invisible for: hyctl resolvable on
+// PATH, exactly like a shell would find it.
+func TestCheckHyctl_FoundOnPath(t *testing.T) {
+	dir := t.TempDir()
+	fakeHyctl(t, dir, "hydra v9.9.9-test")
+	withPath(t, dir)
+	withHyctlSearchDirs(t) // PATH alone must be enough; no fallback needed
+
+	st := New().CheckHyctl()
+	if !st.Found {
+		t.Fatal("Found = false with hyctl on PATH")
+	}
+	if st.Version != "hydra v9.9.9-test" {
+		t.Errorf("Version = %q, want the trimmed first line of --version output", st.Version)
+	}
+	if st.Path == "" {
+		t.Error("Path is empty despite Found=true")
+	}
+}
+
+// A GUI app launched from Finder/Dock/a desktop file inherits a minimal PATH
+// that usually omits install.sh's destinations. hyctl must still be found
+// there directly — otherwise the banner would reappear immediately after a
+// successful install, in the very same process that just ran it.
+func TestCheckHyctl_FallsBackToCommonInstallDirs(t *testing.T) {
+	withPath(t, t.TempDir()) // hyctl absent from PATH
+
+	commonDir := t.TempDir()
+	fakeHyctl(t, commonDir, "hydra v1.2.3")
+	withHyctlSearchDirs(t, commonDir)
+
+	st := New().CheckHyctl()
+	if !st.Found {
+		t.Fatal("Found = false; the common-dir fallback did not fire")
+	}
+	if st.Version != "hydra v1.2.3" {
+		t.Errorf("Version = %q, want hydra v1.2.3", st.Version)
+	}
+}
+
+// Supported must reflect the platform InstallHyctl can actually drive, since
+// the frontend uses it to decide whether to render an install button at all.
+func TestInstallSupported(t *testing.T) {
+	cases := map[string]bool{"darwin": true, "linux": true, "windows": false, "freebsd": false}
+	for goos, want := range cases {
+		if got := installSupported(goos); got != want {
+			t.Errorf("installSupported(%q) = %v, want %v", goos, got, want)
+		}
+	}
+}
+
+// On a platform InstallHyctl cannot drive, it must say so — and point at the
+// documented alternative — rather than attempting a network call it cannot
+// finish correctly.
+func TestInstallHyctl_UnsupportedOSReturnsGuidance(t *testing.T) {
+	if installSupported(runtime.GOOS) {
+		t.Skip("this OS is one InstallHyctl supports; see TestInstallHyctl_RunsTheFetchedScript")
+	}
+
+	r := New().InstallHyctl()
+	if r.OK {
+		t.Error("OK = true on an unsupported platform")
+	}
+	if r.Error == "" {
+		t.Error("no Error on an unsupported platform; the banner would show nothing")
+	}
+}
+
+// The full round trip: fetch the (fake) installer over HTTP, run it, and
+// re-check via CheckHyctl — exactly what the frontend's install button
+// triggers. The fake script stands in for install.sh so the test never
+// reaches GitHub or writes outside its own temp directory.
+func TestInstallHyctl_RunsTheFetchedScript(t *testing.T) {
+	if !installSupported(runtime.GOOS) {
+		t.Skip("InstallHyctl only runs the installer on macOS/Linux")
+	}
+
+	binDir := t.TempDir()
+	hyctlPath := filepath.Join(binDir, "hyctl")
+	script := fmt.Sprintf(`#!/bin/sh
+set -e
+cat > %q <<'EOF'
+#!/bin/sh
+echo 'hydra v0.0.0-fake'
+EOF
+chmod +x %q
+echo "installed to %s"
+`, hyctlPath, hyctlPath, binDir)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(script))
+	}))
+	defer ts.Close()
+
+	restoreURL := installScriptURL
+	installScriptURL = ts.URL
+	t.Cleanup(func() { installScriptURL = restoreURL })
+
+	// binDir first so the post-install CheckHyctl finds the script's fake
+	// hyctl ahead of anything real; /usr/bin and /bin stay on PATH because
+	// the fake script itself shells out to cat/chmod, real external commands
+	// that need resolving — unlike the other tests here, which only use sh
+	// builtins (echo, exit) and can tolerate an empty PATH.
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+"/usr/bin"+string(os.PathListSeparator)+"/bin")
+	withHyctlSearchDirs(t)
+
+	r := New().InstallHyctl()
+	if r.Error != "" {
+		t.Fatalf("InstallHyctl returned an error: %s\nlog:\n%s", r.Error, r.Log)
+	}
+	if !r.OK {
+		t.Errorf("OK = false after a successful install; log:\n%s", r.Log)
+	}
+	if r.Version != "hydra v0.0.0-fake" {
+		t.Errorf("Version = %q, want hydra v0.0.0-fake", r.Version)
+	}
+	if r.Log == "" {
+		t.Error("Log is empty; the frontend has nothing to show for what the installer did")
+	}
+}
+
+// A download failure (bad URL, network error, non-200) must come back as a
+// result the frontend can render, not a panic or a hang.
+func TestInstallHyctl_DownloadFailureIsReported(t *testing.T) {
+	if !installSupported(runtime.GOOS) {
+		t.Skip("InstallHyctl only runs the installer on macOS/Linux")
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	restoreURL := installScriptURL
+	installScriptURL = ts.URL
+	t.Cleanup(func() { installScriptURL = restoreURL })
+
+	r := New().InstallHyctl()
+	if r.OK {
+		t.Error("OK = true despite the download failing")
+	}
+	if r.Error == "" {
+		t.Error("no Error despite the download failing")
+	}
+}
+
+// A script that runs but exits non-zero (the real install.sh does this on an
+// unsupported OS/arch or a checksum mismatch) must be reported as a failure
+// with whatever it printed before dying, not silently swallowed.
+func TestInstallHyctl_ScriptFailureIsReportedWithLog(t *testing.T) {
+	if !installSupported(runtime.GOOS) {
+		t.Skip("InstallHyctl only runs the installer on macOS/Linux")
+	}
+
+	const script = "#!/bin/sh\necho 'about to fail'\nexit 1\n"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(script))
+	}))
+	defer ts.Close()
+
+	restoreURL := installScriptURL
+	installScriptURL = ts.URL
+	t.Cleanup(func() { installScriptURL = restoreURL })
+
+	withPath(t, t.TempDir())
+	withHyctlSearchDirs(t)
+
+	r := New().InstallHyctl()
+	if r.OK {
+		t.Error("OK = true despite the installer exiting non-zero")
+	}
+	if r.Error == "" {
+		t.Error("no Error despite the installer exiting non-zero")
+	}
+	if r.Log == "" {
+		t.Error("Log is empty; the installer did print before failing")
+	}
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from 'react'
-import { GetDashboard, GetEdits, GetFleet, GetSession, GetVersion } from './bindings'
+import { CheckHyctl, GetDashboard, GetEdits, GetFleet, GetSession, GetVersion } from './bindings'
 import type {
   Dashboard as DashboardData,
   Edit,
   Fleet as FleetData,
+  HyctlStatus,
   Session as SessionData,
   Version,
 } from './types'
@@ -12,6 +13,7 @@ import { Fleet } from './views/Fleet'
 import { Session } from './views/Session'
 import { Code } from './views/Code'
 import { ChatDock } from './views/ChatDock'
+import { SetupBanner } from './views/SetupBanner'
 
 /** Dashboard is retrospective — a slow refresh is enough and costs nothing. */
 const DASHBOARD_MS = 5000
@@ -41,6 +43,7 @@ export default function App() {
   const [edits, setEdits] = useState<Edit[] | null>(null)
   const [version, setVersion] = useState<Version | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [hyctlStatus, setHyctlStatus] = useState<HyctlStatus | null>(null)
 
   const load = useCallback(async (which: ViewID, id: string) => {
     try {
@@ -66,6 +69,15 @@ export default function App() {
   useEffect(() => {
     GetVersion().then(setVersion).catch(() => {
       /* Version is decoration; failing to read it must not blank the window. */
+    })
+  }, [])
+
+  // One-shot, not polled: this is a first-run check (#383), not a live value.
+  // A machine with hyctl already on PATH — the common case — never shows
+  // anything, since the banner below renders only when Found is false.
+  useEffect(() => {
+    CheckHyctl().then(setHyctlStatus).catch(() => {
+      /* Same as GetVersion: decoration, not worth blanking the window over. */
     })
   }, [])
 
@@ -135,6 +147,12 @@ export default function App() {
       </nav>
 
       <main className="main">
+        {/* Non-blocking: it sits above whichever view is open rather than
+            replacing it, and renders nothing at all once hyctl is found. */}
+        {hyctlStatus && !hyctlStatus.found && (
+          <SetupBanner status={hyctlStatus} onChanged={setHyctlStatus} />
+        )}
+
         {/* An error replaces the body but never the shell — a broken read
             should not look like a crashed app. */}
         {error && <div className="error">{error}</div>}

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -229,6 +229,82 @@ body {
   font-size: 12px;
 }
 
+/* ── Setup banner (#383 — hyctl missing) ──────────────────────────────── */
+
+.setup {
+  background: var(--hy-panel);
+  border: 1px solid var(--hy-line);
+  border-left: 3px solid var(--hy-aqua);
+  border-radius: var(--hy-radius);
+  padding: 15px 17px;
+  margin-bottom: 22px;
+}
+
+.setup__head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.setup__title { font-weight: 600; font-size: 14px; }
+
+.setup__dismiss {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--hy-dim);
+  font-size: 17px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 4px;
+}
+.setup__dismiss:hover { color: var(--hy-ink); }
+.setup__dismiss:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 1px; }
+
+.setup__body { margin: 9px 0 0; font-size: 13px; color: var(--hy-dim); line-height: 1.55; }
+.setup__body code {
+  font-family: var(--hy-font-mono);
+  font-size: 12px;
+  background: var(--hy-bg-2);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius-sm);
+  padding: 1px 6px;
+  color: var(--hy-aqua);
+}
+
+.setup__install {
+  appearance: none;
+  margin-top: 12px;
+  border: 0;
+  border-radius: var(--hy-radius-sm);
+  background: var(--hy-aqua);
+  color: var(--hy-bg);
+  font: inherit;
+  font-weight: 600;
+  font-size: 13px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+.setup__install:disabled { opacity: .6; cursor: default; }
+.setup__install:focus-visible { outline: 2px solid var(--hy-ink); outline-offset: 2px; }
+
+.setup__error {
+  margin: 10px 0 0;
+  color: var(--hy-expensive);
+  font-family: var(--hy-font-mono);
+  font-size: 12px;
+}
+
+.setup__log {
+  margin: 10px 0 0;
+  max-height: 160px;
+  overflow-y: auto;
+  background: var(--hy-bg-2);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius-sm);
+  padding: 10px 12px;
+  font-family: var(--hy-font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  color: var(--hy-dim);
+}
+
 /* ── Fleet ─────────────────────────────────────────────────────────────── */
 
 .rail__live {

--- a/desktop/frontend/src/bindings.ts
+++ b/desktop/frontend/src/bindings.ts
@@ -6,7 +6,17 @@
 // harness. Reading the methods off `window.go` at call time — the same object
 // the generated module wraps — keeps the source tree self-contained.
 
-import type { ChatReply, Dashboard, Diff, Edit, Fleet, Session, Version } from './types'
+import type {
+  ChatReply,
+  Dashboard,
+  Diff,
+  Edit,
+  Fleet,
+  HyctlStatus,
+  InstallResult,
+  Session,
+  Version,
+} from './types'
 
 interface WailsGo {
   api: {
@@ -19,6 +29,8 @@ interface WailsGo {
       ChatEnums(): Promise<string[]>
       GetDiff(runID: string, ref: string, file: string): Promise<Diff>
       GetVersion(): Promise<Version>
+      CheckHyctl(): Promise<HyctlStatus>
+      InstallHyctl(): Promise<InstallResult>
     }
   }
 }
@@ -47,3 +59,5 @@ export const Chat = (prompt: string, enumKey: string): Promise<ChatReply> =>
   backend().Chat(prompt, enumKey)
 export const ChatEnums = (): Promise<string[]> => backend().ChatEnums()
 export const GetVersion = (): Promise<Version> => backend().GetVersion()
+export const CheckHyctl = (): Promise<HyctlStatus> => backend().CheckHyctl()
+export const InstallHyctl = (): Promise<InstallResult> => backend().InstallHyctl()

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -176,6 +176,22 @@ export interface Diff {
   removed: number
 }
 
+export interface HyctlStatus {
+  found: boolean
+  path?: string
+  version?: string
+  /** False on platforms InstallHyctl cannot drive (Windows) — see its Go doc. */
+  supported: boolean
+}
+
+export interface InstallResult {
+  ok: boolean
+  version?: string
+  /** The installer's combined stdout/stderr, shown on both success and failure. */
+  log: string
+  error?: string
+}
+
 export interface ChatReply {
   output: string
   head: string

--- a/desktop/frontend/src/views/SetupBanner.tsx
+++ b/desktop/frontend/src/views/SetupBanner.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import { InstallHyctl } from '../bindings'
+import type { HyctlStatus, InstallResult } from '../types'
+
+/**
+ * The one-time first-run prompt for #383: the desktop app can be downloaded
+ * on its own (install-app.sh), which leaves a real gap when hyctl was never
+ * separately installed — every other view already renders safely with zero
+ * ~/.hydra data, but there is nothing to route to at all.
+ *
+ * Invisible on every machine that already has hyctl working, which is the
+ * common case — App only renders this when CheckHyctl says Found is false.
+ */
+export function SetupBanner({
+  status,
+  onChanged,
+}: {
+  status: HyctlStatus
+  onChanged: (next: HyctlStatus) => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<InstallResult | null>(null)
+  const [dismissed, setDismissed] = useState(false)
+
+  if (dismissed) return null
+
+  async function install() {
+    setBusy(true)
+    setResult(null)
+    try {
+      const r = await InstallHyctl()
+      setResult(r)
+      if (r.ok) {
+        onChanged({ found: true, version: r.version, supported: status.supported })
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="setup">
+      <div className="setup__head">
+        <span className="setup__title">
+          {result?.ok ? 'hyctl installed' : 'hyctl is not set up on this machine'}
+        </span>
+        <button className="setup__dismiss" onClick={() => setDismissed(true)} aria-label="Dismiss">
+          ×
+        </button>
+      </div>
+
+      {!result?.ok && (
+        <p className="setup__body">
+          Hydra routes work to <code>hyctl</code>, but it isn't on this machine's PATH yet. Install
+          it and this message won't come back.
+        </p>
+      )}
+
+      {status.supported ? (
+        <button className="setup__install" onClick={() => void install()} disabled={busy || result?.ok}>
+          {busy ? 'Installing…' : result?.ok ? `Installed ${result.version ?? ''}`.trim() : 'Install hyctl'}
+        </button>
+      ) : (
+        <p className="setup__body">
+          Automatic setup covers macOS and Linux. On Windows, run{' '}
+          <code>irm https://raw.githubusercontent.com/ankit373/hydra/main/install.ps1 | iex</code> or{' '}
+          <code>npm install -g hyctl</code>, then relaunch Hydra.
+        </p>
+      )}
+
+      {result && !result.ok && (
+        <p className="setup__error">{result.error || 'Install failed for an unknown reason.'}</p>
+      )}
+
+      {result?.log && (
+        <pre className="setup__log">{result.log}</pre>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

The desktop app is a real, documented standalone install path (`install-app.sh`) that a
first-time user can reach with `hyctl` never installed at all. Every other view already renders
safely with zero `~/.hydra` data (#227) — this is the harder case: there is nothing to route to,
and no CLI to onboard with.

## Design

**Detection — `API.CheckHyctl()`** (`desktop/api/setup.go`)
- `exec.LookPath("hyctl")` first, then a direct `os.Stat` fallback against `install.sh`'s own
  destinations (`/usr/local/bin`, `~/.local/bin`) and `install.ps1`'s (`%LOCALAPPDATA%\Programs\hyctl`).
  The fallback matters: a GUI app launched from Finder/Dock/a desktop file inherits a minimal PATH
  that usually omits both, so immediately after a successful install, a PATH-only check in the
  same process would still report "not found."
- Reads `hyctl --version` for display; failure there is decoration lost, not a reason to report
  hyctl absent.
- `Supported` reports whether `InstallHyctl` can drive this OS, so the frontend can offer a button
  or point at manual instructions instead.

**Setup action — `API.InstallHyctl()`**
- Runs the same curl-installer documented at the repo root (`install.sh`) rather than
  reimplementing platform/arch detection and checksum verification a second time in Go — that
  logic already exists, is shellchecked in CI, and would drift the moment one copy changed
  without the other.
- Differs from the documented `curl -fsSL … | sh` one-liner only in mechanics, not behaviour: it
  fetches the script itself over HTTPS via `net/http` (same TLS validation curl does) and feeds
  the bytes to `/bin/sh` on stdin. That means no shell string is ever built (no injection surface,
  since no user input reaches the command line), and it drops the assumption that curl is even
  installed — which hyctl being absent says nothing about. `/bin/sh` is invoked by absolute path
  for the same PATH-minimalism reason `CheckHyctl`'s fallback exists.
- Captures combined stdout/stderr via `util.Accumulator` (per repo convention) and returns it in
  `InstallResult.Log` on both success and failure, plus the resolved version — "it eventually
  worked" isn't an answer, the installer's own progress lines are.
- **Scope: macOS and Linux only.** Windows ships `install.ps1`, a different installer (`irm | iex`,
  PowerShell execution policy, a distinct install directory and PATH-refresh story). Wiring a
  second code path for it is left as a follow-up rather than blocking this MVP on full platform
  parity — `CheckHyctl`'s detection itself is already cross-platform.

**Frontend**
- `App.tsx` runs `CheckHyctl()` once on load (not polled — this is a first-run signal, not a live
  value) and renders `SetupBanner` only when `Found` is false, so a machine with hyctl already
  working — the common case — shows nothing at all.
- `SetupBanner` (`desktop/frontend/src/views/SetupBanner.tsx`) offers a one-click install with
  busy/success/failure states and the installer's log, or manual instructions when `Supported` is
  false.

## Tests

`desktop/api/setup_test.go` exercises `CheckHyctl`'s PATH and common-dir fallback paths,
`installSupported`'s OS gate, and the full `InstallHyctl` round trip against an `httptest` server
serving a **fake** script — never the real installer, never a real network call to GitHub. Every
test that touches a fixed filesystem path goes through a var-based seam (`hyctlSearchDirs`) so it
can never read or write the developer's real `/usr/local/bin` or `~/.local/bin`. Extended
`dto_test.go` and `firstrun_test.go`'s existing first-run/DTO contracts to cover the two new types.

## Verification

- `go test ./desktop/... -race -count=1`, `gofmt -l .`, `go vet ./...`, `staticcheck ./api/...` —
  all clean.
- `wails build` succeeds; the generated `wailsjs` bindings for `CheckHyctl`/`InstallHyctl` match
  the hand-written frontend mirrors exactly.
- `npm run build` / `npm run typecheck` in `desktop/frontend` — clean.
- Launched the built `.app` against this machine's real, already-installed `hyctl` and confirmed
  it starts clean with **no banner** — the invisible-when-present invariant.
- Could not screenshot a live "not found" banner in this sandboxed session (no accessibility
  permission for window capture, and a blind full-screen capture risked exposing unrelated content
  on the host's real desktop). That path is covered instead by the Go test suite above plus static
  review of the (trivial) conditional render in `App.tsx`.

## Follow-up (not in this PR)
- Windows support for `InstallHyctl` via `install.ps1`.

Closes #383