### PR TITLE
fix(desktop): Fleet still looked empty — filter zero-agent ghost runs

### DIFF
--- a/desktop/api/fleet.go
+++ b/desktop/api/fleet.go
@@ -119,8 +119,20 @@ func (a *API) GetFleet() (*Fleet, error) {
 		if r.Live {
 			f.LiveCount++
 		}
+		// A finished run with zero agents and no error carries no information —
+		// dispatch never reached a head, most commonly a --dry-run preview
+		// (before #390 fixed dry-run writing these in the first place; this
+		// machine's own history still has 16 of them from before that fix).
+		// Sorted live-first-then-most-recent, a pile of these outranks real
+		// history and makes Fleet look empty even when hasRuns is technically
+		// true. A live run is never filtered — it may not have picked a head
+		// yet, and it is the one the user opened the app to watch.
+		if !r.Live && r.AllCount == 0 && r.Error == "" {
+			continue
+		}
 		f.Runs = append(f.Runs, r)
 	}
+	f.HasRuns = len(f.Runs) > 0
 
 	// Live first, then most recent. Run ids are timestamp-prefixed, so a
 	// reverse lexical compare is a reverse chronological one — no parsing, and

--- a/desktop/api/fleet_test.go
+++ b/desktop/api/fleet_test.go
@@ -274,6 +274,92 @@ func TestGetFleet_MalformedLinesAreSurfacedNotHidden(t *testing.T) {
 	}
 }
 
+// A finished, non-live run with zero agents and no error carries no
+// information — before #390, --dry-run wrote exactly this shape to the
+// runlog. Once real machines accumulate enough of these (sorted
+// live-first-then-newest, so they outrank real history), Fleet looks empty
+// even though HasRuns is technically true. #390 stopped writing new ones;
+// this is the other half — don't surface the ones already on disk either.
+func TestGetFleet_ZeroAgentGhostRunsAreFilteredOut(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T090000Z-ghost",
+		runlog.Event{Kind: runlog.KindRunStarted},
+		runlog.Event{Kind: runlog.KindRunFinished},
+	)
+	writeRun(t, "20260802T100000Z-real",
+		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"},
+		runlog.Event{Kind: runlog.KindDispatchFinished, Head: "h", Status: "ok"},
+	)
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := runByID(f, "20260802T090000Z-ghost"); r != nil {
+		t.Error("a finished, zero-agent, error-free run was not filtered out")
+	}
+	if r := runByID(f, "20260802T100000Z-real"); r == nil {
+		t.Error("the real run was dropped along with the ghost")
+	}
+	if len(f.Runs) != 1 {
+		t.Errorf("len(Runs) = %d, want 1 (ghost filtered, real kept)", len(f.Runs))
+	}
+}
+
+// A machine whose only history is dry-run ghosts must still get the honest
+// "no runs yet" empty state, not a blank list with no explanation — the
+// exact failure this filter would otherwise reintroduce.
+func TestGetFleet_AllGhostRunsStillShowHonestEmptyState(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T090000Z-ghost1",
+		runlog.Event{Kind: runlog.KindRunStarted},
+		runlog.Event{Kind: runlog.KindRunFinished},
+	)
+	writeRun(t, "20260802T100000Z-ghost2",
+		runlog.Event{Kind: runlog.KindRunStarted},
+		runlog.Event{Kind: runlog.KindRunFinished},
+	)
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.HasRuns {
+		t.Error("HasRuns = true with every run filtered out — the view would render a blank list with no explanation")
+	}
+	if len(f.Runs) != 0 {
+		t.Errorf("len(Runs) = %d, want 0", len(f.Runs))
+	}
+}
+
+// A live run must never be filtered even with zero agents so far — it may
+// not have picked a head yet, and it is the one the user opened the app to
+// watch. A run with a read error must never be filtered either — the error
+// itself is the information (see TestGetFleet_MalformedLinesAreSurfacedNotHidden
+// for the read-error case; this covers the live case).
+func TestGetFleet_LiveZeroAgentRunIsNeverFiltered(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-justStarted",
+		runlog.Event{Kind: runlog.KindRunStarted},
+	)
+	markLive(t, "20260802T100000Z-justStarted")
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := runByID(f, "20260802T100000Z-justStarted")
+	if r == nil {
+		t.Fatal("a live run with zero agents so far was filtered out")
+	}
+	if !r.Live {
+		t.Error("run is not marked live")
+	}
+}
+
 // Reading the fleet holds no state and must be safe to poll from several places
 // at once, as the frontend does.
 func TestGetFleet_ConcurrentCallsAreSafe(t *testing.T) {


### PR DESCRIPTION
## Summary
Found live, on the actual RC3 build, running on a real machine: Fleet still
looked empty after #390. Root cause — #390 stopped *writing* new zero-agent
ghost runs (from `--dry-run`), but did nothing about the ones already on
disk. This machine had 16 of 17 run-log files as pre-#390 ghosts, sorted
above the one run with real content.

## Fix
`GetFleet` now drops a run that's finished, has zero agents, and has no read
error. Live runs are never filtered (may not have picked a head yet — it's
the one being watched). Read-error runs are never filtered (the error is
the information). `HasRuns` is recomputed post-filter so an all-ghost
machine still gets the honest empty state, not a blank list.

## Test plan
- [x] 3 new tests: ghost filtered + real kept, all-ghost still shows honest
  empty state, live zero-agent run never filtered
- [x] Full existing `TestGetFleet_*` suite passes unchanged
- [x] `go test ./desktop/... -race -count=1` clean

Closes #417