### PR TITLE
fix(desktop): graph label truncation + artifact node state

### DIFF
--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1250,9 +1250,12 @@ body {
 .edge--a2a { stroke: var(--hy-violet); stroke-dasharray: 4 4; }
 
 .gnode { fill: var(--hy-bg-2); stroke: var(--hy-line); stroke-width: 1; }
-.gnode--ok      { stroke: var(--hy-cheap); }
-.gnode--failed  { stroke: var(--hy-expensive); }
-.gnode--running { stroke: var(--hy-aqua); }
+.gnode--ok       { stroke: var(--hy-cheap); }
+.gnode--failed   { stroke: var(--hy-expensive); }
+.gnode--running  { stroke: var(--hy-aqua); }
+/* Not an agent run — an edit-target node, say — so it gets a distinct dashed
+   neutral border rather than the "still to run" implication of pending. */
+.gnode--artifact { stroke: var(--hy-faint); stroke-dasharray: 3 3; }
 
 .gnode__label { fill: var(--hy-ink); font-family: var(--hy-font-mono); font-size: 11px; }
 .gnode__sub   { fill: var(--hy-dim); font-family: var(--hy-font-mono); font-size: 10px; }

--- a/desktop/frontend/src/views/RunGraph.tsx
+++ b/desktop/frontend/src/views/RunGraph.tsx
@@ -36,7 +36,7 @@ export function RunGraph({ agents }: { agents: Agent[] }) {
               width={NODE_W}
               height={NODE_H}
               rx={7}
-              className={`gnode gnode--${n.state || 'pending'}`}
+              className={`gnode gnode--${n.state}`}
             />
             <text x={8} y={17} className="gnode__label">
               {n.label}
@@ -53,6 +53,15 @@ function shortLabel(a: Agent): string {
   return s.length > LABEL_MAX ? `${s.slice(0, LABEL_MAX - 1)}…` : s
 }
 
+// A node with none of these signals never went through a run lifecycle — an
+// edit-target node, say — so it isn't "pending" (still to run); it's an
+// artifact the run touched. Reusing 'pending' reads as stuck forever (#462).
+function stateClass(a: Agent): string {
+  if (a.state && a.state !== 'pending') return a.state
+  if (a.tier > 0 || a.durationMs > 0) return 'pending'
+  return 'artifact'
+}
+
 function layout(agents: Agent[]) {
   const { nodes: placed, edges: lines, width, height } = layoutDag(
     agents.map((a) => ({ id: a.id, parent: a.parent })),
@@ -65,7 +74,7 @@ function layout(agents: Agent[]) {
   for (const p of placed) {
     const a = byID.get(p.id)
     if (!a) continue
-    nodes.push({ id: p.id, x: p.x, y: p.y, label: shortLabel(a), state: a.state })
+    nodes.push({ id: p.id, x: p.x, y: p.y, label: shortLabel(a), state: stateClass(a) })
   }
 
   return { nodes, lines, width, height }

--- a/desktop/frontend/src/views/SessionGraph.tsx
+++ b/desktop/frontend/src/views/SessionGraph.tsx
@@ -1,11 +1,14 @@
 import { useMemo } from 'react'
-import type { Session } from '../types'
+import type { Agent, Session } from '../types'
 import { layoutDag } from '../dagreLayout'
 
 // Sugiyama/dagre layout mechanics live in dagreLayout.ts, shared with Fleet's
 // inline run graph — see that file for why dagre over a force-directed layout.
 const NODE_W = 168
 const NODE_H = 46
+// Wider than RunGraph's LABEL_MAX (12): this node has more room, but a full
+// file path (an edit-target node's label) still needs truncating to fit it.
+const LABEL_MAX = 24
 
 interface Placed {
   id: string
@@ -38,7 +41,7 @@ export function SessionGraph({ session }: { session: Session }) {
               width={NODE_W}
               height={NODE_H}
               rx={10}
-              className={`gnode gnode--${n.state || 'pending'}`}
+              className={`gnode gnode--${n.state}`}
             />
             <text x={11} y={19} className="gnode__label">
               {n.label}
@@ -54,6 +57,23 @@ export function SessionGraph({ session }: { session: Session }) {
       </p>
     </div>
   )
+}
+
+function shortLabel(s: string): string {
+  if (s.length <= LABEL_MAX) return s
+  // File paths: the filename at the end is the meaningful part, so truncate
+  // from the start — clipping the end instead hides it (#461).
+  if (s.includes('/')) return `…${s.slice(-(LABEL_MAX - 1))}`
+  return `${s.slice(0, LABEL_MAX - 1)}…`
+}
+
+// A node with none of these signals never went through a run lifecycle — an
+// edit-target node, say — so it isn't "pending" (still to run); it's an
+// artifact the run touched. Reusing 'pending' reads as stuck forever (#462).
+function stateClass(a: Agent): string {
+  if (a.state && a.state !== 'pending') return a.state
+  if (a.tier > 0 || a.durationMs > 0) return 'pending'
+  return 'artifact'
 }
 
 function layout(session: Session) {
@@ -72,12 +92,12 @@ function layout(session: Session) {
       id: p.id,
       x: p.x,
       y: p.y,
-      label: a.model || a.head || a.id,
+      label: shortLabel(a.model || a.head || a.id),
       // Verifiable facts first — tier, state, duration — rather than narration.
       sub: [a.tier > 0 ? `T${a.tier}` : null, a.state, a.durationMs > 0 ? `${a.durationMs}ms` : null]
         .filter(Boolean)
         .join(' · '),
-      state: a.state,
+      state: stateClass(a),
     })
   }
 


### PR DESCRIPTION
Closes #461
Closes #462

SessionGraph node labels had no truncation, so long values (e.g. a full file path from an edit-target node) ran past the SVG node's boundary with no ellipsis. Added a `shortLabel` helper (LABEL_MAX 24, wider than RunGraph's 12 since the node is larger) that truncates from the start for path-like labels so the filename stays visible, and from the end otherwise.

Both RunGraph and SessionGraph rendered node state as `n.state || 'pending'`, so non-agent nodes (e.g. an edited-file node, which the Go backend never advances past its initial pending state) always looked "still in progress" even after the underlying action completed. Added a `stateClass` helper that classifies a node with no state signal, no tier, and no duration as a distinct `artifact` class instead, with a neutral dashed-border style in app.css.