### PR TITLE
chore(release): catch up v1.3.0 with develop (#439 only)

### DIFF
--- a/desktop/api/chat.go
+++ b/desktop/api/chat.go
@@ -38,6 +38,13 @@ type ChatReply struct {
 	RunID string `json:"runId"`
 
 	Error string `json:"error,omitempty"`
+
+	// NeedsProbe is true when the machine has zero discoverable heads at all —
+	// distinct from an ordinary dispatch failure. dispatch.New already probes
+	// fresh on every call, so there is no separate "go discover models" step
+	// to point at; the dock offers to retry (which re-probes) instead of
+	// surfacing a CLI instruction a GUI user has no terminal for (#434).
+	NeedsProbe bool `json:"needsProbe,omitempty"`
 }
 
 // Chat dispatches one prompt and returns the reply.
@@ -72,6 +79,11 @@ func (a *API) Chat(prompt, enum string) (*ChatReply, error) {
 	d, err := dispatch.New(ctx)
 	if err != nil {
 		r.Error = err.Error()
+		return r, nil
+	}
+	if len(d.Heads()) == 0 {
+		r.Error = "No models found on this machine yet."
+		r.NeedsProbe = true
 		return r, nil
 	}
 

--- a/desktop/api/chat_test.go
+++ b/desktop/api/chat_test.go
@@ -5,7 +5,9 @@ package api
 import (
 	"testing"
 
+	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/testutil"
 )
 
 // The picker must not offer a routing key the router does not understand.
@@ -85,5 +87,28 @@ func TestChat_FailedDispatchReturnsAReply(t *testing.T) {
 	}
 	if r.RunID == "" {
 		t.Error("no RunID; a failed chat still has a run the user can inspect")
+	}
+}
+
+// A machine with zero discoverable heads at all is distinct from an ordinary
+// dispatch failure — dispatch.New already probes fresh on every call, so
+// there is no separate "go discover models" step to point the GUI at. The
+// dock offers a retry instead of a raw CLI instruction it has no terminal
+// for (#434).
+func TestChat_NoHeadsAtAllSetsNeedsProbe(t *testing.T) {
+	testutil.NewSandbox(t)
+	if err := config.Save(&config.Config{Cortex: "x"}); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := New().Chat("hello", "SIMPLE")
+	if err != nil {
+		t.Fatalf("zero heads must come back as a reply, not a Go error: %v", err)
+	}
+	if !r.NeedsProbe {
+		t.Error("NeedsProbe = false, want true — nothing was discoverable at all")
+	}
+	if r.Error == "" {
+		t.Error("no Error on the reply; the dock would render an empty message")
 	}
 }

--- a/desktop/api/code.go
+++ b/desktop/api/code.go
@@ -62,7 +62,7 @@ func (a *API) GetEdits(runID string) ([]Edit, error) {
 		}
 		added, removed := parseCounts(e.Detail)
 		out = append(out, Edit{
-			File: e.Agent, TS: e.TS, Detail: e.Detail, Ref: e.Ref,
+			File: e.File, TS: e.TS, Detail: e.Detail, Ref: e.Ref,
 			Added: added, Removed: removed,
 		})
 	}

