### PR TITLE
feat(desktop): HUD-style Dashboard — arc gauges, glow chart, skeleton loader, drill-down

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -109,11 +109,11 @@ export default function App() {
     [fleet, runID, openSession],
   )
 
+  // Dashboard handles its own loading state (a skeleton, not this fallback
+  // text) so its first-load window can look like the rest of the view
+  // instead of a plain sentence.
   const loading =
-    (view === 'dashboard' && !dashboard) ||
-    (view === 'fleet' && !fleet) ||
-    (view === 'session' && !session) ||
-    (view === 'code' && !edits)
+    (view === 'fleet' && !fleet) || (view === 'session' && !session) || (view === 'code' && !edits)
 
   return (
     <div className="shell">
@@ -158,7 +158,7 @@ export default function App() {
         {/* An error replaces the body but never the shell — a broken read
             should not look like a crashed app. */}
         {error && <div className="error">{error}</div>}
-        {!error && view === 'dashboard' && dashboard && <Dashboard data={dashboard} />}
+        {!error && view === 'dashboard' && <Dashboard data={dashboard} />}
         {!error && view === 'fleet' && fleet && <Fleet data={fleet} onOpen={openSession} />}
         {!error && view === 'session' && session && (
           <Session session={session} onBack={() => setView('fleet')} />

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -93,6 +93,13 @@ body {
 
 .view__head { margin-bottom: 22px; }
 .view__title { margin: 0; font-size: 24px; letter-spacing: -0.03em; }
+.view__title--brand {
+  background: var(--hy-brand);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
 .view__sub { margin: 5px 0 0; color: var(--hy-dim); font-size: 13px; }
 
 .section__title {
@@ -145,14 +152,50 @@ body {
 .gov--warning  { color: var(--hy-gov-warning); }
 .gov--critical { color: var(--hy-gov-critical); }
 
-.gov__track {
-  margin-top: 10px;
-  height: 4px;
-  border-radius: 2px;
-  background: var(--hy-line);
-  overflow: hidden;
+/* ── Arc gauges (Governor / Trust) ─────────────────────────────────────── */
+/* Replaces the old flat .gov__track/.trust-cmp__track progress bars: an SVG
+   ring whose stroke-dashoffset encodes the fraction, transitioned in CSS so
+   the sweep-in is one property change, not a JS animation loop. */
+
+.arc-wrap { display: flex; flex-direction: column; align-items: center; gap: 8px; margin-top: 8px; }
+.arc-gauge { overflow: visible; }
+.arc-track { stroke: var(--hy-line); fill: none; }
+.arc-fill {
+  fill: none;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 1.1s cubic-bezier(.22, .9, .3, 1);
 }
-.gov__fill { height: 100%; border-radius: 2px; background: currentColor; }
+.arc-fill--baseline { stroke: var(--hy-dim); }
+.arc-fill--actual   { stroke: var(--hy-aqua); }
+.arc-num {
+  font-family: var(--hy-font-mono);
+  font-size: 19px;
+  font-weight: 600;
+  fill: var(--hy-ink);
+}
+.arc-lbl {
+  font-family: var(--hy-font-mono);
+  font-size: 8.5px;
+  fill: var(--hy-dim);
+  letter-spacing: .3px;
+  text-transform: uppercase;
+}
+.arc-legend {
+  display: flex;
+  gap: 14px;
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  color: var(--hy-dim);
+}
+.arc-legend__dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  margin-right: 5px;
+  vertical-align: middle;
+}
+.arc-legend__dot--actual   { background: var(--hy-aqua); }
+.arc-legend__dot--baseline { background: var(--hy-dim); }
 
 /* ── Tables ────────────────────────────────────────────────────────────── */
 
@@ -213,7 +256,21 @@ body {
 .spend-bar { cursor: default; }
 .spend-bar:focus-visible { outline: none; }
 
-.spend-bar__rect { opacity: .82; transition: opacity .12s; }
+/* Bars grow in from a zero baseline the first time real data lands
+   (Dashboard.tsx's `useReveal`) — transform, not height, so it's a single
+   composited property and never triggers layout. transform-box: fill-box
+   makes "bottom" mean the rect's own bottom edge, not the SVG viewport's. */
+.spend-bar__rect,
+.spend-bar__halo {
+  transform-box: fill-box;
+  transform-origin: bottom;
+  transform: scaleY(0);
+  transition: transform .55s cubic-bezier(.22, .9, .3, 1), opacity .12s;
+}
+.spend-bar__rect.grown,
+.spend-bar__halo.grown { transform: scaleY(1); }
+
+.spend-bar__rect { opacity: .82; }
 .spend-bar:hover .spend-bar__rect,
 .spend-bar:focus-visible .spend-bar__rect { opacity: 1; }
 
@@ -221,6 +278,18 @@ body {
 .spend-bar__rect--cheap     { fill: var(--hy-cheap); }
 .spend-bar__rect--mid       { fill: var(--hy-mid); }
 .spend-bar__rect--expensive { fill: var(--hy-expensive); }
+
+/* A larger, lower-opacity rect behind the crisp bar — a layered solid fill,
+   never `filter: blur`/`backdrop-filter`, so the glow rasterizes like any
+   other shape instead of costing a compositor blur pass. */
+.spend-bar__halo { opacity: .22; }
+.spend-bar:hover .spend-bar__halo,
+.spend-bar:focus-visible .spend-bar__halo { opacity: .4; }
+
+.spend-bar__halo--free      { fill: var(--hy-dim); }
+.spend-bar__halo--cheap     { fill: var(--hy-cheap); }
+.spend-bar__halo--mid       { fill: var(--hy-mid); }
+.spend-bar__halo--expensive { fill: var(--hy-expensive); }
 
 .spend-tip { pointer-events: none; }
 .spend-tip__bg { fill: var(--hy-bg-2); stroke: var(--hy-line); }
@@ -280,40 +349,168 @@ body {
 
 .rank__value { font-size: 12px; font-variant-numeric: tabular-nums; white-space: nowrap; }
 
+/* A "by model" row that opens the drill-down drawer (#408) — a <button>
+   wearing .rank__row's grid layout, so it needs its own reset for the
+   browser's default button chrome plus a hover/focus affordance. */
+.rank__row--detail {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  position: relative;
+  padding: 3px 20px 3px 4px;
+  margin: -3px -4px;
+  border-radius: 6px;
+  transition: background .12s;
+}
+.rank__row--detail:hover,
+.rank__row--detail:focus-visible { background: rgba(255, 255, 255, .045); outline: none; }
+.rank__row--detail:focus-visible { box-shadow: 0 0 0 2px var(--hy-aqua) inset; }
+.rank__row--detail::after {
+  content: "\203A";
+  position: absolute; right: 4px; top: 50%;
+  transform: translateY(-50%);
+  color: var(--hy-faint);
+  opacity: 0;
+  transition: opacity .12s, transform .12s;
+}
+.rank__row--detail:hover::after,
+.rank__row--detail:focus-visible::after { opacity: 1; transform: translateY(-50%) translateX(2px); }
+
 /* ── Dashboard: trust comparison bars ──────────────────────────────────── */
 
-.trust-cmp { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; }
+.trust-cmp { margin-top: 2px; display: flex; flex-direction: column; align-items: center; gap: 6px; }
 
-.trust-cmp__row {
-  display: grid;
-  grid-template-columns: 58px 1fr auto;
-  align-items: center;
-  gap: 8px;
-}
-
-.trust-cmp__label {
-  font-family: var(--hy-font-mono);
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: .06em;
-  color: var(--hy-dim);
-}
-
-.trust-cmp__track {
-  height: 8px;
-  border-radius: 4px;
-  background: var(--hy-line);
-  overflow: hidden;
-}
-.trust-cmp__fill { display: block; height: 100%; border-radius: 4px; }
-.trust-cmp__fill--actual   { background: var(--hy-aqua); }
-.trust-cmp__fill--baseline { background: var(--hy-dim); }
-
-.trust-cmp__value { font-size: 12px; font-variant-numeric: tabular-nums; }
-
-.trust-cmp__delta { margin-top: 3px; font-size: 12px; }
+.trust-cmp__delta { margin-top: 3px; font-size: 12px; text-align: center; }
 .trust-cmp__delta--good { color: var(--hy-cheap); }
 .trust-cmp__delta--bad  { color: var(--hy-expensive); }
+
+/* ── Dashboard: HUD chrome ─────────────────────────────────────────────── */
+/* Corner brackets + scanline + vignette, the same frame language as
+   brand/living/hydra-hud.src.html. Fixed to the viewport but mounted only
+   while the Dashboard component is (#408) — a view-scoped instance of the
+   app-wide chrome rather than a shared-shell change. Pure CSS: a scanline is
+   a repeating gradient and the vignette a radial one, never
+   backdrop-filter/blur, matching this app's no-GPU-blur discipline. */
+
+.hud-corner {
+  position: fixed;
+  width: 22px; height: 22px;
+  border: 1px solid rgba(150, 140, 255, .3);
+  z-index: 1;
+  pointer-events: none;
+}
+.hud-corner--tl { top: 16px; left: 16px; border-right: 0; border-bottom: 0; }
+.hud-corner--tr { top: 16px; right: 16px; border-left: 0; border-bottom: 0; }
+.hud-corner--bl { bottom: 16px; left: 16px; border-right: 0; border-top: 0; }
+.hud-corner--br { bottom: 16px; right: 16px; border-left: 0; border-top: 0; }
+
+.hud-scanline {
+  position: fixed; inset: 0; z-index: 1; pointer-events: none;
+  opacity: .3;
+  mix-blend-mode: overlay;
+  background: repeating-linear-gradient(0deg, rgba(255, 255, 255, .035) 0 1px, transparent 1px 3px);
+}
+.hud-vignette {
+  position: fixed; inset: 0; z-index: 1; pointer-events: none;
+  background: radial-gradient(ellipse at 50% 30%, transparent 55%, rgba(2, 3, 9, .65));
+}
+
+/* ── Dashboard: skeleton loader ────────────────────────────────────────── */
+/* Shown while GetDashboard()'s first call is in flight (dashboard === null
+   in App.tsx) — driven by real React state, not a timer. Shimmer via
+   background-position, never filter/blur. */
+
+.skeleton-block {
+  border-radius: 6px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, .05) 25%, rgba(255, 255, 255, .11) 37%, rgba(255, 255, 255, .05) 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.6s ease-in-out infinite;
+}
+@keyframes shimmer {
+  0%   { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+.skeleton-block--chart { width: 100%; height: 160px; }
+
+/* Cross-fades in once the skeleton is replaced by the real content subtree. */
+.dashboard-content { animation: dashboardFadeIn .4s ease; }
+@keyframes dashboardFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Dashboard: drill-down drawer (By model → Breakdown detail) ──────────── */
+
+.drawer-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(2, 3, 9, .55);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .25s ease;
+  z-index: 40;
+}
+.drawer-backdrop--open { opacity: 1; pointer-events: auto; }
+
+.drawer {
+  position: fixed; top: 0; right: 0; bottom: 0;
+  width: min(400px, 92vw);
+  background: var(--hy-bg-2);
+  border-left: 1px solid var(--hy-line);
+  z-index: 41;
+  transform: translateX(100%);
+  transition: transform .32s cubic-bezier(.22, .9, .3, 1);
+  padding: 24px 24px 30px;
+  overflow-y: auto;
+}
+.drawer--open { transform: translateX(0); }
+
+.drawer__close {
+  position: absolute; top: 16px; right: 18px;
+  background: none;
+  border: none;
+  color: var(--hy-dim);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px;
+}
+.drawer__close:hover { color: var(--hy-ink); }
+.drawer__close:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 1px; }
+
+.drawer__title {
+  font-family: var(--hy-font-mono);
+  font-size: 10.5px;
+  color: var(--hy-aqua);
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  margin: 4px 26px 6px 0;
+}
+.drawer__heading { font-size: 18px; font-weight: 600; margin: 0 0 16px; letter-spacing: -.01em; }
+.drawer__stat { font-size: 30px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.drawer__lbl {
+  font-family: var(--hy-font-mono);
+  font-size: 9.5px;
+  color: var(--hy-dim);
+  text-transform: uppercase;
+  letter-spacing: .8px;
+  margin-top: 3px;
+}
+.drawer__list { margin-top: 14px; display: flex; flex-direction: column; gap: 7px; }
+.drawer__list-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  font-family: var(--hy-font-mono);
+  font-size: 12px;
+  padding: 8px 10px;
+  background: rgba(255, 255, 255, .03);
+  border-radius: 6px;
+}
 
 /* ── Empty / error states ──────────────────────────────────────────────── */
 
@@ -952,4 +1149,21 @@ body {
   font-size: 10px;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+/* ── Reduced motion ────────────────────────────────────────────────────── */
+/* The Dashboard's reveal state (useReveal in reveal.ts) still flips
+   instantly under reduced motion — these rules just stop it from being
+   animated on the way there. */
+@media (prefers-reduced-motion: reduce) {
+  .spend-bar__rect,
+  .spend-bar__halo,
+  .arc-fill,
+  .drawer,
+  .drawer-backdrop,
+  .rank__row--detail::after {
+    transition: none;
+  }
+  .skeleton-block { animation: none; }
+  .dashboard-content { animation: none; }
 }

--- a/desktop/frontend/src/reveal.ts
+++ b/desktop/frontend/src/reveal.ts
@@ -1,0 +1,77 @@
+// Shared entrance-animation primitives for the Dashboard's HUD treatment:
+// arc gauges sweeping in, bars growing from a zero baseline, numbers counting
+// up. All three need the same two things — "has real data arrived" and
+// "should motion play at all" — so they live here once instead of three
+// times.
+
+import { useEffect, useRef, useState } from 'react'
+
+export function prefersReducedMotion(): boolean {
+  return typeof matchMedia === 'function' && matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+/**
+ * Flips from false to true once, the first time `ready` becomes true —
+ * never again after, so a 5s dashboard poll that keeps `ready` true doesn't
+ * replay the entrance on every refresh. Two rAFs after mount so the browser
+ * paints the pre-reveal state first; a CSS transition needs that or it never
+ * animates. Skips straight to true under reduced motion — the caller's CSS
+ * still owns removing the transition itself.
+ */
+export function useReveal(ready: boolean): boolean {
+  const [revealed, setRevealed] = useState(false)
+  const firedRef = useRef(false)
+
+  useEffect(() => {
+    if (!ready || firedRef.current) return
+    firedRef.current = true
+    if (prefersReducedMotion()) {
+      setRevealed(true)
+      return
+    }
+    const raf1 = requestAnimationFrame(() => {
+      requestAnimationFrame(() => setRevealed(true))
+    })
+    return () => cancelAnimationFrame(raf1)
+  }, [ready])
+
+  return revealed
+}
+
+/** Eases 0→1 like the reveal sweep (cubic ease-out), for count-up numbers. */
+function easeOutCubic(p: number): number {
+  return 1 - Math.pow(1 - p, 3)
+}
+
+/**
+ * Counts up to `target` the first time `revealed` flips true. Reports 0
+ * before that, so a stat card never flashes its final value ahead of the
+ * reveal. Later changes to `target` (the next 5s poll landing a new number)
+ * snap straight to the new value instead of re-running the count-up — the
+ * animation is an arrival effect, not something to replay on every refresh.
+ */
+export function useCountUp(target: number, revealed: boolean, durationMs = 900): number {
+  const [value, setValue] = useState(0)
+  const animatedRef = useRef(false)
+
+  useEffect(() => {
+    if (!revealed) return
+    if (animatedRef.current || prefersReducedMotion()) {
+      animatedRef.current = true
+      setValue(target)
+      return
+    }
+    animatedRef.current = true
+    let raf = 0
+    const t0 = performance.now()
+    const step = (t: number) => {
+      const p = Math.min(1, (t - t0) / durationMs)
+      setValue(target * easeOutCubic(p))
+      if (p < 1) raf = requestAnimationFrame(step)
+    }
+    raf = requestAnimationFrame(step)
+    return () => cancelAnimationFrame(raf)
+  }, [revealed, target, durationMs])
+
+  return value
+}

--- a/desktop/frontend/src/tokens.css
+++ b/desktop/frontend/src/tokens.css
@@ -14,6 +14,7 @@
   /* ── Ink ── */
   --hy-ink:       #E7E9F5;              /* primary text */
   --hy-dim:       #9AA0C4;              /* secondary text / labels */
+  --hy-faint:     #525A80;              /* de-emphasized meta (chart ranges, HUD chrome) */
 
   /* ── Brand gradient (the logo) — cyan → violet → magenta ── */
   --hy-cyan:      #2AF0E0;              /* gradient start · center head */

--- a/desktop/frontend/src/views/Dashboard.tsx
+++ b/desktop/frontend/src/views/Dashboard.tsx
@@ -1,14 +1,100 @@
+import { useEffect, useRef, useState } from 'react'
 import type { Breakdown, Dashboard as DashboardData, TrustPanel } from '../types'
-import { clockTime, costBand, govBand, ms, pct, usd, usdExact } from '../format'
-import { Sparkline, SpendTrend } from './DashboardCharts'
+import { clockTime, costBand, govBand, ms, pct, tokens, usd, usdExact } from '../format'
+import { ArcGauge, Sparkline, SpendTrend, TrustArc } from './DashboardCharts'
+import { useCountUp, useReveal } from '../reveal'
 
-export function Dashboard({ data }: { data: DashboardData }) {
+/**
+ * `data` is null until App.tsx's first `GetDashboard()` resolves — the
+ * skeleton below covers exactly that window, driven by real state rather
+ * than a fake timeout. Once data lands the HUD chrome (corner brackets,
+ * scanline, vignette) stays mounted for the lifetime of the view; only the
+ * body swaps from skeleton to `DashboardContent`.
+ */
+export function Dashboard({ data }: { data: DashboardData | null }) {
   return (
     <>
-      <header className="view__head">
-        <h1 className="view__title">Dashboard</h1>
-        <p className="view__sub">Spend, governor pressure, and the trust ensemble's record.</p>
-      </header>
+      <HudChrome />
+      {data ? <DashboardContent data={data} /> : <DashboardSkeleton />}
+    </>
+  )
+}
+
+/** Corner brackets, scanline, vignette — brand/living/hydra-hud.src.html's
+ * frame language, scoped to this view rather than the shared app shell. */
+function HudChrome() {
+  return (
+    <>
+      <div className="hud-corner hud-corner--tl" aria-hidden="true" />
+      <div className="hud-corner hud-corner--tr" aria-hidden="true" />
+      <div className="hud-corner hud-corner--bl" aria-hidden="true" />
+      <div className="hud-corner hud-corner--br" aria-hidden="true" />
+      <div className="hud-scanline" aria-hidden="true" />
+      <div className="hud-vignette" aria-hidden="true" />
+    </>
+  )
+}
+
+function DashboardHeader() {
+  return (
+    <header className="view__head">
+      <h1 className="view__title view__title--brand">Dashboard</h1>
+      <p className="view__sub">Spend, governor pressure, and the trust ensemble's record.</p>
+    </header>
+  )
+}
+
+function DashboardSkeleton() {
+  return (
+    <>
+      <DashboardHeader />
+      <div className="cards">
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+      <section>
+        <h2 className="section__title">Spend by day</h2>
+        <div className="spend-chart">
+          <div className="skeleton-block skeleton-block--chart" />
+        </div>
+      </section>
+    </>
+  )
+}
+
+function SkeletonCard() {
+  return (
+    <div className="card">
+      <div className="skeleton-block" style={{ width: '50%', height: 10 }} />
+      <div className="skeleton-block" style={{ width: '72%', height: 27, marginTop: 11 }} />
+      <div className="skeleton-block" style={{ width: '85%', height: 12, marginTop: 9 }} />
+    </div>
+  )
+}
+
+function DashboardContent({ data }: { data: DashboardData }) {
+  const [drawerRow, setDrawerRow] = useState<Breakdown | null>(null)
+  const [drawerOpen, setDrawerOpen] = useState(false)
+
+  const openDrawer = (row: Breakdown) => {
+    setDrawerRow(row)
+    setDrawerOpen(true)
+  }
+  const closeDrawer = () => setDrawerOpen(false)
+
+  useEffect(() => {
+    if (!drawerOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeDrawer()
+    }
+    addEventListener('keydown', onKey)
+    return () => removeEventListener('keydown', onKey)
+  }, [drawerOpen])
+
+  return (
+    <div className="dashboard-content">
+      <DashboardHeader />
 
       <div className="cards">
         <SpendCard data={data} />
@@ -16,13 +102,18 @@ export function Dashboard({ data }: { data: DashboardData }) {
         <TrustCard data={data} />
       </div>
 
-      {data.hasData ? <Breakdowns data={data} /> : <EmptyState />}
-    </>
+      {data.hasData ? <Breakdowns data={data} onSelectModel={openDrawer} /> : <EmptyState />}
+
+      <ModelDetailDrawer row={drawerRow} open={drawerOpen} onClose={closeDrawer} />
+    </div>
   )
 }
 
 function SpendCard({ data }: { data: DashboardData }) {
   const { spend, hasData, byDay } = data
+  const revealed = useReveal(hasData)
+  const displaySpend = useCountUp(spend.todayUsd, revealed)
+
   if (!hasData) {
     return (
       <div className="card">
@@ -35,7 +126,7 @@ function SpendCard({ data }: { data: DashboardData }) {
   return (
     <div className="card">
       <div className="card__label">Spend today</div>
-      <div className="card__value">{usd(spend.todayUsd)}</div>
+      <div className="card__value">{usd(displaySpend)}</div>
       <div className="card__note">
         {spend.todayCalls} call{spend.todayCalls === 1 ? '' : 's'} · {usd(spend.allTimeUsd)} all time
         {' · '}
@@ -50,6 +141,9 @@ function SpendCard({ data }: { data: DashboardData }) {
 
 function GovernorCard({ data }: { data: DashboardData }) {
   const { governor } = data
+  const revealed = useReveal(governor.known)
+  const displayPct = useCountUp(governor.pct, revealed)
+
   if (!governor.known) {
     return (
       <div className="card">
@@ -64,9 +158,14 @@ function GovernorCard({ data }: { data: DashboardData }) {
   return (
     <div className={`card gov--${band}`}>
       <div className="card__label">Orchestrator context</div>
-      <div className="card__value">{pct(governor.pct)}</div>
-      <div className="gov__track">
-        <div className="gov__fill" style={{ width: `${Math.min(governor.pct, 100)}%` }} />
+      <div className="arc-wrap">
+        <ArcGauge
+          fraction={Math.min(governor.pct, 100) / 100}
+          color={`var(--hy-gov-${band})`}
+          centerValue={`${Math.round(displayPct)}%`}
+          centerLabel={governor.mode}
+          revealed={revealed}
+        />
       </div>
       <div className="card__note">mode: {governor.mode}</div>
     </div>
@@ -75,6 +174,8 @@ function GovernorCard({ data }: { data: DashboardData }) {
 
 function TrustCard({ data }: { data: DashboardData }) {
   const { trust } = data
+  const revealed = useReveal(trust.runs > 0)
+
   if (trust.runs === 0) {
     return (
       <div className="card">
@@ -89,8 +190,7 @@ function TrustCard({ data }: { data: DashboardData }) {
   return (
     <div className="card">
       <div className="card__label">Trust ensemble</div>
-      <div className="card__value">{trust.meanSamples.toFixed(2)}</div>
-      <TrustCompare trust={trust} />
+      <TrustCompare trust={trust} revealed={revealed} />
       <div className="card__note">
         {trust.runs} run{trust.runs === 1 ? '' : 's'}
       </div>
@@ -98,32 +198,24 @@ function TrustCard({ data }: { data: DashboardData }) {
   )
 }
 
-/** SPRT mean samples vs. a fixed-N swarm, same axis, so the saving reads at a
+/** SPRT mean samples vs. a fixed-N swarm, same ring, so the saving reads at a
  * glance instead of as a sentence to parse. */
-function TrustCompare({ trust }: { trust: TrustPanel }) {
-  const max = Math.max(trust.meanSamples, trust.fixedSwarmN, 1)
+function TrustCompare({ trust, revealed }: { trust: TrustPanel; revealed: boolean }) {
   const saved = trust.samplesSavedPct >= 0
   return (
     <div className="trust-cmp">
-      <div className="trust-cmp__row">
-        <span className="trust-cmp__label">SPRT</span>
-        <span className="trust-cmp__track">
-          <span
-            className="trust-cmp__fill trust-cmp__fill--actual"
-            style={{ width: `${(trust.meanSamples / max) * 100}%` }}
-          />
-        </span>
-        <span className="trust-cmp__value">{trust.meanSamples.toFixed(2)}</span>
-      </div>
-      <div className="trust-cmp__row">
-        <span className="trust-cmp__label">Fixed-{trust.fixedSwarmN}</span>
-        <span className="trust-cmp__track">
-          <span
-            className="trust-cmp__fill trust-cmp__fill--baseline"
-            style={{ width: `${(trust.fixedSwarmN / max) * 100}%` }}
-          />
-        </span>
-        <span className="trust-cmp__value">{trust.fixedSwarmN}</span>
+      <div className="arc-wrap">
+        <TrustArc meanSamples={trust.meanSamples} fixedSwarmN={trust.fixedSwarmN} revealed={revealed} />
+        <div className="arc-legend">
+          <span>
+            <span className="arc-legend__dot arc-legend__dot--actual" />
+            what it actually took
+          </span>
+          <span>
+            <span className="arc-legend__dot arc-legend__dot--baseline" />
+            fixed panel of {trust.fixedSwarmN}
+          </span>
+        </div>
       </div>
       <div className={`trust-cmp__delta ${saved ? 'trust-cmp__delta--good' : 'trust-cmp__delta--bad'}`}>
         {saved
@@ -134,7 +226,13 @@ function TrustCompare({ trust }: { trust: TrustPanel }) {
   )
 }
 
-function Breakdowns({ data }: { data: DashboardData }) {
+function Breakdowns({
+  data,
+  onSelectModel,
+}: {
+  data: DashboardData
+  onSelectModel: (row: Breakdown) => void
+}) {
   return (
     <>
       {data.byDay && data.byDay.length > 0 && (
@@ -144,7 +242,7 @@ function Breakdowns({ data }: { data: DashboardData }) {
         </section>
       )}
       <div className="grid-2">
-        <RankedBars title="By model" rows={data.byModel} />
+        <RankedBars title="By model · click a row for detail" rows={data.byModel} onSelect={onSelectModel} />
         <RankedBars title="By tier" rows={data.byTier} />
       </div>
       <RecentTable data={data} />
@@ -153,8 +251,18 @@ function Breakdowns({ data }: { data: DashboardData }) {
 }
 
 /** A ranked horizontal bar list: name, a proportional bar, and the exact
- * dollar amount — replaces the plain by-model/by-tier tables. */
-function RankedBars({ title, rows }: { title: string; rows: Breakdown[] | null }) {
+ * dollar amount — replaces the plain by-model/by-tier tables. Passing
+ * `onSelect` turns each row into a button that opens the drill-down drawer
+ * (used for "By model" only — one list is enough to prove the pattern out). */
+function RankedBars({
+  title,
+  rows,
+  onSelect,
+}: {
+  title: string
+  rows: Breakdown[] | null
+  onSelect?: (row: Breakdown) => void
+}) {
   if (!rows || rows.length === 0) return null
   const max = Math.max(...rows.map((r) => r.costUsd))
   return (
@@ -167,8 +275,8 @@ function RankedBars({ title, rows }: { title: string; rows: Breakdown[] | null }
             // A day with only free/local calls still gets a sliver: present,
             // just not comparable to anything on this ramp.
             const widthPct = max > 0 ? (r.costUsd / max) * 100 : r.calls > 0 ? 4 : 0
-            return (
-              <div className="rank__row" key={r.key}>
+            const inner = (
+              <>
                 <span className="rank__name" title={r.key}>
                   {r.key}
                 </span>
@@ -179,12 +287,98 @@ function RankedBars({ title, rows }: { title: string; rows: Breakdown[] | null }
                   />
                 </span>
                 <span className={`rank__value cost--${band}`}>{usdExact(r.costUsd)}</span>
+              </>
+            )
+            return onSelect ? (
+              <button
+                key={r.key}
+                type="button"
+                className="rank__row rank__row--detail"
+                onClick={() => onSelect(r)}
+              >
+                {inner}
+              </button>
+            ) : (
+              <div className="rank__row" key={r.key}>
+                {inner}
               </div>
             )
           })}
         </div>
       </div>
     </section>
+  )
+}
+
+/** Slide-in detail panel for a "By model" row — the exact Breakdown fields
+ * GetDashboard already computes (Calls/PromptTokens/ResponseTokens/CostUSD/
+ * WallMS), not a stub. `row` is kept around after close so the panel doesn't
+ * blank out mid-slide-out; `open` alone drives the transform. */
+function ModelDetailDrawer({
+  row,
+  open,
+  onClose,
+}: {
+  row: Breakdown | null
+  open: boolean
+  onClose: () => void
+}) {
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (open) closeRef.current?.focus()
+  }, [open])
+
+  return (
+    <>
+      <div
+        className={`drawer-backdrop${open ? ' drawer-backdrop--open' : ''}`}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <aside
+        className={`drawer${open ? ' drawer--open' : ''}`}
+        role="dialog"
+        aria-label="Model detail"
+        aria-hidden={!open}
+      >
+        <button
+          ref={closeRef}
+          className="drawer__close"
+          onClick={onClose}
+          aria-label="Close"
+          tabIndex={open ? 0 : -1}
+        >
+          &times;
+        </button>
+        {row && (
+          <>
+            <div className="drawer__title">Breakdown · by model</div>
+            <h2 className="drawer__heading">{row.key}</h2>
+            <div className="drawer__stat">{usdExact(row.costUsd)}</div>
+            <div className="drawer__lbl">total cost</div>
+            <div className="drawer__list">
+              <div className="drawer__list-row">
+                <span>Calls</span>
+                <span>{row.calls}</span>
+              </div>
+              <div className="drawer__list-row">
+                <span>Prompt tokens</span>
+                <span>{tokens(row.promptTokens)}</span>
+              </div>
+              <div className="drawer__list-row">
+                <span>Response tokens</span>
+                <span>{tokens(row.responseTokens)}</span>
+              </div>
+              <div className="drawer__list-row">
+                <span>Wall time</span>
+                <span>{ms(row.wallMs)}</span>
+              </div>
+            </div>
+          </>
+        )}
+      </aside>
+    </>
   )
 }
 

--- a/desktop/frontend/src/views/DashboardCharts.tsx
+++ b/desktop/frontend/src/views/DashboardCharts.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import type { Breakdown } from '../types'
 import { costBand, usd } from '../format'
+import { useReveal } from '../reveal'
 
 const BAR_W = 16
 const GAP = 8
@@ -8,6 +9,8 @@ const CHART_H = 160
 // Reserves room above the tallest bar for the hover tooltip, so it never
 // clips off the top of the chart.
 const TOP_PAD = 34
+// How far the halo extends past the crisp bar it sits behind, on each edge.
+const HALO_PAD = 3
 
 interface Bar {
   key: string
@@ -24,10 +27,18 @@ interface Bar {
  * then plain SVG primitives render them, styled via tokens.css. Bars pick up
  * the existing cost ramp (free/cheap/mid/expensive) so an expensive day reads
  * as red without a legend.
+ *
+ * Each bar is drawn as a halo (larger, low-opacity, same band color) behind a
+ * crisp full-opacity rect — a layered solid fill, never `filter: blur` or
+ * `backdrop-filter`, so the glow rasterizes like any other shape instead of
+ * costing a compositor blur pass. Bars grow in from a zero baseline
+ * (`transform: scaleY`) the first time real data lands, staggered per bar;
+ * `useReveal` makes that fire once per arrival, not on every 5s poll tick.
  */
 export function SpendTrend({ days }: { days: Breakdown[] }) {
   const [hover, setHover] = useState<number | null>(null)
   const { bars, width } = useMemo(() => layout(days), [days])
+  const revealed = useReveal(bars.length > 0)
 
   if (bars.length === 0) return null
 
@@ -49,12 +60,22 @@ export function SpendTrend({ days }: { days: Breakdown[] }) {
             onBlur={() => setHover(null)}
           >
             <rect
+              x={b.x - HALO_PAD}
+              y={CHART_H - b.barH - HALO_PAD}
+              width={BAR_W + HALO_PAD * 2}
+              height={b.barH + HALO_PAD}
+              rx={5}
+              className={`spend-bar__halo spend-bar__halo--${b.band}${revealed ? ' grown' : ''}`}
+              style={revealed ? { transitionDelay: `${Math.min(i * 12, 220)}ms` } : undefined}
+            />
+            <rect
               x={b.x}
               y={CHART_H - b.barH}
               width={BAR_W}
               height={b.barH}
               rx={2}
-              className={`spend-bar__rect spend-bar__rect--${b.band}`}
+              className={`spend-bar__rect spend-bar__rect--${b.band}${revealed ? ' grown' : ''}`}
+              style={revealed ? { transitionDelay: `${Math.min(i * 12, 220)}ms` } : undefined}
             />
           </g>
         ))}
@@ -138,6 +159,125 @@ export function Sparkline({ days }: { days: Breakdown[] }) {
         fill="none"
       />
       <circle className="spend-spark__dot" cx={last[0]} cy={last[1]} r={2.5} />
+    </svg>
+  )
+}
+
+// ── arc gauges ───────────────────────────────────────────────────────────
+// Replace the flat progress bars on GovernorCard/TrustCard with SVG rings:
+// an outer track, and a fill ring whose stroke-dasharray/dashoffset encode
+// the fraction — animated purely in CSS (tokens.css's `.arc-fill` transition)
+// so the sweep-in is a single reflow-free property change, not a JS loop.
+
+const ARC_SIZE = 112
+const ARC_CENTER = ARC_SIZE / 2
+const ARC_R = 44
+const ARC_STROKE = 8
+const ARC_R_INNER = 33
+const ARC_STROKE_INNER = 5
+
+function arcDash(r: number, frac: number): { circumference: number; offset: number } {
+  const circumference = 2 * Math.PI * r
+  const clamped = Math.max(0, Math.min(1, frac))
+  return { circumference, offset: circumference * (1 - clamped) }
+}
+
+/** Single-ring gauge — Governor's context-window pressure. */
+export function ArcGauge({
+  fraction,
+  color,
+  centerValue,
+  centerLabel,
+  revealed,
+}: {
+  /** 0–1, already clamped by the caller. */
+  fraction: number
+  color: string
+  centerValue: string
+  centerLabel: string
+  revealed: boolean
+}) {
+  const { circumference, offset } = arcDash(ARC_R, revealed ? fraction : 0)
+  return (
+    <svg
+      className="arc-gauge"
+      width={ARC_SIZE}
+      height={ARC_SIZE}
+      viewBox={`0 0 ${ARC_SIZE} ${ARC_SIZE}`}
+      role="img"
+      aria-label={`${centerLabel}: ${centerValue}`}
+    >
+      <circle className="arc-track" cx={ARC_CENTER} cy={ARC_CENTER} r={ARC_R} strokeWidth={ARC_STROKE} />
+      <circle
+        className="arc-fill"
+        cx={ARC_CENTER}
+        cy={ARC_CENTER}
+        r={ARC_R}
+        strokeWidth={ARC_STROKE}
+        stroke={color}
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        transform={`rotate(-90 ${ARC_CENTER} ${ARC_CENTER})`}
+      />
+      <text x={ARC_CENTER} y={ARC_CENTER - 3} textAnchor="middle" className="arc-num">
+        {centerValue}
+      </text>
+      <text x={ARC_CENTER} y={ARC_CENTER + 14} textAnchor="middle" className="arc-lbl">
+        {centerLabel}
+      </text>
+    </svg>
+  )
+}
+
+/** Dual-ring gauge — SPRT mean samples (outer, aqua) vs. a fixed swarm (inner, dim), both scaled to the larger of the two so the comparison reads directly off the rings. */
+export function TrustArc({
+  meanSamples,
+  fixedSwarmN,
+  revealed,
+}: {
+  meanSamples: number
+  fixedSwarmN: number
+  revealed: boolean
+}) {
+  const max = Math.max(meanSamples, fixedSwarmN, 1)
+  const outer = arcDash(ARC_R, revealed ? meanSamples / max : 0)
+  const inner = arcDash(ARC_R_INNER, revealed ? fixedSwarmN / max : 0)
+  return (
+    <svg
+      className="arc-gauge"
+      width={ARC_SIZE}
+      height={ARC_SIZE}
+      viewBox={`0 0 ${ARC_SIZE} ${ARC_SIZE}`}
+      role="img"
+      aria-label={`${meanSamples.toFixed(2)} samples asked on average, versus a fixed panel of ${fixedSwarmN}`}
+    >
+      <circle className="arc-track" cx={ARC_CENTER} cy={ARC_CENTER} r={ARC_R} strokeWidth={ARC_STROKE} />
+      <circle
+        className="arc-fill arc-fill--baseline"
+        cx={ARC_CENTER}
+        cy={ARC_CENTER}
+        r={ARC_R_INNER}
+        strokeWidth={ARC_STROKE_INNER}
+        strokeDasharray={inner.circumference}
+        strokeDashoffset={inner.offset}
+        transform={`rotate(-90 ${ARC_CENTER} ${ARC_CENTER})`}
+      />
+      <circle
+        className="arc-fill arc-fill--actual"
+        cx={ARC_CENTER}
+        cy={ARC_CENTER}
+        r={ARC_R}
+        strokeWidth={ARC_STROKE}
+        strokeDasharray={outer.circumference}
+        strokeDashoffset={outer.offset}
+        transform={`rotate(-90 ${ARC_CENTER} ${ARC_CENTER})`}
+      />
+      <text x={ARC_CENTER} y={ARC_CENTER - 3} textAnchor="middle" className="arc-num">
+        {meanSamples.toFixed(2)}
+      </text>
+      <text x={ARC_CENTER} y={ARC_CENTER + 14} textAnchor="middle" className="arc-lbl">
+        avg asked
+      </text>
     </svg>
   )
 }


### PR DESCRIPTION
## Summary

Ports the validated HUD mockup's *visual and interaction design* into the real React/TypeScript Dashboard — real `GetDashboard()` data and proper React state throughout, not the mockup's vanilla-JS/simulated-data implementation.

### In scope (all six items from #408)

1. **HUD chrome** — corner brackets, scanline, vignette, gradient-text heading (`brand/living/hydra-hud.src.html`'s frame language). Scoped to the Dashboard view (fixed overlay, mounted only while `Dashboard` is): a Dashboard-scoped implementation rather than an app-shell refactor, per the issue's guidance when that question is ambiguous.
2. **Arc gauges** — SVG circle + `stroke-dasharray`/`stroke-dashoffset`, swept in via a CSS transition — replace the flat `.gov__track`/`.trust-cmp__track` bars on `GovernorCard` and `TrustCard`. Same underlying data/logic (`govBand`, the SPRT-vs-fixed-swarm comparison) — visual swap only.
3. **Glow hero chart** — `SpendTrend`'s bars now draw a halo (larger, lower-opacity, same cost-band color) behind the crisp bar: a solid layered fill, never `blur`/`backdrop-filter`.
4. **Real skeleton loader** — `Dashboard` now takes `data: DashboardData | null`; while `App.tsx`'s first `GetDashboard()` is in flight it renders a shimmer skeleton (CSS `background-position`, no timeout), then cross-fades to content once data lands.
5. **Reveal transitions** — bars grow in (`scaleY(0)→1`), arcs sweep, the spend/governor numbers count up, all firing once per real arrival via a new `useReveal`/`useCountUp` pair (`reveal.ts`), not on every 5s poll. Collapses to the final state under `prefers-reduced-motion`.
6. **Click-to-drill-down** — "By model" rows are now buttons that open a slide-in drawer with that row's full `Breakdown` (`Calls`/`PromptTokens`/`ResponseTokens`/`CostUSD`/`WallMS`) — real data already returned by `GetDashboard`, no stub.

### Explicitly deferred (separate follow-up issues, not built here)
- The mockup's simulated live routing log (fake dispatch events on a timer) — a demo flourish over fabricated data.
- The mockup's five other panel categories (calibration leaderboard, blast-radius, optimal parallelism, budget risk, ledger safety, capability leaderboard) — these need new backend Go methods that don't exist yet.

## Changes
- `desktop/frontend/src/reveal.ts` — new: `useReveal` (fires once per data arrival, reduced-motion aware) and `useCountUp` (count-up-once-then-snap on later updates).
- `desktop/frontend/src/views/DashboardCharts.tsx` — `ArcGauge`/`TrustArc` components; `SpendTrend` gets the halo layer + grow-in reveal.
- `desktop/frontend/src/views/Dashboard.tsx` — HUD chrome, skeleton state, arc-gauge wiring, drill-down drawer.
- `desktop/frontend/src/App.tsx` — passes `dashboard` (possibly `null`) straight to `Dashboard`; the generic "Reading logs…" fallback no longer covers the dashboard view.
- `desktop/frontend/src/app.css`, `tokens.css` — new styles + one new token (`--hy-faint`, already used by the mockup's de-emphasis text); dead `.gov__track`/`.trust-cmp__track` CSS removed.

## Test plan
- [x] `cd desktop/frontend && npm run build` (tsc + vite) — clean
- [x] `go test ./desktop/...` — passes, including `firstrun_test.go`'s empty-state contract (`desktop/api` untouched)
- [x] `go build`/`go vet`/`go test -race` on the `desktop` module — clean
- [x] No GUI available in this environment for `wails dev`. In its place: rendered `Dashboard` via `react-dom/server` for all three states (loading/empty/populated) against realistic mock data, plus 17 structural assertions (arc radii/classes, halo classes, by-model rows are buttons vs by-tier rows are plain divs, drawer starts closed, skeleton present only while loading) — all passing, no render exceptions.

Closes #408