### PR TITLE
fix(config): honor $HYDRA_HOME for all runtime state

### DIFF
--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/ankit373/hydra/internal/config"
 )
 
 //go:embed data.json
@@ -149,8 +151,7 @@ func (db *DB) Entries() []Entry {
 
 // DefaultOverlayPath is where user-added models live.
 func DefaultOverlayPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".hydra", "models.json")
+	return filepath.Join(config.Dir(), "models.json")
 }
 
 // LoadOverlay reads the user overlay. A missing file yields no entries.

--- a/internal/capabilities/coverage_test.go
+++ b/internal/capabilities/coverage_test.go
@@ -13,10 +13,25 @@ func TestDefaultOverlayPath_IsUnderTheUsersHydraDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_HOME", "")
 
 	want := filepath.Join(home, ".hydra", "models.json")
 	if got := DefaultOverlayPath(); got != want {
 		t.Errorf("DefaultOverlayPath() = %q, want %q", got, want)
+	}
+}
+
+// $HYDRA_HOME must win over $HOME (#442).
+func TestDefaultOverlayPath_PrefersHydraHomeOverHome(t *testing.T) {
+	home := t.TempDir()
+	hydraHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_HOME", hydraHome)
+
+	want := filepath.Join(hydraHome, "models.json")
+	if got := DefaultOverlayPath(); got != want {
+		t.Errorf("DefaultOverlayPath() = %q, want %q ($HYDRA_HOME, not $HOME)", got, want)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,8 +31,15 @@ type Config struct {
 	Policies map[string]Policy `toml:"policies,omitempty"`
 }
 
-// Dir returns the Hydra config directory (~/.hydra).
+// Dir returns the Hydra state directory: $HYDRA_HOME if set, else ~/.hydra.
+// Every subsystem that persists Hydra state (cost, trust, ledger, security,
+// run logs, config.toml) must resolve its path through this function rather
+// than calling os.UserHomeDir() directly, or $HYDRA_HOME silently stops being
+// an isolation boundary for it (#442).
 func Dir() string {
+	if h := os.Getenv("HYDRA_HOME"); h != "" {
+		return filepath.Clean(h)
+	}
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".hydra")
 }

--- a/internal/config/config_failure_test.go
+++ b/internal/config/config_failure_test.go
@@ -18,11 +18,16 @@ import (
 // accumulates silently on every collision.
 
 func TestSave_UnwritableConfigDirIsAnErrorNotSilentDataLoss(t *testing.T) {
-	s := testutil.NewSandbox(t)
+	testutil.NewSandbox(t)
 
-	// ~/.hydra is a regular file, so MkdirAll cannot create the directory. This
-	// happens for real when a stray `hydra` file is written by a script.
-	if err := os.WriteFile(filepath.Join(s.Home, ".hydra"), []byte("not a dir"), 0o600); err != nil {
+	// Dir() is a regular file, so MkdirAll cannot create the directory. This
+	// happens for real when a stray `hydra` file is written by a script. The
+	// sandbox pre-creates Dir() as an empty directory, so it must be removed
+	// first or the file write below would fail as "is a directory".
+	if err := os.RemoveAll(Dir()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(Dir(), []byte("not a dir"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -73,7 +78,12 @@ func TestSave_ReadOnlyConfigDirIsAnError(t *testing.T) {
 	}
 	testutil.NewSandbox(t)
 
-	if err := os.MkdirAll(Dir(), 0o500); err != nil {
+	// The sandbox pre-creates Dir(), so MkdirAll here would be a permission-set
+	// no-op on an already-existing directory — Chmod is what actually locks it.
+	if err := os.MkdirAll(Dir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(Dir(), 0o500); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(Dir(), 0o700) })

--- a/internal/config/config_io_test.go
+++ b/internal/config/config_io_test.go
@@ -22,8 +22,23 @@ import (
 // write loses the user's whole setup, and Save is the only thing standing
 // between them and that.
 
-func TestDirAndPath_LiveUnderTheUsersHome(t *testing.T) {
+// Dir prefers $HYDRA_HOME over $HOME/.hydra (#442) — the sandbox sets both to
+// distinct directories, so this only passes if HYDRA_HOME actually wins.
+func TestDirAndPath_PrefersHydraHomeOverUsersHome(t *testing.T) {
 	s := testutil.NewSandbox(t)
+
+	if got, want := Dir(), s.HydraHome; got != want {
+		t.Errorf("Dir() = %q, want $HYDRA_HOME %q", got, want)
+	}
+	if got, want := Path(), filepath.Join(s.HydraHome, "config.toml"); got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+}
+
+// With no $HYDRA_HOME at all, Dir falls back to $HOME/.hydra.
+func TestDirAndPath_FallBackToUsersHomeWithNoHydraHome(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	t.Setenv("HYDRA_HOME", "")
 
 	if got, want := Dir(), filepath.Join(s.Home, ".hydra"); got != want {
 		t.Errorf("Dir() = %q, want %q", got, want)

--- a/internal/cost/cost_log_test.go
+++ b/internal/cost/cost_log_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/testutil"
 )
 
@@ -21,11 +22,11 @@ import (
 // format contract as much as a data structure, and a parse that silently drops
 // rows understates what the user has spent.
 
-// fixture writes a cost log under the sandbox's HOME and returns its path.
+// fixture writes a cost log under the sandbox's $HYDRA_HOME and returns its path.
 func fixture(t *testing.T, lines ...string) string {
 	t.Helper()
-	s := testutil.NewSandbox(t)
-	dir := filepath.Join(s.Home, ".hydra", "logs")
+	testutil.NewSandbox(t)
+	dir := filepath.Join(config.Dir(), "logs")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/editor/edit_test.go
+++ b/internal/editor/edit_test.go
@@ -889,6 +889,11 @@ func TestWriteLastEdit_UnwritableLogDirIsAnError(t *testing.T) {
 	testutil.NewSandbox(t)
 
 	// ~/.hydra is a regular file, so logs/ cannot be created.
+	// The sandbox pre-creates config.Dir() as an empty directory, so it must
+	// be removed before a file can occupy that path instead.
+	if err := os.RemoveAll(config.Dir()); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(config.Dir(), []byte("not a dir"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -903,6 +908,11 @@ func TestLogEdit_IsBestEffort(t *testing.T) {
 	testutil.NewSandbox(t)
 
 	// Nothing to write into, and nothing may panic or block.
+	// The sandbox pre-creates config.Dir() as an empty directory, so it must
+	// be removed before a file can occupy that path instead.
+	if err := os.RemoveAll(config.Dir()); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(config.Dir(), []byte("not a dir"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/executor/providers_test.go
+++ b/internal/executor/providers_test.go
@@ -781,7 +781,11 @@ func TestRestoreAndRecover_AreBestEffortOnBadInput(t *testing.T) {
 func TestWriteAuthRequired_UnwritableLogDirIsSilent(t *testing.T) {
 	testutil.NewSandbox(t)
 
-	// ~/.hydra is a regular file, so logs/ cannot be created.
+	// Dir() is a regular file, so logs/ cannot be created. The sandbox
+	// pre-creates it as an empty directory, so remove that first.
+	if err := os.RemoveAll(config.Dir()); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(config.Dir(), []byte("not a dir"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ledger/coverage_test.go
+++ b/internal/ledger/coverage_test.go
@@ -17,6 +17,9 @@ func TestDefaultPaths_AreDistinctAndUnderHydraDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	// A developer or CI runner with a stray $HYDRA_HOME already exported must
+	// not leak into this "no override" case (#442 was found exactly this way).
+	t.Setenv("HYDRA_HOME", "")
 
 	log, policy := DefaultPath(), DefaultPolicyPath()
 	if !strings.HasPrefix(log, filepath.Join(home, ".hydra")) {
@@ -28,6 +31,23 @@ func TestDefaultPaths_AreDistinctAndUnderHydraDir(t *testing.T) {
 	if log == policy {
 		t.Error("the ledger and its policy are the same file; appending events " +
 			"would destroy the rules")
+	}
+}
+
+// $HYDRA_HOME must win over $HOME for the ledger — the whole point of #442 is
+// that this subsystem is exactly what silently ignored it before.
+func TestDefaultPaths_PreferHydraHomeOverHome(t *testing.T) {
+	home := t.TempDir()
+	hydraHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_HOME", hydraHome)
+
+	if got, want := DefaultPath(), filepath.Join(hydraHome, "mcp_ledger.jsonl"); got != want {
+		t.Errorf("DefaultPath() = %q, want %q ($HYDRA_HOME, not $HOME)", got, want)
+	}
+	if got, want := DefaultPolicyPath(), filepath.Join(hydraHome, "mcp_policy.json"); got != want {
+		t.Errorf("DefaultPolicyPath() = %q, want %q ($HYDRA_HOME, not $HOME)", got, want)
 	}
 }
 

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -194,8 +194,7 @@ func LatestBound(events []Event, tool, resource string) (Event, bool) {
 
 // DefaultPath is where the ledger lives (~/.hydra/mcp_ledger.jsonl).
 func DefaultPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".hydra", "mcp_ledger.jsonl")
+	return filepath.Join(config.Dir(), "mcp_ledger.jsonl")
 }
 
 // Record appends one event, stamping TS and Config (best-effort) if blank.
@@ -473,8 +472,7 @@ func ruleOr(s string) string {
 
 // DefaultPolicyPath is where the access policy lives (~/.hydra/mcp_policy.json).
 func DefaultPolicyPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".hydra", "mcp_policy.json")
+	return filepath.Join(config.Dir(), "mcp_policy.json")
 }
 
 // LoadPolicy reads a policy file. A missing file yields a default-allow policy

--- a/internal/parallel/edit_test.go
+++ b/internal/parallel/edit_test.go
@@ -782,7 +782,11 @@ func TestTSCTemplate_OnlyWhenTSCIsInstalled(t *testing.T) {
 func TestPersistResults_UnwritableLogDirIsReportedNotFatal(t *testing.T) {
 	testutil.NewSandbox(t)
 
-	// ~/.hydra is a regular file, so logs/ cannot be created.
+	// Dir() is a regular file, so logs/ cannot be created. The sandbox
+	// pre-creates it as an empty directory, so remove that first.
+	if err := os.RemoveAll(config.Dir()); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(config.Dir(), []byte("not a dir"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pricing/load_test.go
+++ b/internal/pricing/load_test.go
@@ -240,7 +240,11 @@ func TestFetchAndSave_UnwritableCacheStillReturnsThePrices(t *testing.T) {
 	testutil.NewSandbox(t)
 	stubOpenRouter(t, map[string]orPricing{"a/one": {Prompt: "0.000001", Completion: "0.000002"}})
 
-	// ~/.hydra is a regular file, so the cache directory cannot be created.
+	// Dir() is a regular file, so the cache directory cannot be created. The
+	// sandbox pre-creates it as an empty directory, so remove that first.
+	if err := os.RemoveAll(filepath.Dir(cachePath())); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Dir(cachePath()), []byte("not a dir"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/security/history.go
+++ b/internal/security/history.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/ankit373/hydra/internal/config"
 )
 
 // scoreEntry is one line of ~/.hydra/security_score.jsonl — one hyctl
@@ -51,8 +53,7 @@ func toHistoryPoints(entries []scoreEntry) []HistoryPoint {
 
 // DefaultScoreHistoryPath is where the coverage trend is persisted.
 func DefaultScoreHistoryPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".hydra", "security_score.jsonl")
+	return filepath.Join(config.Dir(), "security_score.jsonl")
 }
 
 // loadScoreHistory reads all entries; a missing file yields none.

--- a/internal/sysinfo/history.go
+++ b/internal/sysinfo/history.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"sort"
 	"time"
+
+	"github.com/ankit373/hydra/internal/config"
 )
 
 const (
@@ -25,13 +27,9 @@ type memorySample struct {
 	WiredGB float64   `json:"wired_gb"`
 }
 
-// historyPath returns ~/.hydra/memory_history.jsonl, or "" if the home dir is unavailable.
+// historyPath returns $HYDRA_HOME (or ~/.hydra)/memory_history.jsonl.
 func historyPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".hydra", historyFile)
+	return filepath.Join(config.Dir(), historyFile)
 }
 
 // recordSample appends the current reading to the history file if enough time

--- a/internal/trust/calibration.go
+++ b/internal/trust/calibration.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ankit373/hydra/internal/config"
 )
 
 // laplacePrior is the pseudo-count added to every confusion cell so a brand-new
@@ -80,8 +82,7 @@ func New(path string) (*Calibrator, error) {
 
 // DefaultPath is where calibration is persisted for the CLI (~/.hydra/calibration.jsonl).
 func DefaultPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".hydra", "calibration.jsonl")
+	return filepath.Join(config.Dir(), "calibration.jsonl")
 }
 
 // record is one persisted training event.

--- a/internal/trust/coupling.go
+++ b/internal/trust/coupling.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/ankit373/hydra/internal/config"
 )
 
 // defaultCorrelationDiscount is FamilyDiscount's fallback below minCoAgreementSamples.
@@ -61,8 +63,7 @@ type coAgreementRecord struct {
 
 // DefaultCoAgreementPath is where co-agreement observations are persisted.
 func DefaultCoAgreementPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".hydra", "coagreement.jsonl")
+	return filepath.Join(config.Dir(), "coagreement.jsonl")
 }
 
 // RecordCoAgreement clusters one task's answers by agreement and appends the

--- a/internal/trust/coverage_test.go
+++ b/internal/trust/coverage_test.go
@@ -14,10 +14,12 @@ func TestDefaultPaths_LiveUnderTheUsersHydraDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_HOME", "")
 
 	for name, got := range map[string]string{
 		"calibration.jsonl": DefaultPath(),
 		"trust.jsonl":       DefaultLogPath(),
+		"coagreement.jsonl": DefaultCoAgreementPath(),
 	} {
 		want := filepath.Join(home, ".hydra", name)
 		if got != want {
@@ -28,6 +30,26 @@ func TestDefaultPaths_LiveUnderTheUsersHydraDir(t *testing.T) {
 	// ledger, and merging them would corrupt both.
 	if DefaultPath() == DefaultLogPath() {
 		t.Error("calibration and run-log paths are the same file")
+	}
+}
+
+// $HYDRA_HOME must win over $HOME (#442).
+func TestDefaultPaths_PreferHydraHomeOverHome(t *testing.T) {
+	home := t.TempDir()
+	hydraHome := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_HOME", hydraHome)
+
+	for name, got := range map[string]string{
+		"calibration.jsonl": DefaultPath(),
+		"trust.jsonl":       DefaultLogPath(),
+		"coagreement.jsonl": DefaultCoAgreementPath(),
+	} {
+		want := filepath.Join(hydraHome, name)
+		if got != want {
+			t.Errorf("path for %s = %q, want %q ($HYDRA_HOME, not $HOME)", name, got, want)
+		}
 	}
 }
 

--- a/internal/trust/log.go
+++ b/internal/trust/log.go
@@ -34,8 +34,7 @@ type RunLog struct {
 
 // DefaultLogPath is where SPRT runs are persisted (~/.hydra/trust.jsonl).
 func DefaultLogPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".hydra", "trust.jsonl")
+	return filepath.Join(config.Dir(), "trust.jsonl")
 }
 
 // TaskHash is a short stable identifier for a prompt, used to correlate a run

--- a/internal/tui/init_wizard_test.go
+++ b/internal/tui/init_wizard_test.go
@@ -381,10 +381,14 @@ func TestExportToRoutingYAML_NoFileOnDiskIsNotAnError(t *testing.T) {
 // A save that cannot write must surface on the done screen rather than showing
 // a success the user will act on.
 func TestInitWizard_SaveFailureIsSurfaced(t *testing.T) {
-	s := testutil.NewSandbox(t)
+	testutil.NewSandbox(t)
 
-	// ~/.hydra is a regular file, so the config directory cannot be created.
-	if err := os.WriteFile(filepath.Join(s.Home, ".hydra"), []byte("not a dir"), 0o600); err != nil {
+	// Dir() is a regular file, so the config directory cannot be created. The
+	// sandbox pre-creates it as an empty directory, so remove that first.
+	if err := os.RemoveAll(config.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.Dir(), []byte("not a dir"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Closes #442

`config.Dir()` hardcoded `os.UserHomeDir()+"/.hydra"`, ignoring `$HYDRA_HOME` entirely — only `ScriptHome()` honored it, and that's solely for registry override lookups. Every stateful subsystem (cost, trust, ledger, security, run logs, config.toml, capabilities overlay) resolved through `Dir()` or called `os.UserHomeDir()` directly, so `$HYDRA_HOME` never actually isolated anything: a scratch `$HYDRA_HOME` still read and wrote the real `~/.hydra`, and a real `hyctl init` overwrote the real `config.toml`.

## Fix
- `Dir()` now checks `$HYDRA_HOME` first (same precedence `ScriptHome()` already uses), falling back to `$HOME/.hydra`.
- Seven direct `os.UserHomeDir()` call sites now route through `config.Dir()` instead: `internal/ledger` (both default paths), `internal/trust` (calibration/log/coupling), `internal/capabilities` (overlay path), `internal/security` (score-history path), `internal/sysinfo` (memory-history path).
- `internal/cost`, `internal/runlog`, and `internal/security`'s supply-chain/controls paths already went through `Dir()` and are fixed for free.

## Tests
Several existing tests encoded the old bug as intentional (asserting `Dir()` lived under `$HOME` while the sandbox sets `$HOME` and `$HYDRA_HOME` to different directories), or relied on `MkdirAll`'s no-op-on-an-existing-directory behavior to "block" a path the sandbox now pre-creates as a real directory — updated those, and added explicit `$HYDRA_HOME`-precedence tests in config/ledger/trust/capabilities.

`go build`/`go vet` clean. `go test ./...` clean. `go test -race` clean on every touched package.