--- a/desktop/api/code_test.go
+++ b/desktop/api/code_test.go
@@ -199,8 +199,8 @@ func TestGetEdits_ListsAppliedEditsInOrder(t *testing.T) {
 
 	writeRun(t, "20260802T100000Z-edits",
 		runlog.Event{Kind: runlog.KindHeadSelected, Head: "h"},
-		runlog.Event{Kind: runlog.KindEdit, Agent: "/src/a.go", Ref: "000001", Detail: "+12/-3"},
-		runlog.Event{Kind: runlog.KindEdit, Agent: "/src/b.go", Ref: "000002", Detail: "+1/-0"},
+		runlog.Event{Kind: runlog.KindEdit, File: "/src/a.go", Ref: "000001", Detail: "+12/-3"},
+		runlog.Event{Kind: runlog.KindEdit, File: "/src/b.go", Ref: "000002", Detail: "+1/-0"},
 	)
 
 	edits, err := New().GetEdits("20260802T100000Z-edits")

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { Code } from './views/Code'
 import { ChatDock } from './views/ChatDock'
 import { UpdateNotice } from './views/UpdateNotice'
 import { SetupBanner } from './views/SetupBanner'
+import { HydraMark, HydraSpinner } from './brand'
 
 /** Dashboard is retrospective — a slow refresh is enough and costs nothing. */
 const DASHBOARD_MS = 5000
@@ -132,7 +133,7 @@ export default function App() {
     <div className="shell">
       <nav className="rail">
         <div className="rail__brand">
-          <span className="rail__mark" />
+          <HydraMark className="rail__mark" />
           Hydra
         </div>
         <div className="rail__nav">
@@ -192,7 +193,12 @@ export default function App() {
             <Code runID={runID} edits={edits} />
           </>
         )}
-        {!error && loading && <p style={{ color: 'var(--hy-dim)' }}>Reading logs…</p>}
+        {!error && loading && (
+          <div className="loading">
+            <HydraSpinner className="loading__mark" />
+            <p>Reading logs…</p>
+          </div>
+        )}
       </main>
 
       <ChatDock

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -40,10 +40,29 @@ body {
   font-size: 15px;
 }
 
-.rail__mark {
-  width: 10px; height: 10px; border-radius: 3px;
-  background: var(--hy-brand);
+.rail__mark { width: 22px; height: 22px; flex: 0 0 auto; }
+
+/* Rotation only — no filter/blur, so it costs nothing on a GPU-less machine.
+   The mark's own SVG has no glow filter baked in (unlike brand/svg/mark.svg)
+   for exactly that reason: fine once as a static icon, wasted looping. */
+.hy-spinner { animation: hy-spin 2.2s linear infinite; transform-origin: 50% 50%; }
+@media (prefers-reduced-motion: reduce) {
+  .hy-spinner { animation: none; }
 }
+@keyframes hy-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 60px 0;
+  color: var(--hy-dim);
+}
+.loading__mark { width: 28px; height: 28px; }
 
 .rail__nav { display: flex; flex-direction: column; gap: 2px; }
 
@@ -1163,6 +1182,22 @@ body {
 }
 .turn__meta:hover { color: var(--hy-aqua); }
 .turn__meta:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; }
