### PR TITLE
fix(tui): polish bundle (init screen, case-insensitive commands, hint bar)

### DIFF
--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -315,27 +315,30 @@ func ckCodeTick(gen int) tea.Cmd {
 func (m Cockpit) submit() (tea.Model, tea.Cmd) {
 	t := strings.TrimSpace(m.input)
 	m.input = ""
+	// Commands are matched case-insensitively (#465) — free-text task input
+	// below is not, since a real task's casing is meaningful.
+	lt := strings.ToLower(t)
 	switch {
-	case t == "":
+	case lt == "":
 		return m, nil
-	case t == ":q" || t == ":quit":
+	case lt == ":q" || lt == ":quit":
 		return m, tea.Quit
-	case t == ":dash":
+	case lt == ":dash":
 		m.view = 1
 		return m, nil
-	case t == ":chat":
+	case lt == ":chat":
 		m.view = 0
 		return m, nil
-	case t == ":tree":
+	case lt == ":tree":
 		m.view = 2
 		return m, nil
-	case t == ":security":
+	case lt == ":security":
 		m.view = ckViewSecurity
 		return m, nil
-	case strings.HasPrefix(t, "/"):
-		switch t {
+	case strings.HasPrefix(lt, "/"):
+		switch lt {
 		case "/dispatch", "/swarm", "/trust", "/local":
-			m.mode = t[1:]
+			m.mode = lt[1:]
 			m.log = append(m.log, ckDimS.Render("mode → ")+ckCyanS.Render(m.mode))
 		default:
 			m.log = append(m.log, ckDimS.Render("unknown command "+t))
@@ -607,10 +610,13 @@ func (m Cockpit) chatMain(w, h int) string {
 
 func (m Cockpit) hint() string {
 	k := func(s string) string { return ckAquaS.Render(s) }
+	// #465: this used to omit /dispatch (a valid mode command, alongside
+	// /swarm /trust /local) and the :dash/:chat/:tree/:security jump
+	// commands entirely — both discoverable only by reading the source.
 	return ckFaintS.Render(" ") + k("enter") + ckFaintS.Render(" dispatch   ") +
-		k("tab") + ckFaintS.Render(" chat/dash/tree/security   ") +
+		k("tab") + ckFaintS.Render("/") + k(":dash :chat :tree :security") + ckFaintS.Render(" jump   ") +
 		k("↑↓") + ckFaintS.Render(" select   ") +
-		k("/trust /swarm /local") + ckFaintS.Render(" mode   ") +
+		k("/dispatch /trust /swarm /local") + ckFaintS.Render(" mode   ") +
 		k(":q") + ckFaintS.Render(" quit")
 }
 

--- a/internal/tui/cockpit_interaction_test.go
+++ b/internal/tui/cockpit_interaction_test.go
@@ -81,6 +81,32 @@ func TestCockpit_ModeCommandsAreAcknowledged(t *testing.T) {
 	}
 }
 
+// Commands are matched case-insensitively (#465) — /Trust used to report
+// "unknown command" purely because of its capitalization.
+func TestCockpit_CommandsAreCaseInsensitive(t *testing.T) {
+	if m, _ := enter(typed(NewCockpit(), ":DASH")); m.view != 1 {
+		t.Errorf(":DASH left view = %d, want 1", m.view)
+	}
+	if m, _ := enter(typed(NewCockpit(), "/Trust")); m.mode != "trust" {
+		t.Errorf("/Trust left mode = %q, want trust", m.mode)
+	}
+	if _, c := enter(typed(NewCockpit(), ":Q")); c == nil {
+		t.Error(":Q did not quit")
+	}
+}
+
+// The hint bar must mention every command it claims to document — /dispatch
+// and the :dash/:chat/:tree/:security jump commands were both real and
+// working but omitted, discoverable only by reading the source (#465).
+func TestCockpit_HintMentionsEveryCommand(t *testing.T) {
+	out := NewCockpit().hint()
+	for _, want := range []string{"/dispatch", "/trust", "/swarm", "/local", ":dash", ":chat", ":tree", ":security", ":q"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("hint() does not mention %q:\n%s", want, out)
+		}
+	}
+}
+
 // An unknown slash command must be reported, not silently ignored — a user who
 // typos a command otherwise thinks it worked.
 func TestCockpit_UnknownCommandIsReported(t *testing.T) {

--- a/internal/tui/init.go
+++ b/internal/tui/init.go
@@ -144,7 +144,10 @@ func (m InitModel) View() string {
 		m.viewDone(&b)
 	}
 
-	b.WriteString(sHint.Render("\n  ↑↓ navigate   enter select   q quit\n"))
+	// Same lipgloss gotcha as viewDone (#465): a blank line written inside
+	// Render gets padded to the block's widest line instead of staying a real
+	// newline, so both surrounding newlines stay outside the styled text.
+	b.WriteString("\n" + sHint.Render("  ↑↓ navigate   enter select   q quit") + "\n")
 	return b.String()
 }
 
@@ -219,7 +222,11 @@ func (m InitModel) viewDone(b *strings.Builder) {
 		b.WriteString(sError.Render(fmt.Sprintf("  ✗ Setup failed: %v\n", m.err)))
 		return
 	}
-	b.WriteString(sSelected.Render("  ✓ Hydra is ready\n\n"))
+	// The blank line must stay outside Render: lipgloss pads every line of a
+	// multi-line render to its widest line, turning a trailing blank segment
+	// into a row of spaces glued directly onto the next line with no real
+	// newline between them (#465).
+	b.WriteString(sSelected.Render("  ✓ Hydra is ready") + "\n\n")
 	b.WriteString(fmt.Sprintf("  Cortex : %s\n", m.cortex.Name))
 	b.WriteString(fmt.Sprintf("  Config : %s\n", config.Path()))
 }

--- a/internal/tui/init_wizard_test.go
+++ b/internal/tui/init_wizard_test.go
@@ -107,6 +107,28 @@ func TestInitWizard_FullWalkWritesALoadableConfig(t *testing.T) {
 	}
 }
 
+// The done screen must not have a stray whitespace-only line between "ready"
+// and "Cortex :" — lipgloss pads every line of a multi-line Render to its
+// widest line, so a blank line written *inside* the styled block became a row
+// of spaces glued onto the next line instead of a real newline (#465).
+func TestInitWizard_DoneScreenHasNoStrayWhitespaceLine(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	m := tea.Model(NewInitModel(wizardHeads()))
+	m, _ = send(m, "enter", "enter", "enter", "enter")
+
+	im := m.(InitModel)
+	if im.err != nil {
+		t.Fatalf("the wizard reported an error: %v", im.err)
+	}
+	for _, line := range strings.Split(im.View(), "\n") {
+		if strings.TrimSpace(line) == "" && strings.Trim(line, " ") != line {
+			t.Errorf("done screen has a whitespace-only (not empty) line: %q\nfull view:\n%s",
+				line, im.View())
+		}
+	}
+}
+
 // Declining local-only must leave no PII policy, rather than writing one that
 // says something else.
 func TestInitWizard_DecliningLocalOnlyWritesNoPIIPolicy(t *testing.T) {


### PR DESCRIPTION
Closes #465

## Init done-screen stray whitespace
`hyctl init`'s final "done" screen had a stray whitespace-only line before "Cortex : Claude Code" — lipgloss pads every line of a multi-line `Render` to its widest line, so a blank line written *inside* `sSelected.Render("...ready\n\n")` became a row of spaces glued to the next line instead of a real newline. Moved both trailing newlines outside `Render`. Found and fixed the identical pattern in `View()`'s footer hint line while in the same function.

## Case-sensitive commands
Cockpit slash/mode commands (`/trust`, `/swarm`, `/local`, `/dispatch`) and jump commands (`:dash`, `:chat`, `:tree`, `:security`, `:q`, `:quit`) were exact-match case-sensitive — `/Trust` reported "unknown command" purely over capitalization. `submit()` now matches on a lowercased copy of the input, while the free-text task path (and the "unknown command" message) still uses the original casing, since a real task's casing is meaningful.

## Incomplete hint bar
The hint bar omitted `/dispatch` (a valid mode command alongside the three it did list) and never mentioned the working `:dash`/`:chat`/`:tree`/`:security` jump commands — both discoverable only by reading the source. Hint text now names all of them.

## Tests
New tests: case-insensitive command matching for a jump, a mode, and quit; the hint bar mentions every command it claims to document; the done screen has no whitespace-only line.

`go build`/`go vet` clean. `go test ./...` clean. `go test -race` clean on `internal/tui`. `covergate` passes (40 floors met, 39/40 skips used — no new skips).