### PR TITLE
fix(dispatch): validate tier names/bounds distinctly from routability

### DIFF
--- a/cmd/hydra/cli_more_test.go
+++ b/cmd/hydra/cli_more_test.go
@@ -215,6 +215,10 @@ func TestCLI_Dispatch_RefusesBadFlagsBeforeSpending(t *testing.T) {
 		// #453: --dry-run must reject a bad --swarm-mode exactly like a real
 		// run does, not print a plan for a mode Run would then refuse.
 		{"unknown swarm mode with dry run", []string{"dispatch", "--swarm", "--swarm-mode", "sideways", "--dry-run", "x"}},
+		{"unknown tier name", []string{"dispatch", "--tier", "expert", "x"}},
+		{"tier zero", []string{"dispatch", "--tier", "0", "x"}},
+		{"negative tier", []string{"dispatch", "--tier", "-1", "x"}},
+		{"tier above max", []string{"dispatch", "--tier", "11", "x"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -228,6 +232,42 @@ func TestCLI_Dispatch_RefusesBadFlagsBeforeSpending(t *testing.T) {
 				if strings.Count(string(rows), "\n") > 2 {
 					t.Error("a rejected dispatch wrote a cost row")
 				}
+			}
+		})
+	}
+}
+
+// A named --tier absent from config (#451) and an out-of-range numeric --tier
+// (#454) are both config/input problems, not routability problems. Each must
+// say so distinctly, naming what was actually wrong, rather than falling
+// through to the generic "no routable heads" message that blames the head pool.
+func TestCLI_Dispatch_TierErrorsNameTheActualProblem(t *testing.T) {
+	populated(t)
+
+	cases := []struct {
+		name   string
+		tier   string
+		wantIn []string
+	}{
+		{"unknown named tier", "expert", []string{"expert"}},
+		{"tier zero", "0", []string{"0"}},
+		{"negative tier", "-1", []string{"-1"}},
+		{"tier above max", "11", []string{"11"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, cobraOut, err := run(t, "dispatch", "--tier", tc.tier, "x")
+			if err == nil {
+				t.Fatalf("`hyctl dispatch --tier %s` was accepted", tc.tier)
+			}
+			combined := err.Error() + cobraOut
+			for _, want := range tc.wantIn {
+				if !strings.Contains(combined, want) {
+					t.Errorf("error = %q, want it to mention %q", combined, want)
+				}
+			}
+			if strings.Contains(combined, "no routable heads") || strings.Contains(combined, "no available heads") {
+				t.Errorf("error = %q, blames routability instead of the actual %s", combined, tc.name)
 			}
 		})
 	}

--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -340,6 +340,45 @@ func TestDispatch_AllHeadsFailingReportsWhy(t *testing.T) {
 	}
 }
 
+// The end-to-end repro for #451: a documented tier name ("expert") that does
+// not exist in cfg.Tiers must fail with an error naming the bad tier, not the
+// generic "no routable heads" message that blames the head pool for a config
+// problem. A live, perfectly routable head is present, so a regression back to
+// the old behavior would still dispatch successfully rather than error at all.
+func TestDispatch_UnknownNamedTierIsDistinctFromNoRoutableHeads(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	dd := liveDispatcher(echoHead(t, s, "cloud", 90))
+
+	_, err := dd.Dispatch(context.Background(), "go", Options{TierHint: "expert"})
+	if err == nil {
+		t.Fatal("dispatch succeeded with a tier name absent from config")
+	}
+	if !strings.Contains(err.Error(), "unknown tier") || !strings.Contains(err.Error(), "expert") {
+		t.Errorf("error = %v, want it to name \"expert\" as an unknown tier", err)
+	}
+	if strings.Contains(err.Error(), "no routable heads") || strings.Contains(err.Error(), "no available heads") {
+		t.Errorf("error = %v, blames routability for a config problem", err)
+	}
+}
+
+// The end-to-end repro for #454: an out-of-range numeric --tier must fail
+// clearly, naming the requested value, rather than silently behaving as "no
+// tier" (0, negative) or getting clamped to 10 with no trace of the input.
+func TestDispatch_OutOfRangeNumericTierIsRejected(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	dd := liveDispatcher(echoHead(t, s, "cloud", 90))
+
+	for _, hint := range []string{"0", "-1", "11", "20"} {
+		_, err := dd.Dispatch(context.Background(), "go", Options{TierHint: hint})
+		if err == nil {
+			t.Fatalf("dispatch succeeded with out-of-range tier %q", hint)
+		}
+		if !strings.Contains(err.Error(), hint) {
+			t.Errorf("tier %q: error = %v, want it to name the requested value", hint, err)
+		}
+	}
+}
+
 // PII in the prompt forces local-only routing. With no local head that must be
 // a refusal naming the cause, not a quiet escalation to a paid API head — the
 // whole point of the policy.

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -122,8 +122,13 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 	// Resolve the hint to a capability number BEFORE the governor runs. A named
 	// config tier ("expert") is otherwise opaque to claudeMode's Atoi, which
 	// left the whole token-preservation table inert for every non-numeric hint
