### PR TITLE
fix(desktop): raise the chat dock above the model-detail drawer

### DIFF
--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1345,7 +1345,11 @@ body {
   position: fixed;
   right: 22px;
   bottom: 20px;
-  z-index: 10;
+  /* Above .drawer (41) and .drawer-backdrop (40): the drawer spans the same
+     bottom-right corner, and opening the dock already closes the drawer
+     (#460) — so the dock must win the stacking conflict, not lose it and
+     become an unclickable button hidden behind the drawer's panel (#489). */
+  z-index: 42;
   font-family: var(--hy-font-display);
 }
 


### PR DESCRIPTION
## Summary
- `.dock` (the persistent "Ask Hydra" chat dock) sits at `z-index: 10`, bottom-right; `.drawer` (Dashboard's model-detail panel) spans the full viewport height on the right 400px at `z-index: 41` — the same corner. Opening any model's spend breakdown made the dock completely hidden and unreachable by click until the drawer was dismissed first.
- Confirmed live via headless browser: with the drawer open, `document.elementFromPoint()` at the dock's screen position returned the drawer element, and a real click on the dock timed out (Playwright's actionability check never succeeded — something else was on top). A screenshot with the drawer open shows no trace of the "Ask Hydra" button at all.
- The dock already closes the drawer when it opens (#460), so it needs to win this stacking conflict, not lose it.
- Verified fixed live end-to-end: dock button now visible over the drawer, `elementFromPoint` returns the dock, and clicking it opens the dock and closes the drawer in one click.

## Changes
- `desktop/frontend/src/app.css` — `.dock`'s z-index raised from 10 to 42 (above `.drawer-backdrop` at 40 and `.drawer` at 41)

Closes #489