### PR TITLE
fix(cost): tail 0 returns no rows

### DIFF
--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -241,9 +241,13 @@ func ByRun(runID string) (*ByRunResult, error) {
 }
 
 // Tail returns the last N rows, newest first, via a backward tail-seek rather
-// than loading the whole log.
+// than loading the whole log. n == 0 returns no rows, matching `tail -n 0`.
+// n < 0 returns everything — see #464 for tightening that UX separately.
 func Tail(n int) ([]Row, error) {
-	if n <= 0 {
+	if n == 0 {
+		return nil, nil
+	}
+	if n < 0 {
 		return LoadAll()
 	}
 	lines, err := tailLines(costLogPath(), n)

--- a/internal/cost/cost_log_test.go
+++ b/internal/cost/cost_log_test.go
@@ -578,7 +578,7 @@ func TestTail_NewestFirstAndClamped(t *testing.T) {
 		t.Errorf("Tail(2) = %+v, want newest first", two)
 	}
 
-	for _, n := range []int{0, -1, 999} {
+	for _, n := range []int{-1, 999} {
 		all, err := Tail(n)
 		if err != nil {
 			t.Fatal(err)
@@ -586,6 +586,23 @@ func TestTail_NewestFirstAndClamped(t *testing.T) {
 		if len(all) != 3 {
 			t.Errorf("Tail(%d) returned %d rows, want all 3 clamped", n, len(all))
 		}
+	}
+}
+
+// Tail(0) must mean "no rows", matching the `tail -n 0` convention — the
+// previous behavior returned everything, identical to Tail(999999) (#455).
+func TestTail_ZeroReturnsNoRows(t *testing.T) {
+	fixture(t,
+		row(t, Row{TS: "2026-08-01T00:00:00Z", Model: "a", PromptTokens: 1}),
+		row(t, Row{TS: "2026-08-02T00:00:00Z", Model: "b", PromptTokens: 1}),
+	)
+
+	got, err := Tail(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("Tail(0) returned %d rows, want 0", len(got))
 	}
 }
 


### PR DESCRIPTION
Closes #455

`cost.Tail(0)` treated `n <= 0` as "no limit" and returned every row, identical to `Tail(999999)` — inverting the standard `tail -n 0` convention (print nothing). Fixed `n == 0` to return an empty slice unconditionally; `n < 0` (only reachable via `cost tail -- -5`, since cobra rejects a bare `-5`) still returns everything, left as-is per #464 which covers negative-number UX separately.