### PR TITLE
fix(oracle): trim {answer}'s trailing newline, keep {file} bytes exact

### DIFF
--- a/internal/oracle/coverage_test.go
+++ b/internal/oracle/coverage_test.go
@@ -152,6 +152,36 @@ func TestBuildArgsFromArgv_SubstitutesAnswerAndFile(t *testing.T) {
 	}
 }
 
+// A candidate file written the ordinary way (echo, any text editor) ends in
+// a trailing newline by convention. That newline is not part of the answer,
+// so a verifier doing plain string equality on {answer} must not see it —
+// while {file} still gets the exact original bytes, since a verifier that
+// reads the file itself (compiler, linter) needs the real content (#487).
+func TestBuildArgsFromArgv_AnswerDropsTrailingNewlineButFileKeepsIt(t *testing.T) {
+	var gotFileContent string
+	o := &CommandOracle{
+		Args:   []string{"diff", "{answer}", "{file}"},
+		Source: "v",
+		writeTemp: func(content string) (string, func(), error) {
+			gotFileContent = content
+			return "/tmp/f", func() {}, nil
+		},
+	}
+	parts, cleanup, err := o.buildArgs("42\r\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+	if parts[1] != "42" {
+		t.Errorf("{answer} = %q, want the trailing newline trimmed", parts[1])
+	}
+	if gotFileContent != "42\r\n" {
+		t.Errorf("{file} was materialized from %q, want the untrimmed candidate", gotFileContent)
+	}
+}
+
 // {file} materialization failing through the Args path must abort the same
 // way it does through Template — an oracle that ran against a stale or
 // missing file would misreport the candidate as wrong.
@@ -254,6 +284,33 @@ func TestBuildArgs_SubstitutionAndSpacing(t *testing.T) {
 	}
 	if len(p2) < 2 || p2[0] != "go" {
 		t.Errorf("buildArgs = %q", p2)
+	}
+}
+
+// The Template path must trim {answer}'s trailing newline exactly like Args
+// does — the two substitution paths must not diverge on this (#487).
+func TestBuildArgs_AnswerDropsTrailingNewlineButFileKeepsIt(t *testing.T) {
+	var gotFileContent string
+	o := &CommandOracle{
+		Template: "diff {answer} {file}",
+		Source:   "v",
+		writeTemp: func(content string) (string, func(), error) {
+			gotFileContent = content
+			return "/tmp/f", func() {}, nil
+		},
+	}
+	parts, cleanup, err := o.buildArgs("42\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+	if parts[1] != "42" {
+		t.Errorf("{answer} = %q, want the trailing newline trimmed", parts[1])
+	}
+	if gotFileContent != "42\n" {
+		t.Errorf("{file} was materialized from %q, want the untrimmed candidate", gotFileContent)
 	}
 }
 

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -51,7 +51,9 @@ type Oracle interface {
 
 // CommandOracle runs an external command as the verifier. Exit code 0 is a pass;
 // any non-zero exit is a fail. The candidate answer is written to a temp file
-// and substituted for {file}; the raw answer is substituted for {answer}.
+// verbatim for {file}; {answer} gets the same content with a trailing
+// newline trimmed — a file-write artifact (echo, any editor), not part of
+// the answer a verifier is comparing against.
 type CommandOracle struct {
 	// Args is the command argv, verbatim, e.g. []string{"sh", "-c", "exit 1"}.
 	// Each element is substituted in place for {file}/{answer} and passed to
@@ -127,7 +129,15 @@ func (o *CommandOracle) buildArgs(candidate string) (parts []string, cleanup fun
 		cleanup = cl
 		filePath = path
 	}
-	return splitTemplate(tmpl, candidate, filePath), cleanup, nil
+	return splitTemplate(tmpl, answerFor(candidate), filePath), cleanup, nil
+}
+
+// answerFor is what fills an {answer} slot: the candidate with a trailing
+// newline trimmed. {file} materialization uses the raw candidate untouched —
+// a verifier reading the file itself (compiler, linter) must see the exact
+// bytes the candidate was.
+func answerFor(candidate string) string {
+	return strings.TrimRight(candidate, "\r\n")
 }
 
 // buildArgsFromArgv substitutes {answer}/{file} inside each Args element in
@@ -155,7 +165,7 @@ func (o *CommandOracle) buildArgsFromArgv(candidate string) (parts []string, cle
 	}
 	parts = make([]string, len(o.Args))
 	for i, a := range o.Args {
-		a = strings.ReplaceAll(a, "{answer}", candidate)
+		a = strings.ReplaceAll(a, "{answer}", answerFor(candidate))
 		a = strings.ReplaceAll(a, "{file}", filePath)
 		parts[i] = a
 	}


### PR DESCRIPTION
## Summary
- `hyctl oracle verify ... --candidate <file>` reads the candidate byte-for-byte and substituted it verbatim into `{answer}`. A candidate file written the ordinary way (`echo`, any text editor) ends in a trailing newline by convention, which a verifier doing plain string equality never expects — a semantically correct candidate failed verification.
- Verified live before/after: `echo "42" > candidate.txt` against a verifier checking `$1 == "42"` failed before this fix, passes after.
- `{file}` materialization is untouched — a verifier that reads the file itself (compiler, linter) still gets the candidate's exact original bytes, confirmed with a byte-count check.
- The pre-existing argv-corruption fix (#444) is unaffected — re-verified live with a multi-word single argument.

## Changes
- `internal/oracle/oracle.go` — new `answerFor()` helper trims `\r`/`\n` before filling an `{answer}` slot, in both the `Args`-based and `Template`-based substitution paths; `{file}` materialization keeps using the raw candidate
- `internal/oracle/coverage_test.go` — regression tests for both substitution paths confirming `{answer}` is trimmed while `{file}` keeps the untrimmed candidate

Closes #487