### PR TITLE
fix(dispatch): surface --a2a errors instead of swallowing them

### DIFF
--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -132,11 +132,24 @@ func TestCLI_Dispatch_TierAndSystemPromptAndA2A(t *testing.T) {
 		t.Fatalf("`--tier 6 --system` failed: %v (%s)", err, cobraOut)
 	}
 
-	// --a2a prepends a prior handoff. A file that is not there must not fail the
-	// run: a first dispatch pointed at a not-yet-written handoff still runs.
-	if _, _, err := run(t, "dispatch", "--tier", "6",
-		"--a2a", filepath.Join(repo, "absent.json"), "hello"); err != nil {
-		t.Errorf("an absent --a2a file failed the dispatch: %v", err)
+	// --a2a names a file the user explicitly asked for: an absent one must fail
+	// the dispatch with a clear message, not silently proceed without it (#450).
+	absent := filepath.Join(repo, "absent.json")
+	if _, cobraOut, err := run(t, "dispatch", "--tier", "6",
+		"--a2a", absent, "hello"); err == nil {
+		t.Error("an absent --a2a file did not fail the dispatch")
+	} else if !strings.Contains(err.Error()+cobraOut, absent) {
+		t.Errorf("error = %v (%s), want it to name the offending path", err, cobraOut)
+	}
+
+	// Malformed JSON must fail the same way.
+	bad := filepath.Join(repo, "bad.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, cobraOut, err := run(t, "dispatch", "--tier", "6",
+		"--a2a", bad, "hello"); err == nil {
+		t.Errorf("a malformed --a2a file did not fail the dispatch (%s)", cobraOut)
 	}
 
 	// A real handoff is read and injected.

--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -362,9 +362,9 @@ func TestDispatch_PIIForcesLocalOnlyAndSaysSoWhenNothingIsLocal(t *testing.T) {
 	}
 }
 
-// A2A injection: the handoff's context must reach the prompt, and a missing or
-// corrupt handoff file must leave the prompt untouched rather than failing the
-// dispatch.
+// A2A injection: the handoff's context must reach the prompt when the file is
+// valid, and a missing or corrupt handoff file must fail loudly (#450) rather
+// than silently dispatching without the context the user asked for.
 func TestInjectA2A(t *testing.T) {
 	dir := t.TempDir()
 
@@ -388,39 +388,69 @@ func TestInjectA2A(t *testing.T) {
 		}
 	}
 
