### PR TITLE
perf: round 2 — deeper business-logic speed audit across algorithms/data structures

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1893,18 +1893,19 @@ func cmdGraph() *cobra.Command {
 				return err
 			}
 			file := args[0]
-			radius := g.BlastRadiusForFile(file)
+			impact := g.Impact(file)
+			radius := impact.Radius
 			task := trust.Task{BlastRadius: radius}
 			dm := trust.NewDefectModel()
 
-			deps := g.DependentCountForFile(file)
-			pFactor := g.PercolationFactor(file)
+			deps := impact.Dependents
+			pFactor := impact.Percolation
 			// A radius of 1.0 means either "nothing depends on this" or "I have
 			// no idea" — opposite conclusions that used to render identically.
 			// internal/a2a reported 6 dependents and 97.4% required confidence
 			// with the graph, and "subcritical — edits stay local" at 90.0%
 			// without it (#251).
-			loaded, known := !g.Empty(), g.Knows(file)
+			loaded, known := !g.Empty(), impact.Known
 			if jsonOut {
 				return json.NewEncoder(os.Stdout).Encode(map[string]any{
 					"file": file, "blast_radius": radius, "transitive_dependents": deps,
@@ -2967,10 +2968,12 @@ func cmdTrustCalibration() *cobra.Command {
 			// A family whose members have converged on effectively one vote is a
 			// coordination risk the se/sp table above cannot show — two "sources"
 			// that always agree are one opinion, not confirming evidence.
-			for _, fam := range trust.KnownFamilies(trust.DefaultCoAgreementPath()) {
-				if j, warn := trust.FalseConsensusWarning(trust.DefaultCoAgreementPath(), fam); warn {
+			coPath := trust.DefaultCoAgreementPath()
+			coupling := trust.AllFamilyCoupling(coPath)
+			for _, fam := range trust.KnownFamilies(coPath) {
+				if r := coupling[fam]; r.Warn {
 					fmt.Printf("\n  %s\n", warnStyle.Render(fmt.Sprintf(
-						"false-consensus warning: %q's members measured J=%.2f — effectively one vote, not independent confirmation", fam, j)))
+						"false-consensus warning: %q's members measured J=%.2f — effectively one vote, not independent confirmation", fam, r.J)))
 				}
 			}
 			fmt.Println()

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -51,8 +51,7 @@ var (
 	loadCacheMu  sync.Mutex
 	loadCacheKey string
 	loadCacheDB  *DB
-	loadCacheErr error
-	loadCached   bool
+	loadCached   bool // only ever set true alongside a successful result — see Load
 )
 
 // loadCacheFingerprint is overlayPath plus its file state: mtime+size when it
@@ -83,17 +82,25 @@ func Load(overlayPath string) (*DB, error) {
 
 	loadCacheMu.Lock()
 	if loadCached && loadCacheKey == key {
-		db, err := loadCacheDB, loadCacheErr
+		db := loadCacheDB
 		loadCacheMu.Unlock()
-		return db, err
+		return db, nil
 	}
 	loadCacheMu.Unlock()
 
 	db, err := loadUncached(overlayPath)
 
-	loadCacheMu.Lock()
-	loadCacheKey, loadCacheDB, loadCacheErr, loadCached = key, db, err, true
-	loadCacheMu.Unlock()
+	// Only a successful result is cached. A stale cached error (e.g. from a
+	// malformed overlay JSON) is worse than a stale cached success: it can
+	// never self-heal once the overlay is fixed, since a fix that happens to
+	// land on the identical mtime+size (SaveOverlay doesn't use an atomic
+	// temp-file+rename, so a same-length rewrite is realistic) would still
+	// match the cached fingerprint and keep serving the old error forever.
+	if err == nil {
+		loadCacheMu.Lock()
+		loadCacheKey, loadCacheDB, loadCached = key, db, true
+		loadCacheMu.Unlock()
+	}
 
 	return db, err
 }

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -8,10 +8,12 @@ package capabilities
 import (
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/ankit373/hydra/internal/config"
 )
@@ -45,10 +47,58 @@ type DB struct {
 	index map[string]Entry
 }
 
+var (
+	loadCacheMu  sync.Mutex
+	loadCacheKey string
+	loadCacheDB  *DB
+	loadCacheErr error
+	loadCached   bool
+)
+
+// loadCacheFingerprint is overlayPath plus its file state: mtime+size when it
+// exists, a fixed marker otherwise. The embedded defaults never change at
+// runtime, so the overlay is the only thing that can invalidate a cached DB.
+func loadCacheFingerprint(overlayPath string) string {
+	if overlayPath == "" {
+		return "none"
+	}
+	info, err := os.Stat(overlayPath)
+	if err != nil {
+		return overlayPath + "|absent"
+	}
+	return fmt.Sprintf("%s|%s|%d", overlayPath, info.ModTime(), info.Size())
+}
+
 // Load builds a DB from the embedded defaults, then MERGES a user overlay if
 // overlayPath is non-empty and present: overlay entries add new models and
 // override built-ins by ID. Pass "" for built-ins only.
+//
+// Cached per fingerprint (path + mtime+size, so an overlay edit invalidates
+// on the next call): probe.Run fans out to the cli/env/port providers
+// concurrently, and each independently called Load with the identical
+// overlay path, tripling the embedded-unmarshal + merge work for the same
+// result every single probe.
 func Load(overlayPath string) (*DB, error) {
+	key := loadCacheFingerprint(overlayPath)
+
+	loadCacheMu.Lock()
+	if loadCached && loadCacheKey == key {
+		db, err := loadCacheDB, loadCacheErr
+		loadCacheMu.Unlock()
+		return db, err
+	}
+	loadCacheMu.Unlock()
+
+	db, err := loadUncached(overlayPath)
+
+	loadCacheMu.Lock()
+	loadCacheKey, loadCacheDB, loadCacheErr, loadCached = key, db, err, true
+	loadCacheMu.Unlock()
+
+	return db, err
+}
+
+func loadUncached(overlayPath string) (*DB, error) {
 	var d data
 	if err := json.Unmarshal(defaultData, &d); err != nil {
 		return nil, err

--- a/internal/capabilities/coverage_test.go
+++ b/internal/capabilities/coverage_test.go
@@ -233,6 +233,53 @@ func TestLoad_MalformedOverlayIsAnError(t *testing.T) {
 	}
 }
 
+// Load caches its result per overlay path, keyed on mtime+size — but an error
+// must never be cached past a fix. mtime alone would usually change on a
+// rewrite anyway, which would mask this bug by accident (a fresh mtime is a
+// fresh cache key regardless of whether errors are cached) — os.Chtimes
+// forces the second write to share the first write's exact mtime, and the
+// replacement is deliberately the same byte length too ("{broken" and
+// "[]     " are both 7 bytes — trailing whitespace after a JSON value is
+// valid), so the fingerprint is provably identical across both calls and the
+// only thing that can make the second Load succeed is NOT caching the error.
+func TestLoad_ErrorIsNotCachedPastAFix(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "models.json")
+
+	if err := os.WriteFile(path, []byte("{broken"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("malformed overlay loaded without error — the fixture is wrong")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstModTime := info.ModTime()
+
+	fixed := []byte("[]     ") // valid empty JSON array + trailing whitespace, same 7 bytes
+	if len(fixed) != len("{broken") {
+		t.Fatalf("test fixture bug: replacement is %d bytes, want %d", len(fixed), len("{broken"))
+	}
+	if err := os.WriteFile(path, fixed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, firstModTime, firstModTime); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(path); err != nil || info.ModTime() != firstModTime {
+		t.Fatalf("test fixture bug: mtime did not stick (got %v, want %v)", info.ModTime(), firstModTime)
+	}
+
+	db, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load still errors after the overlay was fixed (same mtime+size as the broken write): %v — a stale cached error is masking the fix", err)
+	}
+	if db == nil {
+		t.Fatal("Load returned a nil DB after the overlay was fixed — a stale cached error entry is masking the fix")
+	}
+}
+
 func TestLoad_EmbeddedCatalogueIsPopulated(t *testing.T) {
 	db, err := Load("")
 	if err != nil {

--- a/internal/config/breadcrumb.go
+++ b/internal/config/breadcrumb.go
@@ -23,8 +23,7 @@ var (
 	breadcrumbCacheMu     sync.Mutex
 	breadcrumbCacheKey    string
 	breadcrumbCacheResult string
-	breadcrumbCacheErr    error
-	breadcrumbCached      bool
+	breadcrumbCached      bool // only ever set true alongside a successful result — see Breadcrumb
 )
 
 // breadcrumbFingerprint is a cheap (stat-only) signal for whether Breadcrumb
@@ -38,6 +37,12 @@ var (
 func breadcrumbFingerprint() string {
 	home := ScriptHome()
 	var b strings.Builder
+	// home must be part of the key: two different registry roots whose files
+	// happen to coincide on mtime+size (plausible on filesystems with coarser
+	// mtime resolution — NFS, some CI runners, tmpfs) would otherwise produce
+	// the identical fingerprint string and silently serve one home's cached
+	// hash to the other.
+	b.WriteString(home + "\x00")
 	for _, name := range BreadcrumbFiles {
 		info, err := os.Stat(filepath.Join(home, "registry", name))
 		if err != nil {
@@ -71,17 +76,23 @@ func Breadcrumb() (string, error) {
 
 	breadcrumbCacheMu.Lock()
 	if breadcrumbCached && breadcrumbCacheKey == key {
-		result, err := breadcrumbCacheResult, breadcrumbCacheErr
+		result := breadcrumbCacheResult
 		breadcrumbCacheMu.Unlock()
-		return result, err
+		return result, nil
 	}
 	breadcrumbCacheMu.Unlock()
 
 	result, err := computeBreadcrumb()
 
-	breadcrumbCacheMu.Lock()
-	breadcrumbCacheKey, breadcrumbCacheResult, breadcrumbCacheErr, breadcrumbCached = key, result, err, true
-	breadcrumbCacheMu.Unlock()
+	// Only a successful result is cached. A stale cached error is worse than a
+	// stale cached success: it can never self-heal until an unrelated file
+	// perturbs the fingerprint, whereas retrying costs nothing but the next
+	// call's own read.
+	if err == nil {
+		breadcrumbCacheMu.Lock()
+		breadcrumbCacheKey, breadcrumbCacheResult, breadcrumbCached = key, result, true
+		breadcrumbCacheMu.Unlock()
+	}
 
 	return result, err
 }

--- a/internal/config/breadcrumb.go
+++ b/internal/config/breadcrumb.go
@@ -6,6 +6,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 
 	"github.com/ankit373/hydra/registry"
 )
@@ -15,23 +19,74 @@ import (
 // pricing.yaml is included because it drives cost-based routing decisions.
 var BreadcrumbFiles = []string{"routing.yaml", "models.yaml", "domains.yaml", "pricing.yaml"}
 
+var (
+	breadcrumbCacheMu     sync.Mutex
+	breadcrumbCacheKey    string
+	breadcrumbCacheResult string
+	breadcrumbCacheErr    error
+	breadcrumbCached      bool
+)
+
+// breadcrumbFingerprint is a cheap (stat-only) signal for whether Breadcrumb
+// needs to actually recompute: for each registry file, either its on-disk
+// mtime+size (an operator's override, which genuinely can change under a
+// long-running process like the TUI) or a fixed "embedded" marker (the
+// compiled-in copy, which cannot change without a binary rebuild). This is
+// what makes caching safe where a blind process-lifetime cache would not be:
+// an edit to an on-disk override changes the fingerprint and forces a real
+// recompute on the very next call, so freshness is never traded away.
+func breadcrumbFingerprint() string {
+	home := ScriptHome()
+	var b strings.Builder
+	for _, name := range BreadcrumbFiles {
+		info, err := os.Stat(filepath.Join(home, "registry", name))
+		if err != nil {
+			b.WriteString(name + "|embedded\x00")
+			continue
+		}
+		fmt.Fprintf(&b, "%s|%s|%d\x00", name, info.ModTime(), info.Size())
+	}
+	return b.String()
+}
+
 // Breadcrumb is a SHA256 hex fingerprint of the registry files that define
 // this Hydra deployment's routing behavior. It lets ledger/trust/cost log
 // entries be tied back to the exact routing rules in effect when they were
 // written, and lets logs from different machines — or from before/after a
 // registry edit — be told apart.
 //
-// Deliberately not memoized: it is read once per logged event (never inside a
-// loop — the swarm writer hoists it), the registry is ~36 KB, and a
-// process-lifetime cache would serve a stale fingerprint to the long-running
-// TUI after `hyctl init` or a registry edit. Freshness is worth more than the
-// microseconds. Revisit only with a profile that says otherwise.
+// Cached, keyed on breadcrumbFingerprint (mtime+size for an on-disk override,
+// a fixed marker for the embedded fallback) rather than memoized forever: a
+// dispatch fallback loop or swarm fan-out calls this once per candidate head
+// for the identical registry state, and re-reading + re-hashing ~36 KB that
+// many times over was pure waste, but an edit to an on-disk override must
+// still invalidate on the very next call, which the fingerprint guarantees.
 // Reads each file through registry.Read, so an installed binary fingerprints
 // its embedded rules and an operator with on-disk overrides fingerprints those
 // instead — which is the distinction the breadcrumb exists to record. Before
 // #238 this read disk only and returned an error on every installed binary, so
 // the fingerprint was silently absent from exactly the logs it was added for.
 func Breadcrumb() (string, error) {
+	key := breadcrumbFingerprint()
+
+	breadcrumbCacheMu.Lock()
+	if breadcrumbCached && breadcrumbCacheKey == key {
+		result, err := breadcrumbCacheResult, breadcrumbCacheErr
+		breadcrumbCacheMu.Unlock()
+		return result, err
+	}
+	breadcrumbCacheMu.Unlock()
+
+	result, err := computeBreadcrumb()
+
+	breadcrumbCacheMu.Lock()
+	breadcrumbCacheKey, breadcrumbCacheResult, breadcrumbCacheErr, breadcrumbCached = key, result, err, true
+	breadcrumbCacheMu.Unlock()
+
+	return result, err
+}
+
+func computeBreadcrumb() (string, error) {
 	home := ScriptHome()
 	h := sha256.New()
 	for _, name := range BreadcrumbFiles {

--- a/internal/config/breadcrumb_test.go
+++ b/internal/config/breadcrumb_test.go
@@ -5,7 +5,10 @@
 package config_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/testutil"
@@ -96,6 +99,44 @@ func TestBreadcrumb_CoversPricing(t *testing.T) {
 	}
 	if before == after {
 		t.Error("a pricing.yaml edit must change the deployment fingerprint")
+	}
+}
+
+// A fingerprint keyed only on (filename, mtime, size) — without the registry
+// root itself — would let two different HYDRA_HOME directories whose files
+// happen to share mtime+size (plausible on filesystems with coarser mtime
+// resolution: NFS, some CI runners, tmpfs) collide on the identical cache
+// key, silently serving one home's hash to the other. Forcing matching sizes
+// AND mtimes here proves `home` itself is part of the key, rather than the
+// test passing only because real-world mtimes/sizes usually differ.
+func TestBreadcrumb_DifferentHomesDoNotCollideEvenWithMatchingFileStats(t *testing.T) {
+	dirA, dirB := t.TempDir(), t.TempDir()
+	testutil.WriteRegistry(t, dirA, "routing: AAA", "models: b", "domains: c", "pricing: d")
+	testutil.WriteRegistry(t, dirB, "routing: ZZZ", "models: b", "domains: c", "pricing: d")
+
+	fixed := time.Now()
+	for _, dir := range []string{dirA, dirB} {
+		for _, name := range config.BreadcrumbFiles {
+			if err := os.Chtimes(filepath.Join(dir, "registry", name), fixed, fixed); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	t.Setenv("HYDRA_HOME", dirA)
+	a, err := config.Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HYDRA_HOME", dirB)
+	b, err := config.Breadcrumb()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a == b {
+		t.Error("two different HYDRA_HOME directories with matching file stats produced the same fingerprint — the cache is not actually keyed on home")
 	}
 }
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -243,9 +243,13 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 
 	var lastErr error
 	for i, h := range candidates {
+		// Computed once per candidate instead of once per use below (event
+		// logging, cost estimation): rank.UITier re-derives the same int for
+		// the identical head every time it's called.
+		tier := rank.UITier(h)
 		_ = rl.Append(runlog.Event{
 			Kind: runlog.KindHeadSelected, TaskID: taskID,
-			Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
+			Head: h.ID, Model: h.Name, Tier: tier,
 			Detail: fmt.Sprintf("candidate %d of %d", i+1, len(candidates)),
 		})
 		// Fails closed like ledger.Check itself: a policy-check error (unreadable
@@ -262,19 +266,19 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 			lastErr = fmt.Errorf("%s: head %s", detail, h.ID)
 			_ = rl.Append(runlog.Event{
 				Kind: runlog.KindError, TaskID: taskID,
-				Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
+				Head: h.ID, Model: h.Name, Tier: tier,
 				Status: "denied", Detail: detail,
 			})
 			continue
 		}
 		if opts.MaxCostUSD > 0 {
 			estInputTokens := len(prompt) / 4
-			estCost := d.estimateCost(rank.UITier(h), estInputTokens, estInputTokens/2)
+			estCost := d.estimateCost(tier, estInputTokens, estInputTokens/2)
 			if estCost > opts.MaxCostUSD {
 				lastErr = fmt.Errorf("estimated cost $%.4f for head %s exceeds limit $%.4f", estCost, h.ID, opts.MaxCostUSD)
 				_ = rl.Append(runlog.Event{
 					Kind: runlog.KindError, TaskID: taskID,
-					Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
+					Head: h.ID, Model: h.Name, Tier: tier,
 					Status: "denied", Detail: "exceeds cost ceiling",
 				})
 				// Shares the ledger's accountability trail with policy denials
@@ -301,7 +305,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 			// fallback chain advanced, and nothing else records it.
 			_ = rl.Append(runlog.Event{
 				Kind: runlog.KindError, TaskID: taskID,
-				Head: h.ID, Model: h.Name, Tier: rank.UITier(h),
+				Head: h.ID, Model: h.Name, Tier: tier,
 				Status: "failed", DurationMS: time.Since(started).Milliseconds(),
 				Detail: truncate(err.Error(), 200),
 			})
@@ -310,8 +314,8 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		r := &Result{Output: resp.Output, Head: h, Retries: i, Response: resp}
 		_ = rl.Append(runlog.Event{
 			Kind: runlog.KindDispatchFinished, TaskID: taskID,
-			Head: h.ID, Model: resp.Model, Tier: rank.UITier(h), Status: "ok",
-			CostUSD:    d.estimateCost(rank.UITier(h), resp.InputTokens, resp.OutputTokens),
+			Head: h.ID, Model: resp.Model, Tier: tier, Status: "ok",
+			CostUSD:    d.estimateCost(tier, resp.InputTokens, resp.OutputTokens),
 			DurationMS: resp.Duration.Milliseconds(),
 		})
 		_ = d.logDispatch(r, prompt, opts)

--- a/internal/glob/glob.go
+++ b/internal/glob/glob.go
@@ -22,6 +22,7 @@ package glob
 import (
 	"path"
 	"strings"
+	"sync"
 )
 
 // Match reports whether the "/"-separated path matches pattern.
@@ -36,7 +37,33 @@ func Match(pattern, p string) bool {
 		return true
 	}
 	p = strings.TrimPrefix(p, "./")
-	return matchSegments(strings.Split(p, "/"), strings.Split(pattern, "/"))
+	return matchSegments(strings.Split(p, "/"), splitPattern(pattern))
+}
+
+var (
+	splitCacheMu sync.Mutex
+	splitCache   = map[string][]string{}
+)
+
+// splitPattern caches a pattern's "/"-split segments. Patterns come from a
+// small, fixed, operator-controlled set (policy/workspace config rules) that
+// Match is called against repeatedly — once per rule, per resource checked —
+// while the path side genuinely differs on every call, so only the pattern
+// side is worth memoizing. The returned slice is never mutated by callers.
+func splitPattern(pattern string) []string {
+	splitCacheMu.Lock()
+	if segs, ok := splitCache[pattern]; ok {
+		splitCacheMu.Unlock()
+		return segs
+	}
+	splitCacheMu.Unlock()
+
+	segs := strings.Split(pattern, "/")
+
+	splitCacheMu.Lock()
+	splitCache[pattern] = segs
+	splitCacheMu.Unlock()
+	return segs
 }
 
 // matchSegments is memoized on (path index, pattern index).

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -233,7 +233,38 @@ func (g *Graph) BlastRadiusForFile(file string) float64 {
 	}
 	count := len(g.transitiveDependents(seeds))
 	base := 1.0 + math.Log2(1.0+float64(count))
-	return base * g.PercolationFactor(file)
+	return base * g.percolationFactorForSeeds(seeds)
+}
+
+// FileImpact bundles what BlastRadiusForFile, PercolationFactor,
+// DependentCountForFile, and Knows each separately compute about one file.
+// Every caller that wants more than one of these numbers (hyctl graph blast,
+// the TUI dashboard, hyctl security's blast-radius check all want at least
+// three) used to resolve seedsForFile once per call and run
+// transitiveDependents' BFS twice over — Impact resolves the seed set once
+// and derives all four from that single pass.
+type FileImpact struct {
+	Known       bool
+	Dependents  int
+	Radius      float64
+	Percolation float64
+}
+
+// Impact is the single-resolution counterpart to calling BlastRadiusForFile,
+// PercolationFactor, DependentCountForFile, and Knows separately for file.
+func (g *Graph) Impact(file string) FileImpact {
+	seeds := g.seedsForFile(file)
+	if len(seeds) == 0 {
+		return FileImpact{Radius: 1.0, Percolation: 1.0}
+	}
+	count := len(g.transitiveDependents(seeds))
+	percolation := g.percolationFactorForSeeds(seeds)
+	return FileImpact{
+		Known:       true,
+		Dependents:  count,
+		Radius:      (1.0 + math.Log2(1.0+float64(count))) * percolation,
+		Percolation: percolation,
+	}
 }
 
 // Kappa is the Molloy–Reed ratio κ = ⟨k²⟩/⟨k⟩ of the (undirected projection of
@@ -267,11 +298,21 @@ const percolationCap = 2.0
 // differently when one is a densely-connected hub and the other is peripheral.
 // Subcritical graph, unknown file, or no graph → exactly 1.0 (backward compatible).
 func (g *Graph) PercolationFactor(file string) float64 {
-	if g == nil || g.meanDeg <= 0 || g.kappa < 2.0 {
+	if g == nil {
 		return 1.0
 	}
 	seeds := g.seedsForFile(file)
 	if len(seeds) == 0 {
+		return 1.0
+	}
+	return g.percolationFactorForSeeds(seeds)
+}
+
+// percolationFactorForSeeds is PercolationFactor over an already-resolved seed
+// set — the seed-set counterpart Impact uses so it doesn't pay for a second
+// seedsForFile resolution of the same file.
+func (g *Graph) percolationFactorForSeeds(seeds []string) float64 {
+	if g.meanDeg <= 0 || g.kappa < 2.0 {
 		return 1.0
 	}
 	maxDeg := 0

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -122,31 +122,56 @@ func TestBlastRadius_UnknownAndEmpty(t *testing.T) {
 	}
 }
 
+// checkImpactMatchesSeparateCalls is the shared assertion TestImpact_* uses:
+// Impact must agree exactly with calling BlastRadiusForFile, PercolationFactor,
+// DependentCountForFile, and Knows separately for the same file.
+func checkImpactMatchesSeparateCalls(t *testing.T, g *Graph, file string) {
+	t.Helper()
+	impact := g.Impact(file)
+	if impact.Known != g.Knows(file) {
+		t.Errorf("%s: Impact.Known = %v, want %v", file, impact.Known, g.Knows(file))
+	}
+	if wantRadius := g.BlastRadiusForFile(file); math.Abs(impact.Radius-wantRadius) > 1e-9 {
+		t.Errorf("%s: Impact.Radius = %v, want %v", file, impact.Radius, wantRadius)
+	}
+	if wantDeps := g.DependentCountForFile(file); impact.Dependents != wantDeps {
+		t.Errorf("%s: Impact.Dependents = %v, want %v", file, impact.Dependents, wantDeps)
+	}
+	if wantPct := g.PercolationFactor(file); math.Abs(impact.Percolation-wantPct) > 1e-9 {
+		t.Errorf("%s: Impact.Percolation = %v, want %v", file, impact.Percolation, wantPct)
+	}
+}
+
 // Impact resolves seedsForFile once and derives Radius/Dependents/Percolation
-// from that single pass — it must agree exactly with calling
-// BlastRadiusForFile, PercolationFactor, DependentCountForFile, and Knows
-// separately, for a known hub, a known leaf, and an unknown file.
+// from that single pass — it must agree exactly with calling the four
+// separate functions, for a known hub, a known leaf, and an unknown file, all
+// on a subcritical graph where Percolation is trivially 1.0 everywhere.
 func TestImpact_MatchesSeparateCalls(t *testing.T) {
 	g := sampleGraph()
 	for _, file := range []string{"a.go", "c.go", "nonexistent.go"} {
-		impact := g.Impact(file)
-		if impact.Known != g.Knows(file) {
-			t.Errorf("%s: Impact.Known = %v, want %v", file, impact.Known, g.Knows(file))
-		}
-		if wantRadius := g.BlastRadiusForFile(file); math.Abs(impact.Radius-wantRadius) > 1e-9 {
-			t.Errorf("%s: Impact.Radius = %v, want %v", file, impact.Radius, wantRadius)
-		}
-		if wantDeps := g.DependentCountForFile(file); impact.Dependents != wantDeps {
-			t.Errorf("%s: Impact.Dependents = %v, want %v", file, impact.Dependents, wantDeps)
-		}
-		if wantPct := g.PercolationFactor(file); math.Abs(impact.Percolation-wantPct) > 1e-9 {
-			t.Errorf("%s: Impact.Percolation = %v, want %v", file, impact.Percolation, wantPct)
-		}
+		checkImpactMatchesSeparateCalls(t, g, file)
 	}
 
 	var empty *Graph
 	if got := empty.Impact("a.go"); got.Known || got.Radius != 1.0 || got.Percolation != 1.0 || got.Dependents != 0 {
 		t.Errorf("nil graph Impact = %+v, want the all-neutral zero value", got)
+	}
+}
+
+// The equivalence above is trivial on a subcritical graph, where
+// percolationFactorForSeeds' maxDeg/excess/superMargin/lift arithmetic never
+// runs (PercolationFactor short-circuits to 1.0 before touching it). This
+// exercises Impact on supercriticalGraph's hub file (x.go), where Percolation
+// is genuinely > 1.0 — the only way to catch a copy/paste error in that
+// arithmetic during the BlastRadiusForFile/PercolationFactor→
+// percolationFactorForSeeds extraction.
+func TestImpact_MatchesSeparateCalls_NonTrivialPercolation(t *testing.T) {
+	g := supercriticalGraph()
+	if pct := g.PercolationFactor("x.go"); pct <= 1.0 {
+		t.Fatalf("test fixture bug: x.go's PercolationFactor = %.3f, want > 1.0 (not exercising the non-trivial branch)", pct)
+	}
+	for _, file := range []string{"x.go", "y.go"} {
+		checkImpactMatchesSeparateCalls(t, g, file)
 	}
 }
 
@@ -254,15 +279,18 @@ func TestKappa_TopologyOrdering(t *testing.T) {
 
 // A hub-core file and a peripheral file with the SAME transitive-dependent count
 // must be priced differently once the graph is supercritical.
-func TestPercolation_EqualCountDifferentDegree(t *testing.T) {
+// supercriticalGraph returns a graph with κ≥2: X is a fan-in hub with 6 direct
+// dependents (degree 6, count 6), Y heads a 6-long dependent chain (degree 1
+// at Y, count 6) — equal transitive-dependent counts but very different
+// degree, so PercolationFactor lifts the hub (x.go) above 1.0 while leaving
+// the peripheral chain head (y.go) at exactly 1.0.
+func supercriticalGraph() *Graph {
 	nodes := []Node{{ID: "X", File: "x.go"}, {ID: "Y", File: "y.go"}}
 	var edges []Edge
-	// X: a fan-in hub with 6 direct dependents (degree 6, count 6).
 	for _, d := range []string{"a", "b", "c", "g", "h", "i"} {
 		nodes = append(nodes, Node{ID: d, File: d + ".go"})
 		edges = append(edges, Edge{From: d, To: "X"})
 	}
-	// Y: a 6-long chain of dependents (degree 1 at Y, count 6).
 	chain := []string{"d", "e", "f", "p", "q", "r"}
 	prev := "Y"
 	for _, c := range chain {
@@ -270,7 +298,11 @@ func TestPercolation_EqualCountDifferentDegree(t *testing.T) {
 		edges = append(edges, Edge{From: c, To: prev})
 		prev = c
 	}
-	g := fromDoc(Doc{Nodes: nodes, Edges: edges})
+	return fromDoc(Doc{Nodes: nodes, Edges: edges})
+}
+
+func TestPercolation_EqualCountDifferentDegree(t *testing.T) {
+	g := supercriticalGraph()
 
 	if !g.Percolates() {
 		t.Fatalf("test graph κ = %.3f, expected supercritical", g.Kappa())

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -122,6 +122,34 @@ func TestBlastRadius_UnknownAndEmpty(t *testing.T) {
 	}
 }
 
+// Impact resolves seedsForFile once and derives Radius/Dependents/Percolation
+// from that single pass — it must agree exactly with calling
+// BlastRadiusForFile, PercolationFactor, DependentCountForFile, and Knows
+// separately, for a known hub, a known leaf, and an unknown file.
+func TestImpact_MatchesSeparateCalls(t *testing.T) {
+	g := sampleGraph()
+	for _, file := range []string{"a.go", "c.go", "nonexistent.go"} {
+		impact := g.Impact(file)
+		if impact.Known != g.Knows(file) {
+			t.Errorf("%s: Impact.Known = %v, want %v", file, impact.Known, g.Knows(file))
+		}
+		if wantRadius := g.BlastRadiusForFile(file); math.Abs(impact.Radius-wantRadius) > 1e-9 {
+			t.Errorf("%s: Impact.Radius = %v, want %v", file, impact.Radius, wantRadius)
+		}
+		if wantDeps := g.DependentCountForFile(file); impact.Dependents != wantDeps {
+			t.Errorf("%s: Impact.Dependents = %v, want %v", file, impact.Dependents, wantDeps)
+		}
+		if wantPct := g.PercolationFactor(file); math.Abs(impact.Percolation-wantPct) > 1e-9 {
+			t.Errorf("%s: Impact.Percolation = %v, want %v", file, impact.Percolation, wantPct)
+		}
+	}
+
+	var empty *Graph
+	if got := empty.Impact("a.go"); got.Known || got.Radius != 1.0 || got.Percolation != 1.0 || got.Dependents != 0 {
+		t.Errorf("nil graph Impact = %+v, want the all-neutral zero value", got)
+	}
+}
+
 func TestCycleSafety(t *testing.T) {
 	g := fromDoc(Doc{
 		Nodes: []Node{{ID: "a", File: "a.go"}, {ID: "b", File: "b.go"}},

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -305,6 +305,15 @@ func VerifyChain(path string) (ChainResult, error) {
 	if err != nil {
 		return ChainResult{}, err
 	}
+	return VerifyChainEvents(events, path), nil
+}
+
+// VerifyChainEvents is VerifyChain for a caller that already loaded events
+// (e.g. security.Build, which loads the ledger once for its own report and
+// would otherwise pay for a second full read+parse of the identical file just
+// to verify it). path is still needed to look up the sidecar chain-hash
+// anchor, which lives alongside the ledger file, not inside it.
+func VerifyChainEvents(events []Event, path string) ChainResult {
 	res := ChainResult{Intact: true}
 	prevHash := ""
 	chainStarted := false
@@ -353,7 +362,7 @@ func VerifyChain(path string) (ChainResult, error) {
 		res.Truncated = true
 		res.Intact = false
 	}
-	return res, nil
+	return res
 }
 
 // Load reads all events; a missing ledger yields no events. Unparseable lines

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -4,8 +4,8 @@
 package rank
 
 import (
-	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/ankit373/hydra/internal/provider"
 )
@@ -80,8 +80,7 @@ func dedupeKey(h provider.Head) string {
 func UITier(h provider.Head) int {
 	if h.Source == "registry" {
 		if t := h.Meta["tier"]; t != "" {
-			var n int
-			if _, err := fmt.Sscanf(t, "%d", &n); err == nil {
+			if n, err := strconv.Atoi(t); err == nil {
 				return n
 			}
 		}

--- a/internal/security/blast.go
+++ b/internal/security/blast.go
@@ -87,14 +87,15 @@ func AssessBlastRadius() BlastReport {
 	}
 
 	for file, n := range edits {
-		ef := EditedFile{File: file, Edits: n, Known: g.Knows(file)}
+		impact := g.Impact(file)
+		ef := EditedFile{File: file, Edits: n, Known: impact.Known}
 		if !ef.Known {
 			r.Unknown++
 			r.Files = append(r.Files, ef)
 			continue
 		}
-		ef.Radius = g.BlastRadiusForFile(file)
-		ef.Dependents = g.DependentCountForFile(file)
+		ef.Radius = impact.Radius
+		ef.Dependents = impact.Dependents
 		r.Files = append(r.Files, ef)
 	}
 

--- a/internal/security/evidence.go
+++ b/internal/security/evidence.go
@@ -53,16 +53,14 @@ type EvidenceQuality struct {
 	UncalibratedSources []string `json:"uncalibratedSources,omitempty"`
 }
 
-// AssessEvidence reads the trust logs and reports what the confidence rests on.
-// Every input is optional: a machine that has never run an ensemble gets an
-// empty result, not an invented one.
-func AssessEvidence() EvidenceQuality {
+// AssessEvidence reports what the confidence in runs rests on. runs is what
+// Build already loaded (via trust.LoadRuns) — passed in rather than reloaded
+// here, since owasp.go's LLM09 check needs the identical data. Every input is
+// optional: a machine that has never run an ensemble gets an empty result,
+// not an invented one.
+func AssessEvidence(runs []trust.RunLog) EvidenceQuality {
 	var q EvidenceQuality
-
-	runs, err := trust.LoadRuns(trust.DefaultLogPath())
-	if err == nil {
-		q.Runs = len(runs)
-	}
+	q.Runs = len(runs)
 
 	// Which sources actually carried a vote — a weak source nobody uses is
 	// not a finding.
@@ -74,10 +72,10 @@ func AssessEvidence() EvidenceQuality {
 	}
 
 	coPath := trust.DefaultCoAgreementPath()
+	coupling := trust.AllFamilyCoupling(coPath)
 	for _, fam := range trust.KnownFamilies(coPath) {
-		j, warn := trust.FalseConsensusWarning(coPath, fam)
-		if warn {
-			q.Families = append(q.Families, FamilyRisk{Family: fam, Coupling: j, Critical: true})
+		if r := coupling[fam]; r.Warn {
+			q.Families = append(q.Families, FamilyRisk{Family: fam, Coupling: r.J, Critical: true})
 		}
 	}
 	sort.Slice(q.Families, func(i, j int) bool { return q.Families[i].Coupling > q.Families[j].Coupling })

--- a/internal/security/evidence_test.go
+++ b/internal/security/evidence_test.go
@@ -14,7 +14,7 @@ import (
 // the quality of confidence it has never claimed.
 func TestAssessEvidence_EmptyOnAFreshMachine(t *testing.T) {
 	testutil.NewSandbox(t)
-	q := AssessEvidence()
+	q := AssessEvidence(nil)
 	if q.Runs != 0 || len(q.Families) != 0 || len(q.WeakSources) != 0 {
 		t.Errorf("AssessEvidence = %+v, want empty", q)
 	}
@@ -34,7 +34,11 @@ func TestAssessEvidence_UncalibratedIsNotWeak(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	q := AssessEvidence()
+	runs, err := trust.LoadRuns(trust.DefaultLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := AssessEvidence(runs)
 	if len(q.WeakSources) != 0 {
 		t.Errorf("WeakSources = %+v, want none — the source was never calibrated", q.WeakSources)
 	}
@@ -73,7 +77,11 @@ func TestAssessEvidence_MeasuredCoinFlipSourceIsWeak(t *testing.T) {
 		}
 	}
 
-	q := AssessEvidence()
+	runs, err := trust.LoadRuns(trust.DefaultLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := AssessEvidence(runs)
 	if len(q.WeakSources) != 1 || q.WeakSources[0].Source != "coinflip" {
 		t.Fatalf("WeakSources = %+v, want the measured coin-flip source", q.WeakSources)
 	}
@@ -102,7 +110,7 @@ func TestAssessEvidence_UnusedSourcesAreNotReported(t *testing.T) {
 		}
 	}
 	// No run references it.
-	if q := AssessEvidence(); len(q.WeakSources) != 0 {
+	if q := AssessEvidence(nil); len(q.WeakSources) != 0 {
 		t.Errorf("WeakSources = %+v, want none for a source no run used", q.WeakSources)
 	}
 }

--- a/internal/security/incident.go
+++ b/internal/security/incident.go
@@ -143,6 +143,13 @@ func CorrelateIncidents(events []ledger.Event, blast BlastReport) []Incident {
 		byActor[e.Tool] = append(byActor[e.Tool], e)
 	}
 
+	// Built once and shared by every incident's scoreImpact call below, instead
+	// of each one linearly scanning all of blast.Files per event to find a
+	// match — O(events_in_incident × len(blast.Files)) repeated once per
+	// incident, when blast.Files is already fully built and doesn't change
+	// within one CorrelateIncidents call.
+	widelyDepended := widelyDependedFiles(blast)
+
 	var out []Incident
 	for actor, evs := range byActor {
 		sort.SliceStable(evs, func(i, j int) bool { return evs[i].TS < evs[j].TS })
@@ -153,10 +160,10 @@ func CorrelateIncidents(events []ledger.Event, blast BlastReport) []Incident {
 				group = append(group, e)
 				continue
 			}
-			out = append(out, buildIncident(actor, group, blast))
+			out = append(out, buildIncident(actor, group, widelyDepended))
 			group = []ledger.Event{e}
 		}
-		out = append(out, buildIncident(actor, group, blast))
+		out = append(out, buildIncident(actor, group, widelyDepended))
 	}
 
 	// Worst first: an operator reads top-down and stops when they run out of
@@ -183,7 +190,21 @@ func withinSession(a, b string) bool {
 	return tb.Sub(ta) <= sessionGap
 }
 
-func buildIncident(actor string, evs []ledger.Event, blast BlastReport) Incident {
+// widelyDependedFiles indexes blast.Files by path, keeping only the files
+// scoreImpact actually cares about (known to the graph and depended on by at
+// least one other file) — an O(1) lookup by e.Resource replaces a linear scan
+// of the whole slice per event.
+func widelyDependedFiles(blast BlastReport) map[string]bool {
+	out := make(map[string]bool, len(blast.Files))
+	for _, f := range blast.Files {
+		if f.Known && f.Dependents > 0 {
+			out[f.File] = true
+		}
+	}
+	return out
+}
+
+func buildIncident(actor string, evs []ledger.Event, widelyDepended map[string]bool) Incident {
 	in := Incident{
 		Actor:  actor,
 		Start:  evs[0].TS,
@@ -229,7 +250,7 @@ func buildIncident(actor string, evs []ledger.Event, blast BlastReport) Incident
 	}
 
 	in.Likelihood = scoreLikelihood(evs, seen)
-	in.Impact = scoreImpact(evs, seen, blast)
+	in.Impact = scoreImpact(evs, seen, widelyDepended)
 	in.Severity = rateSeverity(in.Likelihood, in.Impact)
 	in.Narrative = narrate(in)
 	return in
@@ -259,7 +280,7 @@ func scoreLikelihood(evs []ledger.Event, seen map[Stage]bool) int {
 
 // scoreImpact is the OWASP Risk Rating impact factor, 0-9: how much damage the
 // attempted operations could do.
-func scoreImpact(evs []ledger.Event, seen map[Stage]bool, blast BlastReport) int {
+func scoreImpact(evs []ledger.Event, seen map[Stage]bool, widelyDepended map[string]bool) int {
 	score := 0
 	// Action class. Executing or reaching the network dominates reading.
 	for _, e := range evs {
@@ -278,11 +299,8 @@ func scoreImpact(evs []ledger.Event, seen map[Stage]bool, blast BlastReport) int
 	}
 	// A touched file the graph knows to be widely depended on raises the reach.
 	for _, e := range evs {
-		for _, f := range blast.Files {
-			if f.Known && f.File == e.Resource && f.Dependents > 0 {
-				score += 1
-				break
-			}
+		if widelyDepended[e.Resource] {
+			score += 1
 		}
 	}
 	return clamp09(score)

--- a/internal/security/incident_test.go
+++ b/internal/security/incident_test.go
@@ -50,6 +50,37 @@ func TestCorrelateIncidents_TheWorkedExample(t *testing.T) {
 	}
 }
 
+// scoreImpact adds +1 per event that touches a file the graph knows to be
+// widely depended on — every qualifying event in an incident should raise the
+// score, not just the first one found. No prior test exercised this with a
+// non-empty BlastReport; a regression here (e.g. reintroducing a break that
+// only lets the first qualifying event count) would have shipped silently.
+func TestCorrelateIncidents_EachWidelyDependedFileTouchRaisesImpact(t *testing.T) {
+	blast := BlastReport{Files: []EditedFile{
+		{File: "a.go", Known: true, Dependents: 3},
+		{File: "b.go", Known: true, Dependents: 5},
+	}}
+
+	oneMatch := []ledger.Event{
+		{TS: "2026-08-09T10:00:00Z", Tool: "h", Resource: "a.go", Action: ledger.Read, Decision: ledger.Deny},
+		{TS: "2026-08-09T10:00:05Z", Tool: "h", Resource: "unrelated.go", Action: ledger.Read, Decision: ledger.Deny},
+	}
+	twoMatches := []ledger.Event{
+		{TS: "2026-08-09T10:00:00Z", Tool: "h", Resource: "a.go", Action: ledger.Read, Decision: ledger.Deny},
+		{TS: "2026-08-09T10:00:05Z", Tool: "h", Resource: "b.go", Action: ledger.Read, Decision: ledger.Deny},
+	}
+
+	one := CorrelateIncidents(oneMatch, blast)
+	two := CorrelateIncidents(twoMatches, blast)
+	if len(one) != 1 || len(two) != 1 {
+		t.Fatalf("got %d and %d incidents, want exactly 1 each", len(one), len(two))
+	}
+	if two[0].Impact <= one[0].Impact {
+		t.Errorf("two qualifying-file touches scored Impact=%d, one touch scored Impact=%d — "+
+			"each qualifying event should raise the score, not just the first", two[0].Impact, one[0].Impact)
+	}
+}
+
 // Blocked and landed are not the same event. A flagged request that succeeded
 // must outrank the identical request that was denied.
 func TestCorrelateIncidents_SucceededOutranksBlocked(t *testing.T) {

--- a/internal/security/owasp.go
+++ b/internal/security/owasp.go
@@ -56,9 +56,12 @@ type Coverage struct {
 }
 
 // computeCoverage classifies all 10 OWASP LLM Top-10 categories against
-// Hydra's real, currently-observable state. pol and events are what Build
-// already loaded — passed in rather than reloaded here.
-func computeCoverage(pol ledger.Policy, events []ledger.Event, sc SupplyChain) Coverage {
+// Hydra's real, currently-observable state. pol, runs, and costCeilingDenials
+// are what Build already loaded/computed — passed in rather than rederived
+// here (AssessEvidence needs the identical trust runs, and costCeilingCheck
+// needs the identical cost-ceiling-denial count, so Build computes each once
+// for both consumers).
+func computeCoverage(pol ledger.Policy, sc SupplyChain, runs []trust.RunLog, costCeilingDenials int) Coverage {
 	cats := []Category{
 		{ID: "LLM01", Name: "Prompt Injection", Status: Enforced,
 			Detail: "untrusted content is framed as data (a2a/editor/parallel) and scanned for injection markers automatically"},
@@ -73,8 +76,8 @@ func computeCoverage(pol ledger.Policy, events []ledger.Event, sc SupplyChain) C
 			Detail: "no protection exists for --system content today"},
 		{ID: "LLM08", Name: "Vector and Embedding Weaknesses", Status: NotApplicable,
 			Detail: "Hydra has no RAG pipeline or vector store of its own"},
-		llm09Misinformation(),
-		llm10UnboundedConsumption(events),
+		llm09Misinformation(runs),
+		llm10UnboundedConsumption(costCeilingDenials),
 	}
 
 	var applicable, covered int
@@ -145,10 +148,9 @@ func llm06ExcessiveAgency(pol ledger.Policy) Category {
 
 // llm09Misinformation: the SPRT confidence ensemble is Hydra's real mitigation
 // for hallucinated/wrong answers — Configured once it's actually been used.
-func llm09Misinformation() Category {
+func llm09Misinformation(runs []trust.RunLog) Category {
 	c := Category{ID: "LLM09", Name: "Misinformation"}
-	runs, err := trust.LoadRuns(trust.DefaultLogPath())
-	if err != nil || len(runs) == 0 {
+	if len(runs) == 0 {
 		c.Status = Gap
 		c.Detail = "the SPRT confidence ensemble (hyctl dispatch --confidence) has never been used"
 		return c
@@ -161,14 +163,12 @@ func llm09Misinformation() Category {
 // llm10UnboundedConsumption: Configured once a --max-cost ceiling has
 // actually refused a dispatch — the ledger is the only durable record that
 // the guard was ever exercised.
-func llm10UnboundedConsumption(events []ledger.Event) Category {
+func llm10UnboundedConsumption(costCeilingDenials int) Category {
 	c := Category{ID: "LLM10", Name: "Unbounded Consumption"}
-	for _, e := range events {
-		if costCeilingReason(e) {
-			c.Status = Configured
-			c.Detail = "a --max-cost ceiling has refused at least one dispatch"
-			return c
-		}
+	if costCeilingDenials > 0 {
+		c.Status = Configured
+		c.Detail = "a --max-cost ceiling has refused at least one dispatch"
+		return c
 	}
 	c.Status = Gap
 	c.Detail = "no dispatch has ever been refused for exceeding a cost ceiling — set one with --max-cost"

--- a/internal/security/owasp_test.go
+++ b/internal/security/owasp_test.go
@@ -20,7 +20,7 @@ import (
 func TestComputeCoverage_StaticCategoriesAreFixed(t *testing.T) {
 	testutil.NewSandbox(t)
 
-	cov := computeCoverage(ledger.Policy{}, nil, SupplyChain{})
+	cov := computeCoverage(ledger.Policy{}, SupplyChain{}, nil, 0)
 	want := map[string]CoverageStatus{
 		"LLM01": Enforced, "LLM02": Enforced,
 		"LLM03": Gap, "LLM07": Gap,
@@ -40,7 +40,7 @@ func TestComputeCoverage_StaticCategoriesAreFixed(t *testing.T) {
 func TestComputeCoverage_NAExcludedFromBothNumeratorAndDenominator(t *testing.T) {
 	testutil.NewSandbox(t)
 
-	cov := computeCoverage(ledger.Policy{}, nil, SupplyChain{})
+	cov := computeCoverage(ledger.Policy{}, SupplyChain{}, nil, 0)
 	if cov.Applicable != 8 {
 		t.Errorf("Applicable = %d, want 8 (10 categories minus LLM04 and LLM08)", cov.Applicable)
 	}
@@ -69,7 +69,7 @@ func TestLLM06ExcessiveAgency_ConfiguredOnlyWithAResourceScopedRule(t *testing.T
 func TestLLM09Misinformation_ConfiguredOnlyWithARecordedRun(t *testing.T) {
 	testutil.NewSandbox(t)
 
-	if got := llm09Misinformation().Status; got != Gap {
+	if got := llm09Misinformation(nil).Status; got != Gap {
 		t.Errorf("no trust.jsonl: Status = %q, want Gap", got)
 	}
 
@@ -80,19 +80,23 @@ func TestLLM09Misinformation_ConfiguredOnlyWithARecordedRun(t *testing.T) {
 	if err := os.WriteFile(trust.DefaultLogPath(), []byte(row), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got := llm09Misinformation().Status; got != Configured {
+	runs, err := trust.LoadRuns(trust.DefaultLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := llm09Misinformation(runs).Status; got != Configured {
 		t.Errorf("a recorded run exists: Status = %q, want Configured", got)
 	}
 }
 
 func TestLLM10UnboundedConsumption_ConfiguredOnlyWithACostCeilingDenial(t *testing.T) {
 	none := []ledger.Event{{Tool: "a", Decision: ledger.Deny, Reason: "denied by ledger policy"}}
-	if got := llm10UnboundedConsumption(none).Status; got != Gap {
+	if got := llm10UnboundedConsumption(countCostCeilingDenials(none)).Status; got != Gap {
 		t.Errorf("no cost-ceiling denial: Status = %q, want Gap", got)
 	}
 
 	withCeiling := []ledger.Event{{Tool: "a", Decision: ledger.Deny, Reason: "exceeds cost ceiling: estimated $1 > limit $0.5"}}
-	if got := llm10UnboundedConsumption(withCeiling).Status; got != Configured {
+	if got := llm10UnboundedConsumption(countCostCeilingDenials(withCeiling)).Status; got != Configured {
 		t.Errorf("a cost-ceiling denial exists: Status = %q, want Configured", got)
 	}
 }

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/trust"
 )
 
 // LedgerPanel is the headline accountability figures.
@@ -170,11 +171,15 @@ func Build(heads []provider.Head) (*Report, error) {
 		return nil, err
 	}
 
-	chainRes, err := ledger.VerifyChain(ledger.DefaultPath())
-	if err != nil {
-		return nil, err
-	}
+	chainRes := ledger.VerifyChainEvents(events, ledger.DefaultPath())
 	r.IntegrityIntact = chainRes.Intact
+
+	// Loaded once, shared by AssessEvidence and computeCoverage's LLM09 check
+	// (both used to independently call trust.LoadRuns on the same file).
+	runs, _ := trust.LoadRuns(trust.DefaultLogPath())
+	// Ditto: shared by the check below and LLM10's coverage category, instead
+	// of each re-scanning events for the same cost-ceiling-denial predicate.
+	costCeilingDenials := countCostCeilingDenials(events)
 
 	r.Exposures = Exposures(events, heads)
 	r.PolicyAudit = AuditPolicy(pol, events)
@@ -182,7 +187,7 @@ func Build(heads []provider.Head) (*Report, error) {
 	r.Controls = Controls(events, r.PolicyAudit, chainRes)
 	r.SupplyChain = FingerprintHeads(heads)
 	r.Blast = AssessBlastRadius()
-	r.Evidence = AssessEvidence()
+	r.Evidence = AssessEvidence(runs)
 	r.Drift = DetectConfigDrift(events)
 	r.Incidents = CorrelateIncidents(events, r.Blast)
 	r.Privilege = ReviewPrivilege(events, pol)
@@ -191,7 +196,7 @@ func Build(heads []provider.Head) (*Report, error) {
 
 	r.Checks = []Check{
 		chainCheck(chainRes),
-		costCeilingCheck(events),
+		costCeilingCheck(costCeilingDenials),
 		provenanceCheck(heads),
 		frameworkCheck(pol),
 		exposureCheck(r.Exposures),
@@ -206,7 +211,7 @@ func Build(heads []provider.Head) (*Report, error) {
 	}
 	r.RiskHistory = ledger.ByDayRisk(events)
 
-	r.Coverage = computeCoverage(pol, events, r.SupplyChain)
+	r.Coverage = computeCoverage(pol, r.SupplyChain, runs, costCeilingDenials)
 
 	historyPath := DefaultScoreHistoryPath()
 	prior := loadScoreHistory(historyPath)
@@ -424,14 +429,22 @@ func costCeilingReason(e ledger.Event) bool {
 	return e.Decision == ledger.Deny && strings.Contains(e.Reason, "cost ceiling")
 }
 
-func costCeilingCheck(events []ledger.Event) Check {
-	const name = "Denial-of-wallet guard"
+// countCostCeilingDenials is shared by costCeilingCheck and
+// llm10UnboundedConsumption — both used to independently scan the identical
+// events slice testing the same predicate; Build now scans once and passes
+// the count to both.
+func countCostCeilingDenials(events []ledger.Event) int {
 	n := 0
 	for _, e := range events {
 		if costCeilingReason(e) {
 			n++
 		}
 	}
+	return n
+}
+
+func costCeilingCheck(n int) Check {
+	const name = "Denial-of-wallet guard"
 	if n == 0 {
 		return Check{Name: name, Status: "0 refusals",
 			Detail: "no dispatch has been refused for exceeding a cost ceiling — set one with --max-cost"}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -175,8 +175,16 @@ func Build(heads []provider.Head) (*Report, error) {
 	r.IntegrityIntact = chainRes.Intact
 
 	// Loaded once, shared by AssessEvidence and computeCoverage's LLM09 check
-	// (both used to independently call trust.LoadRuns on the same file).
-	runs, _ := trust.LoadRuns(trust.DefaultLogPath())
+	// (both used to independently call trust.LoadRuns on the same file). A
+	// scan failure partway through (a corrupted trust.jsonl) can hand back a
+	// non-nil, partially-populated slice alongside the error — treated as no
+	// runs at all, matching the "any load error means Gap" invariant LLM09's
+	// check relies on, rather than silently reporting Configured off of
+	// truncated/corrupt data.
+	runs, runsErr := trust.LoadRuns(trust.DefaultLogPath())
+	if runsErr != nil {
+		runs = nil
+	}
 	// Ditto: shared by the check below and LLM10's coverage category, instead
 	// of each re-scanning events for the same cost-ceiling-denial predicate.
 	costCeilingDenials := countCostCeilingDenials(events)

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/testutil"
+	"github.com/ankit373/hydra/internal/trust"
 )
 
 func TestBuild_NoDataOnAnEmptyMachine(t *testing.T) {
@@ -32,6 +33,64 @@ func TestBuild_NoDataOnAnEmptyMachine(t *testing.T) {
 			t.Errorf("check %+v is missing a Name/Status", c)
 		}
 	}
+}
+
+// A scan failure partway through trust.jsonl (bufio.Scanner's ErrTooLong on
+// an oversized line) hands trust.LoadRuns back a partially-populated, non-nil
+// runs slice alongside a non-nil error. Build must treat that as no runs at
+// all — never silently report LLM09 as Configured off truncated/corrupt data.
+func TestBuild_CorruptedTrustLogReportsGapNotConfigured(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	path := trust.DefaultLogPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One valid run first, so LoadRuns has accumulated something before it fails.
+	if _, err := f.WriteString(`{"ts":"2026-01-01T00:00:00Z","task_hash":"a","domain":"go",` +
+		`"target_conf":0.9,"final_conf":0.9,"samples":1,"decision":"accept"}` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	// A single "line" (no newline) bigger than bufio.Scanner's 4MB max token
+	// size, forcing scanner.Err() to return bufio.ErrTooLong.
+	oversized := make([]byte, 5*1024*1024)
+	for i := range oversized {
+		oversized[i] = 'x'
+	}
+	if _, err := f.Write(oversized); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Confirm the fixture actually reproduces LoadRuns' partial+error shape
+	// before trusting Build's behavior against it.
+	runs, loadErr := trust.LoadRuns(path)
+	if loadErr == nil {
+		t.Fatal("test fixture bug: expected trust.LoadRuns to error on the oversized line")
+	}
+	if len(runs) == 0 {
+		t.Fatal("test fixture bug: expected trust.LoadRuns to still return the one valid run parsed before the failure")
+	}
+
+	r, err := Build(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range r.Coverage.Categories {
+		if c.ID == "LLM09" {
+			if c.Status != Gap {
+				t.Errorf("LLM09 status = %q after a corrupted trust.jsonl, want Gap — Build is trusting partial/truncated data", c.Status)
+			}
+			return
+		}
+	}
+	t.Fatal("LLM09 category not found in Coverage.Categories")
 }
 
 // Panel numbers must come straight from ledger.Summarize/ByHeadRisk — no

--- a/internal/swarm/calibrated_judge.go
+++ b/internal/swarm/calibrated_judge.go
@@ -56,9 +56,21 @@ func (j *CalibratedJudge) Judge(_ context.Context, _ string, attempts []Attempt)
 	groups := clusterByAgreement(attempts, successful, j.equiv)
 	recordSwarmCoAgreement(j.domain, successful, attempts, j.equiv)
 
+	// Each successful attempt's LLR only ever takes one of two values — agree
+	// or disagree with whichever hypothesis is being scored — so both are
+	// precomputed once per attempt here instead of lambdaFor calling the
+	// calibrator (an RWMutex-guarded map lookup) once per (hypothesis, attempt)
+	// pair: O(N) lookups total instead of O(N×K) for K hypotheses.
+	llrTrue := make(map[int]float64, len(successful))
+	llrFalse := make(map[int]float64, len(successful))
+	for _, idx := range successful {
+		llrTrue[idx] = j.cal.LLR(attempts[idx].Head.ID, j.domain, true)
+		llrFalse[idx] = j.cal.LLR(attempts[idx].Head.ID, j.domain, false)
+	}
+
 	lambda := make([]float64, len(groups))
 	for k := range groups {
-		lambda[k] = j.lambdaFor(groups[k], successful, attempts)
+		lambda[k] = j.lambdaFor(groups[k], successful, attempts, llrTrue, llrFalse)
 	}
 
 	best := 0
@@ -71,7 +83,7 @@ func (j *CalibratedJudge) Judge(_ context.Context, _ string, attempts []Attempt)
 		return nil, fmt.Errorf("calibrated judge: no calibration data for any candidate in domain %q", j.domain)
 	}
 
-	winner := representative(groups[best], attempts, j.cal, j.domain)
+	winner := representative(groups[best], attempts, llrTrue)
 	probs := softmax(lambda)
 
 	scores := make([]int, len(attempts))
@@ -93,8 +105,9 @@ func (j *CalibratedJudge) Judge(_ context.Context, _ string, attempts []Attempt)
 }
 
 // lambdaFor computes Λ_k: every attempt votes agree/disagree with hypothesis,
-// weighted by its calibrated LLR, same-family repeats discounted.
-func (j *CalibratedJudge) lambdaFor(hypothesis agreementGroup, successful []int, attempts []Attempt) float64 {
+// weighted by its calibrated LLR (precomputed once per attempt by Judge, not
+// recomputed here), same-family repeats discounted.
+func (j *CalibratedJudge) lambdaFor(hypothesis agreementGroup, successful []int, attempts []Attempt, llrTrue, llrFalse map[int]float64) float64 {
 	inGroup := make(map[int]bool, len(hypothesis.members))
 	for _, idx := range hypothesis.members {
 		inGroup[idx] = true
@@ -102,7 +115,10 @@ func (j *CalibratedJudge) lambdaFor(hypothesis agreementGroup, successful []int,
 	seenFamily := map[string]bool{}
 	var lambda float64
 	for _, idx := range successful {
-		llr := j.cal.LLR(attempts[idx].Head.ID, j.domain, inGroup[idx])
+		llr := llrFalse[idx]
+		if inGroup[idx] {
+			llr = llrTrue[idx]
+		}
 		if fam := attempts[idx].Head.Provider; fam != "" {
 			if seenFamily[fam] {
 				llr *= trust.FamilyDiscount(trust.DefaultCoAgreementPath(), fam)
@@ -115,12 +131,14 @@ func (j *CalibratedJudge) lambdaFor(hypothesis agreementGroup, successful []int,
 }
 
 // representative breaks the tie among a hypothesis's equally-valid members by
-// individual evidence, then CapScore.
-func representative(g agreementGroup, attempts []Attempt, cal *trust.Calibrator, domain string) int {
+// individual evidence, then CapScore. llrTrue is Judge's precomputed
+// LLR(id, domain, true) per attempt — always the "true" branch here since
+// representative asks who best supports having actually said the right thing.
+func representative(g agreementGroup, attempts []Attempt, llrTrue map[int]float64) int {
 	best := g.members[0]
-	bestLLR := cal.LLR(attempts[best].Head.ID, domain, true)
+	bestLLR := llrTrue[best]
 	for _, idx := range g.members[1:] {
-		llr := cal.LLR(attempts[idx].Head.ID, domain, true)
+		llr := llrTrue[idx]
 		if llr > bestLLR || (llr == bestLLR && attempts[idx].Head.CapScore > attempts[best].Head.CapScore) {
 			best, bestLLR = idx, llr
 		}

--- a/internal/trust/coupling.go
+++ b/internal/trust/coupling.go
@@ -206,6 +206,80 @@ func FamilyCoupling(path, family string) (j float64, ok bool) {
 	return j, true
 }
 
+// FamilyCouplingResult is one family's measured coupling, as returned by
+// AllFamilyCoupling. Warn mirrors FalseConsensusWarning's threshold check
+// (OK && J >= criticalCoupling) so callers don't need criticalCoupling
+// exported to reproduce it themselves.
+type FamilyCouplingResult struct {
+	J    float64
+	OK   bool
+	Warn bool
+}
+
+// AllFamilyCoupling computes FamilyCoupling for every family observed in the
+// co-agreement log in a single pass, instead of the F full rescans a caller
+// gets from calling FamilyCoupling once per KnownFamilies entry (every real
+// caller of FalseConsensusWarning does exactly that today).
+//
+// The key simplification: family F's "diff" bucket (rate at which anything
+// NOT a same-F pair agrees) is, by construction, every pair that isn't a
+// same-F pair — so diffTotal[F] = (all pairs) - sameTotal[F], and likewise
+// for the agreed counts. That means one global pass collecting each family's
+// own same-family tally, plus one grand total, is enough to derive every
+// family's J — no per-family rescan needed.
+func AllFamilyCoupling(path string) map[string]FamilyCouplingResult {
+	type tally struct{ sameAgree, sameTotal int }
+	same := map[string]*tally{}
+	var totalPairs, totalAgree int
+
+	for _, r := range loadCoAgreement(path) {
+		for i := 0; i < len(r.Sources); i++ {
+			for k := i + 1; k < len(r.Sources); k++ {
+				a, b := r.Sources[i], r.Sources[k]
+				agreed := a.Cluster == b.Cluster
+				totalPairs++
+				if agreed {
+					totalAgree++
+				}
+				if a.Family == b.Family {
+					t := same[a.Family]
+					if t == nil {
+						t = &tally{}
+						same[a.Family] = t
+					}
+					t.sameTotal++
+					if agreed {
+						t.sameAgree++
+					}
+				}
+			}
+		}
+	}
+
+	out := make(map[string]FamilyCouplingResult, len(same))
+	for fam, t := range same {
+		if t.sameTotal < minCoAgreementSamples {
+			out[fam] = FamilyCouplingResult{}
+			continue
+		}
+		sameRate := float64(t.sameAgree) / float64(t.sameTotal)
+		diffTotal := totalPairs - t.sameTotal
+		diffRate := 0.0
+		if diffTotal > 0 {
+			diffRate = float64(totalAgree-t.sameAgree) / float64(diffTotal)
+		}
+		j := sameRate - diffRate
+		switch {
+		case j < 0:
+			j = 0
+		case j > 1:
+			j = 1
+		}
+		out[fam] = FamilyCouplingResult{J: j, OK: true, Warn: j >= criticalCoupling}
+	}
+	return out
+}
+
 // FamilyDiscount replaces the flat correlation constant: 1-J, so a family
 // with no measured excess correlation (J=0) is not discounted at all, and a
 // family whose members are nearly always identical (J→1) contributes almost

--- a/internal/trust/coupling_test.go
+++ b/internal/trust/coupling_test.go
@@ -142,6 +142,51 @@ func TestFamilyCoupling_NoExcessAgreementMeasuresNearZero(t *testing.T) {
 	}
 }
 
+// AllFamilyCoupling derives every family's J by complementation (diff bucket
+// = all pairs minus this family's own same-family pairs) instead of rescanning
+// the log once per family. It must agree exactly with calling FamilyCoupling
+// per family — three families (not two) is the minimum shape that actually
+// exercises the "every other family counts toward MY cross-family baseline"
+// case the complementation trick depends on.
+func TestAllFamilyCoupling_MatchesPerFamilyFamilyCoupling(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "coagreement.jsonl")
+	for i := 0; i < minCoAgreementSamples; i++ {
+		aAnswer, bAnswer := "x", "x"
+		if i%3 == 0 {
+			bAnswer = "y" // famA's two members occasionally disagree
+		}
+		cAnswer, dAnswer := "x", "x"
+		if i%2 == 0 {
+			dAnswer = "y" // famB's two members disagree half the time
+		}
+		RecordCoAgreement(path, "go",
+			[]string{"a1", "a2", "b1", "b2", "c1", "c2"},
+			[]string{"famA", "famA", "famB", "famB", "famC", "famC"},
+			[]string{aAnswer, bAnswer, cAnswer, dAnswer, "x", "y"}, // famC's two members always disagree
+			TextEquivalence)
+	}
+
+	all := AllFamilyCoupling(path)
+	for _, fam := range []string{"famA", "famB", "famC"} {
+		wantJ, wantOK := FamilyCoupling(path, fam)
+		got, present := all[fam]
+		if !present {
+			t.Fatalf("%s: missing from AllFamilyCoupling's result", fam)
+		}
+		if got.OK != wantOK {
+			t.Errorf("%s: AllFamilyCoupling.OK=%v, FamilyCoupling ok=%v", fam, got.OK, wantOK)
+			continue
+		}
+		if wantOK && math.Abs(got.J-wantJ) > 1e-9 {
+			t.Errorf("%s: AllFamilyCoupling.J=%.6f, FamilyCoupling J=%.6f — batched computation diverged from the per-family one", fam, got.J, wantJ)
+		}
+		wantWarn := wantOK && wantJ >= criticalCoupling
+		if got.Warn != wantWarn {
+			t.Errorf("%s: AllFamilyCoupling.Warn=%v, want %v", fam, got.Warn, wantWarn)
+		}
+	}
+}
+
 func TestKnownFamilies_ReturnsDistinctSortedNames(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "coagreement.jsonl")
 	RecordCoAgreement(path, "go", []string{"a", "b"}, []string{"zeta", "alpha"}, []string{"x", "y"}, TextEquivalence)

--- a/internal/trust/sprt.go
+++ b/internal/trust/sprt.go
@@ -108,11 +108,27 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 	A := math.Log((1 - alpha) / alpha)
 	B := -A
 
-	// Sample most-evidence-per-dollar first.
-	order := append([]Source(nil), sources...)
-	sort.SliceStable(order, func(i, j int) bool {
-		return evidencePerCost(cal, order[i], task.Domain) > evidencePerCost(cal, order[j], task.Domain)
+	// Sample most-evidence-per-dollar first. Score is computed once per source
+	// (decorate-sort-undecorate), not inside the comparator: evidencePerCost
+	// takes the calibrator's lock and does two log() calls, so recomputing it
+	// per comparison turns an O(n) computation into O(n log n) lock
+	// acquisitions — real cost when Run is called thousands of times in a
+	// benchmark against a calibration that never changes mid-run.
+	type scoredSource struct {
+		src   Source
+		score float64
+	}
+	decorated := make([]scoredSource, len(sources))
+	for i, src := range sources {
+		decorated[i] = scoredSource{src: src, score: evidencePerCost(cal, src, task.Domain)}
+	}
+	sort.SliceStable(decorated, func(i, j int) bool {
+		return decorated[i].score > decorated[j].score
 	})
+	order := make([]Source, len(decorated))
+	for i, d := range decorated {
+		order[i] = d.src
+	}
 
 	res := &Result{Decision: DecisionStoppedOnBudget}
 	var lambda float64

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -72,6 +72,14 @@ type ckHead struct {
 	price float64
 	up    bool
 	color lipgloss.Color
+
+	// series/lastMS are ckSeriesFor(id, name)'s result, resolved once when the
+	// cockpit is built rather than by dash() on every render: the fallback
+	// match there is a case-fold + substring scan over every distinct model in
+	// the latency history, and neither m.heads nor m.metrics ever change after
+	// construction, so re-resolving it per frame bought nothing.
+	series []float64
+	lastMS int64
 }
 
 // Cockpit views. The name table is the single source of truth — deriving the
@@ -196,6 +204,9 @@ func NewCockpit() Cockpit {
 	pct := ckClaudePct()
 	secReport, _ := security.Build(probed.Heads) // best-effort: nil on error, handled by the view
 	metrics := ckLoadMetrics(pr)
+	for i := range heads {
+		heads[i].series, heads[i].lastMS = metrics.ckSeriesFor(heads[i].name, heads[i].id)
+	}
 	m := Cockpit{
 		mode:      "dispatch",
 		claudePct: pct,

--- a/internal/tui/cockpit_metrics.go
+++ b/internal/tui/cockpit_metrics.go
@@ -36,7 +36,18 @@ type ckMetrics struct {
 
 	// calibrator is nil when no calibration ledger exists yet.
 	calibrator *trust.Calibrator
+
+	// trustStats is nil when no SPRT run has ever been recorded. Loaded once
+	// here instead of by trustSummary() on every View() call — Bubble Tea
+	// calls View() after every Update(), including the 20Hz code-stream tick,
+	// so a per-render trust.jsonl read was up to 20 full re-reads a second.
+	trustStats *trust.Stats
 }
+
+// ckFixedSwarmN is the fixed-N swarm baseline trust.Aggregate compares the
+// real SPRT sample counts against (Aggregate's own fixedN parameter) — not a
+// windowing count; every recorded run is aggregated.
+const ckFixedSwarmN = 5
 
 // ckSparkWidth is how many samples a sparkline shows.
 const ckSparkWidth = 14
@@ -70,6 +81,10 @@ func ckLoadMetrics(pr *pricing.DB) ckMetrics {
 	}
 	if cal, err := trust.New(trust.DefaultPath()); err == nil {
 		m.calibrator = cal
+	}
+	if runs, err := trust.LoadRuns(trust.DefaultLogPath()); err == nil && len(runs) > 0 {
+		st := trust.Aggregate(runs, ckFixedSwarmN)
+		m.trustStats = &st
 	}
 	// graph.json is optional; a missing one simply means no blast radius.
 	if g, err := graph.Load(ckGraphPath()); err == nil {
@@ -166,9 +181,8 @@ func (m ckMetrics) ckBlastFor(file string) (radius float64, dependents int, kapp
 	if m.graph == nil || file == "" {
 		return 0, 0, 0, false
 	}
-	radius = m.graph.BlastRadiusForFile(file)
-	kappa = m.graph.PercolationFactor(file)
-	dependents = m.graph.DependentCountForFile(file)
+	impact := m.graph.Impact(file)
+	radius, kappa, dependents = impact.Radius, impact.Percolation, impact.Dependents
 	// A file absent from the graph yields the neutral radius; saying nothing is
 	// more honest than reporting a floor value as a measurement.
 	if radius <= 1.0 && dependents == 0 {

--- a/internal/tui/cockpit_metrics_test.go
+++ b/internal/tui/cockpit_metrics_test.go
@@ -197,7 +197,9 @@ func TestDashboard_HeadWithNoHistoryRendersDash(t *testing.T) {
 func TestDashboard_RendersRealLatency(t *testing.T) {
 	m := Cockpit{
 		w: 120, h: 30, ready: true, mode: "dispatch",
-		heads: []ckHead{{name: "busy", tier: 3, up: true, color: ckCyan}},
+		// series/lastMS mirror what NewCockpit resolves once via ckSeriesFor —
+		// dash() itself no longer re-matches against metrics.latency per render.
+		heads: []ckHead{{name: "busy", tier: 3, up: true, color: ckCyan, series: []float64{100, 500, 200, 900}, lastMS: 900}},
 		metrics: ckMetrics{
 			latency: map[string][]float64{"busy": {100, 500, 200, 900}},
 			lastMS:  map[string]int64{"busy": 900},

--- a/internal/tui/cockpit_views.go
+++ b/internal/tui/cockpit_views.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ankit373/hydra/internal/budget"
 	"github.com/ankit373/hydra/internal/security"
 	"github.com/ankit373/hydra/internal/tree"
-	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/util"
 )
 
@@ -89,11 +88,12 @@ func (m Cockpit) dash(w, h int) string {
 		name := lipgloss.NewStyle().Foreground(hd.color).Width(15).Render(truncate(hd.name, 15))
 
 		// Real latency history from cost.jsonl wall_ms — "—" for a head that
-		// has never run, rather than a zero-filled chart.
-		series, lastMS := m.metrics.ckSeriesFor(hd.name, hd.id)
+		// has never run, rather than a zero-filled chart. Resolved once per
+		// head in NewCockpit, not re-matched against every distinct model on
+		// every render.
 		spark := lipgloss.NewStyle().Foreground(hd.color).
-			Render(fmt.Sprintf("%-*s", ckSparkWidth, ckSpark(series)))
-		lat := ckDimS.Render(fmt.Sprintf("%7s", ckFmtMS(lastMS)))
+			Render(fmt.Sprintf("%-*s", ckSparkWidth, ckSpark(hd.series)))
+		lat := ckDimS.Render(fmt.Sprintf("%7s", ckFmtMS(hd.lastMS)))
 
 		// Calibrated diagnosticity (nats) where the trust ledger has data.
 		// Keyed by head ID: trust records sources as ids, not display names.
@@ -168,12 +168,11 @@ func (m Cockpit) dash(w, h int) string {
 // trustSummary renders real SPRT statistics, or says plainly that there are
 // none yet. It never invents a confidence figure.
 func (m Cockpit) trustSummary() string {
-	runs, err := trust.LoadRuns(trust.DefaultLogPath())
-	if err != nil || len(runs) == 0 {
+	st := m.metrics.trustStats
+	if st == nil {
 		return ckFaintS.Render("no SPRT runs recorded") + "\n " +
 			ckDimS.Render("`hyctl dispatch --confidence 0.95 …`")
 	}
-	st := trust.Aggregate(runs, 5)
 	return lipgloss.NewStyle().Foreground(ckCyan).Bold(true).
 		Render(fmt.Sprintf("%.2f", st.MeanFinalConf)) +
 		ckDimS.Render(fmt.Sprintf("  mean over %d run%s", st.Runs, plural(st.Runs))) + "\n " +


### PR DESCRIPTION
## Summary

Round 2 of the repo-wide algorithms/data-structures audit (#497, shipped in #498), this time going deeper on business-logic decision algorithms rather than correctness/I-O. Ran 5 parallel deep-dive audits (trust/graph, dispatch/rank/swarm, security/policy, cost/capabilities/pricing, TUI/CLI render logic), each briefed on exactly what #498 already fixed so nothing gets re-reported. Several findings were cross-confirmed by 2-3 independent audit passes (the SPRT/judge expensive-comparator pattern, the per-family coupling rescan) — strong signal they're real.

**After the initial round of fixes, ran a second pass of 5 independent adversarial reviewers specifically to re-check this PR's own diff for correctness** (not just "do tests pass" — each reviewer was told to re-derive the logic from scratch, hand-work concrete examples, and write/run throwaway probes to force edge cases). That pass found 3 real bugs and 2 test-coverage gaps in the initial fixes, all now fixed with regression tests (each verified to actually fail against the pre-fix code before being confirmed against the fix).

## Findings fixed (round 2 audit)

**Expensive-comparator / redundant-lookup patterns:**
- `trust.Run`'s sort comparator recomputed `evidencePerCost` (a locked calibrator lookup) twice per comparison — O(n log n) lookups instead of O(n). Fixed with the same decorate-sort-undecorate pattern `swarm.go`'s `rankByCalibratedScore` already used correctly.
- `calibrated_judge.go`'s `lambdaFor` recomputed the same attempt's LLR once per hypothesis group — O(N×K) instead of O(N).
- `trust.FamilyCoupling` was called once per family via a `KnownFamilies` loop, each re-scanning the entire co-agreement log — O(F) full rescans. `AllFamilyCoupling` derives every family's coupling in one pass via complementation.

**Redundant re-reads within one `Build()`/`Dispatch()` call:**
- `security.Build()` read the ledger file twice and `trust.jsonl` twice per run; both now share one load.
- `costCeilingCheck` and LLM10's coverage category both independently scanned `events` for the same predicate — now share one count.

**TUI render-loop cost** (Bubble Tea calls `View()` on every tick, including a 20Hz code-stream animation):
- `trustSummary()` re-read all of `trust.jsonl` on every render; `dash()`'s per-head latency match re-ran its fallback scan every render. Both resolved once now.

**Multi-resolution per query:**
- `hyctl graph blast` (and 2 other callers) each resolved a file's graph seed set up to 5 times and ran the dependents BFS twice. New `Graph.Impact(file)` resolves once.
- `incident.go`'s `scoreImpact` did an O(events × blast.Files) linear scan per incident; now an O(1) map lookup via a path index.

**New caches** (mtime+size-keyed, same pattern #498 introduced): `config.Breadcrumb()`, `capabilities.Load()`, `internal/glob.Match`'s pattern splits.

**Smaller fixes:** `rank.UITier` reflection→`strconv.Atoi`; `dispatch.go`'s fallback loop hoisted 7 redundant `UITier` calls per candidate to 1.

**Explicitly assessed and NOT changed:** `cost.go`'s `ByRun` dual-pass — deriving `Totals` from already-rounded per-group values risks a subtle rounding discrepancy in a money figure for negligible gain.

## Bugs found and fixed during adversarial re-review (new commits, on top of the above)

1. **`config.Breadcrumb`'s cache fingerprint never included the registry root (`home`)** — only `(filename, mtime, size)`. Two different `HYDRA_HOME` directories whose files happen to coincide on mtime+size (plausible on NFS/some CI runners/tmpfs) would silently collide and serve one home's cached hash to the other. Fixed by including `home` in the key; also stopped caching error results (a stale cached error can't self-heal). New test forces a real cross-home mtime+size collision and confirms the fingerprints still differ — verified it fails without the fix.
2. **`capabilities.Load`'s cache had the same "don't cache errors" gap** — a malformed overlay JSON error, once cached, could mask a same-byte-length fix indefinitely (`SaveOverlay` isn't atomic, so this is realistic). New test forces the collision via `os.Chtimes` — verified it fails without the fix.
3. **`security.Build()` discarded `trust.LoadRuns`'s error entirely**, but `LoadRuns` can return a partial non-nil slice *alongside* an error (a scan failure partway through a corrupted `trust.jsonl`). Before the round-2 refactor, any load error always meant "Gap" for the LLM09 coverage category; after it, a partial slice could flip that to a false "Configured". Fixed by normalizing to nil on error. New test writes a valid run followed by an oversized line to force `bufio.Scanner`'s `ErrTooLong`, confirming `Build()` still reports Gap — verified it fails without the fix.
4. **Test-coverage gap**: `TestImpact_MatchesSeparateCalls` only ran against a subcritical graph, where the percolation-lift arithmetic never executes (trivially 1.0 everywhere) — it couldn't have caught a copy/paste bug in that arithmetic. Added a second case against a supercritical hub file.
5. **Test-coverage gap**: no `incident.go` test exercised `scoreImpact`'s blast-radius scoring with a non-empty `BlastReport`, so the multi-event-accumulation behavior the round-2 refactor preserved had zero coverage. Added a test comparing one vs. two qualifying-file touches — verified it fails against the old break-based behavior.

One of the review agents also accidentally deleted an untracked build artifact (`desktop/build/darwin/Info.dev.plist`, a Wails dev-build file) while cleaning up its own throwaway test files. Recovered it from two independent leftover worktrees (byte-identical between them) rather than regenerating it.

## Verification
- `go build ./...`, `go vet ./...` clean.
- `go test -race -count=1 ./...` (cache-cleared, fresh run) — zero new regressions; every failure present is identical to the pre-existing baseline (sandboxed HOME-dir isolation / blocked network egress), confirmed throughout via incremental per-package runs after each change, and independently re-confirmed by one of the review agents via an isolated worktree comparison against `origin/develop`.
- Every one of the 5 bugs/gaps found in adversarial review was fixed with a regression test that was verified to fail against the pre-fix code and pass against the fix — not just written and trusted.

Closes #499