### PR TITLE
fix: validate record flags and fix calibration table truncation

### DIFF
--- a/cmd/hydra/cli_data_test.go
+++ b/cmd/hydra/cli_data_test.go
@@ -284,6 +284,64 @@ func TestCLI_TrustRecordThenCalibration_RoundTrips(t *testing.T) {
 	}
 }
 
+// calibration is append-only, so a blank --domain writes a permanent, unfixable
+// row. It must be refused up front, exactly like --source and --outcome.
+func TestCLI_TrustRecord_RequiresDomain(t *testing.T) {
+	populated(t)
+
+	_, cobraOut, err := run(t, "trust", "record",
+		"--source", "model:test-head", "--said-correct", "--outcome", "correct")
+	if err == nil {
+		t.Fatal("`hyctl trust record` without --domain was accepted")
+	}
+	if !strings.Contains(err.Error()+cobraOut, "--domain") {
+		t.Errorf("error = %v, want it to name --domain", err)
+	}
+}
+
+// Two domains sharing a ten-character prefix (e.g. "trust-bench" and
+// "trust-bench-v2") must not render as the identical truncated label — that
+// makes rows with different n/D visually indistinguishable.
+func TestCLI_TrustCalibration_DistinguishesDomainsWithSharedPrefix(t *testing.T) {
+	populated(t)
+
+	if _, cobraOut, err := run(t, "trust", "record",
+		"--source", "model:x", "--domain", "trust-bench",
+		"--said-correct", "--outcome", "correct"); err != nil {
+		t.Fatalf("`hyctl trust record` (trust-bench) failed: %v (%s)", err, cobraOut)
+	}
+	if _, cobraOut, err := run(t, "trust", "record",
+		"--source", "model:x", "--domain", "trust-bench-v2",
+		"--said-correct", "--outcome", "incorrect"); err != nil {
+		t.Fatalf("`hyctl trust record` (trust-bench-v2) failed: %v (%s)", err, cobraOut)
+	}
+
+	out, cobraOut, err := run(t, "trust", "calibration")
+	if err != nil {
+		t.Fatalf("`hyctl trust calibration` failed: %v", err)
+	}
+	table := out + cobraOut
+
+	var domains []string
+	for _, line := range strings.Split(table, "\n") {
+		if !strings.Contains(line, "model:x") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			t.Fatalf("row for model:x has no domain column: %q", line)
+		}
+		domains = append(domains, fields[1])
+	}
+	if len(domains) != 2 {
+		t.Fatalf("want 2 rows for model:x, got %d (%v):\n%s", len(domains), domains, table)
+	}
+	if domains[0] == domains[1] {
+		t.Errorf("both domains rendered as the same label %q — the rows are "+
+			"visually indistinguishable:\n%s", domains[0], table)
+	}
+}
+
 // The defect model sets how much confidence a task needs. PII and production
 // must both raise the bar — that is the whole point of the flags.
 func TestCLI_TrustDefect_RaisesTheBarForRiskyWork(t *testing.T) {

--- a/cmd/hydra/cli_more_test.go
+++ b/cmd/hydra/cli_more_test.go
@@ -123,6 +123,12 @@ func TestCLI_MCPRecord_RefusesMalformedInput(t *testing.T) {
 		{"mcp", "record", "--tool", "t", "--action", "read",
 			"--decision", "allow", "--resource", "/x", "--agent", "a",
 			"--params", "{not json"},
+		// A bare `hyctl mcp record` (no --tool/--agent) used to exit 0 and
+		// silently append an empty-agent, empty-tool row forever (#457).
+		{"mcp", "record", "--action", "read",
+			"--decision", "allow", "--resource", "/x", "--agent", "a"},
+		{"mcp", "record", "--tool", "t", "--action", "read",
+			"--decision", "allow", "--resource", "/x"},
 	}
 	for _, args := range cases {
 		t.Run(strings.Join(args[2:6], " "), func(t *testing.T) {

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -903,6 +903,12 @@ func cmdMCP() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("--decision: %w", err)
 			}
+			if recTool == "" {
+				return fmt.Errorf("--tool is required")
+			}
+			if recAgent == "" {
+				return fmt.Errorf("--agent is required")
+			}
 			// Bind whenever --params was supplied — including "{}" — so this
 			// agrees with `check`, whose binding keys off a non-nil map.
 			var hash string
@@ -2864,11 +2870,11 @@ func cmdTrustCalibration() *cobra.Command {
 				fmt.Println("\n  No calibration recorded yet. Feed outcomes with `hyctl trust record`.")
 				return nil
 			}
-			fmt.Printf("\n  %-28s %-10s %6s %7s %7s %8s\n", "Source", "Domain", "n", "se", "sp", "D(nats)")
-			fmt.Println("  " + strings.Repeat("─", 74))
+			fmt.Printf("\n  %-28s %-16s %6s %7s %7s %8s\n", "Source", "Domain", "n", "se", "sp", "D(nats)")
+			fmt.Println("  " + strings.Repeat("─", 80))
 			for _, s := range stats {
-				fmt.Printf("  %-28.28s %-10.10s %6.0f %7.3f %7.3f %8.3f\n",
-					s.Source, s.Domain, s.N, s.Se, s.Sp, s.D)
+				fmt.Printf("  %-28.28s %-16s %6.0f %7.3f %7.3f %8.3f\n",
+					s.Source, truncLabel(s.Domain, 16), s.N, s.Se, s.Sp, s.D)
 			}
 			// A family whose members have converged on effectively one vote is a
 			// coordination risk the se/sp table above cannot show — two "sources"
@@ -2901,6 +2907,9 @@ func cmdTrustRecord() *cobra.Command {
 			}
 			if source == "" {
 				return fmt.Errorf("--source is required")
+			}
+			if domain == "" {
+				return fmt.Errorf("--domain is required")
 			}
 			cal, err := trust.New(trust.DefaultPath())
 			if err != nil {


### PR DESCRIPTION
Closes #456
Closes #457
Closes #458

`hyctl trust record` accepted a blank `--domain` and wrote a permanent `"domain":""` row to the append-only calibration log; it now requires `--domain` the same way it already requires `--source` and `--outcome`. `hyctl mcp record` accepted zero flags and silently appended an empty-agent, empty-tool event to the accountability ledger forever; it now requires `--tool` and `--agent`, matching the existing strict validation on `--decision`/`--action`. The calibration table's Domain column used a hard `%-10.10s` format with no ellipsis, so domains sharing a 10-character prefix (e.g. `trust-bench` and `trust-bench-v2`) rendered as identical, indistinguishable rows; the column is now 16 characters wide and truncates with a trailing ellipsis only when it actually needs to. `--json` output was already correct and is unaffected.

Added tests cover all three: `trust record` without `--domain` errors clearly, `mcp record` without `--tool`/`--agent` errors clearly, and a calibration table with two domains sharing a 10-character prefix renders them as distinct rows.