### PR TITLE
fix(executor): invoke codex's exec subcommand instead of its interactive TUI

### DIFF
--- a/internal/executor/cli.go
+++ b/internal/executor/cli.go
@@ -68,7 +68,7 @@ func (t cliTemplate) buildArgs(prompt string) []string {
 // To add a new CLI tool, add an entry here and in capabilities/data.json.
 var cliTemplates = map[string]cliTemplate{
 	"anthropic":   {args: []string{"--print", ""}}, // claude --print "<prompt>"
-	"openai":      {args: []string{""}},            // codex "<prompt>"
+	"openai":      {args: []string{"exec", ""}},    // codex exec "<prompt>" — bare codex launches its interactive TUI (#491)
 	"google":      {args: []string{""}},            // gemini "<prompt>"
 	"antigravity": {args: []string{""}},            // agy "<prompt>"
 	"cursor":      {args: []string{"--stdio"}, stdinPrompt: true},

--- a/internal/executor/local_test.go
+++ b/internal/executor/local_test.go
@@ -280,6 +280,18 @@ func TestCLIBuildArgs_SubstitutesThePromptPlaceholder(t *testing.T) {
 	}
 }
 
+// Bare `codex "<prompt>"` launches codex's interactive TUI, which fails
+// instantly outside a real terminal — every dispatch to codex failed this
+// way and silently fell back to a lower-scoring head (#491). The exec
+// subcommand is the non-interactive entry point.
+func TestCLIBuildArgs_OpenAIUsesTheExecSubcommand(t *testing.T) {
+	got := cliTemplates["openai"].buildArgs("the prompt")
+	want := []string{"exec", "the prompt"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("openai template args = %q, want %q — bare codex launches its interactive TUI", got, want)
+	}
+}
+
 func TestCLIExecute_RunsTheBinaryAndReturnsItsOutput(t *testing.T) {
 	s := testutil.NewSandbox(t)
 


### PR DESCRIPTION
## Summary
- Every dispatch to the `codex` head failed in ~2 seconds (far too fast to be a real model call) and silently fell back to a lower-scoring head.
- Root cause: `internal/executor/cli.go`'s `openai` template invoked bare `codex "<prompt>"`, which launches codex's **interactive TUI mode** — it requires a real terminal and errors instantly ("stdin is not a terminal") when run as a subprocess, exactly like every dispatch does.
- The correct, non-interactive entry point is the `exec` subcommand: `codex exec "<prompt>"`. Verified live — stdout is the clean answer alone (`OK`), all preamble/session/MCP-noise goes to stderr.
- Confirmed fixed end-to-end: before the fix, `hyctl dispatch --swarm --swarm-heads codex ...` failed in 2336ms; after, it succeeds in a realistic ~11.8s with the correct output.

## Changes
- `internal/executor/cli.go` — `openai` template changed to `{args: []string{"exec", ""}}`
- `internal/executor/local_test.go` — regression test asserting the template builds `exec "<prompt>"`, not bare `"<prompt>"`

Closes #491