### PR TITLE
fix(desktop): register the discovery plugins the Ask Hydra dock needs

### DIFF
--- a/desktop/main.go
+++ b/desktop/main.go
@@ -27,6 +27,15 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 
 	"github.com/ankit373/hydra/desktop/api"
+
+	// Self-registering discovery plugins. Without these, provider.All() is
+	// empty and every chat dispatch reports zero heads, no matter what is
+	// actually installed on the machine (#495) — cmd/hydra/main.go imports
+	// the same four for the same reason.
+	_ "github.com/ankit373/hydra/internal/provider/agy"
+	_ "github.com/ankit373/hydra/internal/provider/cli"
+	_ "github.com/ankit373/hydra/internal/provider/env"
+	_ "github.com/ankit373/hydra/internal/provider/port"
 )
 
 //go:embed all:frontend/dist

--- a/desktop/main_test.go
+++ b/desktop/main_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// The desktop binary needs the same self-registering provider imports as
+// cmd/hydra/main.go — without them provider.All() is empty and every chat
+// dispatch reports zero heads, no matter what is actually installed (#495).
+// desktop/api's own tests cannot catch this: they compile a separate binary
+// that never imports this package.
+func TestProviderPluginsAreRegistered(t *testing.T) {
+	if len(provider.All()) == 0 {
+		t.Fatal("provider.All() is empty — the desktop binary is missing the blank " +
+			"imports of internal/provider/{cli,agy,env,port}, so it can never discover a head")
+	}
+}


### PR DESCRIPTION
## Summary
- Every dispatch through the desktop app's "Ask Hydra" dock has always failed with "No models found on this machine yet." — reproduced live on a machine where `hyctl probe` finds 12 heads, with the same `$PATH` confirmed on the running app process (not a PATH/environment issue).
- Root cause: `cmd/hydra/main.go` blank-imports `internal/provider/{cli,agy,env,port}` to trigger their self-registering `init()`. `desktop/main.go` — and nothing else anywhere in the `desktop` module — imports any of them. `provider.All()` was therefore always empty in the desktop binary, so `probe.Run()` (via `dispatch.New()` in `Chat()`) always found zero heads, regardless of what's actually installed.
- Not caught by `desktop/api`'s own tests: they compile a separate binary with the exact same gap, so `TestChat_NoHeadsAtAllSetsNeedsProbe` — meant to test a rare "nothing installed" edge case — was actually exercising the *only* reachable state, and passed for the wrong reason.
- Verified live end-to-end via `wails dev`: before the fix, the dock's "Check again" retry failed repeatedly; after adding the imports, the same prompt now dispatches for real — `OK · Claude Code · T1 · 21.6s · session →`.

## Changes
- `desktop/main.go` — blank-imports the same four provider plugins `cmd/hydra/main.go` already does
- `desktop/main_test.go` — new regression test asserting `provider.All()` is non-empty; confirmed it fails without the fix and passes with it

Closes #495