### PR TITLE
fix(ledger): serialize chainhash read-modify-write to prevent races

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -199,6 +199,9 @@ func DefaultPath() string {
 }
 
 // Record appends one event, stamping TS and Config (best-effort) if blank.
+// The chainhash read-modify-write is guarded by an OS-level advisory lock
+// (chainLock) — an in-process mutex alone can't stop two `hyctl` processes
+// from forking the hash chain.
 func Record(path string, e Event) error {
 	if e.TS == "" {
 		e.TS = time.Now().UTC().Format(time.RFC3339)
@@ -208,14 +211,21 @@ func Record(path string, e Event) error {
 			e.Config = bc
 		}
 	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	lock, err := lockChain(lockPath(path))
+	if err != nil {
+		return err
+	}
+	defer lock.unlock()
+
 	if e.PrevHash == "" {
 		e.PrevHash = readChainHash(chainHashPath(path))
 	}
 	e.Hash = hashEvent(e)
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
-	}
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/ankit373/hydra/internal/testutil"
@@ -852,5 +853,42 @@ func TestVerifyChain_MixedUnchainedThenChainedIsIntact(t *testing.T) {
 	}
 	if !res.Intact || res.Chained != 3 || res.Unchained != 1 {
 		t.Errorf("ChainResult = %+v, want intact with 3 chained, 1 unchained", res)
+	}
+}
+
+// A swarm dispatch fans Record calls across goroutines against the same
+// ledger. Unserialized, two calls can read the same PrevHash and both append
+// a link claiming it, forking the chain (#443).
+func TestRecord_ConcurrentCallsDoNotForkTheChain(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	const n = 20
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = Record(path, Event{Agent: "a", Tool: "t", Decision: Allow})
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Record[%d]: %v", i, err)
+		}
+	}
+
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Intact {
+		t.Errorf("ChainResult = %+v, want Intact after %d concurrent Record calls", res, n)
+	}
+	if res.Chained != n {
+		t.Errorf("Chained = %d, want %d", res.Chained, n)
 	}
 }

--- a/internal/ledger/lock.go
+++ b/internal/ledger/lock.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+
+package ledger
+
+import "os"
+
+// chainLock serializes Record's chainhash read-modify-write. A sync.Mutex
+// only covers goroutines in one process; this needs to hold across separate
+// `hyctl` processes too, hence an OS-level advisory lock (flock/LockFileEx).
+type chainLock struct {
+	f *os.File
+}
+
+// lockChain opens (creating if needed) the sidecar lock file at path and
+// blocks until it holds an exclusive lock on it.
+func lockChain(path string) (*chainLock, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := lockExclusive(f); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &chainLock{f: f}, nil
+}
+
+// unlock releases the lock and closes the file. Closing releases the OS-level
+// lock even if unlockExclusive itself fails, so a panic between the two never
+// leaves the ledger permanently wedged.
+func (l *chainLock) unlock() error {
+	defer l.f.Close()
+	return unlockExclusive(l.f)
+}
+
+func lockPath(ledgerPath string) string { return ledgerPath + ".lock" }

--- a/internal/ledger/lock_unix.go
+++ b/internal/ledger/lock_unix.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package ledger
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// lockExclusive blocks until it holds an exclusive flock on f, retrying on
+// EINTR — a flock interrupted by a signal must be retried, not treated as
+// lock failure.
+func lockExclusive(f *os.File) error {
+	fd := int(f.Fd())
+	for {
+		err := unix.Flock(fd, unix.LOCK_EX)
+		if err != unix.EINTR {
+			return err
+		}
+	}
+}
+
+func unlockExclusive(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}

--- a/internal/ledger/lock_windows.go
+++ b/internal/ledger/lock_windows.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package ledger
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// allBytes locks/unlocks the whole file: LockFileEx takes a byte range, and
+// there's no "whole file" sentinel other than the maximum range.
+const allBytes = ^uint32(0)
+
+func lockExclusive(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.LockFileEx(windows.Handle(f.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, allBytes, allBytes, ol)
+}
+
+func unlockExclusive(f *os.File) error {
+	ol := new(windows.Overlapped)
+	return windows.UnlockFileEx(windows.Handle(f.Fd()), 0, allBytes, allBytes, ol)
+}


### PR DESCRIPTION
Closes #443

Record()'s chainhash read-modify-write (read `.chainhash` sidecar, compute this event's hash, append to the ledger, write the new sidecar hash) had no locking. Swarm dispatch fans work across goroutines that all call `ledger.Record()` concurrently against the same ledger, so two calls could read the same PrevHash and each append a link claiming that predecessor, forking the hash chain — permanently breaking `hyctl mcp verify-chain`.

The critical section is now guarded by an OS-level advisory lock (`flock` via `golang.org/x/sys/unix` on unix, `LockFileEx` via `golang.org/x/sys/windows` on Windows — both already-present transitive deps, no new dependency) on a `.lock` sidecar, so it serializes both goroutines within one process and separate `hyctl` processes. Added a regression test that fires 20 concurrent `Record()` calls at the same ledger and asserts `VerifyChain` reports an intact, fully-chained log; verified it reliably forks the chain against the old code and passes reliably (20x) against the fix, under `-race`.