### PR TITLE
fix(graph): basename-fallback confidence, percolation monotonicity, and a2a clock identity

### DIFF
--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -141,6 +141,51 @@ func TestDispatch_HandoffClockAdvancesAcrossCalls(t *testing.T) {
 	}
 }
 
+// Every LocalOnly head maps to rank.UITier 10 (#248), so two different local
+// models used to tick the identical "hydra-tier-10" clock key. The clock must
+// key on the head's own identity instead, or two genuinely different agents'
+// handoffs are indistinguishable from one agent dispatching twice (#503). The
+// display "From" string is untouched — it still reads as the tier bucket.
+func TestDispatch_HandoffClockDistinguishesSameTierHeads(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	path := filepath.Join(config.Dir(), "logs", "last_handoff.json")
+
+	localHead := func(id string) provider.Head {
+		h := echoHead(t, s, id, 50)
+		h.LocalOnly = true
+		return h
+	}
+
+	if _, err := liveDispatcher(localHead("model-a")).Dispatch(context.Background(), "first", Options{}); err != nil {
+		t.Fatal(err)
+	}
+	first, err := a2a.Load(path)
+	if err != nil || first == nil {
+		t.Fatal(err)
+	}
+
+	if _, err := liveDispatcher(localHead("model-b")).Dispatch(context.Background(), "second", Options{}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := a2a.Load(path)
+	if err != nil || second == nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := first.Clock["model-a"]; !ok {
+		t.Errorf("first handoff clock %v has no entry for model-a's own identity", first.Clock)
+	}
+	if _, ok := second.Clock["model-b"]; !ok {
+		t.Errorf("second handoff clock %v has no entry for model-b's own identity", second.Clock)
+	}
+	if _, ok := second.Clock["hydra-tier-10"]; ok {
+		t.Errorf("clock keyed on the shared tier bucket instead of head identity: %v", second.Clock)
+	}
+	if first.From != "hydra-tier-10" || second.From != "hydra-tier-10" {
+		t.Errorf("display From must stay the tier-bucket string, got %q and %q", first.From, second.From)
+	}
+}
+
 // A dry run must resolve the chain without executing anything.
 func TestDispatch_DryRunResolvesTheChainWithoutRunningIt(t *testing.T) {
 	s := testutil.NewSandbox(t)

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -449,13 +449,19 @@ func (d *Dispatcher) writeHandoff(r *Result, prompt string) (string, error) {
 		base = prior.Clock
 	}
 	from := fmt.Sprintf("hydra-tier-%d", rank.UITier(r.Head))
+	// The clock is keyed on the head's own identity, not its tier bucket:
+	// every LocalOnly head shares tier 10, so two different local models
+	// would otherwise tick the same "hydra-tier-10" key and become
+	// indistinguishable under Clock.Compare (#503). "From" keeps the
+	// tier-bucket string — it is display text, not a clock key.
+	agentKey := r.Head.ID
 
 	h := a2a.Handoff{
 		From:        from,
 		Model:       r.Head.Name,
 		Task:        prompt,
 		PriorOutput: r.Response.Output,
-		Clock:       base.Tick(from),
+		Clock:       base.Tick(agentKey),
 	}
 	return from, h.Save(handoffPath)
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -48,6 +48,11 @@ type Graph struct {
 	// once at load. kappa ≥ 2 ⟹ a giant (cascade-capable) component exists.
 	meanDeg float64
 	kappa   float64
+	// meanDependents is ⟨D⟩, the mean transitive-dependent count over all
+	// nodes — separate from meanDeg/kappa because a node's own imports
+	// inflate its total degree without saying anything about what depends on
+	// it (#503). PercolationFactor keys its per-file lift off this instead.
+	meanDependents float64
 }
 
 // Load reads graph.json from path. A missing file yields an empty graph and no
@@ -102,6 +107,7 @@ func fromDoc(doc Doc) *Graph {
 		nodes[e.To] = true
 	}
 	g.computeKappa(nodes)
+	g.computeMeanDependents(nodes)
 	return g
 }
 
@@ -122,6 +128,22 @@ func (g *Graph) computeKappa(nodes map[string]bool) {
 	if g.meanDeg > 0 {
 		g.kappa = (sumSq / float64(n)) / g.meanDeg
 	}
+}
+
+// computeMeanDependents fills meanDependents = ⟨D⟩ over the given node set,
+// one BFS per node via DependentCount — cheap at package granularity, and the
+// only way to get a per-node reach figure that means the same thing as the
+// count BlastRadiusForFile already uses.
+func (g *Graph) computeMeanDependents(nodes map[string]bool) {
+	n := len(nodes)
+	if n == 0 {
+		return
+	}
+	var sum float64
+	for id := range nodes {
+		sum += float64(g.DependentCount(id))
+	}
+	g.meanDependents = sum / float64(n)
 }
 
 // transitiveDependents returns every node that transitively depends on any node
@@ -183,20 +205,36 @@ func (g *Graph) seedsForFile(file string) []string {
 	if seeds := g.filesToNodes[file]; len(seeds) > 0 {
 		return seeds
 	}
-	base := filepath.Base(file)
-	var seeds []string
-	for f, ids := range g.filesToNodes {
-		if filepath.Base(f) == base {
-			seeds = append(seeds, ids...)
-		}
-	}
-	if len(seeds) > 0 {
+	if seeds := g.basenameSeeds(file); len(seeds) > 0 {
 		return seeds
 	}
 	if pkg := g.packageIDForFile(file); pkg != "" {
 		return g.filesToNodes[pkg]
 	}
 	return nil
+}
+
+// basenameSeeds matches file by its last path segment against every stored
+// path's last segment, requiring the parent segment to also correspond
+// whenever both paths actually have one. A bare filename (no directory, e.g.
+// a flat non-Go index) has no ancestry to check and is accepted as before;
+// once both sides have a directory, a matching basename alone is not enough —
+// any garbage path whose final component happens to collide with a real
+// package's would otherwise resolve to that package's full data (#503).
+func (g *Graph) basenameSeeds(file string) []string {
+	base := filepath.Base(file)
+	fileDir := filepath.Dir(file)
+	var seeds []string
+	for f, ids := range g.filesToNodes {
+		if filepath.Base(f) != base {
+			continue
+		}
+		fDir := filepath.Dir(f)
+		if fDir == "." || fileDir == "." || filepath.Base(fDir) == filepath.Base(fileDir) {
+			seeds = append(seeds, ids...)
+		}
+	}
+	return seeds
 }
 
 // packageIDForFile resolves a specific file to the package node ID that owns
@@ -233,7 +271,7 @@ func (g *Graph) BlastRadiusForFile(file string) float64 {
 	}
 	count := len(g.transitiveDependents(seeds))
 	base := 1.0 + math.Log2(1.0+float64(count))
-	return base * g.PercolationFactor(file)
+	return base * g.percolationFactor(count)
 }
 
 // Kappa is the Molloy–Reed ratio κ = ⟨k²⟩/⟨k⟩ of the (undirected projection of
@@ -258,31 +296,33 @@ func (g *Graph) Percolates() bool { return g.Kappa() >= 2.0 }
 const percolationCap = 2.0
 
 // PercolationFactor returns a multiplier ≥ 1 that raises the blast radius of a
-// file sitting in the graph's cascade-capable core. It is > 1 only when BOTH:
-//   - the graph is supercritical (κ ≥ 2), so cascades are possible at all, and
-//   - the file's hub-iest node is above the mean degree ⟨k⟩, so it is plausibly
-//     part of the giant component rather than the sparse periphery.
-//
-// Two files with an identical transitive-dependent count are thereby priced
-// differently when one is a densely-connected hub and the other is peripheral.
-// Subcritical graph, unknown file, or no graph → exactly 1.0 (backward compatible).
+// file whose OWN transitive dependent count is above the graph's average, and
+// only when the graph itself is supercritical (κ ≥ 2, a cascade-capable core
+// exists at all). κ still comes from total (in+out) degree — the textbook
+// Molloy-Reed criterion for a giant component — but the per-file excess is
+// deliberately a different quantity: the same dependent count
+// BlastRadiusForFile's base term uses. Keying the per-file lift off total
+// degree let a file's own outbound imports (which inflate degree but say
+// nothing about what depends on it) outscore a file with genuinely more
+// dependents — cmd/hydra, a Go main package with 0 dependents, out-scored
+// real leaves this way. Keying it off dependent count instead makes the
+// factor, and therefore the final blast radius, monotonic non-decreasing in a
+// node's own transitive dependent count (#503).
 func (g *Graph) PercolationFactor(file string) float64 {
-	if g == nil || g.meanDeg <= 0 || g.kappa < 2.0 {
-		return 1.0
-	}
 	seeds := g.seedsForFile(file)
 	if len(seeds) == 0 {
 		return 1.0
 	}
-	maxDeg := 0
-	for _, id := range seeds {
-		if d := g.degree[id]; d > maxDeg {
-			maxDeg = d
-		}
+	return g.percolationFactor(len(g.transitiveDependents(seeds)))
+}
+
+func (g *Graph) percolationFactor(count int) float64 {
+	if g.meanDependents <= 0 || g.kappa < 2.0 {
+		return 1.0
 	}
-	excess := float64(maxDeg)/g.meanDeg - 1.0 // how far above average this file's hub is
+	excess := float64(count)/g.meanDependents - 1.0 // how far above average this file's own reach is
 	if excess <= 0 {
-		return 1.0 // at or below average connectivity — periphery, no lift
+		return 1.0 // at or below average reach — periphery, no lift
 	}
 	// superMargin ∈ (0,1]: 0 at the κ=2 threshold, saturating to 1 by κ=4.
 	superMargin := math.Min((g.kappa-2.0)/2.0, 1.0)

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -3,6 +3,7 @@
 package graph
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -61,6 +62,39 @@ func TestBlastRadius_BasenameMatch(t *testing.T) {
 	g := sampleGraph()
 	if got := g.BlastRadiusForFile("/repo/pkg/a.go"); math.Abs(got-3.0) > 1e-9 {
 		t.Errorf("basename match blast = %v, want 3.0", got)
+	}
+}
+
+// A garbage path whose final segment happens to collide with a real
+// package's basename must not silently resolve to that package's data — the
+// exact bug behind `hyctl graph blast zzz/made/up/dispatch` returning numbers
+// identical to internal/dispatch (#503).
+func TestSeedsForFile_BasenameFallbackRejectsAncestryMismatch(t *testing.T) {
+	g := fromDoc(Doc{Nodes: []Node{{ID: "internal/dispatch", File: "internal/dispatch"}}})
+
+	if g.Knows("zzz/made/up/dispatch") {
+		t.Error("a garbage path matching only the final segment resolved to a real package")
+	}
+	if got := g.BlastRadiusForFile("zzz/made/up/dispatch"); got != 1.0 {
+		t.Errorf("garbage path blast radius = %v, want the 1.0 unknown default", got)
+	}
+	if !g.Knows("internal/dispatch") {
+		t.Error("the real package path itself must still resolve")
+	}
+}
+
+// The ancestry check only applies when both sides actually have a parent
+// segment to compare — a legitimate absolute-path lookup that preserves the
+// real parent must still match, and one that swaps in an unrelated parent
+// must not.
+func TestSeedsForFile_BasenameFallbackAncestry(t *testing.T) {
+	g := fromDoc(Doc{Nodes: []Node{{ID: "n", File: "src/foo/bar.go"}}})
+
+	if !g.Knows("/home/dev/repo/src/foo/bar.go") {
+		t.Error("an absolute path preserving the real parent segment should resolve")
+	}
+	if g.Knows("other/bar.go") {
+		t.Error("same basename under an unrelated parent must not resolve")
 	}
 }
 
@@ -224,9 +258,13 @@ func TestKappa_TopologyOrdering(t *testing.T) {
 	}
 }
 
-// A hub-core file and a peripheral file with the SAME transitive-dependent count
-// must be priced differently once the graph is supercritical.
-func TestPercolation_EqualCountDifferentDegree(t *testing.T) {
+// Two files with the SAME transitive-dependent count must be priced
+// identically, even when one has far more total degree than the other via its
+// own outbound imports. Pre-#503 the lift was keyed on total (in+out) degree,
+// so X (a fan-in hub with no imports of its own) scored higher than Y (same
+// dependent count, reached via a chain) purely because X's raw degree was
+// higher — the same mechanism that let cmd/hydra out-score other leaves.
+func TestPercolation_EqualCountEqualFactorRegardlessOfDegree(t *testing.T) {
 	nodes := []Node{{ID: "X", File: "x.go"}, {ID: "Y", File: "y.go"}}
 	var edges []Edge
 	// X: a fan-in hub with 6 direct dependents (degree 6, count 6).
@@ -250,16 +288,109 @@ func TestPercolation_EqualCountDifferentDegree(t *testing.T) {
 	if cx, cy := g.DependentCount("X"), g.DependentCount("Y"); cx != cy {
 		t.Fatalf("precondition: equal counts required, got X=%d Y=%d", cx, cy)
 	}
+	if degX, degY := g.degree["X"], g.degree["Y"]; degX == degY {
+		t.Fatalf("precondition: unequal total degree required, got X=%d Y=%d", degX, degY)
+	}
 	bx, by := g.BlastRadiusForFile("x.go"), g.BlastRadiusForFile("y.go")
-	if bx <= by {
-		t.Errorf("hub file blast (%.3f) should exceed peripheral file blast (%.3f) at equal count", bx, by)
+	if bx != by {
+		t.Errorf("equal-count files priced differently: x=%.4f y=%.4f — blast radius must depend "+
+			"on dependent count, not on a file's own unrelated degree", bx, by)
 	}
-	// The peripheral file (below-mean degree) gets no lift.
-	if f := g.PercolationFactor("y.go"); f != 1.0 {
-		t.Errorf("peripheral PercolationFactor = %.3f, want 1.0", f)
+	if fx, fy := g.PercolationFactor("x.go"), g.PercolationFactor("y.go"); fx != fy {
+		t.Errorf("equal-count PercolationFactor differs: x=%.4f y=%.4f", fx, fy)
 	}
-	if f := g.PercolationFactor("x.go"); f <= 1.0 {
-		t.Errorf("hub PercolationFactor = %.3f, want > 1.0", f)
+}
+
+// The reported #503 case: a Go main package has 0 transitive dependents (a
+// main package can't be imported) but plenty of outbound imports. It must
+// float at the same neutral 1.0 floor as any other zero-dependent leaf, not
+// score higher just because it happens to import a lot.
+func TestPercolation_ZeroDependentLeafNeverLifted(t *testing.T) {
+	nodes := []Node{{ID: "hub", File: "hub.go"}, {ID: "main", File: "main.go"}, {ID: "leaf", File: "leaf.go"}}
+	var edges []Edge
+	// hub: 6 direct dependents, gives the graph a supercritical core.
+	for i := 0; i < 6; i++ {
+		id := fmt.Sprintf("r%d", i)
+		nodes = append(nodes, Node{ID: id, File: id + ".go"})
+		edges = append(edges, Edge{From: id, To: "hub"})
+	}
+	// main: 0 dependents (nothing imports a main package), but imports 5
+	// packages of its own — inflating its own total degree, not its reach.
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("imp%d", i)
+		nodes = append(nodes, Node{ID: id, File: id + ".go"})
+		edges = append(edges, Edge{From: "main", To: id})
+	}
+	// leaf: 0 dependents, 0 imports — the uncontroversial neutral case.
+	g := fromDoc(Doc{Nodes: nodes, Edges: edges})
+
+	if !g.Percolates() {
+		t.Fatalf("test graph κ = %.3f, expected supercritical", g.Kappa())
+	}
+	if g.DependentCount("main") != 0 || g.DependentCount("leaf") != 0 {
+		t.Fatalf("precondition: both main and leaf must have 0 dependents")
+	}
+	if f := g.PercolationFactor("main.go"); f != 1.0 {
+		t.Errorf("main (0 dependents, heavy imports) PercolationFactor = %.4f, want the neutral 1.0 floor", f)
+	}
+	if got, want := g.BlastRadiusForFile("main.go"), g.BlastRadiusForFile("leaf.go"); got != want {
+		t.Errorf("blast radius main=%.4f leaf=%.4f — a 0-dependent main package must not "+
+			"out-score a 0-dependent leaf", got, want)
+	}
+}
+
+// General regression guard for #503: a node's own outbound imports (which
+// inflate its total degree) must never let it out-rank a node with genuinely
+// more transitive dependents. specs are ordered by strictly increasing
+// dependent count and strictly decreasing import count, the exact inverse
+// correlation that produced the reported bug (dispatch's imports out-scoring
+// provider's real dependents).
+func TestPercolation_MonotonicInDependentCount(t *testing.T) {
+	specs := []struct {
+		id      string
+		deps    int
+		imports int
+	}{
+		{"few", 1, 12},
+		{"mid", 4, 4},
+		{"many", 9, 0},
+	}
+	var nodes []Node
+	var edges []Edge
+	for _, s := range specs {
+		nodes = append(nodes, Node{ID: s.id, File: s.id + ".go"})
+		prev := s.id
+		for d := 0; d < s.deps; d++ {
+			id := fmt.Sprintf("%s_dep%d", s.id, d)
+			nodes = append(nodes, Node{ID: id, File: id + ".go"})
+			edges = append(edges, Edge{From: id, To: prev})
+			prev = id
+		}
+		for i := 0; i < s.imports; i++ {
+			id := fmt.Sprintf("%s_imp%d", s.id, i)
+			nodes = append(nodes, Node{ID: id, File: id + ".go"})
+			edges = append(edges, Edge{From: s.id, To: id})
+		}
+	}
+	g := fromDoc(Doc{Nodes: nodes, Edges: edges})
+	if !g.Percolates() {
+		t.Fatalf("test graph κ = %.3f, expected supercritical", g.Kappa())
+	}
+
+	prevID, prevCount, prevRadius := "", -1, -1.0
+	for _, s := range specs {
+		count := g.DependentCount(s.id)
+		radius := g.BlastRadiusForFile(s.id + ".go")
+		if prevCount >= 0 {
+			if count <= prevCount {
+				t.Fatalf("test precondition broken: %s count %d must exceed %s count %d", s.id, count, prevID, prevCount)
+			}
+			if radius < prevRadius {
+				t.Errorf("%s: dependent count %d > %s's %d, but blast radius %.4f < %.4f — "+
+					"not monotonic in dependent count", s.id, count, prevID, prevCount, radius, prevRadius)
+			}
+		}
+		prevID, prevCount, prevRadius = s.id, count, radius
 	}
 }
 


### PR DESCRIPTION
## Summary
- `seedsForFile`'s basename fallback now requires the parent path segment to also correspond (when both sides have one) before accepting a match, so a garbage path like `zzz/made/up/dispatch` no longer silently resolves to `internal/dispatch`'s full data. This reuses the existing #251 Empty/Knows mechanism — a rejected match just falls through to "unknown," so every caller (`hyctl graph blast`, `hyctl graph parallel`, `internal/security/blast.go`, `hyctl trust defect --file`, the cockpit) gets the fix automatically without any caller-side change.
- `PercolationFactor` no longer keys its per-file lift on a node's total (in+out) degree. It now keys on the same transitive dependent count `BlastRadiusForFile`'s base term already uses, so a file's own outbound imports can no longer inflate its own score past a file with genuinely more dependents. `cmd/hydra` (a Go main package, 0 dependents) now correctly floors at the same neutral 1.0 as other zero-dependent leaves instead of getting the percolation-cap blast radius. Kappa/`meanDeg` (the graph-wide Molloy-Reed criterion for whether a cascade-capable core exists at all) is untouched — only the per-file "how much lift" signal changed.
- `writeHandoff` now keys the A2A vector clock on the head's own `ID` instead of `rank.UITier(head)`. Every `LocalOnly` head is hardcoded to tier 10, so two different local models previously ticked the identical `"hydra-tier-10"` clock key and were indistinguishable under `Clock.Compare`. The `From` display string (still `"hydra-tier-N"`) is unchanged, since other consumers read it as display text.

## Verification against the live repo graph (before/after)
- `zzz/made/up/dispatch` → `file_in_graph: false`, `blast_radius: 1` (previously identical to `internal/dispatch`)
- `cmd/hydra` → `transitive_dependents: 0`, `percolation_factor: 1`, `blast_radius: 1` (previously inflated by its own imports)
- `internal/provider` (15 dependents) now correctly scores higher (`blast_radius: 14.67`) than `internal/dispatch` (5 dependents, `blast_radius: 3.58`)

## Tests
- `internal/graph/graph_test.go`: new ancestry-rejection tests for the basename fallback, a zero-dependent-leaf regression test mirroring `cmd/hydra`, and an explicit monotonicity property test (`TestPercolation_MonotonicInDependentCount`) asserting blast radius never decreases as a node's own dependent count strictly increases, even when total degree moves the opposite way. Also updated `TestPercolation_EqualCountDifferentDegree` → `TestPercolation_EqualCountEqualFactorRegardlessOfDegree`, since equal dependent counts must now price identically regardless of raw degree — the old assertion was testing the exact mechanism behind the bug.
- `internal/dispatch/coverage_test.go`: new test asserting two different `LocalOnly` heads (same `rank.UITier` bucket) produce distinct clock keys, and that the display `From` string is unchanged.

`go build ./...`, `go vet ./...` clean. `go test -race -count=1` green on `internal/graph`, `internal/a2a`, `internal/dispatch`, `internal/security`, `internal/tui`, `cmd/hydra` — two pre-existing failures in `internal/dispatch` (`TestLogDispatch_*`) and `cmd/hydra` (`TestCLI_Dispatch_RefusesBadFlagsBeforeSpending`, `TestCLI_Dispatch_LocalOnlyRefusesWhenNothingIsLocal`) reproduce identically on unmodified `origin/develop` and are unrelated to this change (network-sandbox/environment flakiness, confirmed by diffing against a clean baseline).

Closes #503