-	// (#165).
-	hint := d.resolveTierHint(opts.TierHint)
+	// (#165). A hint that is invalid on its face — an unconfigured name or an
+	// out-of-range number — is rejected here, before routability ever enters
+	// the picture, so the error blames the actual cause (#451, #454).
+	hint, err := d.resolveTierHint(opts.TierHint)
+	if err != nil {
+		return nil, err
+	}
 
 	// Apply claude% preservation — may downgrade tier or abort.
 	tier, mode, pct := d.claudeMode(hint)
@@ -294,8 +299,11 @@ func (d *Dispatcher) claudeMode(tierHint string) (tier string, mode string, pct 
 	case "warning":
 		t++
 	}
-	if t > 10 {
-		t = 10
+	// Only escalation overflow reaches this — resolveTierHint already rejects
+	// any raw hint outside 1-10, so this clamps e.g. 9+2=11, never user input
+	// silently getting relabelled as "10" (#454).
+	if t > maxTier {
+		t = maxTier
 	}
 	return strconv.Itoa(t), mode, pct
 }
@@ -394,19 +402,34 @@ func (d *Dispatcher) writeHandoff(r *Result, prompt string) (string, error) {
 	return from, h.Save(handoffPath)
 }
 
-// resolveTierHint normalizes a tier hint to a capability number ("1".."10").
+// minTier and maxTier bound the numeric --tier flag: rank.UITier never
+// produces a value outside this range, so nothing above or below it could
+// ever be routable (#454).
+const (
+	minTier = 1
+	maxTier = 10
+)
+
+// resolveTierHint normalizes a tier hint to a capability number ("1".."10"),
+// and reports the two ways a hint can be invalid on its face:
+//   - numeric but outside [minTier,maxTier] — e.g. "0" and "15" both silently
+//     behaved as "no tier" or got clamped to 10 with no indication anything
+//     was wrong (#454).
+//   - named but absent from cfg.Tiers entirely — a config/typo problem, not a
+//     routability one, so the caller must not blame the head pool for it (#451).
 //
