### PR TITLE
fix(oracle): bound subprocess output capture with util.Accumulator

### DIFF
--- a/internal/oracle/coverage_test.go
+++ b/internal/oracle/coverage_test.go
@@ -463,3 +463,70 @@ func TestDefaultWriteTemp_EmptyCandidateStillMaterializes(t *testing.T) {
 		t.Errorf("empty candidate wrote %d bytes", info.Size())
 	}
 }
+
+// A verifier that writes far more than outputCap to stdout, on one line with
+// no newline, must not have that output captured or displayed unbounded: the
+// Accumulator caps memory at outputCap, and firstLine caps the displayed
+// Detail independently at detailMaxLen — a truncation marker inside the
+// captured buffer supplies the newline firstLine slices on (#504).
+func TestVerify_LargeOutputIsBoundedAndTruncated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Log("windows: no yes/head/tr pipeline to generate the fixture")
+		return
+	}
+	// Generated via a pipeline, not embedded in argv, so this never touches
+	// the {answer}/argv size guard tested separately below.
+	script := `yes | head -c 300000 | tr -d '\n'; exit 1`
+	o := &CommandOracle{Args: []string{"sh", "-c", script}, Source: "v"}
+
+	v, err := o.Verify(context.Background(), "x", trust.Task{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Passed {
+		t.Fatal("a command exiting 1 reported a pass")
+	}
+	if got, max := len(v.Detail), detailMaxLen+len("...(truncated)"); got > max {
+		t.Errorf("Detail is %d bytes, want <= %d — a ~150000-byte verifier line reached the caller unbounded", got, max)
+	}
+	if !strings.HasSuffix(v.Detail, "...(truncated)") {
+		t.Errorf("Detail = %q, want it to end with the truncation marker", v.Detail)
+	}
+}
+
+// A candidate too large to pass via {answer} must fail with a clear,
+// actionable error before exec is ever attempted — not the raw OS
+// "fork/exec: argument list too long" (#504).
+func TestVerify_OversizedAnswerCandidateReturnsCleanError(t *testing.T) {
+	o := &CommandOracle{Template: "echo {answer}", Source: "v"}
+	huge := strings.Repeat("a", maxArgvBytes+1)
+
+	_, err := o.Verify(context.Background(), huge, trust.Task{})
+	if err == nil {
+		t.Fatal("an oversized {answer} candidate verified without error")
+	}
+	if !strings.Contains(err.Error(), "candidate too large to pass via {answer}") {
+		t.Errorf("error = %q, want a clear oversized-candidate message naming {answer}", err)
+	}
+	if !strings.Contains(err.Error(), "{file}") {
+		t.Errorf("error = %q, want it to suggest {file} as the alternative", err)
+	}
+	if strings.Contains(err.Error(), "argument list too long") {
+		t.Error("the raw OS fork/exec error leaked through instead of a clean message")
+	}
+}
+
+// The same guard must apply through the Args path (buildArgsFromArgv), not
+// just Template — both substitution shapes reach the same exec.Command call.
+func TestVerify_OversizedAnswerViaArgsReturnsCleanError(t *testing.T) {
+	o := &CommandOracle{Args: []string{"echo", "{answer}"}, Source: "v"}
+	huge := strings.Repeat("b", maxArgvBytes+1)
+
+	_, err := o.Verify(context.Background(), huge, trust.Task{})
+	if err == nil {
+		t.Fatal("an oversized {answer} candidate via Args verified without error")
+	}
+	if !strings.Contains(err.Error(), "candidate too large to pass via {answer}") {
+		t.Errorf("error = %q, want a clear oversized-candidate message", err)
+	}
+}

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -15,6 +15,25 @@ import (
 	"strings"
 
 	"github.com/ankit373/hydra/internal/trust"
+	"github.com/ankit373/hydra/internal/util"
+)
+
+const (
+	// outputCap bounds the verifier's combined stdout+stderr capture. This is
+	// diagnostic output for the Detail field, not a primary answer, so it gets
+	// the smaller "stderr-like" cap used elsewhere (cli.go, agy.go) rather than
+	// the default unbounded-answer size.
+	outputCap = 64 << 10
+
+	// detailMaxLen bounds what firstLine ever returns, independent of the
+	// Accumulator's cap — a single newline-free line can otherwise still be
+	// outputCap bytes and flood the terminal.
+	detailMaxLen = 4 << 10
+
+	// maxArgvBytes is a conservative, cross-platform-safe guard against the OS
+	// argv limit (ARG_MAX). Real limits vary (Linux ~2MB, macOS ~256KB-1MB
+	// per historical defaults); this stays well under all of them.
+	maxArgvBytes = 256 << 10
 )
 
 // defaultWriteTemp materializes the candidate to a temp file for {file} oracles.
@@ -93,15 +112,37 @@ func (o *CommandOracle) Verify(ctx context.Context, candidate string, _ trust.Ta
 		// the chain can tell an unconfigured oracle from a satisfied one.
 		return Verdict{}, fmt.Errorf("oracle %s: empty command template", o.Source)
 	}
+	if err := checkArgvSize(parts, candidate); err != nil {
+		return Verdict{}, err
+	}
 	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
-	out, runErr := cmd.CombinedOutput()
+	// Both streams share one bounded Accumulator, matching CombinedOutput's
+	// interleaving — but capped, unlike the bytes.Buffer it replaces.
+	out := util.NewAccumulator(outputCap)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	runErr := cmd.Run()
 	if runErr != nil {
 		if _, ok := runErr.(*exec.ExitError); ok {
-			return Verdict{Passed: false, Detail: firstLine(string(out))}, nil
+			return Verdict{Passed: false, Detail: firstLine(out.String())}, nil
 		}
 		return Verdict{}, runErr // couldn't launch the verifier at all
 	}
 	return Verdict{Passed: true}, nil
+}
+
+// checkArgvSize rejects an argv too large to exec before the OS gets a chance
+// to fail with a raw "fork/exec: argument list too long". Only {answer}
+// substitution can grow argv this large; {file} always substitutes a short path.
+func checkArgvSize(parts []string, candidate string) error {
+	total := 0
+	for _, p := range parts {
+		total += len(p)
+	}
+	if total > maxArgvBytes {
+		return fmt.Errorf("candidate too large to pass via {answer} (%d bytes) — use {file} instead", len(candidate))
+	}
+	return nil
 }
 
 // buildArgs builds the argv to execute. When Args holds real argv it is used
