### PR TITLE
fix(desktop): stop treating a cross-run A2A handoff as same-run graph structure

### DIFF
--- a/desktop/api/session.go
+++ b/desktop/api/session.go
@@ -120,6 +120,17 @@ func (a *API) GetSession(runID string) (*Session, error) {
 			Detail:     n.Detail,
 		})
 		for _, h := range n.Handoffs {
+			// An A2A handoff always crosses runs — the target picks it up in a
+			// later, separate `hyctl dispatch` invocation with its own run_id —
+			// so it can never resolve to a node in *this* run's tree. Every
+			// successful dispatch writes one of these unconditionally (as
+			// bookkeeping for a possible future --a2a chain), so treating it as
+			// a same-run edge made ordinary, single-head runs non-linear 100%
+			// of the time (#485). Only a same-run-resolvable target is real
+			// graph structure.
+			if _, ok := t.Nodes[h.To]; !ok {
+				continue
+			}
 			s.Edges = append(s.Edges, Edge{
 				From: n.ID, To: h.To, TS: formatTS(h.TS), Detail: h.Detail,
 			})

--- a/desktop/api/session_test.go
+++ b/desktop/api/session_test.go
@@ -146,22 +146,53 @@ func TestGetSession_FanOutIsNonLinear(t *testing.T) {
 	}
 }
 
-// An A2A cross-edge makes a run non-linear even when the ownership tree is a
-// chain — that edge is precisely the thing a timeline cannot draw.
-func TestGetSession_HandoffAloneMakesItNonLinear(t *testing.T) {
+// A real hyctl dispatch always crosses runs for its A2A handoff — the target
+// picks up last_handoff.json in a later, separate invocation with its own
+// run_id — so writeHandoff's ref (e.g. "hydra-tier-4") never names a node in
+// this run's own tree. Every successful dispatch writes one of these
+// unconditionally, so treating it as same-run graph structure made ordinary,
+// single-head runs non-linear 100% of the time (#485): the Graph tab always
+// appeared, and always showed one isolated node with no visible edge, since
+// SessionGraph can't place a node it has no Agent for either.
+func TestGetSession_DanglingHandoffIsNotNonLinear(t *testing.T) {
 	sandbox(t)
 
 	writeRun(t, "20260802T100000Z-a2a",
 		runlog.Event{Kind: runlog.KindHeadSelected, Head: "a"},
-		runlog.Event{Kind: runlog.KindHandoff, Agent: "a", Ref: "b", Detail: "context"},
+		runlog.Event{Kind: runlog.KindHandoff, Agent: "a", Ref: "hydra-tier-4", Detail: "context handed to hydra-tier-4"},
 	)
 
 	s, err := New().GetSession("20260802T100000Z-a2a")
 	if err != nil {
 		t.Fatal(err)
 	}
+	if s.NonLinear {
+		t.Error("NonLinear = true for a handoff whose target is not a node in this run")
+	}
+	if len(s.Edges) != 0 {
+		t.Errorf("%d edges, want 0 — the target does not exist in this session", len(s.Edges))
+	}
+}
+
+// A handoff whose target IS a node in the same run — the one shape the
+// current architecture never actually produces, but the graph must still
+// render correctly if it ever does — is real structure a timeline cannot
+// draw, and must still make the run non-linear.
+func TestGetSession_ResolvableHandoffMakesItNonLinear(t *testing.T) {
+	sandbox(t)
+
+	writeRun(t, "20260802T100000Z-a2a-resolvable",
+		runlog.Event{Kind: runlog.KindTaskStarted, Agent: "a"},
+		runlog.Event{Kind: runlog.KindTaskStarted, Agent: "b"},
+		runlog.Event{Kind: runlog.KindHandoff, Agent: "a", Ref: "b", Detail: "context"},
+	)
+
+	s, err := New().GetSession("20260802T100000Z-a2a-resolvable")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !s.NonLinear {
-		t.Error("NonLinear = false despite an A2A edge")
+		t.Error("NonLinear = false despite an A2A edge resolving to a real node")
 	}
 	if len(s.Edges) != 1 {
 		t.Fatalf("%d edges, want 1", len(s.Edges))


### PR DESCRIPTION
## Summary
- Every successful `hyctl dispatch` writes a handoff event (`internal/dispatch/dispatch.go:390-411`) whose `Ref` is a generic tier identity (`hydra-tier-N`) meant for a later, separate invocation to pick up via `--a2a` — it can never resolve to a node in the same run's own tree.
- `GetSession` was treating every handoff as a graph edge and feeding it into `isNonLinear()`, so 100% of dispatches (confirmed against real local run logs) were marked non-linear, always offering a Graph tab.
- Clicking Graph showed a single isolated node with no visible edge, since `SessionGraph.tsx` silently drops any node it can't resolve back to a real agent — hiding the very thing that supposedly justified showing the tab.
- Verified live end-to-end via `wails dev`: before the fix, a real run in `~/.hydra/logs/runs/` showed a spurious Timeline/Graph toggle; after the fix, the same run goes straight to Timeline, and the handoff still shows as an audit-trail row.

## Changes
- `desktop/api/session.go` — only count a handoff as a graph edge when its target resolves to a node in this run's tree (`t.Nodes`)
- `desktop/api/session_test.go` — flipped `TestGetSession_HandoffAloneMakesItNonLinear` (renamed `TestGetSession_DanglingHandoffIsNotNonLinear`) to match the corrected invariant, added `TestGetSession_ResolvableHandoffMakesItNonLinear` to keep the real (if currently unreachable) resolvable-handoff case covered

Closes #485