### PR TITLE
fix(dispatch): validate --swarm-mode in dry-run

### DIFF
--- a/cmd/hydra/cli_more_test.go
+++ b/cmd/hydra/cli_more_test.go
@@ -206,6 +206,9 @@ func TestCLI_Dispatch_RefusesBadFlagsBeforeSpending(t *testing.T) {
 		{"confidence of zero", []string{"dispatch", "--confidence", "0", "x"}},
 		{"negative confidence", []string{"dispatch", "--confidence", "-0.5", "x"}},
 		{"unknown swarm mode", []string{"dispatch", "--swarm", "--swarm-mode", "sideways", "x"}},
+		// #453: --dry-run must reject a bad --swarm-mode exactly like a real
+		// run does, not print a plan for a mode Run would then refuse.
+		{"unknown swarm mode with dry run", []string{"dispatch", "--swarm", "--swarm-mode", "sideways", "--dry-run", "x"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -184,6 +184,28 @@ func TestCLI_Dispatch_SwarmDryRunFiresNothing(t *testing.T) {
 	}
 }
 
+// Every real swarm mode must still plan cleanly under --dry-run — #453 fixed
+// dry-run to validate --swarm-mode, and that must not catch valid modes too.
+func TestCLI_Dispatch_SwarmDryRunValidModesFireNothing(t *testing.T) {
+	for _, mode := range []string{"race", "best", "all"} {
+		t.Run(mode, func(t *testing.T) {
+			dispatchable(t, "answered")
+
+			out, cobraOut, err := run(t, "dispatch", "--swarm", "--swarm-mode", mode,
+				"--dry-run", "--tier", "6", "implement a rate limiter")
+			if err != nil {
+				t.Fatalf("a %s dry run failed: %v (%s)", mode, err, cobraOut)
+			}
+			if !strings.Contains(out+cobraOut, "DRY RUN") {
+				t.Errorf("the plan is not labelled as a dry run:\n%s", out+cobraOut)
+			}
+			if _, statErr := os.Stat(filepath.Join(config.Dir(), "logs", "cost.jsonl")); statErr == nil {
+				t.Errorf("a %s dry run wrote cost rows", mode)
+			}
+		})
+	}
+}
+
 // A real risk signal — PII in the prompt, or --irreversible/--production —
 // must trigger SPRT mode on its own, not just --file's blast radius.
 func TestCLI_Dispatch_RiskSignalsTriggerSPRTWithoutFileOrConfidence(t *testing.T) {

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -102,6 +102,18 @@ func New(d *dispatch.Dispatcher, heads []provider.Head, pricing PricingReader) *
 	return &Swarm{d: d, heads: heads, pricing: pricing}
 }
 
+// validateMode rejects any SwarmMode Run does not know how to execute. Plan
+// calls this too, so a `--dry-run` reports a plan only for a mode Run would
+// actually accept, instead of previewing a run that Run then refuses (#453).
+func validateMode(m SwarmMode) error {
+	switch m {
+	case ModeRace, ModeBest, ModeAll:
+		return nil
+	default:
+		return fmt.Errorf("swarm: unknown mode %q", m)
+	}
+}
+
 // Plan reports what Run or RunSPRT would do without executing anything: which
 // heads would be engaged, and what one round of fan-out is estimated to cost.
 //
@@ -114,6 +126,13 @@ func New(d *dispatch.Dispatcher, heads []provider.Head, pricing PricingReader) *
 // selector against the same options; a plan that picked different heads from the
 // run it describes would be worse than no plan.
 func (s *Swarm) Plan(prompt string, opts Options) (heads []provider.Head, estUSD float64, err error) {
+	if opts.Mode == "" {
+		opts.Mode = ModeBest
+	}
+	if err := validateMode(opts.Mode); err != nil {
+		return nil, 0, err
+	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, 0, fmt.Errorf("swarm: config load: %w", err)
@@ -133,6 +152,9 @@ func (s *Swarm) Plan(prompt string, opts Options) (heads []provider.Head, estUSD
 func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmResult, error) {
 	if opts.Mode == "" {
 		opts.Mode = ModeBest
+	}
+	if err := validateMode(opts.Mode); err != nil {
+		return nil, err
 	}
 
 	cfg, err := config.Load()
@@ -165,8 +187,6 @@ func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmRes
 		attempts = runRace(ctx, selected, prompt, opts)
 	case ModeBest, ModeAll:
 		attempts = runAll(ctx, selected, prompt, opts)
-	default:
-		return nil, fmt.Errorf("swarm: unknown mode %q", opts.Mode)
 	}
 
 	wallDuration := time.Since(startedAt)

--- a/internal/swarm/swarm_test.go
+++ b/internal/swarm/swarm_test.go
@@ -381,3 +381,32 @@ func TestPlan_EmptyResultIsAlwaysAnError(t *testing.T) {
 		}
 	})
 }
+
+// #453: `--dry-run` used to print a full plan for a mode Run would reject
+// outright, because Plan never validated Mode at all. Plan must fail the same
+// way Run does, before it ever reports heads or cost as if the run were sound.
+func TestPlan_RejectsUnknownModeLikeRun(t *testing.T) {
+	withTempConfig(t)
+	all := []provider.Head{registryHead("h1", "H1", 90)}
+	s := New(nil, all, fakePricing{per: 0.01})
+
+	_, _, planErr := s.Plan("p", Options{Mode: "bogus"})
+	if planErr == nil {
+		t.Fatal("Plan accepted an unknown swarm mode")
+	}
+	_, runErr := s.Run(context.Background(), "p", Options{Mode: "bogus"})
+	if runErr == nil {
+		t.Fatal("Run accepted an unknown swarm mode")
+	}
+	if planErr.Error() != runErr.Error() {
+		t.Errorf("Plan and Run disagree on an unknown mode:\nPlan: %v\nRun:  %v", planErr, runErr)
+	}
+
+	// Every mode Run actually executes must still plan cleanly, including the
+	// zero value, which both Plan and Run default to ModeBest.
+	for _, mode := range []SwarmMode{ModeRace, ModeBest, ModeAll, ""} {
+		if _, _, err := s.Plan("p", Options{Mode: mode}); err != nil {
+			t.Errorf("Plan rejected valid mode %q: %v", mode, err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #453

`hyctl dispatch --swarm --dry-run --swarm-mode bogus "task"` used to print a full dry-run plan and exit 0, because `Swarm.Plan` never checked `opts.Mode` — only `Swarm.Run`'s execution switch did, and dry-run never reaches it. Extracted that check into a shared `validateMode` helper called by both `Plan` and `Run`, so a dry run now fails with the identical `swarm: unknown mode "bogus"` error a real run produces, while valid modes (race/best/all) still plan exactly as before.