@@ -208,7 +249,10 @@ func LLR(cal *trust.Calibrator, source, domain string, v Verdict) float64 {
 func firstLine(s string) string {
 	s = strings.TrimSpace(s)
 	if i := strings.IndexByte(s, '\n'); i >= 0 {
-		return s[:i]
+		s = s[:i]
+	}
+	if len(s) > detailMaxLen {
+		return s[:detailMaxLen] + "...(truncated)"
 	}
 	return s
 }


### PR DESCRIPTION
## Summary
- `CommandOracle.Verify` used `cmd.CombinedOutput()` — an unbounded `bytes.Buffer` under the hood — violating CLAUDE.md's hard invariant that all subprocess output capture must go through `internal/util.Accumulator`. A verifier writing 100MB to stdout then exiting 1 produced a ~476MB peak memory footprint and, since `firstLine()` had no length cap and the payload had no newline, dumped the entire 100MB blob to the terminal as the failure detail.
- Both stdout and stderr now share one `util.Accumulator` capped at 64KB (matching the "stderr-like diagnostic" convention used in `internal/executor/cli.go`/`agy.go` — oracle output is diagnostic verifier output, not a primary answer, so a bounded cap is correct here).
- `firstLine()` independently caps the displayed `Detail` at 4KB with a clear `...(truncated)` marker, so even a single very long newline-free line can't flood the terminal, regardless of the Accumulator's cap.
- A candidate too large to pass via `{answer}` (> 256KB total argv) is now rejected with `candidate too large to pass via {answer} (N bytes) — use {file} instead` before `exec` is attempted, instead of a raw OS `fork/exec: argument list too long`.

## Changes
- `internal/oracle/oracle.go` — Accumulator-backed capture in `Verify`, capped/truncated `firstLine`, new `checkArgvSize` guard
- `internal/oracle/coverage_test.go` — regression tests for bounded/truncated large output and the clean oversized-`{answer}` error (both `Template` and `Args` paths)

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race ./internal/oracle/...` — all pass, including new tests
- [x] `go test -race ./internal/executor/... ./internal/util/...` — pass (unaffected reference packages)
- [x] Verified pre-existing failures in `internal/runlog`, `internal/swarm`, `internal/sysinfo`, `internal/cost`, and two `cmd/hydra` CLI tests are environmental (sandbox network/config-path restrictions) by reproducing them identically with these changes stashed out — unrelated to this fix

Closes #504