### PR TITLE
feat(desktop): Fleet empty state starts a task instead of just telling you to use the CLI

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -46,6 +46,19 @@ export default function App() {
   const [error, setError] = useState<string | null>(null)
   const [hyctlStatus, setHyctlStatus] = useState<HyctlStatus | null>(null)
 
+  // ChatDock's open state lives here, not inside ChatDock, so other views
+  // (Fleet's empty state) can open it — the app already has a way to start a
+  // task without a terminal, it just wasn't reachable from anywhere that
+  // needed it. focusSignal is a counter rather than a boolean so opening it
+  // twice in a row (already open, click "start a task" again) still refocuses
+  // the input instead of no-oping on an unchanged value.
+  const [dockOpen, setDockOpen] = useState(false)
+  const [dockFocusSignal, setDockFocusSignal] = useState(0)
+  const startTask = useCallback(() => {
+    setDockOpen(true)
+    setDockFocusSignal((n) => n + 1)
+  }, [])
+
   const load = useCallback(async (which: ViewID, id: string) => {
     try {
       if (which === 'fleet') setFleet(await GetFleet())
@@ -159,7 +172,9 @@ export default function App() {
             should not look like a crashed app. */}
         {error && <div className="error">{error}</div>}
         {!error && view === 'dashboard' && <Dashboard data={dashboard} />}
-        {!error && view === 'fleet' && fleet && <Fleet data={fleet} onOpen={openSession} />}
+        {!error && view === 'fleet' && fleet && (
+          <Fleet data={fleet} onOpen={openSession} onStartTask={startTask} />
+        )}
         {!error && view === 'session' && session && (
           <Session session={session} onBack={() => setView('fleet')} />
         )}
@@ -178,7 +193,12 @@ export default function App() {
         {!error && loading && <p style={{ color: 'var(--hy-dim)' }}>Reading logs…</p>}
       </main>
 
-      <ChatDock onOpenRun={openSession} />
+      <ChatDock
+        onOpenRun={openSession}
+        open={dockOpen}
+        onOpenChange={setDockOpen}
+        focusSignal={dockFocusSignal}
+      />
     </div>
   )
 }

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -531,6 +531,22 @@ body {
   padding: 2px 7px;
   color: var(--hy-aqua);
 }
+.empty__cta {
+  appearance: none;
+  background: var(--hy-aqua);
+  color: var(--hy-bg);
+  border: 0;
+  border-radius: 999px;
+  font: inherit;
+  font-weight: 600;
+  font-size: 13px;
+  padding: 10px 22px;
+  margin: 10px 0 4px;
+  cursor: pointer;
+}
+.empty__cta:hover { filter: brightness(1.08); }
+.empty__cta:focus-visible { outline: 2px solid var(--hy-ink); outline-offset: 2px; }
+.empty__alt { font-size: 12px; opacity: .75; }
 
 .error {
   border: 1px solid var(--hy-expensive);

--- a/desktop/frontend/src/views/ChatDock.tsx
+++ b/desktop/frontend/src/views/ChatDock.tsx
@@ -14,15 +14,32 @@ interface Turn {
  * Never a permanently-large panel: splitting attention between a chat and the
  * view it is about costs more than it gives (Sweller/Tarmizi's split-attention
  * effect), so it opens on engagement and closes again.
+ *
+ * open/onOpenChange are owned by App, not local state — other views (Fleet's
+ * empty state, #422) need to open this dock, and a callback into a sibling
+ * component isn't a thing React has; lifting the one bit of state that
+ * matters is. focusSignal is a counter App bumps every time something asks
+ * this dock to take focus, so "open it and focus the input" works even when
+ * the dock happens to already be open.
  */
-export function ChatDock({ onOpenRun }: { onOpenRun: (runID: string) => void }) {
-  const [open, setOpen] = useState(false)
+export function ChatDock({
+  onOpenRun,
+  open,
+  onOpenChange,
+  focusSignal,
+}: {
+  onOpenRun: (runID: string) => void
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  focusSignal: number
+}) {
   const [prompt, setPrompt] = useState('')
   const [enumKey, setEnumKey] = useState('')
   const [enums, setEnums] = useState<string[]>([])
   const [turns, setTurns] = useState<Turn[]>([])
   const [busy, setBusy] = useState(false)
   const logRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     ChatEnums().then(setEnums).catch(() => {
@@ -57,9 +74,16 @@ export function ChatDock({ onOpenRun }: { onOpenRun: (runID: string) => void }) 
     }
   }
 
+  // Fires on open (the dock's own toggle button included, not just external
+  // callers) and again on focusSignal so "already open, asked to start a
+  // task again" still moves focus back to the input.
+  useEffect(() => {
+    if (open) inputRef.current?.focus()
+  }, [focusSignal, open])
+
   if (!open) {
     return (
-      <button className="dock dock--closed" onClick={() => setOpen(true)}>
+      <button className="dock dock--closed" onClick={() => onOpenChange(true)}>
         Ask Hydra
         {turns.length > 0 && <span className="dock__count">{turns.length}</span>}
       </button>
@@ -84,7 +108,7 @@ export function ChatDock({ onOpenRun }: { onOpenRun: (runID: string) => void }) 
             </option>
           ))}
         </select>
-        <button className="dock__close" onClick={() => setOpen(false)} aria-label="Collapse">
+        <button className="dock__close" onClick={() => onOpenChange(false)} aria-label="Collapse">
           ×
         </button>
       </header>
@@ -116,6 +140,7 @@ export function ChatDock({ onOpenRun }: { onOpenRun: (runID: string) => void }) 
 
       <div className="dock__input">
         <textarea
+          ref={inputRef}
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           onKeyDown={(e) => {

--- a/desktop/frontend/src/views/Fleet.tsx
+++ b/desktop/frontend/src/views/Fleet.tsx
@@ -3,7 +3,15 @@ import type { Agent, Fleet as FleetData, Run } from '../types'
 import { ms, pct, usdExact } from '../format'
 import { RunGraph } from './RunGraph'
 
-export function Fleet({ data, onOpen }: { data: FleetData; onOpen: (runID: string) => void }) {
+export function Fleet({
+  data,
+  onOpen,
+  onStartTask,
+}: {
+  data: FleetData
+  onOpen: (runID: string) => void
+  onStartTask: () => void
+}) {
   return (
     <>
       <header className="view__head">
@@ -18,8 +26,12 @@ export function Fleet({ data, onOpen }: { data: FleetData; onOpen: (runID: strin
       {!data.hasRuns ? (
         <div className="empty">
           <p className="empty__title">No runs yet</p>
-          <p>
-            Run <code>hyctl dispatch --enum SIMPLE "…"</code> and it appears here while it works.
+          <p>Start one from here, or run it from a terminal instead:</p>
+          <button className="empty__cta" onClick={onStartTask}>
+            Start a task
+          </button>
+          <p className="empty__alt">
+            <code>hyctl dispatch --enum SIMPLE "…"</code>
           </p>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- Fleet's empty state told you to run `hyctl dispatch` in a terminal even though the app already ships a task-starting UI (`ChatDock`) — it just wasn't reachable from anywhere that needed it.
- Lifts `ChatDock`'s open/focus state up into `App` (it owned its own `useState` before) so a sibling view can open it and land focus in the input.
- Fleet's empty state now has a real "Start a task" button that opens the dock and focuses it; the CLI hint stays as a smaller secondary line for anyone who prefers it.

## Changes
- `desktop/frontend/src/App.tsx` — `dockOpen`/`dockFocusSignal` state + `startTask` callback, passed down to `Fleet` and `ChatDock`
- `desktop/frontend/src/views/ChatDock.tsx` — `open`/`onOpenChange`/`focusSignal` are now controlled props instead of local state; focuses the textarea via `inputRef` when asked
- `desktop/frontend/src/views/Fleet.tsx` — accepts `onStartTask`, empty state gets a real CTA button
- `desktop/frontend/src/app.css` — `.empty__cta` / `.empty__alt` styles matching the existing dock pill-button language

## Test plan
- [x] `npm run build` (tsc + vite) — clean
- [x] `go test ./...` in `desktop/` — all passing
- [ ] Manual click-through in the running app (open Fleet with no runs → click "Start a task" → dock opens focused)

Closes #422