### PR TITLE
fix: TUI chat-log overflow/cross-tab silent submit; desktop dock occlusion and row-reorder flicker

### DIFF
--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1384,7 +1384,10 @@ body {
 .dock--open {
   display: flex;
   flex-direction: column;
-  width: min(430px, calc(100vw - 44px));
+  /* 254 = the 44px of margin this reserved before, plus .rail's 210px — below
+     ~474px viewport width the old formula pinned the dock's left edge inside
+     the rail instead of shrinking around it (#506). */
+  width: min(430px, max(0px, calc(100vw - 254px)));
   max-height: min(560px, calc(100vh - 60px));
   background: var(--hy-bg-2);
   border: 1px solid var(--hy-line);

--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -642,8 +642,14 @@ func groupBy(rows []Row, key func(Row) string) []GroupRow {
 		g.EstCostUSD = math.Round(g.EstCostUSD*1_000_000) / 1_000_000
 		result = append(result, *g)
 	}
+	// Ties (often several $0 rows) need a deterministic tiebreaker — result is
+	// built from a map, whose iteration order is randomized, so without one
+	// equal-cost rows visibly swapped position on every poll (#506).
 	sort.Slice(result, func(i, j int) bool {
-		return result[i].EstCostUSD > result[j].EstCostUSD
+		if result[i].EstCostUSD != result[j].EstCostUSD {
+			return result[i].EstCostUSD > result[j].EstCostUSD
+		}
+		return result[i].Key < result[j].Key
 	})
 	return result
 }

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -165,6 +165,42 @@ func TestTokensEstimated_Precedence(t *testing.T) {
 	}
 }
 
