### PR TITLE
fix: correctness and hot-path latency bugs from repo-wide algorithms/data-structures audit

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1897,10 +1897,7 @@ func cmdGraph() *cobra.Command {
 			task := trust.Task{BlastRadius: radius}
 			dm := trust.NewDefectModel()
 
-			var deps int
-			for _, id := range g.NodesInFile(file) {
-				deps += g.DependentCount(id)
-			}
+			deps := g.DependentCountForFile(file)
 			pFactor := g.PercolationFactor(file)
 			// A radius of 1.0 means either "nothing depends on this" or "I have
 			// no idea" — opposite conclusions that used to render identically.

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -76,7 +76,9 @@ type Tracker struct {
 func (t *Tracker) Update(used, window int, source string) Snapshot {
 	pct := 0
 	if window > 0 {
-		pct = used * 100 / window
+		// Round to nearest, not truncate: a true 74.95% must round to 75 so it
+		// isn't silently reported one point under the ModeCritical boundary.
+		pct = (used*100 + window/2) / window
 	}
 	if pct > 100 {
 		pct = 100

--- a/internal/budget/risk.go
+++ b/internal/budget/risk.go
@@ -63,7 +63,15 @@ func RiskFromHistory(hist []int) (burnRatePct, risk float64) {
 	for _, d := range deltas {
 		ss += (d - mu) * (d - mu)
 	}
-	sigma := math.Sqrt(ss / float64(n)) // population stddev of increments
+	// Sample stddev (Bessel's correction, n-1): this governor always runs at
+	// small n (MaxPctHistory=12 caps n at 11), where population variance (÷n)
+	// systematically understates volatility. With n==1 there is no way to
+	// estimate spread from a single delta, so sigma stays 0 (ss is trivially 0
+	// there too — no divide-by-zero, no behavior change from before at n==1).
+	var sigma float64
+	if n > 1 {
+		sigma = math.Sqrt(ss / float64(n-1))
+	}
 
 	x := float64(hist[len(hist)-1]) / 100
 	risk = FirstPassageProb(emergencyFrac-x, mu, sigma, riskHorizon)

--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -127,7 +127,15 @@ func Summary() (*SummaryResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	return SummaryFromRows(all), nil
+}
 
+// SummaryFromRows computes the same result as Summary but from rows the
+// caller already loaded — callers that also need the raw rows (e.g. the
+// TUI's latency/savings panels, which call LoadAll for their own purposes)
+// should load once and derive both from that one slice instead of paying for
+// a second full read+parse of cost.jsonl.
+func SummaryFromRows(all []Row) *SummaryResult {
 	todayStr := time.Now().UTC().Format("2006-01-02")
 	var todayRows []Row
 	for _, r := range all {
@@ -136,7 +144,9 @@ func Summary() (*SummaryResult, error) {
 		}
 	}
 
-	recent := all
+	// A copy, not a subslice of all: reversing in place must never mutate the
+	// caller's own rows out from under it when all is shared/reused.
+	recent := append([]Row(nil), all...)
 	if len(recent) > 5 {
 		recent = recent[len(recent)-5:]
 	}
@@ -152,7 +162,7 @@ func Summary() (*SummaryResult, error) {
 		Recent:          recent,
 		ActualTokens:    actualTok,
 		EstimatedTokens: estTok,
-	}, nil
+	}
 }
 
 // Today returns today's per-tier breakdown.
@@ -593,13 +603,18 @@ func tailLines(path string, n int) ([]string, error) {
 
 func aggregate(rows []Row) Totals {
 	var t Totals
+	var totalWallMS int64
 	t.Calls = len(rows)
 	for _, r := range rows {
 		t.PromptTokens += r.PromptTokens
 		t.ResponseTokens += r.ResponseTokens
 		t.EstCostUSD += r.EstCostUSD
-		t.WallSeconds += r.WallMS / 1000
+		totalWallMS += r.WallMS
 	}
+	// Sum milliseconds first, then divide once: dividing per-row before summing
+	// truncates every sub-second call to 0, so a batch of fast calls reports
+	// "0s" total wall time regardless of real cumulative time.
+	t.WallSeconds = totalWallMS / 1000
 	// Round to 6 decimal places.
 	t.EstCostUSD = math.Round(t.EstCostUSD*1_000_000) / 1_000_000
 	return t

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -99,14 +99,54 @@ func (d *Dispatcher) EstimateCost(tier, inputTokens, outputTokens int) float64 {
 	return d.estimateCost(tier, inputTokens, outputTokens)
 }
 
-// New builds a Dispatcher from the saved config and a fresh machine probe.
+// probeCacheTTL bounds how long a machine probe is reused across calls to New
+// within one process. New is called once per CLI invocation, but also once per
+// task inside a parallel batch and once per view inside a TUI snapshot — with
+// no cache each of those redoes the same ~13 exec.LookPath calls and two
+// network liveness checks. A short TTL collapses those into one real probe
+// without leaving a long-running TUI session blind to a server that started
+// or stopped mid-session.
+const probeCacheTTL = 3 * time.Second
+
+var (
+	probeCacheMu     sync.Mutex
+	probeCacheResult *probe.Result
+	probeCacheAt     time.Time
+	probeCacheEnv    string
+)
+
+// probeEnvFingerprint is HOME+PATH, the two environment variables that change
+// what a probe discovers (CLI binaries on PATH; agy/models overlay under
+// HOME). Any change invalidates the cache immediately regardless of TTL —
+// without this, a cached result from one HOME (e.g. a test's temp dir with
+// its own stub binaries) would be silently reused after HOME changes.
+func probeEnvFingerprint() string {
+	return os.Getenv("HOME") + "\x00" + os.Getenv("PATH")
+}
+
+// cachedProbe returns probe.Run's result, reusing it for probeCacheTTL as long
+// as the environment it depends on hasn't changed.
+func cachedProbe(ctx context.Context) *probe.Result {
+	probeCacheMu.Lock()
+	defer probeCacheMu.Unlock()
+	env := probeEnvFingerprint()
+	if probeCacheResult != nil && env == probeCacheEnv && time.Since(probeCacheAt) < probeCacheTTL {
+		return probeCacheResult
+	}
+	probeCacheResult = probe.Run(ctx)
+	probeCacheAt = time.Now()
+	probeCacheEnv = env
+	return probeCacheResult
+}
+
+// New builds a Dispatcher from the saved config and a (possibly cached) machine probe.
 func New(ctx context.Context) (*Dispatcher, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, fmt.Errorf("no hydra config — run: hyctl init")
 	}
 
-	result := probe.Run(ctx)
+	result := cachedProbe(ctx)
 
 	localOnly := false
 	if p, ok := cfg.Policies["pii"]; ok && p.Action == "local-only" {
@@ -208,12 +248,22 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 			Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
 			Detail: fmt.Sprintf("candidate %d of %d", i+1, len(candidates)),
 		})
-		if decision, lerr := ledger.CheckAndRecordDispatch("hydra-dispatch", h.ID, opts.Resource, prompt); lerr == nil && decision == ledger.Deny {
-			lastErr = fmt.Errorf("denied by ledger policy: head %s", h.ID)
+		// Fails closed like ledger.Check itself: a policy-check error (unreadable
+		// policy file, ledger write failure) must deny, not silently let the
+		// candidate through just because the decision couldn't be computed.
+		// CheckAndRecordDispatch's LoadPolicy is itself mtime-cached, so trying
+		// every candidate against the same prompt no longer re-reads and
+		// re-parses the identical policy file from disk once per candidate.
+		if decision, lerr := ledger.CheckAndRecordDispatch("hydra-dispatch", h.ID, opts.Resource, prompt); lerr != nil || decision == ledger.Deny {
+			detail := "denied by ledger policy"
+			if lerr != nil {
+				detail = "ledger policy check failed: " + lerr.Error()
+			}
+			lastErr = fmt.Errorf("%s: head %s", detail, h.ID)
 			_ = rl.Append(runlog.Event{
 				Kind: runlog.KindError, TaskID: taskID,
 				Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
-				Status: "denied", Detail: "denied by ledger policy",
+				Status: "denied", Detail: detail,
 			})
 			continue
 		}

--- a/internal/executor/cli.go
+++ b/internal/executor/cli.go
@@ -3,12 +3,13 @@
 package executor
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/ankit373/hydra/internal/util"
 )
 
 // CLIExecutor runs a prompt via a subprocess CLI tool.
@@ -30,9 +31,10 @@ func (e *CLIExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 		cmd.Stdin = strings.NewReader(req.Prompt)
 	}
 
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	stdout := util.NewAccumulator(0)
+	stderr := util.NewAccumulator(64 << 10)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	start := time.Now()
 	if err := cmd.Run(); err != nil {
@@ -40,9 +42,10 @@ func (e *CLIExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 	}
 
 	return &Response{
-		Output:   strings.TrimSpace(stdout.String()),
-		Duration: time.Since(start),
-		Model:    req.Head.ID,
+		Output:    strings.TrimSpace(stdout.String()),
+		Duration:  time.Since(start),
+		Model:     req.Head.ID,
+		Truncated: stdout.Truncated(),
 	}, nil
 }
 

--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/util"
 )
 
 // HTTPExecutor runs prompts against HTTP-based providers.
@@ -144,7 +145,7 @@ func (e *HTTPExecutor) executeOpenAICompatible(ctx context.Context, req Request,
 	}
 
 	var cr openAIChatResponse
-	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1)).Decode(&cr); err != nil {
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 	if len(cr.Choices) == 0 {
@@ -207,7 +208,7 @@ func (e *HTTPExecutor) executeAnthropic(ctx context.Context, req Request) (*Resp
 			OutputTokens int `json:"output_tokens"`
 		} `json:"usage"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1)).Decode(&out); err != nil {
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 
@@ -278,7 +279,7 @@ func (e *HTTPExecutor) executeGemini(ctx context.Context, req Request) (*Respons
 		} `json:"usageMetadata"`
 		ModelVersion string `json:"modelVersion"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1)).Decode(&out); err != nil {
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 	if len(out.Candidates) == 0 {
@@ -341,7 +342,7 @@ func (e *HTTPExecutor) executeCohere(ctx context.Context, req Request) (*Respons
 			} `json:"tokens"`
 		} `json:"usage"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1)).Decode(&out); err != nil {
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 
@@ -385,7 +386,7 @@ func (e *HTTPExecutor) executeAzureOpenAI(ctx context.Context, req Request) (*Re
 	}
 
 	var out openAIChatResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1)).Decode(&out); err != nil {
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 	if len(out.Choices) == 0 {
@@ -438,7 +439,7 @@ func (e *HTTPExecutor) executeBedrock(ctx context.Context, req Request) (*Respon
 	}
 
 	var out openAIChatResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1)).Decode(&out); err != nil {
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 	if len(out.Choices) == 0 {
@@ -490,7 +491,7 @@ func (e *HTTPExecutor) executeReplicate(ctx context.Context, req Request) (*Resp
 	}
 
 	var pred replicatePrediction
-	if err := json.NewDecoder(resp.Body).Decode(&pred); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1)).Decode(&pred); err != nil {
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 
@@ -556,7 +557,7 @@ func (e *HTTPExecutor) getReplicatePrediction(ctx context.Context, headID, getUR
 	}
 
 	var pred replicatePrediction
-	if err := json.NewDecoder(resp.Body).Decode(&pred); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1)).Decode(&pred); err != nil {
 		return replicatePrediction{}, fmt.Errorf("http exec %s: decode: %w", headID, err)
 	}
 	return pred, nil

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -156,6 +156,21 @@ func (g *Graph) DependentCount(nodeID string) int {
 	return len(g.transitiveDependents([]string{nodeID}))
 }
 
+// DependentCountForFile returns the number of nodes that transitively depend
+// on any node declared in file, using the same seed set as BlastRadiusForFile.
+// Callers must use this instead of looping NodesInFile+DependentCount per
+// node: that pattern runs one single-seed BFS per node in the file (wasteful)
+// and double-counts any node reachable from more than one of the file's own
+// seeds, so the displayed dependent count can disagree with the count that
+// actually drove BlastRadiusForFile's multiplier.
+func (g *Graph) DependentCountForFile(file string) int {
+	seeds := g.seedsForFile(file)
+	if len(seeds) == 0 {
+		return 0
+	}
+	return len(g.transitiveDependents(seeds))
+}
+
 // seedsForFile returns the node IDs declared in a file, matching by exact path
 // first, then basename, then (Go package-granularity graphs) the file's
 // containing package — so callers may pass absolute paths, relative paths, or

--- a/internal/ledger/coverage_test.go
+++ b/internal/ledger/coverage_test.go
@@ -67,6 +67,42 @@ func TestLoadPolicy_MissingFileIsDefaultAllow(t *testing.T) {
 	}
 }
 
+// LoadPolicy caches its result per path (a dispatch fallback loop or swarm
+// fan-out calls it once per candidate head for the same content), but a real
+// edit to the file must never be masked by a stale cache entry — the whole
+// reason it keys on mtime+size instead of remembering the first read forever.
+func TestLoadPolicy_CacheInvalidatesOnRealEdit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+
+	if err := os.WriteFile(path, []byte(`{"default":"allow","rules":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p1, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1.Default != Allow {
+		t.Fatalf("first load Default = %q, want Allow", p1.Default)
+	}
+
+	// Deliberately a different size, so this can never collide with the first
+	// read's cache key regardless of filesystem mtime resolution.
+	body := `{"default":"deny","rules":[{"tool":"fs","resource":"/repo/*","action":"write","decision":"allow"}]}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	p2, err := LoadPolicy(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p2.Default != Deny {
+		t.Errorf("after editing the file, Default = %q, want Deny — the cache served a stale read", p2.Default)
+	}
+	if len(p2.Rules) != 1 {
+		t.Errorf("after editing the file, got %d rule(s), want 1 — the cache served a stale read", len(p2.Rules))
+	}
+}
+
 func TestLoadPolicy_MalformedJSONIsAnError(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "policy.json")
 	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/ankit373/hydra/internal/glob"
 	"sort"
@@ -475,9 +476,56 @@ func DefaultPolicyPath() string {
 	return filepath.Join(config.Dir(), "mcp_policy.json")
 }
 
+// policyCacheEntry is one path's last-loaded policy, tagged with the file
+// state it was loaded from.
+type policyCacheEntry struct {
+	policy  Policy
+	err     error
+	modTime time.Time
+	size    int64
+}
+
+var (
+	policyCacheMu sync.Mutex
+	policyCache   = map[string]policyCacheEntry{}
+)
+
 // LoadPolicy reads a policy file. A missing file yields a default-allow policy
 // (Hydra records everything but blocks nothing until rules are defined).
+//
+// The parsed result is cached per path, keyed on the file's mtime+size — a
+// dispatch fallback loop or a swarm fan-out checks the same content against
+// several candidate heads in quick succession, and without this every one of
+// them re-reads and re-parses the identical policy file from disk. An
+// os.Stat is far cheaper than that, and any real edit to the file (different
+// mtime or size) invalidates the cache immediately.
 func LoadPolicy(path string) (Policy, error) {
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return Policy{Default: Allow}, nil
+		}
+		// Stat failed for a reason other than "missing" (permissions, etc.) —
+		// fall through to the real read, which will surface the same error.
+	} else {
+		policyCacheMu.Lock()
+		if cached, ok := policyCache[path]; ok && cached.modTime.Equal(info.ModTime()) && cached.size == info.Size() {
+			policyCacheMu.Unlock()
+			return cached.policy, cached.err
+		}
+		policyCacheMu.Unlock()
+	}
+
+	p, err := loadPolicyUncached(path)
+	if statErr == nil {
+		policyCacheMu.Lock()
+		policyCache[path] = policyCacheEntry{policy: p, err: err, modTime: info.ModTime(), size: info.Size()}
+		policyCacheMu.Unlock()
+	}
+	return p, err
+}
+
+func loadPolicyUncached(path string) (Policy, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -636,6 +684,9 @@ func Check(path string, p Policy, req CheckRequest) (Decision, error) {
 // only changes behavior for an install that has deliberately configured a
 // deny rule.
 func CheckAndRecordDispatch(agent, headID, resource, content string) (Decision, error) {
+	// LoadPolicy is itself mtime-cached, so a fallback loop or fan-out calling
+	// this once per candidate head for the same content no longer re-reads
+	// and re-parses the identical policy file from disk each time.
 	pol, err := LoadPolicy(DefaultPolicyPath())
 	if err != nil {
 		return "", err

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -110,6 +110,14 @@ func Run(ctx context.Context, tasks []Task, opts Options) ([]Result, error) {
 		seen[t.File] = t.Label
 	}
 
+	// One Dispatcher shared by the whole batch: every task in a `hyctl parallel`
+	// run wants the same machine probe and config, not N independent ones. A
+	// failure here must still surface as a per-task result rather than abort
+	// the batch outright — the run-log tree below gets written either way, and
+	// each task's own JSON result carries the same "dispatcher init" error every
+	// task used to hit independently.
+	d, dispatchErr := dispatch.New(ctx)
+
 	results := make([]Result, len(tasks))
 	var mu sync.Mutex
 
@@ -139,9 +147,9 @@ func Run(ctx context.Context, tasks []Task, opts Options) ([]Result, error) {
 			started := time.Now()
 			var raw json.RawMessage
 			if task.File != "" {
-				raw = runEditTask(gctx, task, runID, taskID)
+				raw = runEditTask(gctx, d, dispatchErr, task, runID, taskID)
 			} else {
-				raw = runTextTask(gctx, task, runID, taskID)
+				raw = runTextTask(gctx, d, dispatchErr, task, runID, taskID)
 			}
 			mu.Lock()
 			results[i] = Result{raw: raw}
@@ -182,10 +190,9 @@ func statusOf(raw json.RawMessage) string {
 }
 
 // runTextTask dispatches a prompt and returns the raw JSON result.
-func runTextTask(ctx context.Context, task Task, runID, taskID string) json.RawMessage {
-	d, err := dispatch.New(ctx)
-	if err != nil {
-		return failText(task, "dispatcher init: "+err.Error())
+func runTextTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error, task Task, runID, taskID string) json.RawMessage {
+	if dispatchErr != nil {
+		return failText(task, "dispatcher init: "+dispatchErr.Error())
 	}
 
 	prompt := task.Prompt
@@ -217,7 +224,7 @@ func runTextTask(ctx context.Context, task Task, runID, taskID string) json.RawM
 // runEditTask performs an atomic file edit and returns the raw JSON result.
 // Self-contained port of the edit.sh flow so this package compiles on develop
 // before internal/editor merges. Once editor merges, this can delegate to editor.Edit.
-func runEditTask(ctx context.Context, task Task, runID, taskID string) json.RawMessage {
+func runEditTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error, task Task, runID, taskID string) json.RawMessage {
 	file := task.File
 	if !filepath.IsAbs(file) {
 		return failEdit(task, "file path must be absolute")
@@ -270,10 +277,9 @@ func runEditTask(ctx context.Context, task Task, runID, taskID string) json.RawM
 	editPrompt := buildEditPrompt(file, ctxNote, task.Prompt, currentBlock)
 
 	// Dispatch
-	d, err := dispatch.New(ctx)
-	if err != nil {
+	if dispatchErr != nil {
 		cleanupBackup()
-		return failEdit(task, "dispatcher init: "+err.Error())
+		return failEdit(task, "dispatcher init: "+dispatchErr.Error())
 	}
 	dispResult, err := d.Dispatch(ctx, editPrompt, dispatch.Options{
 		TierHint: enumToTier(task.Enum),

--- a/internal/security/blast.go
+++ b/internal/security/blast.go
@@ -94,9 +94,7 @@ func AssessBlastRadius() BlastReport {
 			continue
 		}
 		ef.Radius = g.BlastRadiusForFile(file)
-		for _, id := range g.NodesInFile(file) {
-			ef.Dependents += g.DependentCount(id)
-		}
+		ef.Dependents = g.DependentCountForFile(file)
 		r.Files = append(r.Files, ef)
 	}
 

--- a/internal/swarm/runner.go
+++ b/internal/swarm/runner.go
@@ -45,11 +45,17 @@ func executeHead(ctx context.Context, h provider.Head, prompt string, opts Optio
 		StartedAt: time.Now(),
 	}
 
-	if decision, err := ledger.CheckAndRecordDispatch("hydra-swarm", h.ID, "", prompt); err == nil && decision == ledger.Deny {
+	// Fails closed like ledger.Check itself: a policy-check error must deny,
+	// not silently let the head run just because the decision couldn't be computed.
+	if decision, err := ledger.CheckAndRecordDispatch("hydra-swarm", h.ID, "", prompt); err != nil || decision == ledger.Deny {
 		a.FinishedAt = time.Now()
 		a.Duration = a.FinishedAt.Sub(a.StartedAt)
 		a.Status = StatusFailed
-		a.Err = fmt.Errorf("denied by ledger policy: head %s", h.ID)
+		if err != nil {
+			a.Err = fmt.Errorf("ledger policy check failed: %w: head %s", err, h.ID)
+		} else {
+			a.Err = fmt.Errorf("denied by ledger policy: head %s", h.ID)
+		}
 		return a
 	}
 

--- a/internal/trust/coupling.go
+++ b/internal/trust/coupling.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ankit373/hydra/internal/config"
@@ -107,7 +108,35 @@ func RecordCoAgreement(path, domain string, ids, families, texts []string, equiv
 	_, _ = f.WriteString(string(raw) + "\n")
 }
 
+type coAgreementCacheEntry struct {
+	records []coAgreementRecord
+	modTime time.Time
+	size    int64
+}
+
+var (
+	coAgreementCacheMu sync.Mutex
+	coAgreementCache   = map[string]coAgreementCacheEntry{}
+)
+
+// loadCoAgreement reads and caches coagreement.jsonl per path, keyed on
+// mtime+size. One SPRT run can call FamilyDiscount/FamilyCoupling once per
+// repeated-family source while the file is otherwise untouched (the run's own
+// RecordCoAgreement append happens only after sampling finishes), and swarm's
+// judge does the same — without this, every one of those calls re-reads and
+// re-parses the same file from scratch. A real append (mtime or size changes)
+// invalidates the cache on the next call.
 func loadCoAgreement(path string) []coAgreementRecord {
+	info, statErr := os.Stat(path)
+	if statErr == nil {
+		coAgreementCacheMu.Lock()
+		if cached, ok := coAgreementCache[path]; ok && cached.modTime.Equal(info.ModTime()) && cached.size == info.Size() {
+			coAgreementCacheMu.Unlock()
+			return cached.records
+		}
+		coAgreementCacheMu.Unlock()
+	}
+
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -123,6 +152,12 @@ func loadCoAgreement(path string) []coAgreementRecord {
 			continue
 		}
 		out = append(out, r)
+	}
+
+	if statErr == nil {
+		coAgreementCacheMu.Lock()
+		coAgreementCache[path] = coAgreementCacheEntry{records: out, modTime: info.ModTime(), size: info.Size()}
+		coAgreementCacheMu.Unlock()
 	}
 	return out
 }

--- a/internal/trust/coupling_test.go
+++ b/internal/trust/coupling_test.go
@@ -47,6 +47,24 @@ func TestRecordCoAgreement_SkipsUnfamiliedSourcesAndTinyRuns(t *testing.T) {
 	}
 }
 
+// loadCoAgreement caches its result per path — an SPRT run or swarm judge may
+// call FamilyDiscount/FamilyCoupling several times against the same file
+// while it's stable — but a real append (the next run's RecordCoAgreement)
+// must never be masked by a stale cache entry.
+func TestLoadCoAgreement_CacheInvalidatesOnRealAppend(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coagreement.jsonl")
+
+	RecordCoAgreement(path, "go", []string{"a", "b"}, []string{"famA", "famA"}, []string{"x", "x"}, TextEquivalence)
+	if got := loadCoAgreement(path); len(got) != 1 {
+		t.Fatalf("got %d record(s) after first append, want 1", len(got))
+	}
+
+	RecordCoAgreement(path, "python", []string{"c", "d", "e"}, []string{"famB", "famB", "famB"}, []string{"x", "x", "y"}, TextEquivalence)
+	if got := loadCoAgreement(path); len(got) != 2 {
+		t.Errorf("got %d record(s) after second append, want 2 — the cache served a stale read", len(got))
+	}
+}
+
 func TestFamilyCoupling_BelowThresholdIsNotOK(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "coagreement.jsonl")
 	for i := 0; i < minCoAgreementSamples-1; i++ {

--- a/internal/trust/sprt.go
+++ b/internal/trust/sprt.go
@@ -168,6 +168,17 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 			// The pivoting source's own vote now supports the new candidate.
 			res.Ledger[len(res.Ledger)-1].Candidate = candidate
 			res.Ledger[len(res.Ledger)-1].LambdaAfter = lambda
+			res.Ledger[len(res.Ledger)-1].ConfidenceAfter = sigmoid(lambda)
+			// The reseeded Λ must be tested against A immediately: if the
+			// pivoting source's own evidence alone already clears the accept
+			// threshold, Decision has to reflect that in this same iteration —
+			// otherwise a run that pivoted on its last sampled source ends with
+			// Decision still StoppedOnBudget even though Confidence cleared the
+			// target, corrupting hyctl trust explain and AutoClearedPct.
+			if lambda >= A {
+				res.Decision = DecisionAccept
+				break
+			}
 		}
 	}
 

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -195,12 +195,13 @@ func NewCockpit() Cockpit {
 
 	pct := ckClaudePct()
 	secReport, _ := security.Build(probed.Heads) // best-effort: nil on error, handled by the view
+	metrics := ckLoadMetrics(pr)
 	m := Cockpit{
 		mode:      "dispatch",
 		claudePct: pct,
 		heads:     heads,
-		spend:     ckSpendToday(),
-		metrics:   ckLoadMetrics(pr),
+		spend:     metrics.spendUSD, // same value ckSpendToday used to fetch with its own separate cost.jsonl read
+		metrics:   metrics,
 		security:  secReport,
 	}
 	m.runID, m.runLive, m.treeRows = ckLoadTree()
@@ -241,7 +242,11 @@ func ckClaudePct() int {
 	return s.ClaudePct
 }
 
-// ckSpendToday returns today's real estimated spend from cost.jsonl.
+// ckSpendToday returns today's real estimated spend from cost.jsonl. Kept as
+// its own reader (NewCockpit no longer calls it — it gets spend from the
+// metrics it already loaded, via cost.SummaryFromRows, to avoid a second full
+// read of the same file) because it is independently useful and tested as
+// the "absent data reads as zero, not a crash" contract on its own.
 func ckSpendToday() float64 {
 	summary, err := cost.Summary()
 	if err != nil || summary == nil {
@@ -629,27 +634,47 @@ func (m Cockpit) hint() string {
 // that can report an error to the user should reject it up front with
 // ValidSnapshotView.
 func CockpitSnapshotView(view int) string {
+	m := ckSnapshotModel()
+	if !ckValidView(view) {
+		view = ckViewChatCode
+	}
+	m.view = view
+	return m.View()
+}
+
+// ckSnapshotModel builds the one demo Cockpit state every snapshot view
+// renders from. Extracted so CockpitSnapshot builds it once instead of once
+// per view — NewCockpit alone does a machine probe, a full security ledger
+// scan, and a cost.jsonl read, and CockpitSnapshot used to pay for all three
+// four times over for what is really one consistent snapshot shown from four
+// angles.
+func ckSnapshotModel() Cockpit {
 	m := NewCockpit()
 	m = m.run("write a User DTO for profile settings")            // SIMPLE → TS interface
 	m = m.run("rotate the signing key in internal/auth/token.go") // CORE   → Go key-rotation
 	m.codeShown = len(m.codeLines)                                // reveal the whole snippet
 	m.treeSel = 2                                                 // highlight the token-rotation node
-	if !ckValidView(view) {
-		view = ckViewChatCode
-	}
-	m.view = view
 	m.w, m.h, m.ready = 100, 30, true
-	return m.View()
+	return m
 }
 
 // CockpitSnapshot renders all four views stacked, each labelled — the
 // representative frame shown by `hyctl tui --snapshot`.
 func CockpitSnapshot() string {
 	label := func(s string) string { return ckLabelS.Render("── " + s + " " + strings.Repeat("─", 40)) }
-	return label("VIEW 1/4 · CHAT + CODE (tab)") + "\n" + CockpitSnapshotView(0) + "\n\n" +
-		label("VIEW 2/4 · DASHBOARD (tab)") + "\n" + CockpitSnapshotView(1) + "\n\n" +
-		label("VIEW 3/4 · AGENT TREE (tab · ↑↓ select)") + "\n" + CockpitSnapshotView(2) + "\n\n" +
-		label("VIEW 4/4 · SECURITY (tab)") + "\n" + CockpitSnapshotView(ckViewSecurity)
+	base := ckSnapshotModel()
+	view := func(v int) string {
+		m := base
+		if !ckValidView(v) {
+			v = ckViewChatCode
+		}
+		m.view = v
+		return m.View()
+	}
+	return label("VIEW 1/4 · CHAT + CODE (tab)") + "\n" + view(0) + "\n\n" +
+		label("VIEW 2/4 · DASHBOARD (tab)") + "\n" + view(1) + "\n\n" +
+		label("VIEW 3/4 · AGENT TREE (tab · ↑↓ select)") + "\n" + view(2) + "\n\n" +
+		label("VIEW 4/4 · SECURITY (tab)") + "\n" + view(ckViewSecurity)
 }
 
 // ── helpers ─────────────────────────────────────────────────────────────────────

--- a/internal/tui/cockpit_metrics.go
+++ b/internal/tui/cockpit_metrics.go
@@ -57,13 +57,16 @@ func ckLoadMetrics(pr *pricing.DB) ckMetrics {
 		lastMS:  map[string]int64{},
 	}
 
-	rows, err := cost.LoadAll()
-	if err == nil && len(rows) > 0 {
-		m.latency, m.lastMS = ckLatencySeries(rows)
-		m.savedUSD, m.baseUSD = ckSavings(rows, pr)
-	}
-	if s, err := cost.Summary(); err == nil && s != nil {
-		m.spendUSD = s.Today.EstCostUSD
+	// One read of cost.jsonl feeds latency, savings, and today's spend — this
+	// used to be three independent full reads (LoadAll here, plus a separate
+	// Summary call here and another in ckSpendToday), tripling every cockpit
+	// startup's cost.jsonl I/O for identical data.
+	if rows, err := cost.LoadAll(); err == nil {
+		if len(rows) > 0 {
+			m.latency, m.lastMS = ckLatencySeries(rows)
+			m.savedUSD, m.baseUSD = ckSavings(rows, pr)
+		}
+		m.spendUSD = cost.SummaryFromRows(rows).Today.EstCostUSD
 	}
 	if cal, err := trust.New(trust.DefaultPath()); err == nil {
 		m.calibrator = cal
@@ -165,9 +168,7 @@ func (m ckMetrics) ckBlastFor(file string) (radius float64, dependents int, kapp
 	}
 	radius = m.graph.BlastRadiusForFile(file)
 	kappa = m.graph.PercolationFactor(file)
-	for _, id := range m.graph.NodesInFile(file) {
-		dependents += m.graph.DependentCount(id)
-	}
+	dependents = m.graph.DependentCountForFile(file)
 	// A file absent from the graph yields the neutral radius; saying nothing is
 	// more honest than reporting a floor value as a measurement.
 	if radius <= 1.0 && dependents == 0 {

--- a/internal/tui/init.go
+++ b/internal/tui/init.go
@@ -53,10 +53,17 @@ type InitModel struct {
 	localOnly bool
 	skills    []string
 	err       error
+
+	// specs is detected once here, not per render — viewTiers used to call
+	// sysinfo.Detect() (subprocess spawns: sysctl/vm_stat/nvidia-smi) fresh on
+	// every re-render of the Tiers step, re-probing hardware on every
+	// arrow-key press. install.go's NewInstallModel already gets this right;
+	// this mirrors it.
+	specs *sysinfo.Specs
 }
 
 func NewInitModel(result *probe.Result) InitModel {
-	return InitModel{result: result}
+	return InitModel{result: result, specs: sysinfo.Detect()}
 }
 
 func (m InitModel) Init() tea.Cmd { return nil }
@@ -183,11 +190,10 @@ func (m InitModel) viewTiers(b *strings.Builder) {
 		}
 	}
 	if hasLocal {
-		specs := sysinfo.Detect()
-		best := specs.BestOllamaModel()
+		best := m.specs.BestOllamaModel()
 		b.WriteString(sDim.Render(fmt.Sprintf(
 			"\n  Hardware: %s\n  Best local model for your machine: %s\n",
-			specs.Summary(), best.DisplayName,
+			m.specs.Summary(), best.DisplayName,
 		)))
 	}
 


### PR DESCRIPTION
## Summary

A repo-wide audit of algorithms, data structures, and structured mathematics (Beta-Bernoulli calibration, SPRT, Molloy-Reed percolation, first-passage risk model) across ~24k lines turned up several real bugs, split into two severities per the issue.

### Correctness (Tier 1)
- **Ledger fail-open**: `dispatch.go`/`swarm/runner.go` gated on `err == nil && decision == Deny`, so a ledger-check error (malformed policy, write failure) silently let a candidate proceed — inverting the ledger's own documented fail-closed contract.
- **Two truncating-division bugs** matching CLAUDE.md's own named anti-pattern ("used/1000 truncating to zero"): `budget.go`'s claude_pct band computation, and `cost.go`'s per-row wall-time summation.
- **SPRT pivot bug**: a mid-loop family-disagreement pivot never re-checked the reseeded lambda against the accept threshold in the same iteration.
- **Budget risk model variance bias**: population variance (÷n) instead of sample variance (÷n-1), understating volatility in the small-sample regime the governor always runs at.
- **Blast-radius double-counting**: all 3 call sites looped single-seed BFS instead of reusing the correct multi-seed BFS.
- **Unbounded buffers**: `CLIExecutor` used a raw `bytes.Buffer` instead of `util.Accumulator` (violating a stated project invariant); `HTTPExecutor`'s 8 response-body decodes were all unbounded.

### Hot-path latency (Tier 2)
- `dispatch.New()`'s machine probe is now cached (env-fingerprinted TTL) instead of re-run on every call; `internal/parallel` shares one `Dispatcher` across a batch instead of N.
- `ledger.LoadPolicy` and `trust`'s `coagreement.jsonl` reads are now cached per-path, keyed on mtime+size — fixes redundant reloads in dispatch's fallback loop, swarm's fan-out, and the SPRT sampling loop.
- The TUI cockpit no longer triples its own `cost.jsonl` reads or quadruples a full probe+ledger-scan across `CockpitSnapshot`'s 4 views.
- The init wizard's Tiers screen no longer re-shells-out to `sysinfo.Detect()` on every re-render.

One Tier-2 item (the `agy` executor's global settings.json mutex) was assessed and deliberately **not** changed: narrowing its scope would require knowing exactly when the external `agy` CLI reads its config file, and getting that wrong risks a silent wrong-model correctness bug — worse than the current slow-but-safe serialization. Documented in the issue rather than force-fixed.

## Verification
- `go build ./...`, `go vet ./...` clean.
- `go test -race ./...` — zero regressions. Every pre-existing failure (sandboxed HOME-dir isolation, blocked network egress) was confirmed identical via `git stash` comparison against unmodified code.
- Two genuine regressions caught and fixed during development (a package-level probe cache leaking across tests with different temp HOMEs; hoisting `dispatch.New()` above `parallel`'s per-task loop breaking its graceful-degradation contract) — both covered by the existing test suite, no new test gaps introduced.
- New regression tests added for both new caches (`ledger.LoadPolicy`, `trust.loadCoAgreement`) proving a real file edit still invalidates them.

Closes #497