### PR TITLE
fix(cost): CLI-head token estimation and state.json budget merge

### DIFF
--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -107,14 +107,24 @@ func TestCLI_Dispatch_SucceedsAndLogsTheSpend(t *testing.T) {
 		t.Errorf("the dispatch row carries no run_id, so nothing correlates it: %v", row)
 	}
 
-	// cost.jsonl is deliberately *not* written here. A CLI-agent head reports no
-	// token usage, so there is no basis to price the call — and a $0.00 row
-	// would read as "this was free", which is the #258/#261 defect class. The
-	// call is still recorded above; only the price is withheld.
-	if _, statErr := os.Stat(filepath.Join(config.Dir(), "logs", "cost.jsonl")); statErr == nil {
-		billed, _ := os.ReadFile(filepath.Join(config.Dir(), "logs", "cost.jsonl"))
-		t.Errorf("a head that reported no tokens was given a cost row, which reads "+
-			"as a free call:\n%s", billed)
+	// A CLI-agent head reports no real token usage, so Hydra estimates from
+	// char/4 (#502) — cost.jsonl must carry that row, clearly labelled as an
+	// estimate rather than a measurement, or the call is silently invisible to
+	// spend tracking despite having actually run.
+	raw, err = os.ReadFile(filepath.Join(config.Dir(), "logs", "cost.jsonl"))
+	if err != nil {
+		t.Fatalf("no cost row for a CLI-head dispatch: %v", err)
+	}
+	var costRow map[string]any
+	if err := json.Unmarshal([]byte(strings.Split(strings.TrimSpace(string(raw)), "\n")[0]), &costRow); err != nil {
+		t.Fatal(err)
+	}
+	if costRow["tokens_source"] != "estimated" {
+		t.Errorf("tokens_source = %v, want \"estimated\" — a char/4 guess must never "+
+			"be presented as measured usage", costRow["tokens_source"])
+	}
+	if pt, _ := costRow["prompt_tokens"].(float64); pt <= 0 {
+		t.Errorf("prompt_tokens = %v, want > 0", costRow["prompt_tokens"])
 	}
 
 	// And the handoff, which is what the next agent's --a2a reads.

--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -698,6 +698,35 @@ func TestSyncStateJSON_PreservesForeignKeysAndExtendsHistory(t *testing.T) {
 	}
 }
 
+// Each `hyctl dispatch` is a fresh process with its own in-memory
+// budget.Registry, so it only ever knows about the head(s) it just ran.
+// Replacing state.json's "budget" map wholesale — instead of merging into it —
+// erased every other model's entry on the very next dispatch (#502).
+func TestSyncStateJSON_MergesBudgetAcrossDispatchesInsteadOfReplacing(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	d1 := liveDispatcher(echoHead(t, s, "tier4-head", 90))
+	if _, err := d1.Dispatch(context.Background(), "work", Options{}); err != nil {
+		t.Fatal(err)
+	}
+	d2 := liveDispatcher(echoHead(t, s, "tier8-head", 40))
+	if _, err := d2.Dispatch(context.Background(), "work", Options{}); err != nil {
+		t.Fatal(err)
+	}
+
+	budgetMap, ok := readState(t)["budget"].(map[string]any)
+	if !ok {
+		t.Fatalf("state[\"budget\"] = %#v, want a map", readState(t)["budget"])
+	}
+	if _, ok := budgetMap["tier4-head"]; !ok {
+		t.Errorf("budget map = %v, missing tier4-head — the first dispatch's entry "+
+			"was overwritten by the second", budgetMap)
+	}
+	if _, ok := budgetMap["tier8-head"]; !ok {
+		t.Errorf("budget map = %v, missing tier8-head", budgetMap)
+	}
+}
+
 // asInt / asIntSlice bridge JSON's float64 numbers back to ints. A wrong answer
 // here silently zeroes the governor's history.
 func TestAsIntAndAsIntSlice(t *testing.T) {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -695,11 +695,17 @@ func (d *Dispatcher) syncStateJSON(r *Result) {
 			asIntSlice(existing["claude_pct_history"]), pct, budget.MaxPctHistory)
 	}
 