+// Equal-cost groups (commonly several $0 rows) must sort in a fixed order —
+// otherwise the dashboard's "by model"/"by tier" rows reorder on every ~5s
+// poll with no underlying data change, since groups is built from a map whose
+// iteration order is randomized (#506).
+func TestGroupBy_StableTiebreakOnEqualCost(t *testing.T) {
+	rows := []Row{
+		makeRow("zebra", 1, 0, 0, 0, 0, "", false),
+		makeRow("apple", 1, 0, 0, 0, 0, "", false),
+		makeRow("mango", 1, 0, 0, 0, 0, "", false),
+		makeRow("kiwi", 1, 0, 0, 5, 0, "", false), // only non-zero cost, must sort first
+	}
+	var first []string
+	for i := 0; i < 20; i++ {
+		groups := GroupBy(rows, func(r Row) string { return r.Model })
+		got := make([]string, len(groups))
+		for j, g := range groups {
+			got[j] = g.Key
+		}
+		if first == nil {
+			first = got
+		} else {
+			for j := range got {
+				if got[j] != first[j] {
+					t.Fatalf("ordering changed between calls: %v then %v", first, got)
+				}
+			}
+		}
+	}
+	want := []string{"kiwi", "apple", "mango", "zebra"}
+	for i := range want {
+		if first[i] != want[i] {
+			t.Fatalf("order = %v, want %v (cost desc, then key ascending)", first, want)
+		}
+	}
+}
+
 func TestGroupBy_Exported(t *testing.T) {
 	rows := []Row{
 		makeRow("a", 1, 0, 0, 0.5, 0, "", false),

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -291,17 +291,30 @@ func (m Cockpit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.treeSel++
 			}
 		case tea.KeyEnter:
-			return m.submit()
+			// Only the chat+code view renders the input line or the log — on
+			// any other tab this used to silently run the full dispatch-preview
+			// pipeline with zero on-screen feedback (#506).
+			if m.view == ckViewChatCode {
+				return m.submit()
+			}
 		case tea.KeyBackspace:
-			if n := len(m.input); n > 0 {
-				m.input = m.input[:n-1]
+			if m.view == ckViewChatCode {
+				if n := len(m.input); n > 0 {
+					m.input = m.input[:n-1]
+				}
 			}
 		case tea.KeyEsc:
-			m.input = ""
+			if m.view == ckViewChatCode {
+				m.input = ""
+			}
 		case tea.KeySpace:
-			m.input += " "
+			if m.view == ckViewChatCode {
+				m.input += " "
+			}
 		case tea.KeyRunes:
-			m.input += string(msg.Runes)
+			if m.view == ckViewChatCode {
+				m.input += string(msg.Runes)
+			}
 		}
 	}
 	return m, nil
@@ -566,9 +579,14 @@ func (m Cockpit) sidebar(h int) string {
 	avail := h - len(head) - len(foot)
 	var shown []ckHead
 	var more int
+	var compact string
 	switch {
 	case avail <= 0:
-		// no room even for a "+N more" line.
+		// No room for even one head row — the header above still states the
+		// real count, so silently showing zero heads would contradict it (#506).
+		if len(m.heads) > 0 {
+			compact = fmt.Sprintf(" %d head%s (not enough room to list)", len(m.heads), plural(len(m.heads)))
+		}
 	case len(m.heads) <= avail:
 		shown = m.heads
 	default:
@@ -589,6 +607,9 @@ func (m Cockpit) sidebar(h int) string {
 	if more > 0 {
 		lines = append(lines, ckDimS.Render(fmt.Sprintf(" +%d more", more)))
 	}
+	if compact != "" {
+		lines = append(lines, ckDimS.Render(compact))
+	}
 	lines = append(lines, foot...)
 
 	return lipgloss.NewStyle().Width(21).Height(h).
@@ -604,13 +625,73 @@ func (m Cockpit) chatMain(w, h int) string {
 	if logH < 1 {
 		logH = 1
 	}
-	lines := m.log
-	if len(lines) > logH {
-		lines = lines[len(lines)-logH:]
-	}
-	logBox := lipgloss.NewStyle().Width(w).Height(logH).Render(strings.Join(lines, "\n"))
+	logBox := lipgloss.NewStyle().Width(w).Height(logH).Render(ckVisibleLog(m.log, w, logH))
 	input := ckCyanS.Render(m.mode+" ❯ ") + ckInkS.Render(m.input) + ckAquaS.Render("▏")
 	return lipgloss.JoinVertical(lipgloss.Left, logBox, ckFaintS.Render(strings.Repeat("╌", max(1, w))), input)
+}
+
+// ckLogEntryCap bounds how many rendered lines a single log entry may
+// occupy. Without it, one long line (a pasted stack trace, a 3000-char task)
+// wraps past the whole pane on its own and pushes the input/divider/hint bar
+// off-frame (#506).
+const ckLogEntryCap = 6
+
+// ckVisibleLog builds the tail of m.log that fits within logH lines as
+// lipgloss will actually render them at width w. Tail-slicing by entry count
+// alone is wrong — Style.Height only pads short content, it never truncates
+// tall content — so a single word-wrapped entry could blow past the pane on
+// its own; each entry is capped before the tail window is sized (#506).
+func ckVisibleLog(log []string, w, logH int) string {
+	entryCap := ckLogEntryCap
+	if logH < entryCap {
+		entryCap = logH
+	}
+	if entryCap < 1 {
+		entryCap = 1
+	}
+
+	clipped := make([]string, len(log))
+	for i, e := range log {
+		clipped[i] = ckClipToLines(e, w, entryCap)
+	}
+
+	start, used := len(clipped), 0
+	for start > 0 {
+		n := ckRenderedLineCount(clipped[start-1], w)
+		if used+n > logH {
+			break
+		}
+		used += n
+		start--
+	}
+	return strings.Join(clipped[start:], "\n")
+}
+
+// ckRenderedLineCount is how many lines s occupies once lipgloss word-wraps
+// it at width w — the same wrapping the log box's own render performs.
+func ckRenderedLineCount(s string, w int) int {
+	if w < 1 {
+		w = 1
+	}
+	return strings.Count(lipgloss.NewStyle().Width(w).Render(s), "\n") + 1
+}
+
+// ckClipToLines truncates one log entry to at most maxLines rendered lines,
+// marking the cut — a single overlong entry must never be able to exceed the
+// whole log pane on its own.
+func ckClipToLines(s string, w, maxLines int) string {
+	if w < 1 {
+		w = 1
+	}
+	rows := strings.Split(lipgloss.NewStyle().Width(w).Render(s), "\n")
+	if len(rows) <= maxLines {
+		return s
+	}
+	if maxLines <= 1 {
+		return ckFaintS.Render("…(truncated)")
+	}
+	rows = append(rows[:maxLines-1], ckFaintS.Render("…(truncated)"))
+	return strings.Join(rows, "\n")
 }
 
 func (m Cockpit) hint() string {

--- a/internal/tui/cockpit_interaction_test.go
+++ b/internal/tui/cockpit_interaction_test.go
@@ -620,6 +620,52 @@ func TestCockpit_KeyBindings(t *testing.T) {
 	}
 }
 
+// Enter-to-submit (and text editing generally) must only affect the chat+code
+// view — only that view renders the input line or the log, so typing on
+// Dashboard/Agent-Tree/Security used to silently run the full dispatch-preview
+// pipeline with zero on-screen feedback (#506).
+func TestCockpit_InputIsScopedToTheChatView(t *testing.T) {
+	m := NewCockpit()
+	m.heads = testHeads()
+	m.view = ckViewChatCode
+	m = typed(m, "half a prompt")
+
+	// Tab away: further keystrokes on another view must not touch the input.
+	m.view = ckViewDashboard
+	before := len(m.log)
+	m = typed(m, " more text")
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = next.(Cockpit)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = next.(Cockpit)
+	if m.input != "half a prompt" {
+		t.Errorf("input on a non-chat view = %q, want untouched", m.input)
+	}
+
+	// Enter on a non-chat view must not run a dispatch preview.
+	m, cmd := enter(m)
+	if len(m.log) != before || cmd != nil {
+		t.Error("enter on the dashboard view ran a dispatch preview with no on-screen feedback")
+	}
+
+	// Esc on a non-chat view must not clear it either.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Cockpit)
+	if m.input != "half a prompt" {
+		t.Errorf("esc on a non-chat view cleared the input: %q", m.input)
+	}
+
+	// Back on chat, the preserved input works normally.
+	m.view = ckViewChatCode
+	m, cmd = enter(m)
+	if len(m.log) <= before {
+		t.Error("enter on the chat view did not submit the preserved input")
+	}
+	if cmd == nil {
+		t.Error("submitting on the chat view did not schedule the code stream")
+	}
+}
+
 func typedModel(m tea.Model, s string) tea.Model {
 	for _, r := range s {
 		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})

--- a/internal/tui/cockpit_test.go
+++ b/internal/tui/cockpit_test.go
@@ -120,6 +120,61 @@ func TestChatMain_OutputIsExactlyHLines(t *testing.T) {
 	}
 }
 
+// One overlong entry (a pasted stack trace, a 3000-char task) must not wrap
+// past the log pane and push the input/divider off-frame — the log renderer
+// used to tail-slice by logical entry count, not rendered visual-line count,
+// and Style.Height only pads short content, it never truncates tall (#506).
+func TestChatMain_OneOverlongEntryDoesNotPushInputOffFrame(t *testing.T) {
+	m := Cockpit{w: 120, h: 40, ready: true, mode: "dispatch", input: "still typing"}
+	m.log = []string{strings.Repeat("x", 3000)}
+
+	for _, h := range []int{10, 24, 30} {
+		out := m.chatMain(60, h)
+		if got := strings.Count(out, "\n") + 1; got != h {
+			t.Errorf("chatMain(60, %d) with one huge entry produced %d lines, want %d", h, got, h)
+		}
+		if !strings.Contains(stripANSI(out), "still typing") {
+			t.Errorf("the input line was pushed off frame by one long entry:\n%s", stripANSI(out))
+		}
+	}
+}
+
+// A single overlong entry must be visibly truncated, not silently dropped —
+// the user should see something was cut, not just less log (#506).
+func TestCkClipToLines_MarksTruncationAndBoundsLength(t *testing.T) {
+	long := strings.Repeat("word ", 400)
+	got := stripANSI(ckClipToLines(long, 20, 4))
+	rows := strings.Split(got, "\n")
+	if len(rows) != 4 {
+		t.Fatalf("ckClipToLines produced %d rows, want 4", len(rows))
+	}
+	if !strings.Contains(rows[len(rows)-1], "truncated") {
+		t.Errorf("the last row does not disclose the truncation: %q", rows[len(rows)-1])
+	}
+
+	short := "a short line"
+	if got := ckClipToLines(short, 60, 4); got != short {
+		t.Errorf("a short entry was altered: %q", got)
+	}
+}
+
+// The visible-log window must size itself in wrapped lines, not logical
+// entries, and always keep the newest entry (#506).
+func TestCkVisibleLog_CapsEachEntryAndFillsFromTheTail(t *testing.T) {
+	log := []string{
+		"short one",
+		strings.Repeat("word ", 400), // would wrap past the whole pane alone
+		"short two",
+	}
+	got := stripANSI(ckVisibleLog(log, 20, 8))
+	if n := len(strings.Split(got, "\n")); n > 8 {
+		t.Errorf("ckVisibleLog produced %d lines, want <= 8:\n%s", n, got)
+	}
+	if !strings.Contains(got, "short two") {
+		t.Errorf("the newest entry is missing:\n%s", got)
+	}
+}
+
 // The sidebar must never exceed the height it's given, however many heads
 // were discovered — an uncapped list let a busy machine's real head count
 // dictate the whole view's height once JoinHorizontal pads every other
@@ -147,6 +202,30 @@ func TestSidebar_NeverExceedsGivenHeight(t *testing.T) {
 	out := m.sidebar(10)
 	if !strings.Contains(out, "more") {
 		t.Errorf("sidebar(10) with 30 heads does not disclose the hidden ones:\n%s", out)
+	}
+}
+
+// At terminal heights too short for even one head row, the sidebar used to
+// show zero heads and no "+N more" line, contradicting the header directly
+// above it, which still states the real count (#506).
+func TestSidebar_DisclosesCountWhenNoRoomForAnyHeadRow(t *testing.T) {
+	heads := make([]ckHead, 12)
+	for i := range heads {
+		heads[i] = ckHead{id: strings.Repeat("x", i%5+1), name: "head", tier: 1}
+	}
+	m := Cockpit{w: 120, h: 40, ready: true, heads: heads, mode: "dispatch"}
+
+	// The fixed GOVERNOR/MODE chrome is 8 lines; h=6 leaves no room for a
+	// single head row (avail <= 0) — exactly the state this bug is about.
+	got := stripANSI(m.sidebar(6))
+	if !strings.Contains(got, "12") {
+		t.Errorf("sidebar(6) with 12 heads does not disclose the real count:\n%s", got)
+	}
+
+	// With no heads at all there is nothing to disclose.
+	empty := Cockpit{w: 120, h: 40, ready: true, mode: "dispatch"}
+	if got := empty.sidebar(6); strings.Contains(got, "not enough room") {
+		t.Errorf("sidebar with zero heads still printed a count line:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Five bugs from adversarial QA on the TUI (`hyctl tui`) and the desktop app (issue #506):

**TUI (`internal/tui/cockpit.go`)**
- The chat log tail-sliced by logical entry count, not rendered visual-line count. `Style.Height()` only pads short content, it never truncates tall content, so one long/word-wrapped entry (a pasted stack trace, a 3000-char task) could wrap past the pane and push the input/divider/hint bar off-frame. Fixed with `ckVisibleLog`/`ckClipToLines`: each entry is capped to a bounded number of rendered lines, then the tail window is sized in wrapped lines rather than entry count.
- Enter-to-submit (and rune/backspace/esc input editing) fired regardless of the active tab — typing on Dashboard/Agent-Tree/Security silently ran the full dispatch-preview pipeline with zero on-screen feedback. Now scoped to `m.view == ckViewChatCode` only.
- The sidebar's "+N more" heads summary disappeared entirely at terminal heights too short for even one head row, contradicting the header directly above it. Now shows a compact "N heads (not enough room to list)" line in that case.

**Cost (`internal/cost/cost.go`)**
- `groupBy` sorted by cost descending with no tiebreaker, over a map with randomized iteration order — equal-cost rows (commonly several $0 heads) visibly reordered on every ~5s dashboard poll. Added an alphabetical-by-key tiebreaker; `ByModel` and `ByTier` both call `groupBy` so both are fixed.

**Desktop (`desktop/frontend/src/app.css`)**
- `.dock--open`'s width formula (`min(430px, calc(100vw - 44px))`) pinned the dock's left edge at a fixed 22px offset regardless of viewport width, overlapping the ~210px nav rail almost entirely below ~474px viewport width. The calc now also reserves the rail's width (`min(430px, max(0px, calc(100vw - 254px)))`), so the dock shrinks around the rail instead of covering it.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./internal/tui/... ./internal/cost/...` — all pass, including new tests for each bug
- [x] Desktop CSS fix verified live: ran `wails dev` from `desktop/`, opened the browser dev URL, set viewport to 400px and 300px, opened the "Ask Hydra" dock, and confirmed via `getBoundingClientRect()`/`elementFromPoint()` that the dock's left edge sits at 232px (clear of the rail's 210px right edge) and that clicking a nav button (e.g. "Fleet") now hits the button, not the dock — matching how the original bug was diagnosed.

Closes #506