### PR TITLE
fix(cli): CLI error-handling and output polish bundle

### DIFF
--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -407,6 +407,34 @@ func TestCLI_OracleVerify_PassingVerdictReportsEvidence(t *testing.T) {
 	}
 }
 
+// A garbage --record used to be silently ignored — no error, no calibration
+// write, discovered only by its absence from `trust calibration` later.
+// `trust record --outcome` already validates this strictly; `oracle verify
+// --record` now does too, and before running the verifier at all (#464).
+func TestCLI_OracleVerify_GarbageRecordIsRejected(t *testing.T) {
+	// --record is validated before the verifier command ever runs (see the
+	// fix itself), so this never actually executes /usr/bin/true — safe on
+	// every platform, no skip needed.
+	populated(t)
+
+	_, cobraOut, err := run(t, "oracle", "verify", "/usr/bin/true",
+		"--source", "verifier:test", "--domain", "go", "--record", "maybe")
+	if err == nil {
+		t.Fatalf("--record maybe was accepted:\n%s", cobraOut)
+	}
+	if !strings.Contains(err.Error()+cobraOut, "--record") {
+		t.Errorf("error = %v, want it to name --record", err)
+	}
+
+	cal, _, calErr := run(t, "trust", "calibration")
+	if calErr != nil {
+		t.Fatal(calErr)
+	}
+	if strings.Contains(cal, "verifier:test") {
+		t.Errorf("a rejected --record still wrote to calibration:\n%s", cal)
+	}
+}
+
 // ── mcp check, allowed ────────────────────────────────────────────────────────
 
 // An allowed check exits 0, so its body runs in process. The decision must be
