### PR TITLE
fix(dispatch): enforce pii local-only policy on the SPRT/swarm path

### DIFF
--- a/cmd/hydra/cli_data_test.go
+++ b/cmd/hydra/cli_data_test.go
@@ -109,6 +109,47 @@ func TestCLI_MCPLogAndReport_SurfaceFlaggedEvents(t *testing.T) {
 	}
 }
 
+// Agent/Tool are attacker/agent-controlled: any local MCP tool or misbehaving
+// agent can set them via `hyctl mcp record` or a real dispatch. `mcp log`
+// already sanitized them at render (util.SafeTerminal), but `mcp report`
+// printed them raw — and a control-heavy value forges a fake verdict line on
+// the terminal. Sanitizing once at Record ingest fixes both by construction,
+// so nobody has to remember to do it at every render site (#500).
+func TestCLI_MCPRecord_SanitizesEscapesForBothLogAndReport(t *testing.T) {
+	testutil.NewSandbox(t)
+
+	evilTool := "evil\x1b[2K\rFAKE OK no findings"
+	if _, cobraOut, err := run(t, "mcp", "record",
+		"--agent", "auditor", "--tool", evilTool,
+		"--resource", "/x", "--decision", "allow"); err != nil {
+		t.Fatalf("`hyctl mcp record` failed: %v (%s)", err, cobraOut)
+	}
+
+	logOut, logCobraOut, err := run(t, "mcp", "log")
+	if err != nil {
+		t.Fatalf("`hyctl mcp log` failed: %v", err)
+	}
+	logCombined := logOut + logCobraOut
+	if strings.Contains(logCombined, "\x1b[2K") || strings.Contains(logCombined, "\rFAKE OK") {
+		t.Errorf("`mcp log` printed a raw escape/CR sequence:\n%q", logCombined)
+	}
+	if !strings.Contains(logCombined, "FAKE OK") {
+		t.Errorf("`mcp log` lost the tool name's ordinary text entirely:\n%q", logCombined)
+	}
+
+	repOut, repCobraOut, err := run(t, "mcp", "report")
+	if err != nil {
+		t.Fatalf("`hyctl mcp report` failed: %v", err)
+	}
+	repCombined := repOut + repCobraOut
+	if strings.Contains(repCombined, "\x1b[2K") || strings.Contains(repCombined, "\rFAKE OK") {
+		t.Errorf("`mcp report` printed a raw escape/CR sequence — the exact defect #500 reports:\n%q", repCombined)
+	}
+	if !strings.Contains(repCombined, "FAKE OK") {
+		t.Errorf("`mcp report` lost the tool name's ordinary text entirely:\n%q", repCombined)
+	}
+}
+
 // `hyctl mcp verify-chain` is the tamper-evidence check over the ledger —
 // it must report intact after ordinary recording and confirm gate-ability
 // (a non-zero exit) when it isn't, matching the other ledger verify commands.

--- a/cmd/hydra/cli_more_test.go
+++ b/cmd/hydra/cli_more_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/testutil"
 )
 
