### PR TITLE
fix(tui): cockpit height/overflow/narrow-terminal layout bugs

### DIFF
--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -540,27 +540,59 @@ func (m Cockpit) header() string {
 }
 
 func (m Cockpit) sidebar(h int) string {
-	var b strings.Builder
-	b.WriteString(ckLabelS.Render("GOVERNOR") + "\n")
-	b.WriteString(ckBar(m.claudePct, 15) + "\n")
-	b.WriteString(ckDimS.Render(fmt.Sprintf("claude %d%%", m.claudePct)) + "\n\n")
-	b.WriteString(ckLabelS.Render("HEADS") + "\n")
-	for _, hd := range m.heads {
+	head := []string{
+		ckLabelS.Render("GOVERNOR"),
+		ckBar(m.claudePct, 15),
+		ckDimS.Render(fmt.Sprintf("claude %d%%", m.claudePct)),
+		"",
+		ckLabelS.Render("HEADS"),
+	}
+	foot := []string{"", ckLabelS.Render("MODE"), " " + ckCyanS.Render(m.mode)}
+
+	// An uncapped head list can run to 20+ lines on a busy machine, and
+	// lipgloss.Height only pads shorter content — it never truncates taller
+	// content. Left alone, the sidebar's real height dictates the whole
+	// view's height once JoinHorizontal pads every other column to match it
+	// (#446). Cap the list to what's left after the fixed chrome above and
+	// below it, and say how many were left out.
+	avail := h - len(head) - len(foot)
+	var shown []ckHead
+	var more int
+	switch {
+	case avail <= 0:
+		// no room even for a "+N more" line.
+	case len(m.heads) <= avail:
+		shown = m.heads
+	default:
+		keep := avail - 1
+		shown = m.heads[:keep]
+		more = len(m.heads) - keep
+	}
+
+	lines := append([]string{}, head...)
+	for _, hd := range shown {
 		st := ckCheapS.Render("✓")
 		if !hd.up {
 			st = ckExpS.Render("✗")
 		}
 		name := lipgloss.NewStyle().Foreground(hd.color).Render(truncate(hd.name, 15))
-		b.WriteString(" " + st + " " + name + "\n")
+		lines = append(lines, " "+st+" "+name)
 	}
-	b.WriteString("\n" + ckLabelS.Render("MODE") + "\n " + ckCyanS.Render(m.mode) + "\n")
+	if more > 0 {
+		lines = append(lines, ckDimS.Render(fmt.Sprintf(" +%d more", more)))
+	}
+	lines = append(lines, foot...)
+
 	return lipgloss.NewStyle().Width(21).Height(h).
 		BorderStyle(lipgloss.NormalBorder()).BorderRight(true).BorderForeground(ckLineC).
-		Render(b.String())
+		Render(strings.Join(lines, "\n"))
 }
 
 func (m Cockpit) chatMain(w, h int) string {
-	logH := h - 1
+	// h covers the log box, the ╌ divider below it, and the input line — not
+	// just the log box, or the total comes out to h+1 and Bubble Tea crops the
+	// overflow off the TOP, deleting the header on every launch (#445).
+	logH := h - 2
 	if logH < 1 {
 		logH = 1
 	}

--- a/internal/tui/cockpit_test.go
+++ b/internal/tui/cockpit_test.go
@@ -5,6 +5,8 @@ package tui
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 // `hyctl tui --snapshot --view 3` used to panic with an index-out-of-range:
@@ -101,5 +103,71 @@ func TestTabCycleStaysInRange(t *testing.T) {
 	}
 	if view != 0 {
 		t.Errorf("cycling %d times should return to view 0, got %d", ckViewCount()*3, view)
+	}
+}
+
+// chatMain's total output must be exactly h lines. It previously forgot the
+// divider row stacked below the log box, coming out h+1 lines — Bubble Tea's
+// renderer crops overflow off the TOP, silently deleting the header on every
+// launch of the default tab (#445).
+func TestChatMain_OutputIsExactlyHLines(t *testing.T) {
+	m := Cockpit{w: 120, h: 40, ready: true, mode: "dispatch"}
+	for _, h := range []int{10, 24, 30, 60} {
+		out := m.chatMain(60, h)
+		if got := strings.Count(out, "\n") + 1; got != h {
+			t.Errorf("chatMain(60, %d) produced %d lines, want %d", h, got, h)
+		}
+	}
+}
+
+// The sidebar must never exceed the height it's given, however many heads
+// were discovered — an uncapped list let a busy machine's real head count
+// dictate the whole view's height once JoinHorizontal pads every other
+// column to match it (#446).
+func TestSidebar_NeverExceedsGivenHeight(t *testing.T) {
+	heads := make([]ckHead, 30)
+	for i := range heads {
+		heads[i] = ckHead{id: strings.Repeat("x", i%5+1), name: "head", tier: 1}
+	}
+	m := Cockpit{w: 120, h: 40, ready: true, heads: heads, mode: "dispatch"}
+
+	// The GOVERNOR/MODE chrome above and below the head list is fixed at 8
+	// lines regardless of h — h below that floor is asking for something the
+	// layout cannot do. The bug this guards is a large head list blowing past
+	// h once h is at least big enough for that fixed chrome to fit.
+	for _, h := range []int{10, 15, 20} {
+		out := m.sidebar(h)
+		if got := strings.Count(out, "\n") + 1; got > h {
+			t.Errorf("sidebar(%d) with 30 heads produced %d lines, want <= %d", h, got, h)
+		}
+	}
+
+	// With more heads than fit, the overflow must be disclosed, not silently
+	// dropped.
+	out := m.sidebar(10)
+	if !strings.Contains(out, "more") {
+		t.Errorf("sidebar(10) with 30 heads does not disclose the hidden ones:\n%s", out)
+	}
+}
+
+// Below the width the two-column layout needs, dash and dashSecurity must
+// stack into a single column rather than corrupt: join-then-clamp-to-w splits
+// box borders across the wrong rows once a box's real width exceeds what's
+// left after clamping (#447).
+func TestDashAndDashSecurity_NoLineExceedsWidthWhenNarrow(t *testing.T) {
+	m := Cockpit{w: 40, h: 30, ready: true, mode: "dispatch"}
+
+	for name, render := range map[string]func(w, h int) string{
+		"dash":         m.dash,
+		"dashSecurity": m.dashSecurity,
+	} {
+		t.Run(name, func(t *testing.T) {
+			out := render(40, 20)
+			for i, line := range strings.Split(out, "\n") {
+				if got := lipgloss.Width(line); got > 40 {
+					t.Errorf("line %d is %d cells wide, want <= 40:\n%q", i, got, line)
+				}
+			}
+		})
 	}
 }

--- a/internal/tui/cockpit_views.go
+++ b/internal/tui/cockpit_views.go
@@ -148,9 +148,20 @@ func (m Cockpit) dash(w, h int) string {
 	govBox := ckLabelS.Render("GOVERNOR · claude_pct") + "\n\n " + ckBar(m.claudePct, 20) +
 		ckDimS.Render(fmt.Sprintf("  %d%%", m.claudePct)) + "\n " + govLine
 
+	fleetBox := ckBoxS.Render(fleet.String())
 	right := lipgloss.JoinVertical(lipgloss.Left,
 		ckBoxS.Render(spendBox), ckBoxS.Render(confBox), ckBoxS.Render(govBox))
-	row := lipgloss.JoinHorizontal(lipgloss.Top, ckBoxS.Render(fleet.String()), " ", right)
+
+	// Below the width the two columns need, stack them instead of joining
+	// then clamping to w: the columns no longer share a wrap point once
+	// clamped, which is what split box borders across the wrong rows at
+	// narrow widths (#447) — chatCode() takes the same single-column escape
+	// hatch when it doesn't have room to split.
+	if needed := lipgloss.Width(fleetBox) + 1 + lipgloss.Width(right); w < needed {
+		return lipgloss.NewStyle().Width(w).Height(h).
+			Render(lipgloss.JoinVertical(lipgloss.Left, fleetBox, right))
+	}
+	row := lipgloss.JoinHorizontal(lipgloss.Top, fleetBox, " ", right)
 	return lipgloss.NewStyle().Width(w).Height(h).Render(row)
 }
 
@@ -520,8 +531,16 @@ func (m Cockpit) dashSecurity(w, h int) string {
 		actions.WriteString(" " + style.Render(tag) + age + " " + ckDimS.Render(truncate(ckSafe(a.Title), ckSecRecW)) + "\n")
 	}
 
+	headBox := ckBoxS.Render(head.String())
 	right := lipgloss.JoinVertical(lipgloss.Left, ckBoxS.Render(risk.String()), ckBoxS.Render(actions.String()))
-	row := lipgloss.JoinHorizontal(lipgloss.Top, ckBoxS.Render(head.String()), " ", right)
+
+	// Same narrow-terminal escape hatch as dash(): stack rather than
+	// join-then-clamp, which is what corrupted this box below ~90 columns (#447).
+	if needed := lipgloss.Width(headBox) + 1 + lipgloss.Width(right); w < needed {
+		return lipgloss.NewStyle().Width(w).Height(h).
+			Render(lipgloss.JoinVertical(lipgloss.Left, headBox, right))
+	}
+	row := lipgloss.JoinHorizontal(lipgloss.Top, headBox, " ", right)
 	return lipgloss.NewStyle().Width(w).Height(h).Render(row)
 }
 