@@ -441,6 +469,47 @@ func TestCLI_MCPCheck_AllowedDecisionIsRecorded(t *testing.T) {
 	if !strings.Contains(log+logCobra, "test-agent") {
 		t.Errorf("the allow was not recorded; an unlogged decision is not "+
 			"accountability:\n%s", log+logCobra)
+	}
+}
+
+// tool+"/"+resource used to read as one run-together path whenever resource
+// was itself absolute — "fs.read" + "/tmp/x.txt" rendered as
+// "fs.read//tmp/x.txt", indistinguishable from a single garbled field (#464).
+func TestCLI_MCPCheckAndLog_ToolResourceSeparatorDoesNotCollideWithPaths(t *testing.T) {
+	s := populated(t)
+
+	policy := `{"rules":[{"action":"read","resource":"/tmp/**","decision":"allow"}]}`
+	if err := os.MkdirAll(config.Dir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(config.Dir(), "mcp_policy.json"), []byte(policy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_ = s
+
+	checkOut, checkCobra, err := run(t, "mcp", "check", "fs.read",
+		"--action", "read", "--resource", "/tmp/allowed.txt", "--agent", "test-agent")
+	if err != nil {
+		t.Fatalf("check errored: %v (%s)", err, checkCobra)
+	}
+	combined := checkOut + checkCobra
+	if strings.Contains(combined, "fs.read//tmp") {
+		t.Errorf("mcp check: tool and an absolute resource ran together:\n%s", combined)
+	}
+	if !strings.Contains(combined, "fs.read -> /tmp/allowed.txt") {
+		t.Errorf("mcp check: want tool and resource joined by \" -> \":\n%s", combined)
+	}
+
+	logOut, logCobra, err := run(t, "mcp", "log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logCombined := logOut + logCobra
+	if strings.Contains(logCombined, "fs.read//tmp") {
+		t.Errorf("mcp log: tool and an absolute resource ran together:\n%s", logCombined)
+	}
+	if !strings.Contains(logCombined, "fs.read -> /tmp/allowed.txt") {
+		t.Errorf("mcp log: want tool and resource joined by \" -> \":\n%s", logCombined)
 	}
 }
 
@@ -894,6 +963,52 @@ func TestCLI_Probe_MarksUnroutableHeads(t *testing.T) {
 	// probe is only useful if probe explains itself (#248).
 	if strings.Contains(combined, "ollama") && !strings.Contains(combined, "✗") {
 		t.Errorf("the unroutable ollama binary is listed without being marked:\n%s", combined)
+	}
+}
+
+// `hyctl probe --json` is the one data-producing command that lacked machine-
+// readable output — every sibling (models/cost/stats/pricing/mcp report/
+// security/graph/context entropy) has one (#464).
+func TestCLI_Probe_JSONIsValidAndMarksRoutability(t *testing.T) {
+	s, _ := dispatchable(t, "answered")
+	s.FakeBinary(t, "ollama")
+
+	out, cobraOut, err := run(t, "probe", "--json")
+	if err != nil {
+		t.Fatalf("`hyctl probe --json` failed: %v (%s)", err, cobraOut)
+	}
+
+	var parsed struct {
+		Cortex string `json:"cortex"`
+		Heads  []struct {
+			ID               string `json:"id"`
+			Routable         bool   `json:"routable"`
+			UnroutableReason string `json:"unroutable_reason"`
+		} `json:"heads"`
+	}
+	if err := json.Unmarshal([]byte(out+cobraOut), &parsed); err != nil {
+		t.Fatalf("probe --json did not parse: %v\n%s", err, out+cobraOut)
+	}
+	if len(parsed.Heads) == 0 {
+		t.Fatal("probe --json reported no heads")
+	}
+
+	var sawRoutable, sawUnroutable bool
+	for _, h := range parsed.Heads {
+		if h.Routable {
+			sawRoutable = true
+		} else {
+			sawUnroutable = true
+			if h.UnroutableReason == "" {
+				t.Errorf("head %q is unroutable with no reason given", h.ID)
+			}
+		}
+	}
+	if !sawRoutable {
+		t.Error("no routable head reported")
+	}
+	if !sawUnroutable {
+		t.Error("the unroutable ollama binary is missing from --json output")
 	}
 }
 

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -84,6 +84,13 @@ func rootCmd() *cobra.Command {
 		// subcommand existed. It is the near-universal convention, so people
 		// type it first. Same text as the subcommand, from one function.
 		Version: build.Version,
+		// A runtime error (e.g. "no hydra config") used to dump the full flags
+		// block for every one of ~25 subcommands, drowning the one line that
+		// actually mattered. Propagates to every subcommand — including a
+		// flag-parsing error (unknown flag, bad value), which now reads the
+		// same way: one line naming the problem. Run --help for the flag list
+		// (#464).
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !config.Exists() {
 				return runInit()
@@ -277,16 +284,53 @@ func runInit() error {
 
 // ── probe ─────────────────────────────────────────────────────────────────────
 
+// probeHeadJSON is probe --json's per-head shape. provider.Head has no json
+// tags of its own — it is an internal discovery record, not a wire format —
+// so this stays a local, deliberately-chosen subset rather than exposing
+// every internal field probe.Run happens to populate.
+type probeHeadJSON struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+	Source    string `json:"source"`
+	CapScore  int    `json:"cap_score"`
+	LocalOnly bool   `json:"local_only"`
+	IsCortex  bool   `json:"is_cortex"`
+	// Routable is false when discovery found the head but no executor can
+	// drive it (e.g. the Ollama binary with its server not running) — the
+	// same distinction the human table marks with ✗ (#248).
+	Routable         bool   `json:"routable"`
+	UnroutableReason string `json:"unroutable_reason,omitempty"`
+}
+
 func cmdProbe() *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "probe",
 		Short: "Scan machine for available AI Heads",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			fmt.Println(dimStyle.Render("  Scanning..."))
+			if !jsonOut {
+				fmt.Println(dimStyle.Render("  Scanning..."))
+			}
 			result := probe.Run(context.Background())
 			cortexName := "none"
 			if result.Cortex != nil {
 				cortexName = result.Cortex.Name
+			}
+			if jsonOut {
+				heads := make([]probeHeadJSON, len(result.Heads))
+				for i, h := range result.Heads {
+					why := executor.Unroutable(h)
+					heads[i] = probeHeadJSON{
+						ID: h.ID, Name: h.Name, Provider: h.Provider, Source: h.Source,
+						CapScore: h.CapScore, LocalOnly: h.LocalOnly,
+						IsCortex: result.Cortex != nil && h.ID == result.Cortex.ID,
+						Routable: why == "", UnroutableReason: why,
+					}
+				}
+				return json.NewEncoder(os.Stdout).Encode(map[string]any{
+					"cortex": cortexName, "heads": heads,
+				})
 			}
 			fmt.Println(tui.Splash(cortexName))
 			if len(result.Heads) == 0 {
@@ -326,6 +370,8 @@ func cmdProbe() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
+	return cmd
 }
 
 // ── status ────────────────────────────────────────────────────────────────────
@@ -782,6 +828,19 @@ func cmdOracle() *cobra.Command {
 		Short: "Run a verifier command; report pass/fail + its calibrated LLR",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
+			// Validated before running the verifier at all: a garbage --record
+			// used to be silently ignored — no error, no calibration write, no
+			// indication anything was wrong, discovered only after the command
+			// had already done its real work. Same check `trust record
+			// --outcome` already has (#464).
+			var recordOutcome trust.Outcome
+			if record != "" {
+				recordOutcome = trust.ParseOutcome(record)
+				if recordOutcome == trust.OutcomeUnknown {
+					return fmt.Errorf("--record must be correct|incorrect (got %q)", record)
+				}
+			}
+
 			candidate := ""
 			if candidateFile != "" {
 				raw, err := os.ReadFile(candidateFile)
@@ -805,9 +864,7 @@ func cmdOracle() *cobra.Command {
 				return err
 			}
 			if record != "" {
-				if out := trust.ParseOutcome(record); out != trust.OutcomeUnknown {
-					_ = cal.Update(src, domain, v.Passed, out)
-				}
+				_ = cal.Update(src, domain, v.Passed, recordOutcome)
 			}
 			llr := oracle.LLR(cal, src, domain, v)
 
@@ -869,7 +926,10 @@ func cmdMCP() *cobra.Command {
 			// Report the decision before any error: a Deny that failed to write
 			// to the ledger is still a Deny, and callers gate on exit 3.
 			if decision != "" {
-				fmt.Printf("  %s  %s %s/%s (%s)\n", strings.ToUpper(string(decision)),
+				// tool+"/"+resource used to read as one run-together path when
+				// resource was itself absolute (e.g. "shell//bin/rm -rf /") —
+				// "->" can't collide with path syntax the way "/" does (#464).
+				fmt.Printf("  %s  %s %s -> %s (%s)\n", strings.ToUpper(string(decision)),
 					chkAgent, args[0], chkResource, action)
 			}
 			if checkErr != nil {
@@ -1011,7 +1071,9 @@ func cmdMCP() *cobra.Command {
 				return nil
 			}
 			for _, e := range events {
-				line := fmt.Sprintf("  %s  %-6s  %-12s %s/%s %s", e.TS, strings.ToUpper(string(e.Decision)),
+				// Same "->" separator as `mcp check` (#464) — a "/" read as
+				// one run-together path when the resource was itself absolute.
+				line := fmt.Sprintf("  %s  %-6s  %-12s %s -> %s %s", e.TS, strings.ToUpper(string(e.Decision)),
 					util.SafeTerminal(e.Agent), util.SafeTerminal(e.Tool), util.SafeTerminal(e.Resource),
 					dimStyle.Render(string(e.Action)))
 				if e.Flagged {
@@ -2496,7 +2558,12 @@ func cmdCost() *cobra.Command {
 	tail := &cobra.Command{
 		Use:   "tail [N]",
 		Short: "Last N calls (default 10)",
-		Args:  cobra.MaximumNArgs(1),
+		// A bare negative N (`cost tail -5`) is indistinguishable from an
+		// unrecognized flag to cobra's parser, which rejects it before this
+		// RunE ever sees it — hence the escape hatch below (#464).
+		Long: "Last N calls (default 10). A negative N needs the flag " +
+			"terminator: `hyctl cost tail -- -5`, or cobra reads it as a flag.",
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			n := 10
 			if len(args) > 0 {

--- a/cmd/hydra/naming_test.go
+++ b/cmd/hydra/naming_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/ankit373/hydra/internal/testutil"
 )
 
 // The binary is hyctl. Cobra prints `Use` correctly on its own, but every
@@ -64,5 +66,21 @@ func TestUserFacingText_NeverNamesABinaryThatDoesNotExist(t *testing.T) {
 		if err != nil {
 			t.Fatalf("walking %s: %v", root, err)
 		}
+	}
+}
+
+// A runtime error (e.g. "no config found") used to dump the full flags block
+// for every one of ~25 subcommands, drowning the one line that actually
+// mattered. SilenceUsage on the root command must propagate to every
+// subcommand, including one deep in a command group (#464).
+func TestUserFacingText_RuntimeErrorsDoNotDumpUsage(t *testing.T) {
+	testutil.NewSandbox(t) // no config written
+
+	_, cobraOut, err := run(t, "status")
+	if err == nil {
+		t.Fatal("`hyctl status` on an unconfigured machine did not error")
+	}
+	if strings.Contains(cobraOut, "Usage:") || strings.Contains(cobraOut, "Flags:") {
+		t.Errorf("a runtime error dumped the flags block:\n%s", cobraOut)
 	}
 }

--- a/internal/editor/edit_test.go
+++ b/internal/editor/edit_test.go
@@ -240,6 +240,13 @@ func TestEdit_EmptyReplacementLeavesTheFileUntouched(t *testing.T) {
 	if _, err := os.Stat(file + ".hydra-bak"); err == nil {
 		t.Error("a backup survived a refused edit")
 	}
+	// Scope resolution ran and succeeded well before the empty-replacement
+	// check — failResult used to zero Workspace/GitRoot regardless, making a
+	// downstream failure indistinguishable from "scope was never resolved"
+	// (#464).
+	if res.Workspace == "" {
+		t.Error("Workspace is empty on a failure that happened after scope resolution succeeded")
+	}
 }
 
 func TestEdit_RefusesBeforeDispatching(t *testing.T) {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -61,20 +61,20 @@ type Result struct {
 // fallback chain and cost logging.
 func Edit(ctx context.Context, req Request) (*Result, error) {
 	if !filepath.IsAbs(req.File) {
-		return failResult(req, "file path must be absolute"), nil
+		return failResult(req, "", "", "file path must be absolute"), nil
 	}
 	if req.Enum == "CORE" {
-		return failResult(req, "CORE tier: use Claude's native Edit/Write directly"), nil
+		return failResult(req, "", "", "CORE tier: use Claude's native Edit/Write directly"), nil
 	}
 
 	// ── Scope check ──────────────────────────────────────────────────────────
 	reg, err := workspace.Load(config.ScriptHome())
 	if err != nil {
-		return failResult(req, "workspace registry load failed: "+err.Error()), nil
+		return failResult(req, "", "", "workspace registry load failed: "+err.Error()), nil
 	}
 	wsName, err := reg.Check(req.File)
 	if err != nil {
-		return failResult(req, "scope_rejected: "+err.Error()), nil
+		return failResult(req, "", "", "scope_rejected: "+err.Error()), nil
 	}
 	resolved, _ := reg.Resolve(req.File)
 
@@ -115,7 +115,7 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 	d, err := dispatch.New(ctx)
 	if err != nil {
 		cleanupBackup()
-		return failResult(req, "dispatcher init failed: "+err.Error()), nil
+		return failResult(req, wsName, resolved.GitRoot, "dispatcher init failed: "+err.Error()), nil
 	}
 	tierHint := enumToTier(req.Enum)
 	dispResult, err := d.Dispatch(ctx, editPrompt, dispatch.Options{
@@ -126,7 +126,7 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 	})
 	if err != nil {
 		cleanupBackup()
-		return failResult(req, "route_failed: "+err.Error()), nil
+		return failResult(req, wsName, resolved.GitRoot, "route_failed: "+err.Error()), nil
 	}
 
 	// ── Parse response ────────────────────────────────────────────────────────
@@ -135,20 +135,20 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 
 	if strings.Contains(newContent, markerStart) || strings.Contains(newContent, markerEnd) {
 		cleanupBackup()
-		return failResult(req, "marker_leakage"), nil
+		return failResult(req, wsName, resolved.GitRoot, "marker_leakage"), nil
 	}
 	if newContent == "" {
 		cleanupBackup()
 		if origExisted {
-			return failResult(req, "empty_replacement"), nil
+			return failResult(req, wsName, resolved.GitRoot, "empty_replacement"), nil
 		}
-		return failResult(req, "marker_parse_failed"), nil
+		return failResult(req, wsName, resolved.GitRoot, "marker_parse_failed"), nil
 	}
 
 	// ── Atomic write ──────────────────────────────────────────────────────────
 	if err := atomicWrite(req.File, newContent+"\n"); err != nil {
 		cleanupBackup()
-		return failResult(req, "write_failed: "+err.Error()), nil
+		return failResult(req, wsName, resolved.GitRoot, "write_failed: "+err.Error()), nil
 	}
 
 	// ── Validate ──────────────────────────────────────────────────────────────
@@ -268,12 +268,19 @@ snippet) between these exact markers and nothing else:
 	)
 }
 
-func failResult(req Request, errMsg string) *Result {
+// failResult builds a failure Result. wsName/gitRoot are whatever scope
+// resolution had already determined before the failure — empty for the
+// handful of failures that happen before Edit resolves scope at all. Zeroing
+// them unconditionally used to hide that resolution had succeeded and the
+// real failure was downstream, e.g. response-parsing (#464).
+func failResult(req Request, wsName, gitRoot, errMsg string) *Result {
 	return &Result{
-		Status: "fail",
-		File:   req.File,
-		Enum:   req.Enum,
-		Error:  errMsg,
+		Status:    "fail",
+		File:      req.File,
+		Workspace: wsName,
+		GitRoot:   gitRoot,
+		Enum:      req.Enum,
+		Error:     errMsg,
 	}
 }
 


### PR DESCRIPTION
Closes #464

Six small, independent CLI polish fixes found during a QA pass (the seventh named in the issue, ledger field sanitization, was already fixed independently by #433):

- **`SilenceUsage: true`** on the root command. A runtime error (e.g. "no hydra config") used to dump the full flags block for every one of ~25 subcommands, drowning the one line that mattered. Propagates to every subcommand, including flag-parsing errors, which now read the same one-line way — run `--help` for the flag list.
- **`hyctl probe --json`**. Every other data-producing command (models, cost, stats, pricing, mcp report, security, graph, context entropy) already had one; probe was the exception. `probeHeadJSON` is a deliberate subset of `provider.Head` (which carries no json tags of its own), plus a `routable`/`unroutable_reason` pair mirroring the human table's ✗ marker.
- **`hyctl cost tail -N`**'s help text now documents the `--` escape a negative N needs, since cobra reads a bare `-5` as an unrecognized flag before this command's `RunE` ever sees it.
- **`mcp check`/`mcp log`** now join tool and resource with `" -> "` instead of `"/"`. A resource that is itself an absolute path made `"tool/resource"` read as one run-together path (e.g. `"shell//bin/rm -rf /"`).
- **`oracle verify --record <garbage>`** is now validated the same way `trust record --outcome` already is, and before the verifier command runs at all rather than after — a garbage value used to be silently ignored, discoverable only by its absence from `trust calibration` later.
- **`internal/editor`'s `failResult()`** no longer zeroes `Workspace`/`GitRoot` unconditionally. Six of its ten call sites happen after scope resolution already succeeded; a downstream failure (dispatch error, marker leakage, empty replacement, write failure) used to be indistinguishable from "scope was never resolved" in the reported `Result`.

## Tests
New tests for each of the six fixes. `go build`/`go vet` clean. `go test ./...` clean. `go test -race` clean on `cmd/hydra`, `internal/editor`, `internal/oracle`. `covergate` passes (40 floors met, 39/40 skips used — no net new skips: one added, one removed once restructuring `oracle verify` to validate `--record` upfront made a Windows guard on that test unnecessary).