### PR TITLE
fix(executor): pass --print to agy, or a TUI error masquerades as an answer

### DIFF
--- a/internal/executor/cli.go
+++ b/internal/executor/cli.go
@@ -70,7 +70,7 @@ var cliTemplates = map[string]cliTemplate{
 	"anthropic":   {args: []string{"--print", ""}}, // claude --print "<prompt>"
 	"openai":      {args: []string{"exec", ""}},    // codex exec "<prompt>" — bare codex launches its interactive TUI (#491)
 	"google":      {args: []string{""}},            // gemini "<prompt>"
-	"antigravity": {args: []string{""}},            // agy "<prompt>"
+	"antigravity": {args: []string{"--print", ""}}, // agy --print "<prompt>" — bare agy launches its interactive TUI and, unlike codex, still exits 0 (#492)
 	"cursor":      {args: []string{"--stdio"}, stdinPrompt: true},
 	"amazon":      {args: []string{""}},                       // kiro "<prompt>"
 	"codeium":     {args: []string{""}},                       // windsurf "<prompt>"

--- a/internal/executor/local_test.go
+++ b/internal/executor/local_test.go
@@ -292,6 +292,18 @@ func TestCLIBuildArgs_OpenAIUsesTheExecSubcommand(t *testing.T) {
 	}
 }
 
+// Bare `agy "<prompt>"` launches agy's interactive TUI too, but — unlike
+// codex — still exits 0, with the TUI error text on stdout. CLIExecutor only
+// checks the exit code, so this silently reports a false success carrying an
+// error message as if it were the model's real answer (#492).
+func TestCLIBuildArgs_AntigravityUsesPrintFlag(t *testing.T) {
+	got := cliTemplates["antigravity"].buildArgs("the prompt")
+	want := []string{"--print", "the prompt"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("antigravity template args = %q, want %q — bare agy launches its interactive TUI", got, want)
+	}
+}
+
 func TestCLIExecute_RunsTheBinaryAndReturnsItsOutput(t *testing.T) {
 	s := testutil.NewSandbox(t)
 


### PR DESCRIPTION
## Summary
- Bare `agy "<prompt>"` (the current template) launches agy's interactive TUI, which fails outside a real terminal — but unlike codex (#491), it still **exits 0**, with the TUI error text on stdout instead of stderr:
  ```
  $ agy "..." ; echo "EXIT=$?"
  CLI error: bubbletea: error opening TTY: bubbletea: could not open TTY: open /dev/tty: device not configured
  EXIT=0
  ```
- `CLIExecutor.Execute` only checks the exit code, so every dispatch to the Antigravity head silently "succeeded" while the actual `Output` was that TUI error message, not a real answer. Confirmed live: `hyctl dispatch --swarm --swarm-heads agy ...` reported `✓ ok` and printed the TTY error as the response.
- This is worse than #491: that one visibly failed and fell back. This one silently returns garbage as a success.
- Scope: only the literal `Antigravity` CLI head is affected. The six other antigravity-backed registry models (Gemini *, Claude Opus/Sonnet via antigravity) route through the separate `AgyExecutor`, which already correctly passes `--print`.
- Fix verified live: after adding `--print`, the same dispatch now returns a clean `OK` in a realistic ~20s.

## Changes
- `internal/executor/cli.go` — `antigravity` template changed to `{args: []string{"--print", ""}}`
- `internal/executor/local_test.go` — regression test asserting the template builds `--print "<prompt>"`

Closes #492