-	// An absent file is "no handoff", not a failure: a2a.Load reports it as
-	// (nil, nil) and the prompt goes through untouched. That distinction is why
-	// a first dispatch with --a2a pointed at a not-yet-written file still runs.
-	got, err = injectA2A(filepath.Join(dir, "absent.json"), "unchanged")
-	if err != nil {
-		t.Errorf("a missing handoff file was an error: %v", err)
-	}
-	if got != "unchanged" {
-		t.Errorf("prompt = %q with no handoff, want it untouched", got)
+	// --a2a always names a file the user explicitly asked for, so a missing
+	// file must be an error, not silently treated as "no handoff".
+	if _, err := injectA2A(filepath.Join(dir, "absent.json"), "unchanged"); err == nil {
+		t.Error("a missing --a2a file did not produce an error")
 	}
 
 	if err := os.WriteFile(path, []byte("{truncated"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got, err := injectA2A(path, "unchanged"); err == nil || got != "unchanged" {
-		t.Errorf("corrupt handoff = (%q, %v), want the prompt untouched and an error", got, err)
+	if _, err := injectA2A(path, "unchanged"); err == nil {
+		t.Error("a malformed --a2a file did not produce an error")
 	}
 }
 
-// A dispatch given --a2a must not be derailed by a broken handoff file.
-func TestDispatch_BrokenA2AFileDoesNotFailTheRun(t *testing.T) {
+// A dispatch given a bad --a2a path must fail clearly instead of silently
+// running without the handoff context the user explicitly asked for (#450).
+func TestDispatch_BadA2AFileFailsTheRun(t *testing.T) {
 	s := testutil.NewSandbox(t)
-	dd := liveDispatcher(echoHead(t, s, "h1", 90))
 
-	res, err := dd.Dispatch(context.Background(), "work", Options{
-		A2AFile: filepath.Join(t.TempDir(), "nope.json"),
+	t.Run("nonexistent file", func(t *testing.T) {
+		dd := liveDispatcher(echoHead(t, s, "h1", 90))
+		_, err := dd.Dispatch(context.Background(), "work", Options{
+			A2AFile: filepath.Join(t.TempDir(), "nope.json"),
+		})
+		if err == nil {
+			t.Fatal("a nonexistent --a2a file did not fail the dispatch")
+		}
+		if !strings.Contains(err.Error(), "nope.json") {
+			t.Errorf("error = %v, want it to name the offending path", err)
+		}
 	})
-	if err != nil {
-		t.Fatalf("an unreadable --a2a file failed the whole dispatch: %v", err)
-	}
-	if res.Output == "" {
-		t.Error("no output despite a working head")
-	}
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		dd := liveDispatcher(echoHead(t, s, "h2", 90))
+		path := filepath.Join(t.TempDir(), "bad.json")
+		if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := dd.Dispatch(context.Background(), "work", Options{A2AFile: path})
+		if err == nil {
+			t.Fatal("a malformed --a2a file did not fail the dispatch")
+		}
+	})
+
+	t.Run("valid file still dispatches", func(t *testing.T) {
+		dd := liveDispatcher(echoHead(t, s, "h3", 90))
+		h := a2a.Handoff{From: "agent-1", Task: "earlier task"}
+		raw, err := json.Marshal(h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(t.TempDir(), "handoff.json")
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		res, err := dd.Dispatch(context.Background(), "work", Options{A2AFile: path})
+		if err != nil {
+			t.Fatalf("a valid --a2a file failed the dispatch: %v", err)
+		}
+		if res.Output == "" {
+			t.Error("no output despite a working head")
+		}
+	})
 }
 
 // claudeMode is the token-preservation governor. Its whole purpose is to

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -142,12 +142,15 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		log.Printf("ℹ️  Claude at %d%% — Consider running /compact.", pct)
 	}
 
-	// Inject A2A handoff context into prompt if provided.
+	// Inject A2A handoff context into prompt if provided. --a2a names a file the
+	// user explicitly asked for, so a read/parse failure must fail the dispatch
+	// rather than silently running without the handoff context (#450).
 	if opts.A2AFile != "" {
 		injected, err := injectA2A(opts.A2AFile, prompt)
-		if err == nil {
-			prompt = injected
+		if err != nil {
+			return nil, fmt.Errorf("--a2a %s: %w", opts.A2AFile, err)
 		}
+		prompt = injected
 	}
 
 	req := policy.Request{Prompt: prompt, TierHint: tier}
@@ -354,13 +357,16 @@ func asIntSlice(v any) []int {
 }
 
 // injectA2A reads a handoff JSON file and prepends a structured block to the prompt.
+// The path always comes from the user-supplied --a2a flag, so unlike a2a.Load's
+// "missing file = no prior handoff" contract for its other (auto-load) callers,
+// a missing or malformed file here is a mistake the user needs to hear about.
 func injectA2A(path, prompt string) (string, error) {
 	h, err := a2a.Load(path)
 	if err != nil {
-		return prompt, fmt.Errorf("a2a: %w", err)
+		return prompt, fmt.Errorf("a2a: malformed handoff file %s: %w", path, err)
 	}
 	if h == nil {
-		return prompt, nil // no handoff → prompt unchanged
+		return prompt, fmt.Errorf("a2a: handoff file not found: %s", path)
 	}
 	return h.PromptBlock(prompt) + "\n\nADDITIONAL INSTRUCTION:\n" + prompt, nil
 }


### PR DESCRIPTION
Closes #450

`Dispatch()` discarded the error from `injectA2A()`, so a missing or malformed `--a2a` file silently ran the dispatch without the handoff context the user asked for, with no indication anything was wrong. `injectA2A` also treated an absent file as "no handoff" (borrowed from `a2a.Load`'s auto-load contract used elsewhere), which masked typo'd paths the same way.

Now a bad `--a2a` path (unreadable or invalid JSON) fails the dispatch with a clear error naming the offending path, while a valid handoff file behaves exactly as before.