### PR TITLE
feat(chat): stream the live timeline into ChatDock while a task runs

### DIFF
--- a/desktop/api/chat.go
+++ b/desktop/api/chat.go
@@ -50,13 +50,25 @@ type ChatReply struct {
 	NeedsProbe bool `json:"needsProbe,omitempty"`
 }
 
+// NewRunID mints a run id for the caller to hold before a dispatch starts.
+//
+// The frontend uses this to poll GetSession(runId) for an in-flight chat turn
+// instead of waiting for Chat to return — the run's log exists and is being
+// appended to from the moment Chat begins, not just once it finishes. A thin
+// wrapper rather than the frontend minting its own: the timestamp-prefix +
+// hex format is a contract Fleet's sort depends on (see fleet.go), so there is
+// exactly one place allowed to generate it.
+func (a *API) NewRunID() string { return runid.New() }
+
 // Chat dispatches one prompt and returns the reply.
 //
 // enum is a routing key ("SIMPLE", "STANDARD", …); empty lets dispatch pick.
+// runID lets the caller supply an id minted via NewRunID so it can watch the
+// run live; empty mints a fresh one, same as before NewRunID existed.
 // Errors come back inside the reply rather than as a Go error: a failed
 // dispatch is a normal outcome the dock renders as a message, not an exception
 // that should blank the window.