### PR DESCRIPTION
Closes #445
Closes #446
Closes #447

Three related layout bugs in the `hyctl tui` cockpit, found during a live QA pass.

## #445 — header invisible on the default chat/code tab
`chatMain()` computed `logH := h - 1`, forgetting the divider row also stacked below the log box, so the view returned `h+1` lines total. Bubble Tea's renderer crops overflow off the top, silently deleting the header (view name, MODE band, today's spend) on every launch. `--snapshot` mode doesn't reproduce this since it prints `View()` directly, bypassing the renderer's cropping. Fixed to `h - 2`.

## #446 — sidebar overflow pushes the whole UI off-screen
`sidebar()` wrote one line per discovered head with no cap. On a machine with many heads, `lipgloss.JoinHorizontal` pads every other column to the sidebar's real height, pushing the entire view off-screen at a short terminal. The head list is now capped to what's left after the fixed GOVERNOR/MODE chrome, with a "+N more" line when it doesn't all fit.

## #447 — dashboard/security corrupt below ~90 columns
`dash()` and `dashSecurity()` built fixed-width two-box layouts with no width guard, unlike `chatCode()`'s existing single-column fallback. Below the width the two columns need, join-then-clamp split box borders across the wrong rows. Both now stack into a single column when too narrow to split, same escape hatch `chatCode()` already uses.

## Tests
New tests: `chatMain`'s output is exactly `h` lines for any height; the sidebar never exceeds a height its fixed chrome fits in however many heads are discovered, and discloses the overflow; `dash`/`dashSecurity` produce no line wider than a narrow terminal.

`go build`/`go vet` clean. `go test ./...` clean. `go test -race` clean on `internal/tui`.