### PR TITLE
perf(tree): index nodes by task ID instead of scanning on every edit event

### DIFF
--- a/internal/tree/tree.go
+++ b/internal/tree/tree.go
@@ -85,6 +85,11 @@ type Tree struct {
 	Roots []string
 	Nodes map[string]*Node
 
+	// byTaskID indexes nodes by task, parallel to Nodes indexing by node ID.
+	// It lets an event with no identity of its own (e.g. KindEdit) find the
+	// node already tracking its task in O(1) instead of scanning Order (#523).
+	byTaskID map[string]*Node
+
 	// Order is node-creation order, so a renderer can lay nodes out stably
 	// rather than at the mercy of map iteration.
 	Order []string
@@ -120,7 +125,7 @@ type Timeline struct {
 
 // NewTree returns an empty tree ready for Apply.
 func NewTree(runID string) *Tree {
-	return &Tree{RunID: runID, Nodes: map[string]*Node{}}
+	return &Tree{RunID: runID, Nodes: map[string]*Node{}, byTaskID: map[string]*Node{}}
 }
 
 // Reconstruct builds a tree and timeline from a run's events. Events are taken
@@ -177,13 +182,19 @@ func Apply(t *Tree, e runlog.Event) *Tree {
 	// agent/head identity (#434). Attribute it to that existing node instead.
 	var n *Node
 	if e.Agent == "" && e.Head == "" && e.TaskID != "" {
-		n = t.nodeByTaskID(e.TaskID)
+		n = t.byTaskID[e.TaskID]
 	}
 	if n == nil {
 		n = t.node(id)
 	}
 	if e.TaskID != "" {
 		n.TaskID = e.TaskID
+		// First claim wins, mirroring the file's existing "first owner wins"
+		// rule for Parent (see link()) — and matching the creation-order
+		// first-match the old linear scan returned when two nodes shared a task.
+		if _, ok := t.byTaskID[e.TaskID]; !ok {
+			t.byTaskID[e.TaskID] = n
+		}
 	}
 	if e.Head != "" {
 		n.Head = e.Head
@@ -262,19 +273,6 @@ func (t *Tree) node(id string) *Node {
 	t.Order = append(t.Order, id)
 	t.Roots = append(t.Roots, id) // provisional; link() promotes it to a child
 	return n
-}
-
-// nodeByTaskID finds a node already tracking this task, regardless of what
-// key it was created under (a task's first event sets that key; it is
-// usually the agent/head, not the task id itself). Runs are small enough
-// that a scan costs nothing worth indexing for.
-func (t *Tree) nodeByTaskID(taskID string) *Node {
-	for _, id := range t.Order {
-		if n := t.Nodes[id]; n != nil && n.TaskID == taskID {
-			return n
-		}
-	}
-	return nil
 }
 
 // link records an ownership edge, creating either endpoint if needed. A node

--- a/internal/tree/tree_test.go
+++ b/internal/tree/tree_test.go
@@ -448,3 +448,87 @@ func TestTimeline_RunLevelEntriesNameNoNode(t *testing.T) {
 		}
 	}
 }
+
+// editOnlyEvents builds n KindEdit events, each its own distinct task with no
+// Agent/Head — the shape that made nodeByTaskID's linear scan over Order pay
+// O(n) per event, O(n^2) for the run (#523).
+func editOnlyEvents(n int) []runlog.Event {
+	events := make([]runlog.Event, n)
+	for i := range events {
+		events[i] = runlog.Event{
+			V: runlog.SchemaVersion, Seq: uint64(i + 1), RunID: "run-edits",
+			TS: time.Now().UTC().Format(time.RFC3339Nano), Kind: runlog.KindEdit,
+			TaskID: fmt.Sprintf("task-%d", i), File: "/scratch/f.py", Detail: "+1/-0",
+		}
+	}
+	return events
+}
+
+// A run of many distinct edit-only tasks must still reconstruct into one node
+// per task, correctly attributed — the byTaskID index changes the lookup's
+// cost, not its result.
+func TestReconstruct_ManyDistinctEditTasks(t *testing.T) {
+	const n = 5000
+	events := editOnlyEvents(n)
+
+	tr, tl := Reconstruct(events)
+
+	if len(tr.Nodes) != n {
+		t.Fatalf("got %d nodes, want %d — one per distinct edit-only task", len(tr.Nodes), n)
+	}
+	if len(tr.Order) != n {
+		t.Fatalf("Order has %d entries, want %d", len(tr.Order), n)
+	}
+	if len(tr.Roots) != n {
+		t.Fatalf("Roots has %d entries, want %d — no Parent was ever set", len(tr.Roots), n)
+	}
+	if len(tl.Entries) != n {
+		t.Fatalf("timeline has %d entries, want %d", len(tl.Entries), n)
+	}
+	if tr.Skipped != 0 {
+		t.Errorf("Skipped = %d, want 0", tr.Skipped)
+	}
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("task-%d", i)
+		node := tr.Nodes[id]
+		if node == nil {
+			t.Fatalf("no node for %s", id)
+		}
+		if node.TaskID != id {
+			t.Errorf("node %s TaskID = %q, want %q", id, node.TaskID, id)
+		}
+		// node() seeds a fresh node at StatePending, and KindEdit's own
+		// "if n.State == \"\"" guard never fires on it, so it stays pending.
+		if node.State != StatePending {
+			t.Errorf("node %s state = %q, want pending", id, node.State)
+		}
+		if node.Detail != "+1/-0" {
+			t.Errorf("node %s detail = %q, want the edit's line counts", id, node.Detail)
+		}
+	}
+
+	// Folding one at a time must agree with the bulk reconstruction (the same
+	// invariant TestApply_EqualsReconstruct pins for smaller, mixed-kind runs).
+	folded := NewTree(events[0].RunID)
+	for _, e := range events {
+		folded = Apply(folded, e)
+	}
+	if len(folded.Nodes) != len(tr.Nodes) {
+		t.Fatalf("folded %d nodes, bulk %d", len(folded.Nodes), len(tr.Nodes))
+	}
+}
+
+// BenchmarkReconstruct tracks the cost of folding a run of distinct edit-only
+// tasks. Before the byTaskID index (#523), ns/op per event grew with n
+// (O(n^2) total); after it, ns/op per event should stay roughly flat.
+func BenchmarkReconstruct(b *testing.B) {
+	for _, n := range []int{2000, 8000, 32000} {
+		events := editOnlyEvents(n)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				Reconstruct(events)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `Apply`'s `nodeByTaskID` helper scanned every node created so far (`t.Order`) to attribute a `KindEdit` event (which has empty `Agent`/`Head` but a set `TaskID`) to its owning node. `Reconstruct` calls `Apply` once per event, so a run with many distinct edit-only tasks paid `O(current tree size)` per event — `O(n^2)` for the whole run.
- Replaces the scan with a `byTaskID map[string]*Node` index on `Tree`, parallel to the existing `Nodes` map. It's populated at the same point a node's `TaskID` field is set (not just at node creation), since a node can exist before its task ID is known (e.g. `head_selected` creates the node, a later anonymous `edit` event references its task) — first claim wins, mirroring the file's existing "first owner wins" rule for `Parent`.
- Deletes the now-dead `nodeByTaskID` scan.

## Changes
- `internal/tree/tree.go` — add `byTaskID` index field, initialize in `NewTree`, populate/query it in `Apply`, remove `nodeByTaskID`.
- `internal/tree/tree_test.go` — `TestReconstruct_ManyDistinctEditTasks` (5,000 distinct edit-only tasks; asserts node count, attribution, state, fold-vs-bulk equivalence) and `BenchmarkReconstruct` at n=2000/8000/32000.

## Verification
All of `go build ./...`, `go vet ./...`, and `go test -race ./internal/tree/... ./internal/tui/... ./internal/runlog/...` pass clean. Full `go test -race ./...` passes except two pre-existing failures unrelated to this change (confirmed via `git stash` against unmodified code): a `runlog` env-isolation gap in this sandbox and a `cmd/hydra` `--local` test that needs real network egress.

**`go test -bench` (n=2000/8000/32000, before vs after):**
| n | before (scan) | after (index) |
|---|---|---|
| 2,000 | 24.3ms | 0.90ms |
| 8,000 | 449ms (18.5x for 4x n) | 3.54ms (3.9x for 4x n) |
| 32,000 | 7.84s (17.5x for 4x n) | 13.5ms (3.8x for 4x n) |

**Real binary, `hyctl tui --snapshot --view 2` against a synthetic run log of unique-task `KindEdit` events (matching the issue's audit methodology), before vs after:**
| n | before | after |
|---|---|---|
| 0 | 1.60s | 0.79s |
| 10,000 | 0.88s | 0.17s |
| 20,000 | 3.20s (3.6x) | 0.31s (1.8x) |
| 40,000 | 13.03s (4.1x) | 0.59s (1.9x) |

Before: each doubling of n roughly quadruples the marginal cost (the textbook O(n²) signature, matching the issue's own measurements). After: each doubling roughly doubles it — linear.

Closes #523