### PR TITLE
fix(desktop): surface attestation, AI-BOM and least-privilege, and pin the TS mirror

### DIFF
--- a/desktop/api/typesparity_test.go
+++ b/desktop/api/typesparity_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/security"
+)
+
+// types.ts is a hand-written mirror and nothing was checking it, so it drifted:
+// attestation, bom and privilege were computed, shipped on the wire, and
+// invisible to the desktop because TypeScript had never heard of them (#435).
+//
+// dto_test.go guards the Go side of the wire. This guards the mirror.
+
+var tsFieldRE = regexp.MustCompile(`(?m)^\s*([A-Za-z0-9_]+)\??:`)
+
+// tsInterface returns the field names declared on a TypeScript interface.
+func tsInterface(t *testing.T, src, name string) map[string]bool {
+	t.Helper()
+	re := regexp.MustCompile(`(?s)export interface ` + regexp.QuoteMeta(name) + ` \{(.*?)\n\}`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		t.Fatalf("types.ts declares no interface %q", name)
+	}
+	out := map[string]bool{}
+	for _, f := range tsFieldRE.FindAllStringSubmatch(m[1], -1) {
+		out[f[1]] = true
+	}
+	return out
+}
+
+// jsonFields returns the wire names of a Go struct, skipping anything the
+// encoder drops entirely.
+func jsonFields(v any) map[string]bool {
+	out := map[string]bool{}
+	rt := reflect.TypeOf(v)
+	for i := 0; i < rt.NumField(); i++ {
+		tag := rt.Field(i).Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		out[name] = true
+	}
+	return out
+}
+
+func readTypesTS(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile("../frontend/src/types.ts")
+	if err != nil {
+		t.Fatalf("cannot read the TypeScript mirror: %v", err)
+	}
+	return string(raw)
+}
+
+func TestTypesTS_MirrorsEveryFieldOnTheWire(t *testing.T) {
+	src := readTypesTS(t)
+
+	for _, c := range []struct {
+		iface string
+		goVal any
+	}{
+		{"SecurityReport", security.Report{}},
+		{"Attestation", security.Attestation{}},
+		{"AttestedEvidence", security.AttestedEvidence{}},
+		{"BOMEntry", security.BOMEntry{}},
+		{"AgentPrivilege", security.AgentPrivilege{}},
+		{"Incident", security.Incident{}},
+		{"Risk", security.Risk{}},
+		{"RiskRegister", security.RiskRegister{}},
+		{"Posture", security.Posture{}},
+	} {
+		t.Run(c.iface, func(t *testing.T) {
+			ts := tsInterface(t, src, c.iface)
+			for name := range jsonFields(c.goVal) {
+				if !ts[name] {
+					t.Errorf("%s.%s ships on the wire but types.ts does not declare it — "+
+						"the desktop cannot render a field it has never heard of",
+						c.iface, name)
+				}
+			}
+		})
+	}
+}
+
+// The reverse direction: a TypeScript field with no Go counterpart is always
+// undefined at runtime, which typechecks and then renders nothing.
+func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
+	src := readTypesTS(t)
+	for _, c := range []struct {
+		iface string
+		goVal any
+	}{
+		{"SecurityReport", security.Report{}},
+		{"Attestation", security.Attestation{}},
+		{"BOMEntry", security.BOMEntry{}},
+		{"AgentPrivilege", security.AgentPrivilege{}},
+	} {
+		t.Run(c.iface, func(t *testing.T) {
+			g := jsonFields(c.goVal)
+			for name := range tsInterface(t, src, c.iface) {
+				if !g[name] {
+					t.Errorf("types.ts declares %s.%s but the backend never sends it — "+
+						"it is permanently undefined", c.iface, name)
+				}
+			}
+		})
+	}
+}

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -331,6 +331,72 @@ export interface SecurityReport {
   incidents?: Incident[]
   /** The governed view: every finding as one kind of object. */
   register: RiskRegister
+  /** Checkable, point-in-time statement of posture. Deliberately unsigned. */
+  attestation: Attestation
+  /** Entitlement review: what each agent touched vs what a rule scopes. */
+  privilege?: AgentPrivilege[]
+  /** AI bill of materials: the model estate, with provenance. */
+  bom?: BOMEntry[]
+}
+
+/** What was true, under which rules, over which evidence. */
+export interface Attestation {
+  generatedAt: string
+  tool: string
+  version: string
+  commit?: string
+  /** Deployment breadcrumb: which routing/policy files were in force. */
+  configFingerprint?: string
+  evidence: AttestedEvidence
+  verdict: Verdict
+  trigger: string
+  coveragePercent: number
+  openRisks: number
+  bySeverity: Record<Severity, number>
+  slaBreached: number
+  incidents: number
+  /** Open risks per framework, so a reader can see it from their own standard. */
+  frameworks?: Record<string, number>
+  /** sha256 over every field above, so two copies can be compared. */
+  digest: string
+}
+
+/** The state of the log the attestation rests on. */
+export interface AttestedEvidence {
+  events: number
+  chainedEvents: number
+  chainIntact: boolean
+  /** Reported, never hidden: an attestation over an unverifiable log must say so. */
+  truncated?: boolean
+  anchorMissing?: boolean
+}
+
+/** One agent's observed footprint, for the least-privilege review. */
+export interface AgentPrivilege {
+  agent: string
+  allowed: number
+  denied: number
+  resources?: string[]
+  actions?: string[]
+  heads?: string[]
+  /** True when no policy rule names this agent, so it runs under the default. */
+  unscoped: boolean
+  writesOrExecs: number
+}
+
+/** One model in the estate. */
+export interface BOMEntry {
+  headId: string
+  name?: string
+  provider?: string
+  /** How it was discovered: cli, env, port. */
+  source?: string
+  /** "builtin" (curated catalog) or "user" (added at runtime). */
+  origin?: string
+  local: boolean
+  fingerprint?: string
+  /** True when the ledger shows this head actually handling work. */
+  used: boolean
 }
 
 export interface DayRisk {

--- a/desktop/frontend/src/views/Security.tsx
+++ b/desktop/frontend/src/views/Security.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
 import type {
   Action,
+  AgentPrivilege,
+  Attestation,
+  BOMEntry,
   Category,
   Check,
   ConfigDrift,
@@ -374,7 +377,10 @@ const DETAIL_TABS = [
   { id: 'policy', label: 'Policy' },
   { id: 'exposure', label: 'Exposure' },
   { id: 'threats', label: 'Threats' },
+  { id: 'access', label: 'Access' },
+  { id: 'estate', label: 'Estate' },
   { id: 'evidence', label: 'Evidence' },
+  { id: 'attest', label: 'Attestation' },
 ] as const
 
 type DetailTab = (typeof DETAIL_TABS)[number]['id']
@@ -437,8 +443,167 @@ function Detailed({ data }: { data: SecurityReport }) {
       )}
       {tab === 'exposure' && <ExposureView exposures={data.exposures ?? []} />}
       {tab === 'threats' && <ThreatsView threats={data.threats} />}
+      {tab === 'access' && <PrivilegeView rows={data.privilege ?? []} />}
+      {tab === 'estate' && <BOMView entries={data.bom ?? []} />}
       {tab === 'evidence' && <EvidenceView events={data.events ?? []} truncated={!!data.truncated} />}
+      {tab === 'attest' && <AttestationView a={data.attestation} />}
     </>
+  )
+}
+
+// Least privilege: what an agent actually touched against what a rule scopes.
+// An unscoped agent that changes state leads, because that is the finding.
+function PrivilegeView({ rows }: { rows: AgentPrivilege[] }) {
+  if (rows.length === 0) {
+    return <p className="card__note">No ledger event names an agent, so there is no footprint to review.</p>
+  }
+  return (
+    <section>
+      <h2 className="section__title">Agent entitlements</h2>
+      <p className="card__note">
+        Hydra&rsquo;s default is allow, so an agent no rule names is governed only by that
+        default. Unscoped agents that change state are listed first.
+      </p>
+      <div className="table__wrap">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Agent</th><th>Scope</th><th className="num">Allowed</th><th className="num">Denied</th>
+              <th className="num">State-changing</th><th>Touched</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((p) => (
+              <tr key={p.agent}>
+                <td className="mono">{p.agent}</td>
+                <td>
+                  <span className={`sec-cat__status ${p.unscoped ? 'sec-sev--high' : 'sec-cat__status--enforced'}`}>
+                    {p.unscoped ? 'unscoped' : 'scoped'}
+                  </span>
+                </td>
+                <td className="num">{p.allowed}</td>
+                <td className="num">{p.denied}</td>
+                <td className={`num ${p.unscoped && p.writesOrExecs > 0 ? 'cost--expensive' : ''}`}>
+                  {p.writesOrExecs}
+                </td>
+                <td className="card__note">
+                  {(p.actions ?? []).join(', ') || '—'}
+                  {(p.resources ?? []).length > 0 && ` · ${p.resources!.length} resource(s)`}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+// The AI-BOM: an inventory of what is installed is less useful than one that
+// says what is live and what leaves the machine.
+function BOMView({ entries }: { entries: BOMEntry[] }) {
+  if (entries.length === 0) {
+    return <p className="card__note">No heads discovered — run <code>hyctl probe</code>.</p>
+  }
+  const remote = entries.filter((b) => !b.local).length
+  const runtime = entries.filter((b) => b.origin === 'user').length
+  return (
+    <section>
+      <h2 className="section__title">Model estate (AI-BOM)</h2>
+      <p className="card__note">
+        {entries.length} head(s) · {remote} route off-machine
+        {runtime > 0 ? ` · ${runtime} added at runtime rather than from the curated catalog` : ''}
+      </p>
+      <div className="table__wrap">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Head</th><th>Provider</th><th>Source</th><th>Origin</th>
+              <th>Egress</th><th>Live</th><th>Fingerprint</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((b) => (
+              <tr key={b.headId}>
+                <td className="mono">{b.headId}</td>
+                <td>{b.provider || '—'}</td>
+                <td>{b.source || '—'}</td>
+                <td>{b.origin === 'user' ? 'runtime' : 'builtin'}</td>
+                <td>
+                  <span className={`sec-cat__status ${b.local ? 'sec-cat__status--enforced' : 'sec-sev--medium'}`}>
+                    {b.local ? 'local' : 'remote'}
+                  </span>
+                </td>
+                <td className="card__note">{b.used ? 'used' : 'idle'}</td>
+                <td className="mono card__note">{b.fingerprint ? b.fingerprint.slice(0, 12) : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+// The attestation is only worth something if a reader can check it without
+// trusting the reporter, so the evidence state leads and never hides.
+function AttestationView({ a }: { a: Attestation }) {
+  if (!a || !a.digest) {
+    return <p className="card__note">No attestation was produced for this run.</p>
+  }
+  const trustworthy =
+    a.evidence.chainIntact &&
+    !a.evidence.truncated &&
+    !a.evidence.anchorMissing &&
+    !(a.evidence.events > 0 && a.evidence.chainedEvents === 0)
+  return (
+    <section>
+      <h2 className="section__title">Attestation</h2>
+      {!trustworthy && (
+        <div className="error">
+          The audit log underneath this attestation cannot be independently checked, so the
+          claims above rest on evidence that is not tamper-evident.
+        </div>
+      )}
+      <div className="cards">
+        <div className="card">
+          <div className="card__label">Posture</div>
+          <div className="card__value--sm">{a.verdict}</div>
+          <p className="card__note">{a.trigger}</p>
+        </div>
+        <div className="card">
+          <div className="card__label">Open risks</div>
+          <div className="card__value--sm">
+            {a.openRisks}
+            {a.slaBreached > 0 ? ` · ${a.slaBreached} past SLA` : ''}
+          </div>
+        </div>
+        <div className="card">
+          <div className="card__label">Evidence</div>
+          <div className="card__value--sm">
+            {a.evidence.events} event(s), {a.evidence.chainedEvents} chained
+          </div>
+          <p className="card__note">
+            {a.evidence.truncated
+              ? 'truncated — records were deleted from the end'
+              : a.evidence.anchorMissing
+                ? 'unanchored — truncation would not be detected'
+                : a.evidence.chainIntact
+                  ? 'chain intact'
+                  : 'chain broken — the log was modified after recording'}
+          </p>
+        </div>
+      </div>
+      <p className="card__note" style={{ marginTop: 12 }}>
+        Generated {clockTime(a.generatedAt)} by {a.tool} {a.version}
+        {a.configFingerprint ? ` · rules in force ${a.configFingerprint.slice(0, 12)}` : ''}
+      </p>
+      <p className="card__note">
+        Digest <span className="mono">{a.digest.slice(0, 16)}</span> covers every claim above, so two
+        copies can be compared without trusting either holder. Deliberately unsigned: Hydra has no
+        key management, and a signature without one would be theatre.
+      </p>
+    </section>
   )
 }
 


### PR DESCRIPTION
## Problem

`desktop/frontend/src/types.ts` is a hand-written mirror of the Go DTOs (Wails'
generated bindings are a gitignored build artefact, so the source tree cannot
typecheck against them). Nothing was checking that mirror, and it drifted:

```
security.Report fields  : 26
types.ts SecurityReport : 23
missing                 : attestation, bom, privilege
```

`security.Build` computes all three and `GetSecurity` ships them in the JSON.
The desktop simply could not render a field it had never heard of, so three of
the six workstreams the security programme was built around were invisible in
the app while the CLI surfaced all of them.

## Fix

Mirror the missing types, then surface them:

| Tab | Shows |
|---|---|
| **Access** | Entitlement review. Unscoped state-changing agents lead, because Hydra's default is allow and an agent no rule names runs under that default. |
| **Estate** | The AI-BOM: provenance, egress, and whether a head is actually live rather than merely installed. |
| **Attestation** | Posture, open risk, evidence state and digest, with the unverifiable-log warning first-class rather than footnoted. |

## The part that matters

`TestTypesTS_MirrorsEveryFieldOnTheWire` walks the Go struct tags against the
interfaces in `types.ts` and fails when either side gains a field the other
lacks. Both directions are checked:

- a Go field with no TS counterpart is **invisible**
- a TS field with no Go counterpart is **permanently undefined** — it typechecks
  and then renders nothing

`dto_test.go` already guarded the Go side of the wire. Nothing guarded the
mirror, which is exactly how this got through, and without the test it recurs
on the next field.

## Verification

- The test fails on the drift before the fix (naming all three fields and four
  missing interfaces) and passes after.
- All three tabs render real data from `hyctl security --json` against a live
  React harness: Estate 12 rows, Access 1 row, Attestation 3 cards + digest.
- `npm run typecheck`, `npm run build`, `staticcheck ./...` and
  `go test -race ./...` green in **both** modules (root and `desktop/`).

Closes #435
