### PR TITLE
fix(oracle): stop mangling verifier args via join/re-split

### DIFF
--- a/cmd/hydra/cli_data_test.go
+++ b/cmd/hydra/cli_data_test.go
@@ -678,7 +678,8 @@ func TestCLI_OracleVerify_PassAndFailDifferByExitCode(t *testing.T) {
 // PASS for a command that actually exits 1.
 func TestCLI_OracleVerify_ArgumentWithSpaceIsNotCorrupted(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("windows has no /bin/sh")
+		t.Log("windows: no /bin/sh-style true/false to drive exit codes here")
+		return
 	}
 	s := populated(t)
 

--- a/cmd/hydra/cli_data_test.go
+++ b/cmd/hydra/cli_data_test.go
@@ -671,6 +671,24 @@ func TestCLI_OracleVerify_PassAndFailDifferByExitCode(t *testing.T) {
 	}
 }
 
+// A verifier argument containing a space (a shell -c script) must reach the
+// verifier exactly as typed, not get corrupted by joining argv into a string
+// and re-splitting it on whitespace (#444). Before the fix, `sh -c "exit 1"`
+// silently became `sh -c exit 1`, which bash runs as `sh -c 'exit'` — a false
+// PASS for a command that actually exits 1.
+func TestCLI_OracleVerify_ArgumentWithSpaceIsNotCorrupted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows has no /bin/sh")
+	}
+	s := populated(t)
+
+	code, out := runBinary(t, s, "oracle", "verify", "--", "sh", "-c", "exit 1")
+	if code == 0 {
+		t.Errorf("`sh -c \"exit 1\"` exited 0 — the quoted argument's space was "+
+			"re-tokenized into two argv elements:\n%s", out)
+	}
+}
+
 // An empty template is a misconfiguration, not a passing verdict: an oracle
 // that votes yes when unset produces confident false evidence, and its LLR
 // outweighs several models.

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -794,7 +794,7 @@ func cmdOracle() *cobra.Command {
 			if src == "" {
 				src = "verifier:" + args[0]
 			}
-			o := &oracle.CommandOracle{Template: strings.Join(args, " "), Source: src}
+			o := &oracle.CommandOracle{Args: args, Source: src}
 			v, err := o.Verify(context.Background(), candidate, trust.Task{Domain: domain})
 			if err != nil {
 				return err

--- a/internal/oracle/coverage_test.go
+++ b/internal/oracle/coverage_test.go
@@ -102,6 +102,40 @@ func TestVerify_ExitStatusDecidesTheVerdict(t *testing.T) {
 	}
 }
 
+// Args holds real argv (e.g. straight from cobra). An element containing a
+// space, like a shell -c script, must reach exec.Command as one atomic
+// argument — not get re-split by whitespace the way joining argv into
+// Template and re-tokenizing it would (#444). Before the fix, "sh -c \"exit
+// 1\"" (3 argv elements) silently became "sh -c exit 1" (4 elements), which
+// bash parses as `sh -c 'exit'` — a false PASS for a command that fails.
+func TestVerify_ArgsElementWithSpaceIsNotReTokenized(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows has no /bin/sh")
+	}
+	o := &CommandOracle{Args: []string{"sh", "-c", "exit 1"}, Source: "verifier:test"}
+	v, err := o.Verify(context.Background(), "candidate", trust.Task{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Passed {
+		t.Error("Passed = true for a command that exits 1 — the -c script's " +
+			"space was re-tokenized, splitting \"exit 1\" into two argv elements")
+	}
+}
+
+// The Template path (no real argv, just a config-authored string) still needs
+// its own whitespace splitting — Args is an addition, not a replacement.
+func TestVerify_TemplateStillSplitsOnWhitespace(t *testing.T) {
+	o := &CommandOracle{Template: "true", Source: "verifier:test"}
+	v, err := o.Verify(context.Background(), "candidate", trust.Task{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !v.Passed {
+		t.Error("Passed = false for `true`")
+	}
+}
+
 // A missing binary must not be read as "the candidate is wrong" — that is the
 // oracle being unavailable, and treating it as evidence would let a broken
 // toolchain veto correct answers.

--- a/internal/oracle/coverage_test.go
+++ b/internal/oracle/coverage_test.go
@@ -110,7 +110,8 @@ func TestVerify_ExitStatusDecidesTheVerdict(t *testing.T) {
 // bash parses as `sh -c 'exit'` — a false PASS for a command that fails.
 func TestVerify_ArgsElementWithSpaceIsNotReTokenized(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("windows has no /bin/sh")
+		t.Log("windows: no /bin/sh-style true/false to drive exit codes here")
+		return
 	}
 	o := &CommandOracle{Args: []string{"sh", "-c", "exit 1"}, Source: "verifier:test"}
 	v, err := o.Verify(context.Background(), "candidate", trust.Task{})
@@ -123,16 +124,62 @@ func TestVerify_ArgsElementWithSpaceIsNotReTokenized(t *testing.T) {
 	}
 }
 
-// The Template path (no real argv, just a config-authored string) still needs
-// its own whitespace splitting — Args is an addition, not a replacement.
-func TestVerify_TemplateStillSplitsOnWhitespace(t *testing.T) {
-	o := &CommandOracle{Template: "true", Source: "verifier:test"}
-	v, err := o.Verify(context.Background(), "candidate", trust.Task{})
+// buildArgsFromArgv must substitute {answer}/{file} into Args elements in
+// place, exactly like buildArgs does for Template — Args is an additional
+// input shape, not a reason to drop placeholder support.
+func TestBuildArgsFromArgv_SubstitutesAnswerAndFile(t *testing.T) {
+	const spaced = "/tmp/expected output.txt"
+	o := &CommandOracle{
+		Args:      []string{"diff", "{answer}", "{file}"},
+		Source:    "v",
+		writeTemp: func(string) (string, func(), error) { return spaced, func() {}, nil },
+	}
+	parts, cleanup, err := o.buildArgs("the-answer")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !v.Passed {
-		t.Error("Passed = false for `true`")
+	if cleanup != nil {
+		cleanup()
+	}
+	want := []string{"diff", "the-answer", spaced}
+	if len(parts) != len(want) {
+		t.Fatalf("buildArgs = %q, want %q", parts, want)
+	}
+	for i := range want {
+		if parts[i] != want[i] {
+			t.Errorf("parts[%d] = %q, want %q", i, parts[i], want[i])
+		}
+	}
+}
+
+// {file} materialization failing through the Args path must abort the same
+// way it does through Template — an oracle that ran against a stale or
+// missing file would misreport the candidate as wrong.
+func TestBuildArgsFromArgv_WriteTempFailureIsAnError(t *testing.T) {
+	o := &CommandOracle{
+		Args: []string{"cat", "{file}"},
+		writeTemp: func(string) (string, func(), error) {
+			return "", nil, errors.New("disk full")
+		},
+	}
+	if _, _, err := o.buildArgs("x"); err == nil {
+		t.Error("a materialization failure through Args produced no error")
+	}
+}
+
+// An Args element with no placeholders needs no materialization at all, and
+// therefore no cleanup to run.
+func TestBuildArgsFromArgv_NoPlaceholdersNoCleanup(t *testing.T) {
+	o := &CommandOracle{Args: []string{"go", "test", "./..."}}
+	parts, cleanup, err := o.buildArgs("x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup != nil {
+		t.Error("no {file} placeholder present, but a cleanup function was returned")
+	}
+	if len(parts) != 3 || parts[0] != "go" {
+		t.Errorf("buildArgs = %q", parts)
 	}
 }
 

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -53,7 +53,17 @@ type Oracle interface {
 // any non-zero exit is a fail. The candidate answer is written to a temp file
 // and substituted for {file}; the raw answer is substituted for {answer}.
 type CommandOracle struct {
-	// Template is the command, e.g. "go test ./..." or "tsc --noEmit {file}".
+	// Args is the command argv, verbatim, e.g. []string{"sh", "-c", "exit 1"}.
+	// Each element is substituted in place for {file}/{answer} and passed to
+	// exec.Command as-is — never re-tokenized — so an element containing
+	// whitespace survives intact. Preferred whenever real argv is available
+	// (e.g. parsed CLI args); takes precedence over Template.
+	Args []string
+	// Template is the command as one string, e.g. "go test ./..." or
+	// "tsc --noEmit {file}", split on whitespace. Only used when Args is
+	// empty. Joining real argv into a Template and letting it re-split is
+	// what corrupted any argument containing a space (#444) — a caller
+	// holding argv must use Args instead.
 	Template string
 	// Source is the calibration key for this oracle, e.g. "verifier:go-test".
 	Source string
@@ -92,13 +102,17 @@ func (o *CommandOracle) Verify(ctx context.Context, candidate string, _ trust.Ta
 	return Verdict{Passed: true}, nil
 }
 
-// buildArgs splits the template into argv, substituting {answer} inline and
-// materializing {file} to a temp path. Both substitute as exactly one atomic
-// argv element via splitTemplate — never re-split by whitespace inside the
-// substituted value, so a candidate answer containing whitespace or flag-like
-// tokens cannot inject extra argv entries into whatever binary the template
-// names (CWE-88 argument injection).
+// buildArgs builds the argv to execute. When Args holds real argv it is used
+// verbatim (see buildArgsFromArgv, #444); otherwise it splits Template into
+// argv, substituting {answer} inline and materializing {file} to a temp path.
+// Both substitute as exactly one atomic argv element — never re-split by
+// whitespace inside the substituted value, so a candidate answer containing
+// whitespace or flag-like tokens cannot inject extra argv entries into
+// whatever binary is named (CWE-88 argument injection).
 func (o *CommandOracle) buildArgs(candidate string) (parts []string, cleanup func(), err error) {
+	if len(o.Args) > 0 {
+		return o.buildArgsFromArgv(candidate)
+	}
 	tmpl := o.Template
 	var filePath string
 	if strings.Contains(tmpl, "{file}") {
@@ -114,6 +128,38 @@ func (o *CommandOracle) buildArgs(candidate string) (parts []string, cleanup fun
 		filePath = path
 	}
 	return splitTemplate(tmpl, candidate, filePath), cleanup, nil
+}
+
+// buildArgsFromArgv substitutes {answer}/{file} inside each Args element in
+// place, with no whitespace re-tokenization: an argv element containing
+// spaces (e.g. a shell -c script) reaches exec.Command exactly as given.
+// Joining such argv into a Template string and re-splitting it on whitespace
+// is what silently corrupted arguments containing spaces (#444).
+func (o *CommandOracle) buildArgsFromArgv(candidate string) (parts []string, cleanup func(), err error) {
+	var filePath string
+	for _, a := range o.Args {
+		if !strings.Contains(a, "{file}") {
+			continue
+		}
+		writer := o.writeTemp
+		if writer == nil {
+			writer = defaultWriteTemp
+		}
+		path, cl, werr := writer(candidate)
+		if werr != nil {
+			return nil, nil, werr
+		}
+		cleanup = cl
+		filePath = path
+		break
+	}
+	parts = make([]string, len(o.Args))
+	for i, a := range o.Args {
+		a = strings.ReplaceAll(a, "{answer}", candidate)
+		a = strings.ReplaceAll(a, "{file}", filePath)
+		parts[i] = a
+	}
+	return parts, cleanup, nil
 }
 
 // splitTemplate tokenizes tmpl into argv. Each {answer}/{file} placeholder


### PR DESCRIPTION
Closes #444

`hyctl oracle verify` rejoined cobra's already-correct argv with `strings.Join(args, " ")`, then `buildArgs` re-split that string with `strings.Fields`. Any argument containing a space was silently corrupted: `oracle verify -- sh -c "exit 1"` ran `sh -c exit 1` instead of `sh -c "exit 1"`, turning a real failure (exit 1) into a false PASS (exit 0). Dangerous since oracle is documented as a high-D evidence source that feeds calibration directly via `--record`.

## Fix
`CommandOracle` gets a new `Args []string` field: real argv, substituted per-element and passed to `exec.Command` verbatim, never re-tokenized. It takes precedence over the existing `Template` string field, which still splits on whitespace — that's still correct for config-authored templates (`"go test ./..."`, `"tsc --noEmit {file}"`) that were never real argv to begin with. The CLI now passes cobra's `args` straight through via `Args` instead of joining them into `Template`.

## Tests
- New `internal/oracle` test proving an `Args` element with a space survives intact
- New `cmd/hydra` end-to-end test running the real compiled binary against `oracle verify -- sh -c "exit 1"`
- Manually verified: `oracle verify -- sh -c "exit 1"` now reports FAIL/exit 1

`go build`/`go vet` clean. `go test ./...` clean. `go test -race` clean on `internal/oracle` and `cmd/hydra`.