### PR TITLE
docs: state the real funding need in funding.json

### DIFF
--- a/docs/funding.json
+++ b/docs/funding.json
@@ -45,7 +45,7 @@
         "guid": "sponsor-hydra",
         "status": "active",
         "name": "Sponsor Hydra development",
-        "description": "Recurring or one-time support for Hydra's development — the routing engine, trust control plane, and desktop app.",
+        "description": "Funds the compute and larger benchmark datasets Hydra's trust control plane depends on: running large task sets on a recurring cadence to keep routing-confidence calibration accurate, plus sustaining development pace on the routing engine, trust control plane, and desktop app.",
         "amount": 0,
         "currency": "USD",
         "frequency": "monthly",


### PR DESCRIPTION
## Summary
- Rewrites `plans[0].description` in docs/funding.json from generic boilerplate to the actual need: benchmark compute + larger datasets for the trust control plane's calibration work, run on a recurring cadence, plus development velocity.

## Changes
- `docs/funding.json`

## Test plan
- [x] `python3 -c "import json; json.load(open('docs/funding.json'))"` — valid JSON
- [ ] Confirm live once this reaches main and GitHub Pages redeploys

Closes #405