+
+.turn__probe { display: flex; flex-direction: column; align-items: flex-start; gap: 7px; }
+.turn__retry {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius-sm);
+  padding: 5px 12px;
+  color: var(--hy-ink);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+.turn__retry:hover:not(:disabled) { border-color: var(--hy-aqua); color: var(--hy-aqua); }
+.turn__retry:disabled { opacity: .5; cursor: default; }
+.turn__retry:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; }
 
 .dock__input { border-top: 1px solid var(--hy-line); padding: 9px 11px; }
 .dock__input textarea {

--- a/desktop/frontend/src/brand.tsx
+++ b/desktop/frontend/src/brand.tsx
@@ -1,0 +1,70 @@
+// The converging-necks mark, ported inline from brand/svg/mark.svg (a local
+// design-source workspace, deliberately untracked — see brand/render/build.mjs
+// for the full asset pipeline). This is the one place that source lands in
+// shipped frontend code, so the sidebar and loading states carry the real
+// Hydra identity instead of a plain colored square (#434).
+export function HydraMark({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 512 512" role="img" aria-label="Hydra">
+      <defs>
+        <linearGradient id="hyG-center" x1="256" y1="96" x2="256" y2="392" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#3DF5E6" />
+          <stop offset="1" stopColor="#8B5CF6" />
+        </linearGradient>
+        <linearGradient id="hyG-left" x1="150" y1="150" x2="256" y2="392" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#F062D2" />
+          <stop offset="1" stopColor="#8B5CF6" />
+        </linearGradient>
+        <linearGradient id="hyG-right" x1="362" y1="150" x2="256" y2="392" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#F062D2" />
+          <stop offset="1" stopColor="#8B5CF6" />
+        </linearGradient>
+        <linearGradient id="hyG-headC" x1="256" y1="92" x2="256" y2="150" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#8BFCF0" />
+          <stop offset="1" stopColor="#2AF0E0" />
+        </linearGradient>
+        <linearGradient id="hyG-headS" x1="0" y1="-28" x2="0" y2="16" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#FF8FE6" />
+          <stop offset="1" stopColor="#E852C8" />
+        </linearGradient>
+        <radialGradient id="hyG-cortex" cx="256" cy="388" r="30" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#EAFFFA" />
+          <stop offset="0.45" stopColor="#00E6C3" />
+          <stop offset="1" stopColor="#0A8F7C" />
+        </radialGradient>
+      </defs>
+
+      <g fill="none" stroke="#8B5CF6" strokeWidth="3.5" opacity="0.32" strokeLinecap="round">
+        <path d="M150 166 L256 120 L362 166" />
+        <path d="M198 292 L256 274 L314 292" />
+        <path d="M150 166 L198 292 M362 166 L314 292 M256 120 L256 274" />
+      </g>
+
+      <g fill="none" strokeWidth="15" strokeLinecap="round">
+        <path d="M256 146 C256 236 256 306 256 372" stroke="url(#hyG-center)" />
+        <path d="M144 184 C158 280 200 344 250 374" stroke="url(#hyG-left)" />
+        <path d="M368 184 C354 280 312 344 262 374" stroke="url(#hyG-right)" />
+      </g>
+
+      <circle cx="256" cy="274" r="8" fill="#B7A4FF" />
+      <circle cx="198" cy="292" r="6" fill="#CDA6F2" />
+      <circle cx="314" cy="292" r="6" fill="#CDA6F2" />
+
+      <path d="M0 -28 L13 -8 L9 16 L-9 16 L-13 -8 Z" transform="translate(256 118) scale(1.18)" fill="url(#hyG-headC)" />
+      <path d="M0 -28 L13 -8 L9 16 L-9 16 L-13 -8 Z" transform="translate(150 164) rotate(-30) scale(1.02)" fill="url(#hyG-headS)" />
+      <path d="M0 -28 L13 -8 L9 16 L-9 16 L-13 -8 Z" transform="translate(362 164) rotate(30) scale(1.02)" fill="url(#hyG-headS)" />
+
+      <circle cx="256" cy="388" r="25" fill="url(#hyG-cortex)" />
+      <circle cx="256" cy="388" r="9" fill="#F2FFFC" />
+    </svg>
+  )
+}
+
+// A branded stand-in for a plain spinner. Rotation is a transform, not a
+// filter/blur — cheap on GPU-less machines, unlike the mark's original glow
+// filter (fine for a static icon shown once, wasted on something looping).
+// Respects prefers-reduced-motion by holding a single frame instead of
+// spinning forever for no informational gain.
+export function HydraSpinner({ className }: { className?: string }) {
+  return <HydraMark className={`hy-spinner${className ? ` ${className}` : ''}`} />
+}

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -228,4 +228,7 @@ export interface ChatReply {
   /** Links the reply into Session — "why did it say that" is one click. */
   runId: string
   error?: string
+  /** No heads discoverable at all — the dock offers to retry instead of
+   *  showing a raw dispatch error. */
+  needsProbe?: boolean
 }

--- a/desktop/frontend/src/views/ChatDock.tsx
+++ b/desktop/frontend/src/views/ChatDock.tsx
@@ -74,6 +74,27 @@ export function ChatDock({
     }
   }
 
+  // No heads discoverable at all — dispatch.New already probes fresh on every
+  // call, so retrying the same prompt IS the "look again" action, not a
+  // separate one. Targets a turn by index and reuses its own stored prompt
+  // rather than the (already-cleared) input state.
+  async function retry(i: number) {
+    if (busy) return
+    const p = turns[i].prompt
+    setBusy(true)
+    try {
+      const reply = await Chat(p, enumKey)
+      setTurns((t) => t.map((turn, idx) => (idx === i ? { ...turn, reply } : turn)))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      setTurns((t) =>
+        t.map((turn, idx) => (idx === i ? { ...turn, reply: { ...emptyReply(), error: message } } : turn)),
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
   // Fires on open (the dock's own toggle button included, not just external
   // callers) and again on focusSignal so "already open, asked to start a
   // task again" still moves focus back to the input.
@@ -119,7 +140,17 @@ export function ChatDock({
           <div key={i} className="turn">
             <p className="turn__you">{t.prompt}</p>
             {!t.reply && <p className="turn__wait">routing…</p>}
-            {t.reply?.error && <p className="turn__err">{t.reply.error}</p>}
+            {t.reply?.error && !t.reply.needsProbe && <p className="turn__err">{t.reply.error}</p>}
+            {t.reply?.needsProbe && (
+              <div className="turn__probe">
+                <p className="turn__err">
+                  {t.reply.error} Start a local model or add an API key, then try again.
+                </p>
+                <button className="turn__retry" onClick={() => retry(i)} disabled={busy}>
+                  Check again
+                </button>
+              </div>
+            )}
             {t.reply && !t.reply.error && (
               <>
                 <p className="turn__out">{t.reply.output}</p>

--- a/internal/editor/runlog.go
+++ b/internal/editor/runlog.go
@@ -42,7 +42,7 @@ func logEdit(req Request, before, after string, added, removed int) {
 	_ = runlog.New(runID).Append(runlog.Event{
 		Kind:   runlog.KindEdit,
 		TaskID: taskID,
-		Agent:  req.File,
+		File:   req.File,
 		Ref:    ref,
 		Detail: detail,
 	})

--- a/internal/runlog/runlog.go
+++ b/internal/runlog/runlog.go
@@ -83,7 +83,8 @@ const (
 	// last_handoff.json; appending it here is what makes a chain reconstructable.
 	KindHandoff Kind = "handoff"
 
-	// KindEdit is a file edit. Ref points at the content; the body is never inlined.
+	// KindEdit is a file edit. File is the path changed; Ref points at the
+	// content, which is never inlined.
 	KindEdit Kind = "edit"
 
 	KindError Kind = "error"
@@ -119,6 +120,11 @@ type Event struct {
 	// short human string. Neither may carry a diff or a full model response.
 	Ref    string `json:"ref,omitempty"`
 	Detail string `json:"detail,omitempty"`
+
+	// File is the path a KindEdit event changed. Its own field, not Agent —
+	// an edit has no identity of its own, only a task it happened within
+	// (#434); conflating the two used to mint a phantom tree node per file.
+	File string `json:"file,omitempty"`
 }
 
 // Dir is where per-run files live.

--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -169,7 +169,19 @@ func Apply(t *Tree, e runlog.Event) *Tree {
 		return t
 	}
 
-	n := t.node(id)
+	// An event with no identity of its own — Agent and Head both empty, e.g.
+	// a KindEdit, which records which file changed, not who changed it — has
+	// nodeID fall back to the raw TaskID. Minting a node under that key would
+	// split one task across two disconnected nodes the moment anything else
+	// (head_selected, dispatch_finished) already claimed it under the real
+	// agent/head identity (#434). Attribute it to that existing node instead.
+	var n *Node
+	if e.Agent == "" && e.Head == "" && e.TaskID != "" {
+		n = t.nodeByTaskID(e.TaskID)
+	}
+	if n == nil {
+		n = t.node(id)
+	}
 	if e.TaskID != "" {
 		n.TaskID = e.TaskID
 	}
@@ -250,6 +262,19 @@ func (t *Tree) node(id string) *Node {
 	t.Order = append(t.Order, id)
 	t.Roots = append(t.Roots, id) // provisional; link() promotes it to a child
 	return n
+}
+
+// nodeByTaskID finds a node already tracking this task, regardless of what
+// key it was created under (a task's first event sets that key; it is
+// usually the agent/head, not the task id itself). Runs are small enough
+// that a scan costs nothing worth indexing for.
+func (t *Tree) nodeByTaskID(taskID string) *Node {
+	for _, id := range t.Order {
+		if n := t.Nodes[id]; n != nil && n.TaskID == taskID {
+			return n
+		}
+	}
+	return nil
 }
 
 // link records an ownership edge, creating either endpoint if needed. A node

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -385,6 +385,38 @@ func TestApply_RunLevelEventsNeverCreateNodes(t *testing.T) {
 	}
 }
 
+// A KindEdit event carries no identity of its own — it records which file
+// changed, not who changed it — so nodeID falls back to TaskID. Before #434,
+// Agent held the edited file path instead (a since-removed overload), which
+// took priority over that TaskID fallback and split the run into two
+// disconnected nodes: the real agent, and a phantom one named after the file,
+// stuck at StatePending forever since nothing else ever touched it.
+func TestApply_EditEventJoinsItsTasksNodeNotAPhantomOne(t *testing.T) {
+	events := []runlog.Event{
+		{V: 1, Seq: 1, RunID: "r", TaskID: "task-abc", Kind: runlog.KindHeadSelected, Head: "flash-med"},
+		{V: 1, Seq: 2, RunID: "r", TaskID: "task-abc", Kind: runlog.KindDispatchFinished,
+			Head: "flash-med", Status: "ok"},
+		{V: 1, Seq: 3, RunID: "r", TaskID: "task-abc", Kind: runlog.KindEdit,
+			File: "/private/tmp/scratch/greet.py", Ref: "000001", Detail: "+2/-0"},
+	}
+	tr, _ := Reconstruct(events)
+
+	if len(tr.Nodes) != 1 {
+		t.Fatalf("got %d nodes, want 1 — the edit must join flash-med, not mint its own: %+v",
+			len(tr.Nodes), tr.Nodes)
+	}
+	n := tr.Nodes["flash-med"]
+	if n == nil {
+		t.Fatal("no node keyed by the real head \"flash-med\"")
+	}
+	if n.State != StateOK {
+		t.Errorf("state = %q, want ok — the edit event must not downgrade a finished node", n.State)
+	}
+	if n.Detail != "+2/-0" {
+		t.Errorf("detail = %q, want the edit's line counts", n.Detail)
+	}
+}
+
 // Apply refuses to create a node for a run-level event; entryOf must agree, or
 // the timeline names a node the tree does not have. nodeID falls back to
 // TaskID, which a run_started legitimately carries.


### PR DESCRIPTION
## Summary
Folds PR #439's commit (agent-tree phantom-node fix, branding, chat-probe UX) into `release/v1.3.0`.

**Not a full develop merge.** `develop` has moved much further than just #439 — it now also carries a large, unrelated OWASP security-dashboard feature line (#399, #436: `internal/security/{attest,controls,crosswalk,drift,evidence,exposure,identity,incident,policyaudit,posture,risk,supplychain,threat}.go`, the desktop Security view, TUI security tab). That's a different, still-in-progress work stream this release was never scoped to include, so this cherry-picks only `d945a42` (#439's squash commit) onto `release/v1.3.0` rather than merging all of develop.

## Conflicts
Two, both from that unrelated work being adjacent in the diff, not from real divergence in #439 itself:
- `internal/security/blast.go` — #439 touched this file (fixing its own instance of the `Agent`-field misuse bug), but `blast.go` doesn't exist on `release/v1.3.0` at all — it's part of the not-yet-included security dashboard. Dropped the change; there's no consumer to fix here since the file isn't shipping in this release.
- `desktop/frontend/src/App.tsx` — the patch's context around the loading-spinner change included an adjacent Security-view JSX block from #436 that isn't present on this branch. Resolved to keep only the loading-spinner change; confirmed no stray `Security`/`GetSecurity`/`ErrorBoundary` references remain.

## Test plan
- [x] `go build`/`go vet`/`go test -count=1` clean on the root module (all packages)
- [x] `go build`/`go vet`/`go test -count=1 -race` clean on the desktop module
- [x] `npm run build` (tsc + vite) clean