### PR TITLE
fix: pricing list JSON/tier gaps and models sync overlay-idempotency bugs

### DIFF
--- a/cmd/hydra/cli_data_test.go
+++ b/cmd/hydra/cli_data_test.go
@@ -644,6 +644,115 @@ func TestCLI_Models_AddListRemoveRoundTrips(t *testing.T) {
 	}
 }
 
+// `models add` on an id that already exists in the embedded built-in catalog
+// silently shadowed it with the same "added X" phrasing whether X was
+// brand-new or a full override of a curated, heavily-routed identity like
+// "claude" (#505). This must read differently from a routine add.
+func TestCLI_ModelsAdd_WarnsWhenShadowingABuiltin(t *testing.T) {
+	populated(t)
+
+	out, cobraOut, err := run(t, "models", "add", "claude",
+		"--name", "Claude (tuned)", "--provider", "anthropic", "--cap-score", "50")
+	if err != nil {
+		t.Fatalf("`hyctl models add claude` failed: %v (%s)", err, cobraOut)
+	}
+	combined := out + cobraOut
+	if !strings.Contains(combined, "overriding built-in") {
+		t.Errorf("overriding a built-in id printed the generic message, not a distinct "+
+			"warning:\n%s", combined)
+	}
+
+	// A brand-new id must still get the ordinary phrasing.
+	out, cobraOut, err = run(t, "models", "add", "kimi-k4", "--cap-score", "70")
+	if err != nil {
+		t.Fatalf("`hyctl models add kimi-k4` failed: %v (%s)", err, cobraOut)
+	}
+	combined = out + cobraOut
+	if strings.Contains(combined, "overriding built-in") {
+		t.Errorf("a brand-new model was reported as overriding a built-in:\n%s", combined)
+	}
+	if !strings.Contains(combined, "added") {
+		t.Errorf("a brand-new model add did not say it was added:\n%s", combined)
+	}
+}
+
+// `models sync` re-run used to look up "already known" against the embedded
+// catalog only, never the overlay — so a model the user had already synced
+// and hand-tuned via `models add` looked unrecognized and was silently
+// overwritten back to a fresh heuristic capScore on every re-run, all while
+// the printed message claimed it was "already known, skipped" (#505).
+func TestCLI_ModelsSync_DoesNotRevertUserTunedCapScore(t *testing.T) {
+	populated(t)
+	seedPricingCache(t, map[string]struct{ In, Out float64 }{
+		"testvendor/test-model-xyz": {1.0, 2.0},
+	})
+
+	// First sync imports it at the heuristic score.
+	if _, cobraOut, err := run(t, "models", "sync"); err != nil {
+		t.Fatalf("first `hyctl models sync` failed: %v (%s)", err, cobraOut)
+	}
+
+	// The user tunes it by hand afterwards.
+	if _, cobraOut, err := run(t, "models", "add", "testvendor/test-model-xyz",
+		"--provider", "testvendor", "--cap-score", "99"); err != nil {
+		t.Fatalf("`hyctl models add` failed: %v (%s)", err, cobraOut)
+	}
+
+	// Re-running sync must not revert the hand-tuned score, and must say so.
+	out, cobraOut, err := run(t, "models", "sync")
+	if err != nil {
+		t.Fatalf("second `hyctl models sync` failed: %v (%s)", err, cobraOut)
+	}
+	combined := out + cobraOut
+	if !strings.Contains(combined, "1 already known, skipped") {
+		t.Errorf("sync did not report the user-tuned model as already known:\n%s", combined)
+	}
+
+	listOut, listCobra, err := run(t, "models", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []struct {
+		ID       string `json:"id"`
+		CapScore int    `json:"capScore"`
+	}
+	if err := json.Unmarshal([]byte(listOut), &entries); err != nil {
+		t.Fatalf("models list --json did not parse: %v (%s)", err, listOut+listCobra)
+	}
+	found := false
+	for _, e := range entries {
+		if e.ID == "testvendor/test-model-xyz" {
+			found = true
+			if e.CapScore != 99 {
+				t.Errorf("capScore = %d after re-sync, want 99 (the user's tuning) — "+
+					"sync silently reverted it", e.CapScore)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("synced model missing from `models list` entirely")
+	}
+}
+
+// seedPricingCache writes a fresh pricing_cache.json so `pricing.Load()` sees
+// live OpenRouter-shaped data without reaching the network.
+func seedPricingCache(t *testing.T, models map[string]struct{ In, Out float64 }) {
+	t.Helper()
+	m := make(map[string]map[string]float64, len(models))
+	for id, p := range models {
+		m[id] = map[string]float64{"input_per_mtok": p.In, "output_per_mtok": p.Out}
+	}
+	raw, err := json.Marshal(map[string]any{
+		"fetched_at": time.Now().UTC().Format(time.RFC3339),
+		"source":     "test",
+		"models":     m,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed(t, "pricing_cache.json", string(raw))
+}
+
 // ── oracle ────────────────────────────────────────────────────────────────────
 
 // An oracle is a high-D evidence source — its verdict can outweigh several
@@ -868,6 +977,73 @@ func TestCLI_PricingList_WorksOffline(t *testing.T) {
 	none, noneCobra, err := run(t, "pricing", "list", "definitely-not-a-model-xyz")
 	if err == nil && strings.TrimSpace(none+noneCobra) == "" {
 		t.Error("a filter matching nothing printed nothing at all")
+	}
+}
+
+// `pricing list --json` used to emit `null` (a nil slice) instead of `[]` when
+// a filter matched nothing — valid JSON, but a script/agent iterating the
+// result as an array breaks on it (#505). docs/pricing.md exists precisely
+// because this output is meant to be machine-consumed.
+func TestCLI_PricingListJSON_EmitsEmptyArrayNotNullWhenNothingMatches(t *testing.T) {
+	populated(t)
+
+	out, cobraOut, err := run(t, "pricing", "list", "--json", "definitely-not-a-model-xyz")
+	if err != nil {
+		t.Fatalf("`hyctl pricing list --json <no-match>` failed: %v (%s)", err, cobraOut)
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "null" {
+		t.Fatalf("emitted the literal null; a script iterating this as an array panics:\n%s", out)
+	}
+	var v []any
+	if err := json.Unmarshal([]byte(trimmed), &v); err != nil {
+		t.Fatalf("not a JSON array: %v\n%s", err, trimmed)
+	}
+	if v == nil {
+		t.Error("json.Unmarshal produced a nil slice — the wire form was null, not []")
+	}
+	if len(v) != 0 {
+		t.Errorf("got %d rows for a filter that should match nothing: %v", len(v), v)
+	}
+}
+
+// `pricing list` used to only walk the OpenRouter-fetched map, so CLI-agent
+// heads (claude-core, opus-thinking, …) — priced from registry/pricing.yaml,
+// keyed by tier rather than a model name — could never appear here at all,
+// and a fresh/offline install showed a fully empty table (#505).
+func TestCLI_PricingList_MergesTierPricing(t *testing.T) {
+	populated(t)
+
+	out, cobraOut, err := run(t, "pricing", "list", "claude-core")
+	if err != nil {
+		t.Fatalf("`hyctl pricing list claude-core` failed: %v (%s)", err, cobraOut)
+	}
+	if !strings.Contains(out+cobraOut, "claude-core") {
+		t.Fatalf("tier-based pricing for claude-core never showed up:\n%s", out+cobraOut)
+	}
+
+	jsonOut, jsonCobra, err := run(t, "pricing", "list", "--json")
+	if err != nil {
+		t.Fatalf("`hyctl pricing list --json` failed: %v (%s)", err, jsonCobra)
+	}
+	var rows []struct {
+		Model  string `json:"model"`
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal([]byte(jsonOut), &rows); err != nil {
+		t.Fatalf("not valid JSON: %v\n%s", err, jsonOut)
+	}
+	var sawTier bool
+	for _, r := range rows {
+		if r.Model == "claude-core" {
+			sawTier = true
+			if r.Source != "tier" {
+				t.Errorf("claude-core source = %q, want %q", r.Source, "tier")
+			}
+		}
+	}
+	if !sawTier {
+		t.Fatalf("claude-core is absent from `pricing list --json`:\n%s", jsonOut)
 	}
 }
 

--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -599,16 +599,21 @@ func TestCLI_PricingList_FilterAndJSON(t *testing.T) {
 
 	// The JSON surface must be an array even when the filter matches nothing —
 	// a jq pipeline iterating it should get zero elements, not a parse error.
+	// Tier pricing (registry/pricing.yaml, embedded) means this is never
+	// actually empty, but it must never be the literal `null` either (#505):
+	// see TestCLI_PricingListJSON_EmitsEmptyArrayNotNullWhenNothingMatches for
+	// the filtered-to-nothing case this used to regress on.
 	out, _, err := run(t, "pricing", "list", "--json")
 	if err != nil {
 		t.Fatalf("`pricing list --json` failed: %v", err)
 	}
 	trimmed := strings.TrimSpace(out)
-	if trimmed != "null" {
-		var rows []map[string]any
-		if jerr := json.Unmarshal([]byte(trimmed), &rows); jerr != nil {
-			t.Fatalf("not a JSON array: %v\n%s", jerr, trimmed)
-		}
+	if trimmed == "null" {
+		t.Fatal("emitted the literal null instead of a JSON array")
+	}
+	var rows []map[string]any
+	if jerr := json.Unmarshal([]byte(trimmed), &rows); jerr != nil {
+		t.Fatalf("not a JSON array: %v\n%s", jerr, trimmed)
 	}
 
 	// A filter narrows the table rather than emptying it.
@@ -1009,6 +1014,48 @@ func TestCLI_Probe_JSONIsValidAndMarksRoutability(t *testing.T) {
 	}
 	if !sawUnroutable {
 		t.Error("the unroutable ollama binary is missing from --json output")
+	}
+}
+
+// A corrupted ~/.hydra/models.json overlay makes capabilities.Load fail, which
+// the cli/env/port providers treat as "this whole provider found nothing" —
+// by design, so one broken provider doesn't block the others. But that used to
+// be completely invisible: every head that provider would have found just
+// vanished with no `✗` and no reason, contradicting probe's own "marks
+// unroutable heads with the reason" promise (#248). This drives that failure
+// end to end and checks the warning actually surfaces (#505).
+func TestCLI_Probe_SurfacesACorruptedOverlayAsAWarning(t *testing.T) {
+	s, _ := dispatchable(t, "answered")
+
+	overlay := filepath.Join(s.HydraHome, "models.json")
+	if err := os.WriteFile(overlay, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, cobraOut, err := run(t, "probe")
+	if err != nil {
+		t.Fatalf("`hyctl probe` failed: %v (%s)", err, cobraOut)
+	}
+	combined := out + cobraOut
+	if !strings.Contains(combined, "cli") {
+		t.Errorf("no warning naming the failing provider:\n%s", combined)
+	}
+	if strings.Contains(combined, "cody") {
+		t.Errorf("cody (found by the broken cli provider) should not appear at all:\n%s", combined)
+	}
+
+	jsonOut, jsonCobra, err := run(t, "probe", "--json")
+	if err != nil {
+		t.Fatalf("`hyctl probe --json` failed: %v (%s)", err, jsonCobra)
+	}
+	var parsed struct {
+		Warnings []string `json:"warnings"`
+	}
+	if err := json.Unmarshal([]byte(jsonOut+jsonCobra), &parsed); err != nil {
+		t.Fatalf("probe --json did not parse: %v\n%s", err, jsonOut+jsonCobra)
+	}
+	if len(parsed.Warnings) == 0 {
+		t.Fatal("probe --json reported no warnings for a provider that failed outright")
 	}
 }
 

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -328,11 +328,23 @@ func cmdProbe() *cobra.Command {
 						Routable: why == "", UnroutableReason: why,
 					}
 				}
+				warnings := result.Warnings
+				if warnings == nil {
+					warnings = []string{}
+				}
 				return json.NewEncoder(os.Stdout).Encode(map[string]any{
-					"cortex": cortexName, "heads": heads,
+					"cortex": cortexName, "heads": heads, "warnings": warnings,
 				})
 			}
 			fmt.Println(tui.Splash(cortexName))
+			// A provider that failed outright (e.g. a corrupted models.json
+			// overlay) doesn't even reach the unroutable-head accounting below —
+			// its heads never existed here — so without this it degrades to a
+			// silently smaller head list, contradicting probe's own "marks
+			// unroutable heads with the reason" promise (#248).
+			for _, w := range result.Warnings {
+				fmt.Printf("  %s %s\n", warnStyle.Render("⚠"), dimStyle.Render(w))
+			}
 			if len(result.Heads) == 0 {
 				fmt.Println("  No models found.")
 				return nil
@@ -1734,15 +1746,29 @@ func cmdModels() *cobra.Command {
 			if e.Name == "" {
 				e.Name = args[0]
 			}
+
+			// Check against the built-in catalog alone (no overlay) — this is
+			// "does this id shadow a curated entry", which is a different
+			// question from AddModel's "did the overlay already have it".
+			builtin, err := capabilities.Load("")
+			if err != nil {
+				return err
+			}
+			prior, overridesBuiltin := builtin.Entry(args[0])
+
 			replaced, err := capabilities.AddModel(overlay, e)
 			if err != nil {
 				return err
 			}
-			verb := "added"
-			if replaced {
-				verb = "updated"
+			switch {
+			case overridesBuiltin:
+				fmt.Printf("  overriding built-in model %s (was: %s, score %d) → %s, score %d in %s\n",
+					e.ID, prior.Provider, prior.CapScore, e.Provider, e.CapScore, overlay)
+			case replaced:
+				fmt.Printf("  updated %s (%s, score %d) → %s\n", e.ID, e.Provider, e.CapScore, overlay)
+			default:
+				fmt.Printf("  added %s (%s, score %d) → %s\n", e.ID, e.Provider, e.CapScore, overlay)
 			}
-			fmt.Printf("  %s %s (%s, score %d) → %s\n", verb, e.ID, e.Provider, e.CapScore, overlay)
 			return nil
 		},
 	}
@@ -1788,13 +1814,20 @@ func cmdModels() *cobra.Command {
 					"check network access")
 			}
 			added, skipped := 0, 0
-			builtin, _ := capabilities.Load("")
+			// Must include the overlay, not just the embedded catalog — otherwise
+			// a model the user already synced and hand-tuned via `models add`
+			// looks "unknown" here and gets silently overwritten back to a fresh
+			// heuristic capScore on every re-run (#505).
+			known, err := capabilities.Load(overlay)
+			if err != nil {
+				return err
+			}
 			for _, id := range models {
 				if syncFilter != "" && !strings.Contains(strings.ToLower(id), strings.ToLower(syncFilter)) {
 					continue
 				}
 				// Don't clobber a model already known (built-in or user).
-				if builtin.Name(id) != id {
+				if known.Source(id) != "" {
 					skipped++
 					continue
 				}
@@ -2766,36 +2799,46 @@ func cmdPricingList() *cobra.Command {
 			// Hoist filter once — db.Models() is already sorted.
 			filter := strings.ToLower(strings.Join(args, " "))
 
-			if jsonOut {
-				type row struct {
-					Model            string  `json:"model"`
-					InputPerMillion  float64 `json:"input_per_mtok"`
-					OutputPerMillion float64 `json:"output_per_mtok"`
-				}
-				var rows []row
-				for _, m := range db.Models() {
-					if filter != "" && !strings.Contains(m, filter) {
-						continue
-					}
-					p, _ := db.ModelPrice(m)
-					rows = append(rows, row{m, p.InputPerMillion, p.OutputPerMillion})
-				}
-				return json.NewEncoder(os.Stdout).Encode(rows)
+			type row struct {
+				Model            string  `json:"model"`
+				InputPerMillion  float64 `json:"input_per_mtok"`
+				OutputPerMillion float64 `json:"output_per_mtok"`
+				Source           string  `json:"source"` // "openrouter" or "tier"
 			}
-
-			fmt.Fprintf(os.Stdout, "%-55s  %10s  %11s\n", "Model", "In $/1M", "Out $/1M")
-			fmt.Fprintln(os.Stdout, strings.Repeat("─", 82))
-			count := 0
+			// Must start as [] not nil: JSON-encoded nil is `null`, and a script
+			// treating this as an array (docs/pricing.md's whole audience) breaks
+			// on a filter that matches nothing (#505).
+			rows := []row{}
 			for _, m := range db.Models() {
 				if filter != "" && !strings.Contains(m, filter) {
 					continue
 				}
 				p, _ := db.ModelPrice(m)
-				fmt.Fprintf(os.Stdout, "%-55s  %10.4f  %11.4f\n",
-					m, p.InputPerMillion, p.OutputPerMillion)
-				count++
+				rows = append(rows, row{m, p.InputPerMillion, p.OutputPerMillion, "openrouter"})
 			}
-			if count == 0 {
+			// Tier pricing is what prices CLI-agent heads (claude-core,
+			// opus-thinking, …) — they never appear in OpenRouter's catalog, so
+			// without this merge they can never show up here at all, and a
+			// fresh/offline install (no cache, no network) shows a fully empty
+			// table instead of the tier fallback that's actually pricing calls.
+			for _, te := range db.TierEntries() {
+				if filter != "" && !strings.Contains(strings.ToLower(te.ID), filter) {
+					continue
+				}
+				rows = append(rows, row{te.ID, te.InputPerMillion, te.OutputPerMillion, "tier"})
+			}
+
+			if jsonOut {
+				return json.NewEncoder(os.Stdout).Encode(rows)
+			}
+
+			fmt.Fprintf(os.Stdout, "%-45s  %10s  %11s  %s\n", "Model", "In $/1M", "Out $/1M", "Source")
+			fmt.Fprintln(os.Stdout, strings.Repeat("─", 82))
+			for _, r := range rows {
+				fmt.Fprintf(os.Stdout, "%-45s  %10.4f  %11.4f  %s\n",
+					r.Model, r.InputPerMillion, r.OutputPerMillion, r.Source)
+			}
+			if len(rows) == 0 {
 				fmt.Fprintln(os.Stdout, "(no models matched)")
 			}
 			return nil

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -113,6 +113,16 @@ func (db *DB) Name(id string) string {
 	return id
 }
 
+// Entry returns the full capability record for id — built-in or user overlay —
+// and whether it was found. Score/Name/Source each expose one field of this;
+// callers that need to know what an id already resolves to before changing it
+// (e.g. `models add` warning it is about to shadow a curated built-in) want
+// the whole record, not one field at a time.
+func (db *DB) Entry(id string) (Entry, bool) {
+	e, ok := db.index[id]
+	return e, ok
+}
+
 // Source returns id's capability entry's provenance — "builtin" for the
 // embedded, curated catalog, "user" for one added via the runtime overlay
 // (`hyctl models add`), or "" if id matched neither and fell to DefaultScore.

--- a/internal/capabilities/capabilities_test.go
+++ b/internal/capabilities/capabilities_test.go
@@ -100,6 +100,33 @@ func TestEntries_MarksSourceAndSorts(t *testing.T) {
 	}
 }
 
+// Entry is what a caller needs before overwriting an id — e.g. `models add`
+// warning it is about to shadow a curated built-in — since Score/Name/Source
+// each expose only one field of the record it would need to report on.
+func TestEntry_ReturnsTheFullRecordBuiltinAndUser(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "models.json")
+	if _, err := AddModel(path, Entry{ID: "kimi-k2", Name: "Kimi K2", Provider: "moonshot", CapScore: 82}); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claude, ok := db.Entry("claude")
+	if !ok || claude.Provider != "anthropic" || claude.Source != "builtin" {
+		t.Errorf("Entry(claude) = %+v, ok=%v, want the built-in anthropic record", claude, ok)
+	}
+	kimi, ok := db.Entry("kimi-k2")
+	if !ok || kimi.Provider != "moonshot" || kimi.Source != "user" {
+		t.Errorf("Entry(kimi-k2) = %+v, ok=%v, want the user-added moonshot record", kimi, ok)
+	}
+	if _, ok := db.Entry("never-heard-of-it"); ok {
+		t.Error("Entry(unknown) reported found")
+	}
+}
+
 // Source is the "managed vs. discovered" signal a security dashboard reports
 // on — a user-added model must be distinguishable from an embedded one.
 func TestSource_DistinguishesUserFromBuiltin(t *testing.T) {

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -20,8 +20,19 @@ type ModelPrice struct {
 
 // TierPrice holds per-million-token rates for one tier (from pricing.yaml).
 type TierPrice struct {
+	ID               string  `yaml:"id"`
 	InputPerMillion  float64 `yaml:"input_per_million"`
 	OutputPerMillion float64 `yaml:"output_per_million"`
+}
+
+// TierEntry is one tier's fallback pricing, identified by its registry id
+// (e.g. "claude-core") rather than a tier number — the form callers that
+// merge it alongside OpenRouter model rows want.
+type TierEntry struct {
+	Tier             int
+	ID               string
+	InputPerMillion  float64
+	OutputPerMillion float64
 }
 
 // DB is the live pricing store. Load it once at startup with Load().
@@ -141,6 +152,23 @@ func (db *DB) TierPrice(tier int) (TierPrice, bool) {
 // Returns false when pricing.yaml was missing or unreadable.
 func (db *DB) HasTiers() bool {
 	return len(db.tiers) > 0
+}
+
+// TierEntries returns every tier-based fallback price, sorted by tier number.
+// This is what prices the CLI-agent heads (claude-core, opus-thinking, …) that
+// never appear in OpenRouter's catalog — `pricing list` merges this in
+// alongside Models() so those heads are visible at all (#505).
+func (db *DB) TierEntries() []TierEntry {
+	out := make([]TierEntry, 0, len(db.tiers))
+	for tier, tp := range db.tiers {
+		if tp.ID == "" {
+			continue
+		}
+		out = append(out, TierEntry{Tier: tier, ID: tp.ID,
+			InputPerMillion: tp.InputPerMillion, OutputPerMillion: tp.OutputPerMillion})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Tier < out[j].Tier })
+	return out
 }
 
 func cost(inputPerM, outputPerM float64, inputTokens, outputTokens int) float64 {

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -129,6 +129,75 @@ func TestDB_Models_Sorted(t *testing.T) {
 	}
 }
 
+// ── DB.TierEntries ────────────────────────────────────────────────────────────
+
+// TierEntries is what lets `pricing list` show CLI-agent heads (claude-core,
+// opus-thinking, …) at all — they're keyed by tier number, not a model name,
+// so without this they can never appear in Models() (#505).
+func TestDB_TierEntries_SortedByTierNumber(t *testing.T) {
+	db := &DB{
+		models: map[string]ModelPrice{},
+		tiers: map[int]TierPrice{
+			3:  {ID: "sonnet-thinking", InputPerMillion: 3, OutputPerMillion: 15},
+			1:  {ID: "claude-core", InputPerMillion: 15, OutputPerMillion: 75},
+			10: {ID: "qwen-grunt", InputPerMillion: 0, OutputPerMillion: 0},
+		},
+	}
+	got := db.TierEntries()
+	if len(got) != 3 {
+		t.Fatalf("got %d entries, want 3: %+v", len(got), got)
+	}
+	wantOrder := []string{"claude-core", "sonnet-thinking", "qwen-grunt"}
+	for i, want := range wantOrder {
+		if got[i].ID != want {
+			t.Errorf("entry %d = %q, want %q (tier-ascending order)", i, got[i].ID, want)
+		}
+	}
+}
+
+// A tier with no id in pricing.yaml has nothing meaningful to show as a
+// "model" name in `pricing list` — it must be skipped, not surfaced as an
+// empty-string row.
+func TestDB_TierEntries_SkipsTiersWithNoID(t *testing.T) {
+	db := &DB{
+		models: map[string]ModelPrice{},
+		tiers: map[int]TierPrice{
+			1: {ID: "claude-core", InputPerMillion: 15, OutputPerMillion: 75},
+			2: {InputPerMillion: 1, OutputPerMillion: 2}, // no ID
+		},
+	}
+	got := db.TierEntries()
+	if len(got) != 1 || got[0].ID != "claude-core" {
+		t.Errorf("got %+v, want only the tier carrying an id", got)
+	}
+}
+
+func TestDB_TierEntries_EmptyWhenNoTiersLoaded(t *testing.T) {
+	db := &DB{models: map[string]ModelPrice{}, tiers: map[int]TierPrice{}}
+	got := db.TierEntries()
+	if len(got) != 0 {
+		t.Errorf("got %+v, want none", got)
+	}
+}
+
+// registry/pricing.yaml's own ids must round-trip through the YAML tag,
+// since `pricing list` keys tier rows off TierPrice.ID.
+func TestLoadFallbackTiers_CarriesTheRegistryID(t *testing.T) {
+	t.Setenv("HYDRA_HOME", t.TempDir())
+
+	tiers, err := loadFallbackTiers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp, ok := tiers[1]
+	if !ok {
+		t.Fatal("tier 1 missing")
+	}
+	if tp.ID != "claude-core" {
+		t.Errorf("tier 1 id = %q, want %q", tp.ID, "claude-core")
+	}
+}
+
 // ── OpenRouter fetch ──────────────────────────────────────────────────────────
 
 func TestFetchFromOpenRouter(t *testing.T) {

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -6,6 +6,8 @@ package probe
 
 import (
 	"context"
+	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/ankit373/hydra/internal/provider"
@@ -14,8 +16,9 @@ import (
 
 // Result is the output of a full machine scan.
 type Result struct {
-	Heads  []provider.Head // all discovered heads, ranked best → worst
-	Cortex *provider.Head  // highest-ranked head, recommended as Cortex
+	Heads    []provider.Head // all discovered heads, ranked best → worst
+	Cortex   *provider.Head  // highest-ranked head, recommended as Cortex
+	Warnings []string        // non-fatal provider failures — e.g. a corrupted models.json overlay
 }
 
 // Run concurrently queries every registered provider and returns a ranked Result.
@@ -32,6 +35,7 @@ func RunWith(ctx context.Context, providers []provider.Provider) *Result {
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	var all []provider.Head
+	var warnings []string
 
 	for _, p := range providers {
 		wg.Add(1)
@@ -46,6 +50,15 @@ func RunWith(ctx context.Context, providers []provider.Provider) *Result {
 
 			heads, err := p.Discover(ctx)
 			if err != nil {
+				// The failure itself must stay non-fatal — one broken provider
+				// (e.g. a corrupted ~/.hydra/models.json overlay) must not hide
+				// every other head — but silently dropping it entirely
+				// contradicts hyctl probe's own "✗ marks unroutable heads with
+				// the reason" promise (#248): this provider's heads don't even
+				// get that far. Recording it here is the only visible trace.
+				mu.Lock()
+				warnings = append(warnings, fmt.Sprintf("%s: %v", p.ID(), err))
+				mu.Unlock()
 				return
 			}
 			mu.Lock()
@@ -54,10 +67,13 @@ func RunWith(ctx context.Context, providers []provider.Provider) *Result {
 		}(p)
 	}
 	wg.Wait()
+	// Providers run concurrently, so append order is nondeterministic — sort so
+	// a repeated probe on the same broken machine reports the same order.
+	sort.Strings(warnings)
 
 	ranked := rank.ByCapScore(all)
 
-	r := &Result{Heads: ranked}
+	r := &Result{Heads: ranked, Warnings: warnings}
 	if len(ranked) > 0 {
 		r.Cortex = &ranked[0]
 	}

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -5,7 +5,9 @@ package probe
 import (
 	"context"
 	"errors"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -242,5 +244,56 @@ func TestRunWith_EachProviderIsAskedOnce(t *testing.T) {
 
 	if p.calls != 1 {
 		t.Errorf("provider called %d times, want 1", p.calls)
+	}
+}
+
+// A provider failure (e.g. cli/env/port's capabilities.Load choking on a
+// corrupted ~/.hydra/models.json overlay) must stay non-fatal — the documented
+// contract every other test in this file exercises — but silently dropping it
+// with no trace at all contradicts hyctl probe's own "✗ marks unroutable heads
+// with the reason" promise (#248): this provider's heads never even reached
+// that accounting. Warnings is the visible signal (#505).
+func TestRunWith_AFailingProviderIsRecordedAsAWarning(t *testing.T) {
+	good := &fakeProvider{id: "good", heads: []provider.Head{head("g", 70, false)}}
+	bad := &fakeProvider{id: "cli", err: errors.New("corrupted models.json overlay")}
+
+	res := RunWith(context.Background(), []provider.Provider{bad, good})
+
+	if len(res.Heads) != 1 || res.Heads[0].ID != "g" {
+		t.Fatalf("got %+v, want the one head from the working provider", res.Heads)
+	}
+	if len(res.Warnings) != 1 {
+		t.Fatalf("got %d warnings, want 1: %+v", len(res.Warnings), res.Warnings)
+	}
+	if !strings.Contains(res.Warnings[0], "cli") || !strings.Contains(res.Warnings[0], "corrupted models.json overlay") {
+		t.Errorf("warning = %q, want it to name the provider and the error", res.Warnings[0])
+	}
+}
+
+// A provider that returns no error must not manufacture a warning — Warnings
+// is specifically about failures, not an audit log of every provider run.
+func TestRunWith_NoWarningsWhenEveryProviderSucceeds(t *testing.T) {
+	res := RunWith(context.Background(), []provider.Provider{
+		&fakeProvider{id: "a", heads: []provider.Head{head("a1", 50, false)}},
+		&fakeProvider{id: "b"},
+	})
+	if len(res.Warnings) != 0 {
+		t.Errorf("got warnings %+v with no failing provider", res.Warnings)
+	}
+}
+
+// Warnings must be in a stable order despite concurrent providers, or a probe
+// run against the same broken machine twice would print differently each time.
+func TestRunWith_WarningsAreDeterministicallyOrdered(t *testing.T) {
+	res := RunWith(context.Background(), []provider.Provider{
+		&fakeProvider{id: "zzz", err: errors.New("boom")},
+		&fakeProvider{id: "aaa", err: errors.New("boom")},
+		&fakeProvider{id: "mmm", err: errors.New("boom")},
+	})
+	if len(res.Warnings) != 3 {
+		t.Fatalf("got %d warnings, want 3: %+v", len(res.Warnings), res.Warnings)
+	}
+	if !sort.StringsAreSorted(res.Warnings) {
+		t.Errorf("warnings not sorted: %+v", res.Warnings)
 	}
 }


### PR DESCRIPTION
## Summary

Five bugs found via adversarial QA on `hyctl pricing list` and `hyctl models add|list|remove|sync`:

- **`pricing list --json` emitted `null` instead of `[]`** when a filter matched nothing (a nil slice encoded through `encoding/json`) — breaks any script/agent treating the output as an array.
- **`pricing list` could never show tier-based fallback pricing.** It only walked `db.Models()` (the OpenRouter-fetched map), so CLI-agent heads (claude-core, opus-thinking, sonnet-thinking, ...) never appeared, and a fresh/offline install showed a fully empty table instead of the tier fallback that is actually pricing calls. Added `pricing.TierEntry` / `DB.TierEntries()` and merged it into the list output, labeled by a `source` column (`"openrouter"` / `"tier"`).
- **`models sync` was not idempotent.** Its "already known, skip" check only consulted the embedded builtin catalog, never the user overlay — so a model the user had already synced and hand-tuned via `models add` looked unrecognized on the next sync and was silently overwritten back to a fresh heuristic capScore, while the printed message claimed it was "already known, skipped". Now checks the overlay-merged DB (`capabilities.Load(overlay).Source(id)`).
- **A corrupted `models.json` overlay was silently swallowed everywhere.** `probe.RunWith` discarded a failing provider's error with no trace at all, contradicting probe's own "marks unroutable heads with the reason" promise (#248) — a corrupted `~/.hydra/models.json` overlay makes the cli/env/port providers' `Discover` fail outright, so every head they'd have found just vanished with no explanation. Added `Result.Warnings`, surfaced in both `hyctl probe` text and `--json` output, without changing the "one broken provider never blocks the rest" behavior.
- **`models add` on a builtin id gave misleading phrasing.** Adding an id that already exists in the built-in catalog printed the same "added X" message as a brand-new model, silently shadowing a curated, heavily-routed identity like `claude`. Added `capabilities.DB.Entry()` and a distinct "overriding built-in model ..." message.

## Changes
- `internal/pricing/pricing.go` — `TierEntry` type + `DB.TierEntries()`, `TierPrice.ID` (yaml `id` tag)
- `internal/capabilities/capabilities.go` — `DB.Entry()` lookup
- `internal/probe/probe.go` — `Result.Warnings`, populated on provider `Discover` failure
- `cmd/hydra/main.go` — `pricing list` merges tier entries + emits `[]` not `null`; `models sync` overlay-aware idempotency check; `models add` distinct builtin-override message; `hyctl probe` prints/emits warnings
- Tests: `internal/pricing/pricing_test.go`, `internal/capabilities/capabilities_test.go`, `internal/probe/probe_test.go`, `cmd/hydra/cli_data_test.go`, `cmd/hydra/cli_success_test.go`

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test -race ./internal/pricing/... ./internal/capabilities/... ./internal/probe/...` — all pass
- [x] `go test -race ./cmd/hydra/...` — passes except two pre-existing, unrelated baseline failures (`TestCLI_Dispatch_RefusesBadFlagsBeforeSpending/{confidence_of_zero,negative_confidence}`, `TestCLI_Dispatch_LocalOnlyRefusesWhenNothingIsLocal`), confirmed to fail identically on unmodified `develop` HEAD before any of this branch's changes — unrelated to `internal/dispatch`'s confidence-flag validation and local-only routing, out of scope for this fix

Closes #505