### PR TITLE
feat(desktop): trust calibration leaderboard panel

### DIFF
--- a/desktop/api/dashboard.go
+++ b/desktop/api/dashboard.go
@@ -39,6 +39,14 @@ type Dashboard struct {
 	ByDay   []Breakdown `json:"byDay"`
 
 	Recent []RecentCall `json:"recent"`
+
+	// Calibration is per-(source,domain) calibration quality from
+	// internal/trust — which models/oracles actually earn their stated
+	// confidence. Independent of cost.jsonl (a machine can have calibration
+	// history from `hyctl trust record` without ever having dispatched), so
+	// unlike ByModel/ByTier/ByDay it is always a list, never nil — an empty
+	// leaderboard is a real, renderable state, not "never ran".
+	Calibration []CalibrationRow `json:"calibration"`
 }
 
 // SpendPanel is the headline cost figure.
@@ -85,6 +93,18 @@ type Breakdown struct {
 	WallMS         int64   `json:"wallMs"`
 }
 
+// CalibrationRow is one (source, domain) row of the calibration leaderboard —
+// a direct mapping of trust.Stat, the same shape `hyctl trust calibration`
+// prints.
+type CalibrationRow struct {
+	Source string  `json:"source"`
+	Domain string  `json:"domain"`
+	D      float64 `json:"d"`  // diagnostic power (nats) — sort key, most first
+	Se     float64 `json:"se"` // sensitivity
+	Sp     float64 `json:"sp"` // specificity
+	N      int     `json:"n"`  // real observations (excludes the Laplace prior)
+}
+
 // RecentCall is one row of the activity list.
 type RecentCall struct {
 	TS      string  `json:"ts"`
@@ -113,9 +133,10 @@ func (a *API) GetDashboard() (*Dashboard, error) {
 	}
 
 	d := &Dashboard{
-		HasData:  len(rows) > 0,
-		Governor: governorPanel(),
-		Trust:    trustPanel(),
+		HasData:     len(rows) > 0,
+		Governor:    governorPanel(),
+		Trust:       trustPanel(),
+		Calibration: calibrationPanel(),
 	}
 	if !d.HasData {
 		// Breakdowns stay nil, not empty slices: the frontend distinguishes
@@ -193,6 +214,32 @@ func trustPanel() TrustPanel {
 		MeanFinalConf:   s.MeanFinalConf,
 		TotalCostUSD:    s.TotalCostUSD,
 	}
+}
+
+// calibrationPanel loads the same on-disk calibration store `hyctl trust
+// calibration` reads (trust.New(trust.DefaultPath())) and reports it in the
+// same most-diagnostic-first order (Calibrator.Report). A brand-new machine
+// has no ~/.hydra/calibration.jsonl, which trust.New treats as an empty store
+// rather than an error, so this always returns a non-nil, possibly-empty
+// slice — never an error, never nil.
+func calibrationPanel() []CalibrationRow {
+	cal, err := trust.New(trust.DefaultPath())
+	if err != nil {
+		return []CalibrationRow{}
+	}
+	stats := cal.Report()
+	out := make([]CalibrationRow, 0, len(stats))
+	for _, s := range stats {
+		out = append(out, CalibrationRow{
+			Source: s.Source,
+			Domain: s.Domain,
+			D:      s.D,
+			Se:     s.Se,
+			Sp:     s.Sp,
+			N:      int(s.N),
+		})
+	}
+	return out
 }
 
 func toBreakdowns(gs []cost.GroupRow) []Breakdown {

--- a/desktop/api/dashboard_test.go
+++ b/desktop/api/dashboard_test.go
@@ -348,6 +348,90 @@ func TestSpend_TokenProvenanceShare(t *testing.T) {
 	}
 }
 
+// A fresh machine has no ~/.hydra/calibration.jsonl. That is a real empty
+// leaderboard, not an error — trust.New treats a missing file as an empty
+// store, and the frontend needs a non-nil slice to render "no data yet"
+// rather than a null it can't .map over.
+func TestCalibrationPanel_EmptyOnFreshMachine(t *testing.T) {
+	sandbox(t)
+
+	d, err := New().GetDashboard()
+	if err != nil {
+		t.Fatalf("GetDashboard on a fresh machine must not error: %v", err)
+	}
+	if d.Calibration == nil {
+		t.Error("Calibration is nil; the view iterates it directly and a nil slice marshals to null")
+	}
+	if len(d.Calibration) != 0 {
+		t.Errorf("Calibration has %d rows with no calibration.jsonl", len(d.Calibration))
+	}
+}
+
+// Real calibration history — written the same way `hyctl trust record` does,
+// through trust.Calibrator.Update — must come back out through the Dashboard
+// exactly as trust.Calibrator.Report (the same call `hyctl trust calibration`
+// makes) sees it: most-diagnostic-source first, with Se/Sp/N intact.
+func TestCalibrationPanel_MatchesCalibratorReport(t *testing.T) {
+	home := sandbox(t)
+	path := filepath.Join(home, ".hydra", "calibration.jsonl")
+
+	cal, err := trust.New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// verifier:go-test: near-perfect — should out-rank the model by D.
+	for i := 0; i < 40; i++ {
+		mustUpdate(t, cal, "verifier:go-test", "go", true, trust.OutcomeCorrect)
+	}
+	for i := 0; i < 40; i++ {
+		mustUpdate(t, cal, "verifier:go-test", "go", false, trust.OutcomeIncorrect)
+	}
+	// model:claude-sonnet: right most of the time, but noisier.
+	for i := 0; i < 8; i++ {
+		mustUpdate(t, cal, "model:claude-sonnet", "go", true, trust.OutcomeCorrect)
+	}
+	for i := 0; i < 2; i++ {
+		mustUpdate(t, cal, "model:claude-sonnet", "go", true, trust.OutcomeIncorrect)
+	}
+
+	d, err := New().GetDashboard()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := cal.Report()
+	if len(d.Calibration) != len(want) {
+		t.Fatalf("Calibration has %d rows, Calibrator.Report says %d", len(d.Calibration), len(want))
+	}
+	for i, w := range want {
+		got := d.Calibration[i]
+		if got.Source != w.Source || got.Domain != w.Domain {
+			t.Errorf("row %d: got %s/%s, want %s/%s (ordering must match Report's D-descending sort)",
+				i, got.Source, got.Domain, w.Source, w.Domain)
+		}
+		if got.D != w.D || got.Se != w.Se || got.Sp != w.Sp {
+			t.Errorf("row %d (%s): D/Se/Sp = %v/%v/%v, want %v/%v/%v",
+				i, got.Source, got.D, got.Se, got.Sp, w.D, w.Se, w.Sp)
+		}
+		if got.N != int(w.N) {
+			t.Errorf("row %d (%s): N = %d, want %d", i, got.Source, got.N, int(w.N))
+		}
+	}
+	if want[0].Source != "verifier:go-test" {
+		t.Fatalf("test setup: expected verifier:go-test to lead, got %s", want[0].Source)
+	}
+}
+
+// mustUpdate mirrors internal/trust's own test helper of the same name —
+// duplicated here rather than exported from trust for one call site, since
+// trust.Calibrator.Update already returns a plain error.
+func mustUpdate(t *testing.T, c *trust.Calibrator, source, domain string, saidCorrect bool, outcome trust.Outcome) {
+	t.Helper()
+	if err := c.Update(source, domain, saidCorrect, outcome); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+}
+
 // GetDashboard reads fresh on every call and holds no state, which is what
 // makes it safe for the frontend to poll from several places at once.
 func TestGetDashboard_ConcurrentCallsAreSafe(t *testing.T) {

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -389,6 +389,83 @@ body {
 .trust-cmp__delta--good { color: var(--hy-cheap); }
 .trust-cmp__delta--bad  { color: var(--hy-expensive); }
 
+/* ── Dashboard: calibration leaderboard (#409) ─────────────────────────── */
+/* Same row shape as .rank (name / track / value), plus a domain sub-label and
+   an oracle-vs-model color split. Bars use the spend-bar halo treatment
+   (#414) rotated 90° — a fainter halo layered behind a crisp fill, both
+   growing via `transform: scaleX` from a zero baseline the first time real
+   data lands, never `filter: blur`. */
+
+.cal__row {
+  display: grid;
+  grid-template-columns: minmax(90px, 170px) 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.cal__name {
+  font-family: var(--hy-font-mono);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cal__domain { margin-left: 6px; font-size: 10px; color: var(--hy-faint); }
+
+/* Not `overflow: hidden` — the halo below deliberately bleeds past the track,
+   the same way SpendTrend's SVG halo bleeds HALO_PAD past its crisp bar. */
+.cal__track {
+  position: relative;
+  height: 8px;
+  border-radius: 4px;
+  background: var(--hy-line);
+}
+
+.cal__halo,
+.cal__fill {
+  position: absolute;
+  top: 0; left: 0;
+  height: 100%;
+  border-radius: 4px;
+  transform-origin: left;
+  transform: scaleX(0);
+  transition: transform .55s cubic-bezier(.22, .9, .3, 1);
+}
+.cal__halo.grown, .cal__fill.grown { transform: scaleX(1); }
+
+/* Width/height/inset (the halo's HALO_PAD bleed) are set inline per row from
+   the D-relative fraction; only the reveal grow-in is CSS. */
+.cal__fill { opacity: .95; }
+.cal__halo { opacity: .3; }
+
+.cal__fill--oracle, .cal__halo--oracle { background: linear-gradient(90deg, rgba(0, 230, 195, .5), var(--hy-aqua)); }
+.cal__fill--model,  .cal__halo--model  { background: linear-gradient(90deg, rgba(139, 92, 246, .5), var(--hy-violet)); }
+
+.cal__value {
+  font-family: var(--hy-font-mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.cal-legend {
+  display: flex;
+  gap: 14px;
+  margin-top: 12px;
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  color: var(--hy-dim);
+}
+.cal-legend__dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 2px;
+  margin-right: 5px;
+  vertical-align: middle;
+}
+.cal-legend__dot--oracle { background: var(--hy-aqua); }
+.cal-legend__dot--model  { background: var(--hy-violet); }
+
 /* ── Dashboard: HUD chrome ─────────────────────────────────────────────── */
 /* Corner brackets + scanline + vignette, the same frame language as
    brand/living/hydra-hud.src.html. Fixed to the viewport but mounted only

--- a/desktop/frontend/src/format.ts
+++ b/desktop/frontend/src/format.ts
@@ -50,6 +50,22 @@ export function costBand(v: number, max: number): 'free' | 'cheap' | 'mid' | 'ex
   return 'cheap'
 }
 
+/** internal/trust calibration keys are "verifier:go-test" / "model:claude-sonnet"
+ * — the prefix is the routing/storage key, not something worth showing next to
+ * every row of a leaderboard. Falls back to the raw string for anything else. */
+export function sourceLabel(source: string): string {
+  const i = source.indexOf(':')
+  return i < 0 ? source : source.slice(i + 1)
+}
+
+/** Oracles (verifier:*, e.g. test/lint results) are a structurally different
+ * kind of evidence than a model's own self-report (model:*) — the calibration
+ * leaderboard color-codes by this distinction. Unrecognized prefixes read as
+ * 'model', the more common case. */
+export function sourceKind(source: string): 'oracle' | 'model' {
+  return source.startsWith('verifier:') ? 'oracle' : 'model'
+}
+
 /** "2026-08-02T10:04:11Z" → "10:04:11". Falls back to the raw string. */
 export function clockTime(ts: string): string {
   const t = ts.indexOf('T')

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -39,6 +39,17 @@ export interface Breakdown {
   wallMs: number
 }
 
+/** One (source, domain) row of the calibration leaderboard — mirrors Go's
+ * desktop/api.CalibrationRow, itself a mapping of internal/trust.Stat. */
+export interface CalibrationRow {
+  source: string
+  domain: string
+  d: number
+  se: number
+  sp: number
+  n: number
+}
+
 export interface RecentCall {
   ts: string
   model: string
@@ -59,6 +70,8 @@ export interface Dashboard {
   byTier: Breakdown[] | null
   byDay: Breakdown[] | null
   recent: RecentCall[] | null
+  /** Never null — an empty leaderboard is a real, renderable state. */
+  calibration: CalibrationRow[]
 }
 
 export interface Version {

--- a/desktop/frontend/src/views/Dashboard.tsx
+++ b/desktop/frontend/src/views/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
-import type { Breakdown, Dashboard as DashboardData, TrustPanel } from '../types'
-import { clockTime, costBand, govBand, ms, pct, tokens, usd, usdExact } from '../format'
+import type { Breakdown, CalibrationRow, Dashboard as DashboardData, TrustPanel } from '../types'
+import { clockTime, costBand, govBand, ms, pct, sourceKind, sourceLabel, tokens, usd, usdExact } from '../format'
 import { ArcGauge, Sparkline, SpendTrend, TrustArc } from './DashboardCharts'
 import { useCountUp, useReveal } from '../reveal'
 
@@ -103,6 +103,8 @@ function DashboardContent({ data }: { data: DashboardData }) {
       </div>
 
       {data.hasData ? <Breakdowns data={data} onSelectModel={openDrawer} /> : <EmptyState />}
+
+      <CalibrationLeaderboard rows={data.calibration} />
 
       <ModelDetailDrawer row={drawerRow} open={drawerOpen} onClose={closeDrawer} />
     </div>
@@ -307,6 +309,93 @@ function RankedBars({
         </div>
       </div>
     </section>
+  )
+}
+
+/**
+ * Which sources actually earn their stated confidence — one row per
+ * (source, domain), sorted by D descending (the order internal/trust's
+ * Calibrator.Report already returns, same as `hyctl trust calibration`).
+ * Bars use the SpendTrend halo treatment (#414) turned sideways: a fainter
+ * halo layered behind a crisp fill, both growing in via `transform: scaleX`
+ * once `useReveal` fires, never `filter: blur`. Independent of `hasData` —
+ * calibration history comes from `hyctl trust record`, not the cost log, so
+ * it can be populated (or empty) regardless of whether anything dispatched.
+ */
+function CalibrationLeaderboard({ rows }: { rows: CalibrationRow[] }) {
+  const revealed = useReveal(rows.length > 0)
+
+  if (rows.length === 0) {
+    return (
+      <section>
+        <h2 className="section__title">Calibration leaderboard</h2>
+        <div className="empty" style={{ marginTop: 0 }}>
+          <p className="empty__title">No calibration recorded yet</p>
+          <p>
+            Feed outcomes with <code>hyctl trust record</code> and this fills in.
+          </p>
+        </div>
+      </section>
+    )
+  }
+
+  const maxD = Math.max(...rows.map((r) => r.d))
+  return (
+    <section>
+      <h2 className="section__title">Calibration leaderboard · who to trust</h2>
+      <div className="table__wrap">
+        <div className="rank">
+          {rows.map((r) => (
+            <CalibrationBar key={`${r.source} ${r.domain}`} row={r} maxD={maxD} revealed={revealed} />
+          ))}
+        </div>
+        <div className="cal-legend">
+          <span>
+            <span className="cal-legend__dot cal-legend__dot--oracle" />
+            test/lint verdict
+          </span>
+          <span>
+            <span className="cal-legend__dot cal-legend__dot--model" />
+            model's own answer
+          </span>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// How far the halo bleeds past the crisp bar it sits behind, on each edge —
+// matches SpendTrend's HALO_PAD.
+const CAL_HALO_PAD = 3
+
+function CalibrationBar({ row, maxD, revealed }: { row: CalibrationRow; maxD: number; revealed: boolean }) {
+  const kind = sourceKind(row.source)
+  // A source with real observations but zero diagnostic power (a coin flip)
+  // still gets a sliver — the row itself is informative even at D=0.
+  const widthPct = maxD > 0 ? (row.d / maxD) * 100 : row.n > 0 ? 4 : 0
+  const grown = revealed ? ' grown' : ''
+  return (
+    <div className="cal__row">
+      <span className="cal__name" title={row.source}>
+        {sourceLabel(row.source)}
+        <span className="cal__domain">{row.domain}</span>
+      </span>
+      <span className="cal__track">
+        <span
+          className={`cal__halo cal__halo--${kind}${grown}`}
+          style={{
+            width: `calc(${widthPct}% + ${CAL_HALO_PAD * 2}px)`,
+            height: `calc(100% + ${CAL_HALO_PAD * 2}px)`,
+            left: -CAL_HALO_PAD,
+            top: -CAL_HALO_PAD,
+          }}
+        />
+        <span className={`cal__fill cal__fill--${kind}${grown}`} style={{ width: `${widthPct}%` }} />
+      </span>
+      <span className="cal__value" title={`Se ${row.se.toFixed(2)} · Sp ${row.sp.toFixed(2)} · n=${row.n}`}>
+        {row.d.toFixed(2)}
+      </span>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- Adds a new Dashboard panel: a per-source×domain calibration leaderboard (which models/oracles actually earn their stated confidence), sourced from `internal/trust`'s real on-disk calibration store — not fabricated.
- Backend: `Dashboard.Calibration []CalibrationRow` (`desktop/api/dashboard.go`), populated by `calibrationPanel()`, which loads `trust.New(trust.DefaultPath())` and calls `.Report()` — the exact same call path `hyctl trust calibration` uses, so the two surfaces can never disagree. Always a non-nil, possibly-empty slice (independent of `cost.jsonl`/`hasData`, since calibration history comes from `hyctl trust record`).
- `CalibrationRow{Source, Domain, D, Se, Sp, N}` mirrors `trust.Stat` 1:1.
- Frontend: a ranked horizontal-bar leaderboard sorted by D descending, color-coded oracle (`verifier:*`) vs. model (`model:*`), reusing the #414 halo/glow-bar treatment (a fainter halo layered behind a crisp fill, both growing via `transform: scaleX` on `useReveal`, never `filter: blur`) and the existing `.rank`/`.table__wrap`/`.empty` classes rather than introducing a new visual language. Explicit empty state ("No calibration recorded yet... `hyctl trust record`").

## Changes
- `desktop/api/dashboard.go` — `CalibrationRow` struct, `Dashboard.Calibration` field, `calibrationPanel()`
- `desktop/api/dashboard_test.go` — empty-state test + a populated-state test asserting exact parity with `Calibrator.Report()`
- `desktop/frontend/src/types.ts` — `CalibrationRow`, `Dashboard.calibration`
- `desktop/frontend/src/format.ts` — `sourceLabel`, `sourceKind` helpers
- `desktop/frontend/src/views/Dashboard.tsx` — `CalibrationLeaderboard` + `CalibrationBar` components
- `desktop/frontend/src/app.css` — `.cal__*` / `.cal-legend*` rules

## Test plan
- [x] `cd desktop/frontend && npm run build` (tsc -b + vite) — compiles clean
- [x] `go test ./desktop/... -race` — all pass, including two new calibration tests (empty state on a fresh machine, populated state matching `Calibrator.Report()` row-for-row)
- [x] `go test ./internal/trust/... -race` — unchanged, still green (read-only consumer, no changes to the package)
- [x] `gofmt -l` clean
- [ ] `wails dev` visual check — not run (no GUI in this environment); relied on static review of the markup/CSS against the validated mockup plus the Go/TS test suites instead

Closes #409