### PR TITLE
fix(desktop): coordinate chat/drawer overlay stacking

### DIFF
--- a/desktop/api/dashboard_test.go
+++ b/desktop/api/dashboard_test.go
@@ -15,12 +15,16 @@ import (
 )
 
 // sandbox points config.Dir() and trust.DefaultLogPath() at a temp HOME, so a
-// test never reads (or writes) the developer's real ~/.hydra.
+// test never reads (or writes) the developer's real ~/.hydra. Clearing
+// HYDRA_HOME too matters since config.Dir() prefers it over HOME (#442) — a
+// developer or CI runner with one already exported would otherwise leak
+// straight through every "HOME-only" sandbox in this file.
 func sandbox(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home) // windows
+	t.Setenv("HYDRA_HOME", "")
 	if err := os.MkdirAll(filepath.Join(home, ".hydra", "logs"), 0o700); err != nil {
 		t.Fatal(err)
 	}

--- a/desktop/api/firstrun_test.go
+++ b/desktop/api/firstrun_test.go
@@ -10,13 +10,15 @@ import (
 
 // withEmptyHome points the process at a home directory containing no ~/.hydra,
 // which is the state of a machine that has just downloaded the app and never
-// run hyctl. config.Dir() resolves through os.UserHomeDir, so setting HOME
-// (USERPROFILE on Windows) is enough to isolate it.
+// run hyctl. config.Dir() checks $HYDRA_HOME before $HOME (#442), so a
+// developer or CI runner with one already exported must not leak through —
+// clearing it is as much a part of isolating this as setting HOME/USERPROFILE.
 func withEmptyHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("HYDRA_HOME", "")
 	return home
 }
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -181,7 +181,9 @@ export default function App() {
         {/* An error replaces the body but never the shell — a broken read
             should not look like a crashed app. */}
         {error && <div className="error">{error}</div>}
-        {!error && view === 'dashboard' && <Dashboard data={dashboard} />}
+        {!error && view === 'dashboard' && (
+          <Dashboard data={dashboard} dockOpen={dockOpen} onCloseDock={() => setDockOpen(false)} />
+        )}
         {!error && view === 'fleet' && fleet && (
           <Fleet data={fleet} onOpen={openSession} onStartTask={startTask} />
         )}

--- a/desktop/frontend/src/views/Dashboard.tsx
+++ b/desktop/frontend/src/views/Dashboard.tsx
@@ -10,12 +10,30 @@ import { useCountUp, useReveal } from '../reveal'
  * than a fake timeout. Once data lands the HUD chrome (corner brackets,
  * scanline, vignette) stays mounted for the lifetime of the view; only the
  * body swaps from skeleton to `DashboardContent`.
+ *
+ * dockOpen/onCloseDock coordinate the model-detail drawer with ChatDock
+ * (#460): both are `position: fixed` overlays with independent z-index
+ * stacks, so opening one while the other is already open used to sandwich
+ * the dock behind the drawer but above its backdrop instead of ever hiding
+ * either. Only one may be open at a time.
  */
-export function Dashboard({ data }: { data: DashboardData | null }) {
+export function Dashboard({
+  data,
+  dockOpen,
+  onCloseDock,
+}: {
+  data: DashboardData | null
+  dockOpen: boolean
+  onCloseDock: () => void
+}) {
   return (
     <>
       <HudChrome />
-      {data ? <DashboardContent data={data} /> : <DashboardSkeleton />}
+      {data ? (
+        <DashboardContent data={data} dockOpen={dockOpen} onCloseDock={onCloseDock} />
+      ) : (
+        <DashboardSkeleton />
+      )}
     </>
   )
 }
@@ -73,13 +91,22 @@ function SkeletonCard() {
   )
 }
 
-function DashboardContent({ data }: { data: DashboardData }) {
+function DashboardContent({
+  data,
+  dockOpen,
+  onCloseDock,
+}: {
+  data: DashboardData
+  dockOpen: boolean
+  onCloseDock: () => void
+}) {
   const [drawerRow, setDrawerRow] = useState<Breakdown | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
 
   const openDrawer = (row: Breakdown) => {
     setDrawerRow(row)
     setDrawerOpen(true)
+    onCloseDock()
   }
   const closeDrawer = () => setDrawerOpen(false)
 
@@ -91,6 +118,12 @@ function DashboardContent({ data }: { data: DashboardData }) {
     addEventListener('keydown', onKey)
     return () => removeEventListener('keydown', onKey)
   }, [drawerOpen])
+
+  // The reverse direction: the dock's own toggle button (or Fleet's "start a
+  // task") can open it while the drawer is already up.
+  useEffect(() => {
+    if (dockOpen) setDrawerOpen(false)
+  }, [dockOpen])
 
   return (
     <div className="dashboard-content">


### PR DESCRIPTION
Closes #460

`ChatDock` (`.dock`, z-index 10, `position: fixed` bottom-right) and the Dashboard model-detail drawer (`.drawer`/`.drawer-backdrop`, z-index 40/41, also `position: fixed`) are independent overlays with no shared state. Opening one while the other was already open sandwiched the dock behind the drawer but above its dimmed backdrop instead of either ever closing — live-verified via a real `wails dev` session and screenshots before/after.

## Fix
Made them mutually exclusive (the smaller of the two fixes considered in the issue):
- Opening the drawer (`openDrawer`) now closes the dock via a new `onCloseDock` callback threaded from `App.tsx` → `Dashboard` → `DashboardContent`.
- Opening the dock (`App.tsx`'s `dockOpen` turning true, whether from its own toggle or Fleet's "start a task") now closes the drawer via a `useEffect` watching the `dockOpen` prop passed back down.

Only one may be open at a time.

## The "stray artifact" — investigated, not a bug
Also named in the issue: a rendering artifact in the top-left corner while a backdrop is dimmed. Traced it to the Dashboard view's permanent `.hud-corner--tl` decoration (z-index 1) showing dimly through the backdrop's 55%-opacity dark overlay. Compared screenshots of the same corner with the drawer open and closed side by side — it renders identically either way. That's the correct, intended behavior of a translucent modal backdrop (content behind it stays dimly visible, not hidden), not a bug. No change made there.

## Bonus fix found while verifying
`desktop/api`'s own `sandbox(t)`/`withEmptyHome` test helpers only isolated `$HOME`, not `$HYDRA_HOME` — which `config.Dir()` has preferred since #442. A stray `$HYDRA_HOME` already exported in the environment (exactly the scenario #442 itself was about) leaked straight through every `desktop/api` test using them, corrupting ledger/security/session test expectations with real accumulated data. Both now clear `HYDRA_HOME` alongside `HOME`/`USERPROFILE`.

## Tests
`go build`/`go vet` clean on the main and desktop modules. `go test ./...` clean on both, including with `$HYDRA_HOME` deliberately set to reproduce the exact contamination. `go test -race` clean on `desktop/api`. `npm run typecheck` and `npm run build` clean.

No frontend test framework exists in this repo to add an automated regression test, so this was verified live: `wails dev` + a real browser session driving the actual compiled frontend and Go backend, screenshotted before and after (dock open → click a row → drawer opens, dock cleanly gone, no console errors, no overlap).