@@ -107,6 +108,65 @@ func TestCLI_MCPRecordThenVerify_BindsParameters(t *testing.T) {
 	if code == 0 {
 		t.Errorf("verify passed on parameters that were never approved — the "+
 			"binding is not a binding:\n%s", out)
+	}
+}
+
+// `mcp verify` used to trust the on-disk parameters_hash verbatim: hand-edit
+// it to the hash of parameters that were never actually approved, and it
+// reported MATCH — only `mcp verify-chain` caught the tamper, and the two
+// were never composed. Recomputing/validating against the hash chain here
+// closes that (#500).
+func TestCLI_MCPVerify_DetectsTamperedParametersHash(t *testing.T) {
+	s := populated(t)
+
+	approved := `{"path":"/etc/hosts","mode":"read"}`
+	if code, out := runBinary(t, s, "mcp", "record",
+		"--tool", "fs.read", "--action", "read", "--decision", "allow",
+		"--resource", "/etc/hosts", "--agent", "test-agent",
+		"--params", approved); code != 0 {
+		t.Fatalf("`hyctl mcp record` exited %d:\n%s", code, out)
+	}
+
+	// Simulate an attacker hand-editing the ledger line: retarget
+	// parameters_hash to the hash of parameters that were never approved,
+	// without touching the event's own chain hash — exactly what a raw text
+	// edit (not a re-recording) would do.
+	malicious := map[string]any{"path": "/etc/shadow", "mode": "write"}
+	maliciousHash, err := ledger.HashParams(malicious)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerPath := filepath.Join(s.HydraHome, "mcp_ledger.jsonl")
+	raw, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	var evt map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &evt); err != nil {
+		t.Fatal(err)
+	}
+	evt["parameters_hash"] = maliciousHash
+	tamperedLine, err := json.Marshal(evt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines[len(lines)-1] = string(tamperedLine)
+	if err := os.WriteFile(ledgerPath, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Before #500 this reported MATCH: the malicious parameters hash exactly
+	// the (tampered) field on disk, and nothing checked the field itself was
+	// ever genuine.
+	maliciousParams := `{"path":"/etc/shadow","mode":"write"}`
+	code, out := runBinary(t, s, "mcp", "verify", "fs.read",
+		"--resource", "/etc/hosts", "--params", maliciousParams)
+	if code == 0 {
+		t.Errorf("verify MATCHed a hand-edited parameters_hash instead of detecting the broken chain:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "chain") {
+		t.Errorf("verify output does not explain the chain-tamper cause:\n%s", out)
 	}
 }
 

--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -176,6 +176,43 @@ func TestCLI_Dispatch_LocalOnlyRefusesWhenNothingIsLocal(t *testing.T) {
 	}
 }
 
+// The pii:local-only config policy must be enforced on the SPRT path exactly
+// like it is on the plain dispatch path, even though nobody passed --local.
+// Before #500, touchesPII alone routed a PII prompt into sw.RunSPRT with
+// LocalOnly bound only to --local, so it silently reached "cody" — a remote
+// CLI head — instead of being refused for lack of a local one.
+func TestCLI_Dispatch_PIIPolicyForcesLocalOnlyOnTheSPRTPath(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	if err := config.Save(&config.Config{
+		Cortex:   "cody",
+		Policies: map[string]config.Policy{"pii": {Action: "local-only"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	s.FakeBinary(t, "cody", testutil.EchoScript("cody's answer"))
+	// The sandbox clears $OLLAMA_HOST but an empty value falls back to the real
+	// default (localhost:11434) — on a machine that actually has Ollama running,
+	// the port provider would discover it for real and the test would pass for
+	// the wrong reason (a real local head, not the policy under test). Point it
+	// at a dead loopback port so the only local-only head is whichever tests set.
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:1")
+
+	// A PII-detecting prompt alone triggers the SPRT branch (RequiredConfidence
+	// derives a target > 0 from touchesPII), with no --confidence flag needed —
+	// exactly the reproduction in #500.
+	out, cobraOut, err := run(t, "dispatch", "my SSN is 123-45-6789")
+	combined := out + cobraOut
+	if err == nil {
+		t.Fatalf("a PII prompt reached a non-local head via the SPRT path despite pii:local-only:\n%s", combined)
+	}
+	if !strings.Contains(err.Error()+combined, "no heads available") {
+		t.Errorf("error = %v (%s), want the SPRT path to report no (local) heads available", err, combined)
+	}
+	if strings.Contains(combined, "cody's answer") {
+		t.Error("the remote head actually ran despite the pii:local-only policy")
+	}
+}
+
 // A swarm dry run must name the heads and the estimated cost without firing
 // anything — #167 made --dry-run mean the same thing in every mode.
 func TestCLI_Dispatch_SwarmDryRunFiresNothing(t *testing.T) {

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -628,6 +628,14 @@ func cmdDispatch() *cobra.Command {
 			// user explicitly asked for.
 			effectiveConf := confidence
 			touchesPII := policy.ContainsPII(policy.Request{Prompt: prompt})
+			// The plain dispatch path (d.Dispatch) reads cfg.Policies["pii"] itself
+			// and forces LocalOnly. The SPRT/swarm branches below take a shortcut
+			// straight past it and only ever saw --local — so a PII-touching prompt
+			// silently went out to remote heads the instant touchesPII made
+			// effectiveConf > 0 and picked one of those branches instead (#500).
+			if d.PIILocalOnly() && touchesPII {
+				localOnly = true
+			}
 			if file != "" || irreversible || production || touchesPII {
 				radius := 1.0
 				if file != "" {
@@ -1032,6 +1040,27 @@ func cmdMCP() *cobra.Command {
 			if !ok {
 				return fmt.Errorf("no allowed, parameter-bound ledger event for %s/%s — nothing to verify against", tool, verResource)
 			}
+
+			// A parameters_hash read straight off disk proves nothing if the
+			// ledger itself was edited after recording — comparing against it
+			// verbatim previously reported MATCH even on a hand-tampered hash.
+			// `verify-chain` already recomputes and links every chained event;
+			// compose it here so a broken chain refuses the approval instead of
+			// silently trusting it (#500). Approvals that predate hash-chaining
+			// (Hash == "") were never protected either way, so leave them as-is.
+			if approval.Hash != "" {
+				chain, err := ledger.VerifyChain(ledger.DefaultPath())
+				if err != nil {
+					return err
+				}
+				if !chain.Intact {
+					fmt.Printf("  %s  ledger hash chain is broken (event index %d) — the recorded "+
+						"approval cannot be trusted; refusing to verify against it. Run `hyctl mcp verify-chain` for details.\n",
+						strings.ToUpper(string(ledger.Deny)), chain.BrokenAt)
+					os.Exit(3)
+				}
+			}
+
 			match, err := ledger.VerifyParams(params, approval.ParametersHash)
 			if err != nil {
 				return err

--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -735,6 +735,41 @@ func TestNew_LoadsTheConfigAndArmsThePIIPolicy(t *testing.T) {
 	if action := dd.policy.Evaluate(policy.Request{Prompt: "SSN 123-45-6789", TierHint: "1"}); !action.LocalOnly {
 		t.Error("the pii=local-only config policy did not arm the local-only rule")
 	}
+	// Exported so cmd/hydra's SPRT/swarm dispatch branches — which bypass
+	// Dispatch entirely — can still enforce the same config policy (#500).
+	if !dd.PIILocalOnly() {
+		t.Error("PIILocalOnly() = false, want true for a pii:local-only config")
+	}
+}
+
+// PIILocalOnly is the single source of truth cmd/hydra's SPRT/swarm branches
+// rely on to fold the config policy into their own LocalOnly bool. A wrong
+// answer here reopens #500 regardless of what cmd/hydra does with it.
+func TestDispatcher_PIILocalOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{"no policies configured", &config.Config{}, false},
+		{"pii policy set to something else", &config.Config{
+			Policies: map[string]config.Policy{"pii": {Action: "budget-cap"}},
+		}, false},
+		{"unrelated policy present, pii absent", &config.Config{
+			Policies: map[string]config.Policy{"budget": {Action: "budget-cap"}},
+		}, false},
+		{"pii local-only armed", &config.Config{
+			Policies: map[string]config.Policy{"pii": {Action: "local-only"}},
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dd := &Dispatcher{cfg: tc.cfg}
+			if got := dd.PIILocalOnly(); got != tc.want {
+				t.Errorf("PIILocalOnly() = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }
 
 // writeStatePct seeds logs/state.json with a claude_pct and optional history.

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -94,6 +94,12 @@ type Dispatcher struct {
 // Heads returns the probed head list for external callers (e.g. swarm).
 func (d *Dispatcher) Heads() []provider.Head { return d.heads }
 
+// PIILocalOnly reports whether the configured pii policy forces local-only
+// routing. Exported so callers that bypass Dispatch — the SPRT/swarm branches
+// in cmd/hydra's cmdDispatch — can still enforce it instead of acting only on
+// --local, which was config-blind on that path (#500).
+func (d *Dispatcher) PIILocalOnly() bool { return piiLocalOnly(d.cfg) }
+
 // EstimateCost exposes per-tier cost estimation for external callers.
 func (d *Dispatcher) EstimateCost(tier, inputTokens, outputTokens int) float64 {
 	return d.estimateCost(tier, inputTokens, outputTokens)
@@ -139,6 +145,12 @@ func cachedProbe(ctx context.Context) *probe.Result {
 	return probeCacheResult
 }
 
+// piiLocalOnly reports whether cfg's pii policy forces local-only routing.
+func piiLocalOnly(cfg *config.Config) bool {
+	p, ok := cfg.Policies["pii"]
+	return ok && p.Action == "local-only"
+}
+
 // New builds a Dispatcher from the saved config and a (possibly cached) machine probe.
 func New(ctx context.Context) (*Dispatcher, error) {
 	cfg, err := config.Load()
@@ -147,11 +159,7 @@ func New(ctx context.Context) (*Dispatcher, error) {
 	}
 
 	result := cachedProbe(ctx)
-
-	localOnly := false
-	if p, ok := cfg.Policies["pii"]; ok && p.Action == "local-only" {
-		localOnly = true
-	}
+	localOnly := piiLocalOnly(cfg)
 
 	budgetReg := budget.NewRegistry(budget.LoadWindows(config.ScriptHome()))
 

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/policy"
+	"github.com/ankit373/hydra/internal/util"
 )
 
 // Action is the kind of access an agent attempts against a resource.
@@ -203,6 +204,15 @@ func DefaultPath() string {
 // (chainLock) — an in-process mutex alone can't stop two `hyctl` processes
 // from forking the hash chain.
 func Record(path string, e Event) error {
+	// Agent/Tool/Resource are supplied by whatever's on the other end of an MCP
+	// call — a local tool or a misbehaving agent — and every consumer (log,
+	// report, the TUI Security view) prints them. Sanitising once here, at the
+	// only place an event enters the ledger, makes every consumer safe by
+	// construction instead of each renderer needing its own escape-stripping (#500).
+	e.Agent = util.SafeTerminal(e.Agent)
+	e.Tool = util.SafeTerminal(e.Tool)
+	e.Resource = util.SafeTerminal(e.Resource)
+
 	if e.TS == "" {
 		e.TS = time.Now().UTC().Format(time.RFC3339)
 	}

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/ankit373/hydra/internal/testutil"
+	"github.com/ankit373/hydra/internal/util"
 )
 
 func TestRecord_StampsConfigBreadcrumbWhenBlank(t *testing.T) {
@@ -890,5 +891,60 @@ func TestRecord_ConcurrentCallsDoNotForkTheChain(t *testing.T) {
 	}
 	if res.Chained != n {
 		t.Errorf("Chained = %d, want %d", res.Chained, n)
+	}
+}
+
+// Agent/Tool/Resource are supplied by whatever's on the other end of an MCP
+// call — a local tool or a misbehaving agent — and every consumer (`mcp log`,
+// `mcp report`, the TUI Security view) prints them verbatim. A raw ESC[2K CR
+// in one of these fields erases the line it prints on and can forge a
+// verdict. Sanitising once at Record makes every consumer safe by
+// construction instead of each one needing its own escape-stripping (#500).
+func TestRecord_SanitizesFreeTextFieldsAtIngest(t *testing.T) {
+	cases := []struct {
+		name  string
+		event Event
+	}{
+		{"escape + carriage return forges a verdict line", Event{
+			Agent: "auditor", Tool: "evil\x1b[2K\rFAKE OK", Resource: "/x", Decision: Allow,
+		}},
+		{"control chars in agent", Event{
+			Agent: "att\x1b[31macker", Tool: "t", Resource: "/x", Decision: Allow,
+		}},
+		{"control chars in resource", Event{
+			Agent: "a", Tool: "t", Resource: "/x\x1b[2K\rspoofed", Decision: Allow,
+		}},
+		{"ordinary text is left alone", Event{
+			Agent: "auditor", Tool: "fs.read", Resource: "/etc/hosts", Decision: Allow,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+			if err := Record(path, tc.event); err != nil {
+				t.Fatal(err)
+			}
+			events, err := Load(path)
+			if err != nil || len(events) != 1 {
+				t.Fatalf("Load = %d events, err %v", len(events), err)
+			}
+			got := events[0]
+			for _, field := range []struct {
+				name, want, got string
+			}{
+				{"Agent", util.SafeTerminal(tc.event.Agent), got.Agent},
+				{"Tool", util.SafeTerminal(tc.event.Tool), got.Tool},
+				{"Resource", util.SafeTerminal(tc.event.Resource), got.Resource},
+			} {
+				if field.got != field.want {
+					t.Errorf("%s = %q, want %q (util.SafeTerminal of the input)", field.name, field.got, field.want)
+				}
+				for _, r := range field.got {
+					if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+						t.Errorf("%s = %q still carries a raw control byte after Record", field.name, field.got)
+					}
+				}
+			}
+		})
 	}
 }

--- a/internal/util/untrusted.go
+++ b/internal/util/untrusted.go
@@ -18,7 +18,9 @@ func WrapUntrusted(label, content string) string {
 
 // SafeTerminal replaces every control character in an untrusted single-line
 // string with U+FFFD. A ledger field carrying ESC[2K CR erases the line it
-// prints on and can forge a verdict; sanitise on render, never at ingest.
+// prints on and can forge a verdict. ledger.Record sanitises once at ingest
+// so every consumer inherits it by construction; call this directly for any
+// other untrusted text a render path is about to print.
 func SafeTerminal(s string) string {
 	return strings.Map(func(r rune) rune {
 		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {


### PR DESCRIPTION
## Summary

Three related security gaps found via adversarial QA testing (all "declared safeguard silently not enforced"):

**1. PII `local-only` policy was dead code on the SPRT/swarm dispatch path (most important)**

`cmdDispatch`'s RunE computed `touchesPII` only to raise the SPRT confidence bar. The `LocalOnly` field passed into `swarm.RunSPRT`/swarm options was bound only to `--local`, never to `cfg.Policies["pii"]`. Since any detectable PII unconditionally makes `effectiveConf > 0`, a PII-touching prompt always took the SPRT/swarm branch — the plain `d.Dispatch()` path that *does* enforce `pii: local-only` was unreachable for exactly the scenario it exists to protect.

Fix: `internal/dispatch.Dispatcher` now exposes `PIILocalOnly()` (factored out of the check `New()` already did — `piiLocalOnly(cfg)` is the single source of truth for both). `cmdDispatch` ORs it into `localOnly` right after computing `touchesPII`, so every branch downstream (dry-run plan, SPRT, swarm, plain dispatch) sees the correct value.

**2. `hyctl mcp verify` didn't detect ledger tampering**

It compared execution-time parameters against the on-disk `parameters_hash` verbatim — a hand-edited hash that happens to match different (never-approved) parameters verified as `MATCH`. `mcp verify-chain` already detects this class of tampering but the two commands were never composed.

Fix: `mcp verify` now also runs `ledger.VerifyChain` and refuses (exit 3) when the approval's chain is broken, before comparing parameters. Approvals that predate hash-chaining (`Hash == ""`) are left as-is — they were never protected either way. The existing "params match an approval" contract is unchanged, just gated.

**3. Terminal-escape injection via unsanitized `Agent`/`Tool` ledger fields**

`hyctl mcp log` sanitized these fields via `util.SafeTerminal` at render; `hyctl mcp report` printed them raw.

Fix: sanitize `Agent`/`Tool`/`Resource` once at ingest, in `ledger.Record`, so every consumer (log, report, TUI Security view) is safe by construction rather than each renderer needing its own escape-stripping.

## Changes
- `internal/dispatch/dispatch.go` — `piiLocalOnly()` helper + exported `Dispatcher.PIILocalOnly()`
- `cmd/hydra/main.go` — `cmdDispatch` folds `PIILocalOnly()` into `localOnly`; `mcp verify` composes `VerifyChain`
- `internal/ledger/ledger.go` — `Record` sanitizes `Agent`/`Tool`/`Resource` via `util.SafeTerminal`
- `internal/util/untrusted.go` — updated `SafeTerminal` doc comment (ingest now sanitizes; render-time calls are defense-in-depth for pre-existing data)
- Tests: `internal/dispatch/coverage_test.go`, `internal/ledger/ledger_test.go`, `cmd/hydra/cli_success_test.go`, `cmd/hydra/cli_more_test.go`, `cmd/hydra/cli_data_test.go`

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` — every package passes except two pre-existing failures in `cmd/hydra` confirmed present on a clean `origin/develop` checkout with none of this branch's changes (a `--confidence 0`/negative validation gap unrelated to #500, and a real local Ollama server on this machine causing an environment-dependent test to discover a genuine local head). Neither is touched by this PR.
- [x] Verified each fix live before/after:
  - Bug 1: built the binary, set `pii: local-only` in a scratch config, confirmed a PII prompt on the SPRT path now refuses with "no heads available" instead of reaching a remote head (added `TestCLI_Dispatch_PIIPolicyForcesLocalOnlyOnTheSPRTPath`, confirmed it fails without the fix)
  - Bug 2: recorded an approval, hand-edited its `parameters_hash` to the hash of unapproved parameters, confirmed `mcp verify` now refuses instead of reporting MATCH (added `TestCLI_MCPVerify_DetectsTamperedParametersHash`, confirmed it fails without the fix)
  - Bug 3: `hyctl mcp record --agent auditor --tool $'evil\x1b[2K\rFAKE OK' ...`, confirmed both `mcp report` and `mcp log` show the sanitized form (added `TestCLI_MCPRecord_SanitizesEscapesForBothLogAndReport`, confirmed it fails without the fix)

Closes #500