-// An empty hint stays empty. A numeric hint passes through. A named config
-// tier resolves to the strongest capability tier among its live heads, so the
-// budget governor can reason about — and downgrade — named tiers too. An
-// unrecognized name is returned unchanged so selectHeads yields nothing and
-// the caller can report the bad hint instead of silently widening.
-func (d *Dispatcher) resolveTierHint(hint string) string {
+// A name that IS configured but currently has no live heads is deliberately
+// NOT an error here: it resolves unchanged, and selectHeads/blockedHeads
+// report the routability gap instead — the tier itself was valid.
+func (d *Dispatcher) resolveTierHint(hint string) (string, error) {
 	if hint == "" {
-		return ""
+		return "", nil
 	}
-	if _, err := strconv.Atoi(hint); err == nil {
-		return hint
+	if n, err := strconv.Atoi(hint); err == nil {
+		if n < minTier || n > maxTier {
+			return "", fmt.Errorf("tier %d is out of range — valid tiers are %d-%d", n, minTier, maxTier)
+		}
+		return hint, nil
 	}
 	for _, t := range d.cfg.Tiers {
 		if t.Name != hint {
@@ -426,11 +449,24 @@ func (d *Dispatcher) resolveTierHint(hint string) string {
 			}
 		}
 		if strongest > 0 {
-			return strconv.Itoa(strongest)
+			return strconv.Itoa(strongest), nil
 		}
-		return hint // named tier has no live heads; let the caller report it
+		return hint, nil // named tier has no live heads; let the caller report it
 	}
-	return hint
+	return "", fmt.Errorf("unknown tier %q — configured tiers: %s", hint, d.tierNameList())
+}
+
+// tierNameList formats cfg.Tiers' names for the "unknown tier" error, so the
+// user sees what they could have typed instead of just what they got wrong.
+func (d *Dispatcher) tierNameList() string {
+	if len(d.cfg.Tiers) == 0 {
+		return "(none configured — run `hyctl init`)"
+	}
+	names := make([]string, len(d.cfg.Tiers))
+	for i, t := range d.cfg.Tiers {
+		names[i] = t.Name
+	}
+	return strings.Join(names, ", ")
 }
 
 // blockedHeads describes discovered heads that were excluded because no

--- a/internal/dispatch/routing_test.go
+++ b/internal/dispatch/routing_test.go
@@ -121,14 +121,70 @@ func TestResolveTierHint(t *testing.T) {
 	d := routingDispatcher()
 	tests := []struct{ in, want string }{
 		{"", ""},
-		{"8", "8"},         // numeric passes through
-		{"expert", "1"},    // named → strongest member's capability tier
-		{"local", "10"},    //
-		{"bogus", "bogus"}, // unknown returned as-is so the caller can report it
+		{"8", "8"},      // numeric passes through
+		{"expert", "1"}, // named → strongest member's capability tier
+		{"local", "10"},
 	}
 	for _, tt := range tests {
-		if got := d.resolveTierHint(tt.in); got != tt.want {
+		got, err := d.resolveTierHint(tt.in)
+		if err != nil {
+			t.Errorf("resolveTierHint(%q) unexpected error: %v", tt.in, err)
+		}
+		if got != tt.want {
 			t.Errorf("resolveTierHint(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// A name absent from cfg.Tiers entirely is a config problem, not a
+// routability one — it must produce a distinct error naming the bad tier and
+// what IS configured, rather than resolving to a value selectHeads then fails
+// on with the generic "no routable heads" message (#451).
+func TestResolveTierHint_UnknownNameIsADistinctError(t *testing.T) {
+	d := routingDispatcher()
+	for _, hint := range []string{"bogus", "expret", "Expert"} {
+		got, err := d.resolveTierHint(hint)
+		if err == nil {
+			t.Fatalf("resolveTierHint(%q) = %q, nil — want an error naming the unknown tier", hint, got)
+		}
+		if !strings.Contains(err.Error(), hint) {
+			t.Errorf("resolveTierHint(%q) error = %q, want it to name the bad tier", hint, err)
+		}
+		for _, configured := range []string{"expert", "local"} {
+			if !strings.Contains(err.Error(), configured) {
+				t.Errorf("resolveTierHint(%q) error = %q, want it to list configured tier %q", hint, err, configured)
+			}
+		}
+	}
+}
+
+// A numeric tier outside 1-10 can never be routable (rank.UITier never
+// produces such a value) — it must be rejected with the requested value and
+// the valid range, not silently treated as "no tier" or clamped invisibly (#454).
+func TestResolveTierHint_NumericOutOfRangeIsRejected(t *testing.T) {
+	d := routingDispatcher()
+	for _, hint := range []string{"0", "-1", "11", "15", "20"} {
+		got, err := d.resolveTierHint(hint)
+		if err == nil {
+			t.Fatalf("resolveTierHint(%q) = %q, nil — want an out-of-range error", hint, got)
+		}
+		if !strings.Contains(err.Error(), hint) {
+			t.Errorf("resolveTierHint(%q) error = %q, want it to name the requested value", hint, err)
+		}
+	}
+}
+
+// In-range numeric hints (the boundaries included) must still pass through
+// untouched — only genuinely out-of-range values are rejected.
+func TestResolveTierHint_NumericBoundariesAccepted(t *testing.T) {
+	d := routingDispatcher()
+	for _, hint := range []string{"1", "10"} {
+		got, err := d.resolveTierHint(hint)
+		if err != nil {
+			t.Errorf("resolveTierHint(%q) unexpected error: %v", hint, err)
+		}
+		if got != hint {
+			t.Errorf("resolveTierHint(%q) = %q, want %q", hint, got, hint)
 		}
 	}
 }


### PR DESCRIPTION
Closes #451
Closes #454

`--help` documents `--tier expert/complex/standard/simple/local`, but the default config `hyctl init` writes only defines a tier named `"all"` — none of the documented names resolve. The error blamed Ollama's unroutability instead of the actual cause: no tier named "expert" exists in `cfg.Tiers` at all (#451).

Separately, numeric `--tier` had no bounds validation: `--tier 0`/`-1` satisfied `rank.UITier(h) >= 0/-1` for every head, silently behaving like "no tier" with zero warning; `--tier 11+` was silently clamped to 10 before the log line printed, so logs never showed what was actually requested (#454).

## Fix
`resolveTierHint` now returns `(string, error)` and rejects both cases up front, before routability ever enters the picture:
- A numeric hint outside `[1,10]` errors naming the value and the valid range.
- A named hint absent from `cfg.Tiers` errors naming the tier and listing what IS configured.
- A named tier that exists but has no live heads still resolves unchanged, on purpose — that's a routability gap for `selectHeads`/`blockedHeads` to report, not a config error.
- The `maxTier` clamp in `claudeMode` only ever sees escalation overflow now (e.g. 9+2), never raw user input silently relabelled as 10.

## Tests
`go build`/`go vet` clean. `go test ./...` clean. `go test -race` clean on `internal/dispatch` and `cmd/hydra`. Manually verified:
```
dispatch --tier expert  → Error: unknown tier "expert" — configured tiers: complex
dispatch --tier 0       → Error: tier 0 is out of range — valid tiers are 1-10
dispatch --tier 15      → Error: tier 15 is out of range — valid tiers are 1-10
```