-	// Persist per-model budget snapshots so the TUI and status command can read them.
+	// Persist per-model budget snapshots so the TUI and status command can read
+	// them. Merge into whatever is already on disk instead of replacing it — each
+	// `hyctl` invocation is a fresh process, so d.budget only knows about models
+	// dispatched to in this run, and overwriting would erase every other model's
+	// entry (#502).
 	if d.budget != nil {
-		snaps := d.budget.All()
-		budgetMap := map[string]any{}
-		for _, s := range snaps {
+		budgetMap, ok := existing["budget"].(map[string]any)
+		if !ok {
+			budgetMap = map[string]any{}
+		}
+		for _, s := range d.budget.All() {
 			budgetMap[s.ModelID] = map[string]any{
 				"pct":        s.Pct,
 				"used":       s.Used,

--- a/internal/executor/cli.go
+++ b/internal/executor/cli.go
@@ -41,11 +41,22 @@ func (e *CLIExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 		return nil, fmt.Errorf("cli exec %s: %w — stderr: %s", req.Head.ID, err, stderr.String())
 	}
 
+	output := strings.TrimSpace(stdout.String())
+
+	promptTokens := len(req.Prompt) / 4
+	responseTokens := len(output) / 4
+	writeTokenSidecar(req.Head.ID, "cli", "estimate", promptTokens, responseTokens)
+
 	return &Response{
-		Output:    strings.TrimSpace(stdout.String()),
-		Duration:  time.Since(start),
-		Model:     req.Head.ID,
-		Truncated: stdout.Truncated(),
+		Output:       output,
+		Duration:     time.Since(start),
+		Model:        req.Head.ID,
+		InputTokens:  promptTokens,
+		OutputTokens: responseTokens,
+		Truncated:    stdout.Truncated(),
+		// CLI tools (claude, codex, cursor, ...) report no token usage — these
+		// are char/4 estimates, same heuristic as the agy executor.
+		TokensEstimated: true,
 	}, nil
 }
 

--- a/internal/executor/cli_test.go
+++ b/internal/executor/cli_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// cliHead plants a fake CLI binary that always prints stdout, regardless of
+// the args the executor's template builds — same technique as fakeAgy.
+func cliHead(t *testing.T, s *testutil.Sandbox, id, provName, stdout string) provider.Head {
+	t.Helper()
+	body := "#!/bin/sh\nprintf '%s' " + shellQuote(stdout) + "\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\necho " + stdout + "\r\n"
+	}
+	return provider.Head{
+		ID: id, Name: id, Provider: provName, Source: "cli",
+		Executable: s.FakeBinary(t, id, body),
+	}
+}
+
+// CLI tools (claude, codex, cursor, ...) never report real token usage. Without
+// an estimate here, dispatch's logDispatch/recordBudget gate on InputTokens>0
+// and silently drop every CLI-driven dispatch from cost.jsonl and the budget
+// registry (#502).
+func TestCLIExecute_TokensAreEstimatedAndLabelled(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	head := cliHead(t, s, "codex", "openai", "0123456789012345678901234567890123456789")
+
+	resp, err := (&CLIExecutor{}).Execute(context.Background(), Request{
+		Prompt: strings.Repeat("a", 400), Head: head,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.TokensEstimated {
+		t.Error("TokensEstimated = false; CLI heads report no usage, so these are " +
+			"char/4 guesses and must never be booked as measured spend")
+	}
+	if resp.InputTokens != 100 {
+		t.Errorf("InputTokens = %d, want 400/4", resp.InputTokens)
+	}
+	if resp.OutputTokens != 10 {
+		t.Errorf("OutputTokens = %d, want 40/4", resp.OutputTokens)
+	}
+}
+
+func TestCLIExecute_OutputAndModelAreSet(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	head := cliHead(t, s, "codex", "openai", "the answer")
+
+	resp, err := (&CLIExecutor{}).Execute(context.Background(), Request{
+		Prompt: "hello", Head: head,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Output != "the answer" {
+		t.Errorf("Output = %q", resp.Output)
+	}
+	if resp.Model != "codex" {
+		t.Errorf("Model = %q, want head ID", resp.Model)
+	}
+}


### PR DESCRIPTION
## Summary
- CLI-executor heads (claude, codex, cursor, kiro, windsurf, gh-copilot, cody, amp, continue) never reported token counts, so `dispatch.logDispatch`/`recordBudget` (which gate on `InputTokens>0 || OutputTokens>0`) silently skipped every CLI-driven dispatch. `CLIExecutor.Execute` now sets a char/4 token estimate — the same heuristic the agy executor already uses — labelled `TokensEstimated: true` so it's booked as an estimate, never presented as measured spend.
- `Dispatcher.syncStateJSON` overwrote `state.json`'s `"budget"` map wholesale from the current process's in-memory `budget.Registry`, which only knows about models dispatched in that one process. Since every `hyctl dispatch` is a fresh process, each dispatch wiped out every other model's budget entry. It now reads the existing map first and upserts into it per model-key, using the same atomic tmp-file-then-rename write.

## Changes
- `internal/executor/cli.go` — estimate InputTokens/OutputTokens (char/4), set TokensEstimated, write the token sidecar (matches agy.go's pattern)
- `internal/executor/cli_test.go` — new: asserts tokens are estimated and labelled, output/model wiring
- `internal/dispatch/dispatch.go` — `syncStateJSON` merges the budget map instead of replacing it
- `internal/dispatch/coverage_test.go` — new test: two sequential dispatches to different heads both survive in `state.json`'s budget map
- `cmd/hydra/cli_success_test.go` — updated `TestCLI_Dispatch_SucceedsAndLogsTheSpend`: a CLI-head dispatch now produces a cost.jsonl row labelled `tokens_source: "estimated"` (previously asserted no row was written at all)

## Verification
- `go build ./...`, `go vet ./...` clean
- `go test -race -count=1` clean on `internal/executor`, `internal/dispatch`, `internal/cost`, `internal/budget`, and the full repo (the only failures are two pre-existing `cmd/hydra` tests already broken on `develop`, unrelated to this change)
- Built `hyctl` and dispatched to a real (faked) CLI head twice, tier 1 then tier 3 — confirmed `cost.jsonl` gets a row per dispatch with `tokens_source`/`cost_source: "estimated"`, and `state.json`'s `"budget"` map ends up with both models' entries rather than just the last one

Closes #502