### PR TITLE
fix(desktop): back button and page title now sit on one row

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -181,10 +181,12 @@ export default function App() {
         {!error && view === 'code' && edits && (
           <>
             <header className="view__head">
-              <button className="back" onClick={() => setView('session')}>
-                ← Session
-              </button>
-              <h1 className="view__title">Code</h1>
+              <div className="view__headrow">
+                <button className="back" onClick={() => setView('session')}>
+                  ← Session
+                </button>
+                <h1 className="view__title">Code</h1>
+              </div>
               <p className="view__sub">What this run changed on disk.</p>
             </header>
             <Code runID={runID} edits={edits} />

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -92,6 +92,9 @@ body {
 /* ── Headings ──────────────────────────────────────────────────────────── */
 
 .view__head { margin-bottom: 22px; }
+/* Only the views with a back button need a row — plain title+subtitle
+   (Fleet, Dashboard) stack correctly as block siblings with no flex at all. */
+.view__headrow { display: flex; align-items: baseline; gap: 12px; }
 .view__title { margin: 0; font-size: 24px; letter-spacing: -0.03em; }
 .view__title--brand {
   background: var(--hy-brand);
@@ -860,7 +863,7 @@ body {
   color: var(--hy-dim);
   font: inherit;
   font-size: 12px;
-  padding: 0 0 8px;
+  padding: 3px 0;
   cursor: pointer;
 }
 .back:hover { color: var(--hy-aqua); }

--- a/desktop/frontend/src/views/Session.tsx
+++ b/desktop/frontend/src/views/Session.tsx
@@ -17,13 +17,15 @@ export function Session({
   return (
     <>
       <header className="view__head">
-        <button className="back" onClick={onBack}>
-          ← Fleet
-        </button>
-        <h1 className="view__title">
-          <span className="session__id">{session.runId}</span>
-          {session.live && <span className="session__live">live</span>}
-        </h1>
+        <div className="view__headrow">
+          <button className="back" onClick={onBack}>
+            ← Fleet
+          </button>
+          <h1 className="view__title">
+            <span className="session__id">{session.runId}</span>
+            {session.live && <span className="session__live">live</span>}
+          </h1>
+        </div>
       </header>
 
       {session.error && <div className="error">unreadable: {session.error}</div>}


### PR DESCRIPTION
## Summary
`.view__head` had no `display: flex`, so the back button (`.back`) and the following `<h1 className="view__title">` — both default block-level — stacked vertically instead of sitting side by side. Confirmed live: rebuilt the real `.app`, launched it, and read the running window's own accessibility geometry (no screenshot permission in this sandbox, but position/size data is just as conclusive) — before the fix the button's box ended at y=147 and the heading started at y=147, i.e. directly beneath it with zero gap.

## Changes
- `desktop/frontend/src/app.css` — new `.view__headrow` flex wrapper (baseline-aligned, 12px gap), scoped separately from `.view__head` so Fleet's/Dashboard's plain title+subtitle stack (no back button, correctly block) is untouched
- `desktop/frontend/src/views/Session.tsx` — wraps its back button + title in `.view__headrow`
- `desktop/frontend/src/App.tsx` — same for the Code view's header

## Test plan
- [x] `go test ./...` (desktop module) — passing
- [x] `npm run build` (tsc + vite) — clean
- [x] Live-verified in the built `.app`: read the window's accessibility tree before and after the fix — button/heading now share a row with a 12px gap instead of stacking

Closes #426