### PR TITLE
fix(graph): resolve files to their containing package for blast radius

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1911,14 +1911,38 @@ func cmdGraph() *cobra.Command {
 			}
 			k := g.Coupling(args)
 			n, speedup := optimal.Agents(serial, k)
+			loaded := !g.Empty()
+			var unknown []string
+			if loaded {
+				for _, f := range args {
+					if !g.Knows(f) {
+						unknown = append(unknown, f)
+					}
+				}
+			}
 			if parJSON {
 				return json.NewEncoder(os.Stdout).Encode(map[string]any{
 					"files": args, "serial_fraction": serial, "coordination_k": k,
 					"optimal_agents": n, "speedup": speedup,
+					"graph_loaded": loaded, "unknown_files": unknown,
 				})
 			}
 			fmt.Printf("\n  %s\n", cortexStyle.Render(fmt.Sprintf("%d file(s)", len(args))))
-			fmt.Printf("    coordination cost k    %.3f\n", k)
+			// Coupling silently treats an unmatched file as having no impact set,
+			// which biases k toward kMin (looks "safe to parallelize") — say so
+			// rather than let a default read as a measurement (#448).
+			if !loaded {
+				fmt.Printf("    %s\n", warnStyle.Render(
+					"no graph at "+parGraph+" — coordination cost k is a default, not a measurement"))
+			} else if len(unknown) > 0 {
+				fmt.Printf("    %s\n", warnStyle.Render(
+					"not in the graph: "+strings.Join(unknown, ", ")+" — their contribution to k is a default, not a measurement"))
+			}
+			suffix := ""
+			if !loaded || len(unknown) > 0 {
+				suffix = "  " + dimStyle.Render("(partially default)")
+			}
+			fmt.Printf("    coordination cost k    %.3f%s\n", k, suffix)
 			fmt.Printf("    optimal agents n*      %d\n", n)
 			fmt.Printf("    speedup S(n*)          %.2f×\n", speedup)
 			if speedup < 1 {
@@ -2933,7 +2957,7 @@ func cmdTrustRecord() *cobra.Command {
 func cmdTrustDefect() *cobra.Command {
 	var domain, file, graphPath string
 	var blast float64
-	var irreversible, pii, production bool
+	var irreversible, pii, production, jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "defect",
 		Short: "Preview the modeled cost of a wrong answer + the confidence it demands",
@@ -2949,7 +2973,14 @@ func cmdTrustDefect() *cobra.Command {
 					return err
 				}
 				blast = g.BlastRadiusForFile(file)
-				blastSource = "graph"
+				// A miss here still yields the 1.0 default, indistinguishable
+				// from a genuinely-measured low-risk file unless the source
+				// tag says so (#448).
+				if g.Empty() || !g.Knows(file) {
+					blastSource = "graph:miss"
+				} else {
+					blastSource = "graph"
+				}
 			}
 
 			task := trust.Task{
@@ -2959,10 +2990,18 @@ func cmdTrustDefect() *cobra.Command {
 				TouchesPII:   pii,
 				Production:   production,
 			}
+			cost, conf := dm.CostUSD(task), dm.RequiredConfidence(task)
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(map[string]any{
+					"defect_cost_usd": cost, "blast_radius": blast, "blast_source": blastSource,
+					"irreversible": irreversible, "pii": pii, "production": production,
+					"required_confidence": conf,
+				})
+			}
 			fmt.Printf("  defect cost ≈ $%.2f  (blast=%.2f [%s] irreversible=%v pii=%v prod=%v)\n",
-				dm.CostUSD(task), blast, blastSource, irreversible, pii, production)
+				cost, blast, blastSource, irreversible, pii, production)
 			fmt.Printf("  → demands confidence ≥ %.1f%%  (use with: hyctl dispatch --confidence %.3f)\n",
-				dm.RequiredConfidence(task)*100, dm.RequiredConfidence(task))
+				conf*100, conf)
 			return nil
 		},
 	}
@@ -2973,6 +3012,7 @@ func cmdTrustDefect() *cobra.Command {
 	cmd.Flags().BoolVar(&irreversible, "irreversible", false, "change cannot be cheaply undone")
 	cmd.Flags().BoolVar(&pii, "pii", false, "task handles personal data")
 	cmd.Flags().BoolVar(&production, "production", false, "target is production")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
 	return cmd
 }
 

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Node is one vertex in the dependency graph.
@@ -156,8 +157,10 @@ func (g *Graph) DependentCount(nodeID string) int {
 }
 
 // seedsForFile returns the node IDs declared in a file, matching by exact path
-// first and falling back to basename so callers may pass absolute or relative
-// paths.
+// first, then basename, then (Go package-granularity graphs) the file's
+// containing package — so callers may pass absolute paths, relative paths, or
+// a specific .go file even though `graph generate` indexes at package
+// granularity (#448).
 func (g *Graph) seedsForFile(file string) []string {
 	if g == nil || len(g.filesToNodes) == 0 {
 		return nil
@@ -172,7 +175,34 @@ func (g *Graph) seedsForFile(file string) []string {
 			seeds = append(seeds, ids...)
 		}
 	}
-	return seeds
+	if len(seeds) > 0 {
+		return seeds
+	}
+	if pkg := g.packageIDForFile(file); pkg != "" {
+		return g.filesToNodes[pkg]
+	}
+	return nil
+}
+
+// packageIDForFile resolves a specific file to the package node ID that owns
+// it under GenerateGo's granularity: one node per Go package, keyed by its
+// module-relative import path (e.g. "internal/dispatch/dispatch.go" →
+// "internal/dispatch"). It matches the containing directory verbatim first,
+// then trims leading path segments so an absolute or otherwise-prefixed path
+// still lines up with a package ID.
+func (g *Graph) packageIDForFile(file string) string {
+	dir := filepath.ToSlash(filepath.Dir(file))
+	if _, ok := g.filesToNodes[dir]; ok {
+		return dir
+	}
+	segs := strings.Split(dir, "/")
+	for i := 1; i < len(segs); i++ {
+		suffix := strings.Join(segs[i:], "/")
+		if _, ok := g.filesToNodes[suffix]; ok {
+			return suffix
+		}
+	}
+	return ""
 }
 
 // BlastRadiusForFile returns a defect-cost multiplier for editing a file:
