### PR TITLE
fix(desktop): friendly setup prompt instead of raw dispatch error in chat

### DIFF
--- a/desktop/api/chat.go
+++ b/desktop/api/chat.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ankit373/hydra/internal/dispatch"
@@ -39,11 +40,13 @@ type ChatReply struct {
 
 	Error string `json:"error,omitempty"`
 
-	// NeedsProbe is true when the machine has zero discoverable heads at all —
-	// distinct from an ordinary dispatch failure. dispatch.New already probes
-	// fresh on every call, so there is no separate "go discover models" step
-	// to point at; the dock offers to retry (which re-probes) instead of
-	// surfacing a CLI instruction a GUI user has no terminal for (#434).
+	// NeedsProbe is true when there is nothing to route this chat to — zero
+	// heads discovered at all, or heads discovered but none dispatchable for
+	// this request (dispatch.ErrNoHeads, e.g. the dock's "auto-route" default
+	// left every candidate filtered out). dispatch.New probes fresh on every
+	// call, so there is no separate "go discover models" step to point at;
+	// the dock offers to retry (which re-probes) instead of surfacing a CLI
+	// instruction a GUI user has no terminal for (#434, #452).
 	NeedsProbe bool `json:"needsProbe,omitempty"`
 }
 
@@ -99,6 +102,13 @@ func (a *API) Chat(prompt, enum string) (*ChatReply, error) {
 		TaskID:   taskID,
 	})
 	if err != nil {
+		if errors.Is(err, dispatch.ErrNoHeads) {
+			// Same dead end as zero heads at all — same friendly retry reply
+			// instead of dispatch's raw, CLI-flavored error text (#452).
+			r.Error = "No model is available to answer this yet."
+			r.NeedsProbe = true
+			return r, nil
+		}
 		r.Error = err.Error()
 		return r, nil
 	}

--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -5,6 +5,7 @@ package dispatch
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -398,6 +399,36 @@ func TestDispatch_PIIForcesLocalOnlyAndSaysSoWhenNothingIsLocal(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "localOnly=true") {
 		t.Errorf("error = %v, want it to name local-only as the cause", err)
+	}
+}
+
+// A no-heads dispatch failure must be matchable by errors.Is(err, ErrNoHeads)
+// so a caller with no terminal to point at (the desktop dock) can render a
+// friendly message instead of dispatch's CLI-flavored text (#452). An empty
+// tier hint — the dock's "auto-route" default — must read as "no tier hint
+// given", not a literal `tier ""`.
+func TestDispatch_NoHeadsErrorIsMatchableAndPhrasesAnEmptyTierClearly(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	dd := &Dispatcher{
+		cfg:    &config.Config{},
+		heads:  []provider.Head{echoHead(t, s, "cloud", 90)},
+		policy: policy.New(policy.DefaultRules(true)),
+		budget: budget.NewRegistry(nil),
+	}
+
+	_, err := dd.Dispatch(context.Background(), "my SSN is 123-45-6789", Options{})
+	if err == nil {
+		t.Fatal("a PII prompt was dispatched to a non-local head")
+	}
+	if !errors.Is(err, ErrNoHeads) {
+		t.Errorf("error = %v, want it to satisfy errors.Is(err, ErrNoHeads)", err)
+	}
+	if strings.Contains(err.Error(), `tier ""`) {
+		t.Errorf(`error = %v, an empty tier hint printed as the literal tier "" instead of being phrased`, err)
+	}
+	if !strings.Contains(err.Error(), "no tier hint given") {
+		t.Errorf("error = %v, want it to say no tier hint was given", err)
 	}
 }
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -7,6 +7,7 @@ package dispatch
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -31,6 +32,12 @@ import (
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
 )
+
+// ErrNoHeads marks a dispatch with no head to run, discovered or routable.
+// Callers match it with errors.Is instead of the formatted message, so a
+// CLI-flavored string (backtick-quoted `hyctl probe`, etc.) never has to leak
+// into a GUI caller that has no terminal to point at (#452).
+var ErrNoHeads = errors.New("no dispatchable heads")
 
 // Options controls dispatch behaviour.
 type Options struct {
@@ -176,11 +183,12 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		// the user looks, sees the head, and learns nothing (#248). Name the
 		// blocked heads and why instead.
 		if blocked := d.blockedHeads(localOnly); blocked != "" {
-			return nil, fmt.Errorf("no routable heads for tier %q (localOnly=%v).\n%s",
-				tier, localOnly, blocked)
+			return nil, fmt.Errorf("%w: no routable heads for %s (localOnly=%v).\n%s",
+				ErrNoHeads, tierClause(tier), localOnly, blocked)
 		}
-		return nil, fmt.Errorf("no available heads for tier %q (localOnly=%v); "+
-			"check `hyctl probe` and the tier names in your config", tier, localOnly)
+		return nil, fmt.Errorf("%w: no available heads for %s (localOnly=%v); "+
+			"check `hyctl probe` and the tier names in your config",
+			ErrNoHeads, tierClause(tier), localOnly)
 	}
 
 	if opts.DryRun {
@@ -467,6 +475,16 @@ func (d *Dispatcher) tierNameList() string {
 		names[i] = t.Name
 	}
 	return strings.Join(names, ", ")
+}
+
+// tierClause phrases the tier for a no-heads error. An empty tier (no hint
+// given at all — e.g. the desktop dock's "auto-route" default) would
+// otherwise print as tier "" — a confusing artifact, not a routing outcome.
+func tierClause(tier string) string {
+	if tier == "" {
+		return "no tier hint given"
+	}
+	return fmt.Sprintf("tier %q", tier)
 }
 
 // blockedHeads describes discovered heads that were excluded because no


### PR DESCRIPTION
Closes #452

`ChatDock`'s default "auto-route" option sends an empty tier hint through to dispatch. When the machine has heads discovered but none dispatchable for the request, the raw dispatch error was rendered verbatim in the chat transcript — CLI-flavored (`check \`hyctl probe\` and the tier names in your config`) and, for an empty tier hint, a literal `tier ""`.

## Fix
- `internal/dispatch` now exports `ErrNoHeads`, a sentinel wrapped into both no-candidate error paths in `Dispatch()`, so a caller can match it with `errors.Is` instead of string-matching a formatted message that was never meant for a GUI.
- A new `tierClause` helper phrases an empty tier hint as "no tier hint given" instead of printing `tier ""` verbatim — fixes the CLI-side message too, not just the desktop one.
- `desktop/api/chat.go`'s `Chat()` already had a `NeedsProbe` reply field and UI path for "zero heads discovered at all" (#439/#434 landed independently while this issue was open); it now also sets `NeedsProbe` when `Dispatch` returns `ErrNoHeads`, covering "heads discovered but none dispatchable" the same friendly way. **No frontend changes needed** — it already renders the retry UI for any `NeedsProbe` reply, regardless of which backend condition set it.

## Tests
New tests: a dispatch-level test proving the no-heads error satisfies `errors.Is(err, ErrNoHeads)` and phrases an empty tier hint clearly instead of as `tier ""`.

`go build`/`go vet` clean. `go test ./...` clean on the main module and the desktop module. `go test -race` clean on `internal/dispatch`, `cmd/hydra`, `desktop/api`. `covergate` passes (40 floors met, 39/40 skips used).