-func (a *API) Chat(prompt, enum string) (*ChatReply, error) {
+func (a *API) Chat(prompt, enum, runID string) (*ChatReply, error) {
 	if prompt == "" {
 		return &ChatReply{Error: "empty prompt"}, nil
 	}
@@ -64,7 +76,7 @@ func (a *API) Chat(prompt, enum string) (*ChatReply, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), ChatTimeout)
 	defer cancel()
 
-	runID, taskID := runid.New(), runid.New()
+	runID, taskID := runid.ResolveRun(runID), runid.New()
 	r := &ChatReply{RunID: runID}
 
 	// The dock's dispatch is a run like any other: it appears in Fleet while it

--- a/desktop/api/chat_test.go
+++ b/desktop/api/chat_test.go
@@ -64,7 +64,7 @@ func atoiTier(t *testing.T, s string) int {
 func TestChat_EmptyPromptIsAReplyNotAnError(t *testing.T) {
 	sandbox(t)
 
-	r, err := New().Chat("", "")
+	r, err := New().Chat("", "", "")
 	if err != nil {
 		t.Fatalf("an empty prompt must not error: %v", err)
 	}
@@ -81,12 +81,39 @@ func TestChat_EmptyPromptIsAReplyNotAnError(t *testing.T) {
 func TestChat_FailedDispatchReturnsAReply(t *testing.T) {
 	sandbox(t)
 
-	r, err := New().Chat("hello", "SIMPLE")
+	r, err := New().Chat("hello", "SIMPLE", "")
 	if err != nil {
 		t.Fatalf("a failed dispatch must come back as a reply, not a Go error: %v", err)
 	}
 	if r.RunID == "" {
 		t.Error("no RunID; a failed chat still has a run the user can inspect")
+	}
+}
+
+// The dock mints its id via NewRunID before dispatching, so it can poll
+// GetSession(runId) while Chat is still in flight (#513). Chat must actually
+// use that id rather than silently minting its own.
+func TestChat_HonoursCallerSuppliedRunID(t *testing.T) {
+	sandbox(t)
+
+	want := New().NewRunID()
+	r, err := New().Chat("hello", "SIMPLE", want)
+	if err != nil {
+		t.Fatalf("a failed dispatch must come back as a reply, not a Go error: %v", err)
+	}
+	if r.RunID != want {
+		t.Errorf("RunID = %q, want the caller-supplied %q — the dock's poll would be watching the wrong log", r.RunID, want)
+	}
+}
+
+func TestNewRunID_NonEmptyAndUnique(t *testing.T) {
+	a := New()
+	first, second := a.NewRunID(), a.NewRunID()
+	if first == "" || second == "" {
+		t.Fatal("NewRunID returned an empty id")
+	}
+	if first == second {
+		t.Error("two calls returned the same id")
 	}
 }
 
@@ -101,7 +128,7 @@ func TestChat_NoHeadsAtAllSetsNeedsProbe(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := New().Chat("hello", "SIMPLE")
+	r, err := New().Chat("hello", "SIMPLE", "")
 	if err != nil {
 		t.Fatalf("zero heads must come back as a reply, not a Go error: %v", err)
 	}

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1427,6 +1427,14 @@ body {
 .dock__log { flex: 1 1 auto; overflow-y: auto; padding: 12px 13px; display: flex; flex-direction: column; gap: 14px; }
 .dock__hint { margin: 0; color: var(--hy-dim); font-size: 12px; }
 
+/* Timeline's row anatomy assumes Session's full-width main column; the dock
+   caps out at 430px (#506), so the two fixed-width label columns need to
+   shrink instead of forcing every row to wrap. */
+.dock__log .timeline { margin-top: 6px; font-size: 12px; }
+.dock__log .tl { padding: 6px 10px; gap: 8px; flex-wrap: wrap; }
+.dock__log .tl__kind { flex-basis: auto; }
+.dock__log .tl__meta { margin-left: 0; }
+
 .turn { display: flex; flex-direction: column; gap: 5px; }
 .turn__you {
   margin: 0;

--- a/desktop/frontend/src/bindings.ts
+++ b/desktop/frontend/src/bindings.ts
@@ -28,8 +28,9 @@ interface WailsGo {
       GetFleet(): Promise<Fleet>
       GetSession(runID: string): Promise<Session>
       GetEdits(runID: string): Promise<Edit[]>
-      Chat(prompt: string, enumKey: string): Promise<ChatReply>
+      Chat(prompt: string, enumKey: string, runID: string): Promise<ChatReply>
       ChatEnums(): Promise<string[]>
+      NewRunID(): Promise<string>
       GetDiff(runID: string, ref: string, file: string): Promise<Diff>
       GetVersion(): Promise<Version>
       GetUpdateStatus(): Promise<UpdateStatus>
@@ -61,9 +62,10 @@ export const GetSession = (runID: string): Promise<Session> => backend().GetSess
 export const GetEdits = (runID: string): Promise<Edit[]> => backend().GetEdits(runID)
 export const GetDiff = (runID: string, ref: string, file: string): Promise<Diff> =>
   backend().GetDiff(runID, ref, file)
-export const Chat = (prompt: string, enumKey: string): Promise<ChatReply> =>
-  backend().Chat(prompt, enumKey)
+export const Chat = (prompt: string, enumKey: string, runID: string): Promise<ChatReply> =>
+  backend().Chat(prompt, enumKey, runID)
 export const ChatEnums = (): Promise<string[]> => backend().ChatEnums()
+export const NewRunID = (): Promise<string> => backend().NewRunID()
 export const GetVersion = (): Promise<Version> => backend().GetVersion()
 export const GetUpdateStatus = (): Promise<UpdateStatus> => backend().GetUpdateStatus()
 export const TriggerUpgrade = (): Promise<UpgradeResult> => backend().TriggerUpgrade()

--- a/desktop/frontend/src/views/ChatDock.tsx
+++ b/desktop/frontend/src/views/ChatDock.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useRef, useState } from 'react'
-import { Chat, ChatEnums } from '../bindings'
-import type { ChatReply } from '../types'
+import { Chat, ChatEnums, GetSession, NewRunID } from '../bindings'
+import type { ChatReply, Session as SessionData } from '../types'
 import { ms, usdExact } from '../format'
+import { Timeline } from './Session'
+
+// Matches App.tsx's LIVE_MS — same reasoning: this is "what is happening now",
+// not a retrospective read.
+const POLL_MS = 2000
 
 interface Turn {
   prompt: string
+  runId: string
   reply?: ChatReply
 }
 
@@ -38,8 +44,35 @@ export function ChatDock({
   const [enums, setEnums] = useState<string[]>([])
   const [turns, setTurns] = useState<Turn[]>([])
   const [busy, setBusy] = useState(false)
+  // The one turn currently in flight, if any — Chat's own busy flag already
+  // guarantees at most one, so this doesn't need to be keyed by turn index.
+  const [liveSession, setLiveSession] = useState<SessionData | null>(null)
   const logRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // A dispatch keeps running even if the window closes mid-poll; the interval
+  // itself must not outlive the component.
+  useEffect(() => () => stopPolling(), [])
+
+  function stopPolling() {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+  }
+
+  // Runlog is written incrementally from the moment Chat begins (chat.go
+  // appends KindRunStarted before dispatching), so GetSession has something to
+  // show well before the blocking Chat call returns — this is what makes a
+  // chat turn narrate the way Session's own Timeline already does, instead of
+  // sitting behind a spinner until the whole thing finishes (#513).
+  function watchRun(runId: string) {
+    setLiveSession(null)
+    const poll = () => void GetSession(runId).then(setLiveSession).catch(() => {})
+    poll()
+    pollRef.current = setInterval(poll, POLL_MS)
+  }
 
   useEffect(() => {
     ChatEnums().then(setEnums).catch(() => {
@@ -56,9 +89,14 @@ export function ChatDock({
     if (!p || busy) return
     setPrompt('')
     setBusy(true)
-    setTurns((t) => [...t, { prompt: p }])
+    // Minted before dispatching (not read off the reply) so watchRun can
+    // start polling immediately — Chat won't resolve until the whole
+    // dispatch finishes, but the run's log exists from the moment it starts.
+    const runId = await NewRunID()
+    setTurns((t) => [...t, { prompt: p, runId }])
+    watchRun(runId)
     try {
-      const reply = await Chat(p, enumKey)
+      const reply = await Chat(p, enumKey, runId)
       setTurns((t) => t.map((turn, i) => (i === t.length - 1 ? { ...turn, reply } : turn)))
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
@@ -70,6 +108,8 @@ export function ChatDock({
         ),
       )
     } finally {
+      stopPolling()
+      setLiveSession(null)
       setBusy(false)
     }
   }
@@ -77,13 +117,18 @@ export function ChatDock({
   // No heads discoverable at all — dispatch.New already probes fresh on every
   // call, so retrying the same prompt IS the "look again" action, not a
   // separate one. Targets a turn by index and reuses its own stored prompt
-  // rather than the (already-cleared) input state.
+  // rather than the (already-cleared) input state. A fresh run id, same as
+  // any other dispatch attempt — the failed attempt's log stays exactly what
+  // it was, a probe that found nothing.
   async function retry(i: number) {
     if (busy) return
     const p = turns[i].prompt
     setBusy(true)
+    const runId = await NewRunID()
+    setTurns((t) => t.map((turn, idx) => (idx === i ? { ...turn, runId } : turn)))
+    watchRun(runId)
     try {
-      const reply = await Chat(p, enumKey)
+      const reply = await Chat(p, enumKey, runId)
       setTurns((t) => t.map((turn, idx) => (idx === i ? { ...turn, reply } : turn)))
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
@@ -91,6 +136,8 @@ export function ChatDock({
         t.map((turn, idx) => (idx === i ? { ...turn, reply: { ...emptyReply(), error: message } } : turn)),
       )
     } finally {
+      stopPolling()
+      setLiveSession(null)
       setBusy(false)
     }
   }
@@ -139,7 +186,18 @@ export function ChatDock({
         {turns.map((t, i) => (
           <div key={i} className="turn">
             <p className="turn__you">{t.prompt}</p>
-            {!t.reply && <p className="turn__wait">routing…</p>}
+            {!t.reply && (
+              <>
+                <p className="turn__wait">{liveSession?.found ? 'working…' : 'routing…'}</p>
+                {/* Same event stream Session's Timeline renders after the fact
+                    (runlog.Append writes each event as it happens) — shown
+                    live here instead of making "what is it doing" a click
+                    through to Session once the whole turn is already done. */}
+                {i === turns.length - 1 && liveSession?.found && (
+                  <Timeline entries={liveSession.timeline} />
+                )}
+              </>
+            )}
             {t.reply?.error && !t.reply.needsProbe && <p className="turn__err">{t.reply.error}</p>}
             {t.reply?.needsProbe && (
               <div className="turn__probe">

--- a/desktop/frontend/src/views/Session.tsx
+++ b/desktop/frontend/src/views/Session.tsx
@@ -78,7 +78,7 @@ export function Session({
   )
 }
 
-function Timeline({ entries }: { entries: TimelineEntry[] }) {
+export function Timeline({ entries }: { entries: TimelineEntry[] }) {
   if (entries.length === 0) return null
   return (
     <ol className="timeline">


### PR DESCRIPTION
## Summary
- ChatDock sent a prompt, showed "routing…", and blocked on `Chat()` for one
  final answer — even though chat.go writes real runlog events for that run
  live, from the moment it starts (`runID` minted up front, `runlog.Append`
  is an incremental `O_APPEND` write per event, not buffered to the end).
  Session.tsx already renders that same stream as a `Timeline`. ChatDock
  never looked at it until the whole dispatch was done.
- `API.NewRunID()` — thin wrapper around `runid.New()` so the frontend can
  mint an id up front without duplicating Go's id-format logic in TS (the
  timestamp-prefix + hex format is a contract Fleet's sort relies on).
- `Chat(prompt, enum, runID)` now accepts a caller-supplied id via
  `runid.ResolveRun`, instead of always minting its own.
- ChatDock mints the id before dispatching, polls `GetSession(runId)` every
  2s while busy (same cadence `App.tsx` already uses for Fleet/Session), and
  renders the now-exported `Timeline` component inline under the in-flight
  turn. Polling stops once `Chat()` resolves, success or error.

## Testing
- `go test ./... -race -count=1` clean (desktop module)
- `npm run typecheck` / `npm run build` clean
- New: `TestChat_HonoursCallerSuppliedRunID`, `TestNewRunID_NonEmptyAndUnique`
- Not done: no live `wails dev` GUI smoke test — no display in this sandbox.
  Worth a manual pass before merge.

Closes #513