@@ -334,12 +364,12 @@ func (g *Graph) Dependents(nodeID string) []string {
 	return g.dependents[nodeID]
 }
 
-// NodesInFile returns the node IDs declared in a file.
+// NodesInFile returns the node IDs associated with a file — resolved the same
+// way as BlastRadiusForFile and Knows (exact path, basename, or containing
+// package), so a dependents count shown alongside a blast radius always
+// reflects the same node set.
 func (g *Graph) NodesInFile(file string) []string {
-	if g == nil {
-		return nil
-	}
-	return g.filesToNodes[file]
+	return g.seedsForFile(file)
 }
 
 // Empty reports whether the graph holds no nodes at all — which is what Load

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -64,6 +64,53 @@ func TestBlastRadius_BasenameMatch(t *testing.T) {
 	}
 }
 
+// graph generate (GenerateGo) indexes at Go package granularity — one node
+// per package, keyed by its module-relative import path — not per file. A
+// caller passing a specific file inside an indexed package must still resolve
+// to that package's real measurement, not silently default to 1.0 (#448).
+func TestBlastRadius_PackageGranularity(t *testing.T) {
+	// Mirrors GenerateGo's output shape: ID == File == package import path.
+	g := fromDoc(Doc{
+		Nodes: []Node{
+			{ID: "internal/dispatch", File: "internal/dispatch"},
+			{ID: "internal/executor", File: "internal/executor"},
+			{ID: "internal/policy", File: "internal/policy"},
+		},
+		Edges: []Edge{
+			{From: "internal/executor", To: "internal/dispatch"},
+			{From: "internal/policy", To: "internal/dispatch"},
+		},
+	})
+
+	want := g.BlastRadiusForFile("internal/dispatch")
+	if want == 1.0 {
+		t.Fatal("precondition: package-level lookup should already be a real measurement")
+	}
+	if got := g.BlastRadiusForFile("internal/dispatch/dispatch.go"); got != want {
+		t.Errorf("blast(internal/dispatch/dispatch.go) = %v, want %v (the package's measured radius)", got, want)
+	}
+	if !g.Knows("internal/dispatch/dispatch.go") {
+		t.Error("Knows(internal/dispatch/dispatch.go) = false, want true — package is in the graph")
+	}
+	if got, want := len(g.NodesInFile("internal/dispatch/dispatch.go")), 1; got != want {
+		t.Errorf("NodesInFile(internal/dispatch/dispatch.go) returned %d node(s), want %d", got, want)
+	}
+
+	// An absolute path into the same package must resolve identically.
+	if got := g.BlastRadiusForFile("/repo/internal/dispatch/dispatch.go"); got != want {
+		t.Errorf("blast(absolute path) = %v, want %v", got, want)
+	}
+
+	// A file in a package that genuinely is NOT in the graph must still report
+	// as unrecognized — the fallback must not over-match.
+	if g.Knows("internal/ledger/ledger.go") {
+		t.Error("Knows(internal/ledger/ledger.go) = true, want false — package is not in the graph")
+	}
+	if got := g.BlastRadiusForFile("internal/ledger/ledger.go"); got != 1.0 {
+		t.Errorf("blast(internal/ledger/ledger.go) = %v, want the 1.0 default", got)
+	}
+}
+
 func TestBlastRadius_UnknownAndEmpty(t *testing.T) {
 	g := sampleGraph()
 	if got := g.BlastRadiusForFile("nonexistent.go"); got != 1.0 {


### PR DESCRIPTION
Closes #448

The graph generator indexes at Go-package granularity (`graph.json` nodes like `internal/dispatch`), but `graph blast`, `graph parallel`, and `trust defect --file` all documented and accepted a specific file path. A path that didn't match a node id verbatim silently fell back to a 1.00x/90%-confidence default — indistinguishable from a genuinely-measured low-risk file:

```
graph blast internal/dispatch/dispatch.go   → 1.00x / 90% (silent default)
graph blast internal/dispatch               → 10.75x / 99.1% (the real measurement)
```

## Fix
- `Knows`/`BlastRadiusForFile`/`NodesInFile` now resolve a file to its containing package (new `packageIDForFile`, matching directory first then trimming leading path segments) when the exact path isn't a graph node, before giving up.
- `graph parallel` and `trust defect --file` now surface when a fallback default is in play instead of presenting it as a real measurement: `parallel` warns and tags `k` as "(partially default)" for graph-less or unrecognized files; `trust defect` tags `blast_source` as `graph:miss` instead of `graph`.
- `trust defect` also gained `--json`, consistent with the other machine-readable subcommands.

## Tests
`go build`/`go vet` clean. `go test ./...` clean. `go test -race` clean on `internal/graph`, `internal/trust`, `cmd/hydra`. Manually verified `graph blast internal/dispatch/dispatch.go` now reports the same 10.75x/99.1% as `graph blast internal/dispatch`.