### PR TITLE
feat(desktop): fold Code into Session as a tab, click a graph node to open it

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -12,7 +12,6 @@ import type {
 import { Dashboard } from './views/Dashboard'
 import { Fleet } from './views/Fleet'
 import { Session } from './views/Session'
-import { Code } from './views/Code'
 import { Security as SecurityView } from './views/Security'
 import { ErrorBoundary } from './ErrorBoundary'
 import { ChatDock } from './views/ChatDock'
@@ -34,7 +33,6 @@ const NAV = [
   { id: 'dashboard', label: 'Dashboard', ready: true },
   { id: 'fleet', label: 'Fleet', ready: true },
   { id: 'session', label: 'Session', ready: true },
-  { id: 'code', label: 'Code', ready: true },
   { id: 'security', label: 'Security', ready: true },
 ] as const
 
@@ -68,9 +66,13 @@ export default function App() {
   const load = useCallback(async (which: ViewID, id: string) => {
     try {
       if (which === 'fleet') setFleet(await GetFleet())
-      else if (which === 'session') setSession(await GetSession(id))
-      else if (which === 'code') setEdits(await GetEdits(id))
-      else if (which === 'security') setSecurity(await GetSecurity())
+      // Code is a tab inside Session now (#519), not its own view — fetch
+      // both together so switching tabs never has to wait on a second load.
+      else if (which === 'session') {
+        const [s, e] = await Promise.all([GetSession(id), GetEdits(id)])
+        setSession(s)
+        setEdits(e)
+      } else if (which === 'security') setSecurity(await GetSecurity())
       else setDashboard(await GetDashboard())
       setError(null)
     } catch (e) {
@@ -102,11 +104,27 @@ export default function App() {
     })
   }, [])
 
+  // Set alongside runID when a caller wants Session to open straight on the
+  // Code tab at a specific file (an artifact-node click, #518) rather than
+  // its own default. Session is keyed by runId below, so a fresh mount reads
+  // this once as initial state — plain opens must clear it, or a later
+  // no-file open of a different run would wrongly inherit it.
+  const [pendingFile, setPendingFile] = useState<string | undefined>()
+
   const openSession = useCallback((id: string) => {
     setRunID(id)
     // Don't show the previous run's data under a new id.
     setSession(null)
     setEdits(null)
+    setPendingFile(undefined)
+    setView('session')
+  }, [])
+
+  const openSessionFile = useCallback((id: string, file: string) => {
+    setRunID(id)
+    setSession(null)
+    setEdits(null)
+    setPendingFile(file)
     setView('session')
   }, [])
 
@@ -115,7 +133,7 @@ export default function App() {
   // further qualification.
   const selectNav = useCallback(
     (id: ViewID) => {
-      if ((id === 'session' || id === 'code') && !runID) {
+      if (id === 'session' && !runID) {
         const first = fleet?.runs?.[0]?.id
         if (!first) return
         setRunID(first)
@@ -126,7 +144,7 @@ export default function App() {
       }
       setView(id)
     },
-    [fleet, runID, openSession],
+    [fleet, runID],
   )
 
   // Dashboard handles its own loading state (a skeleton, not this fallback
@@ -134,8 +152,7 @@ export default function App() {
   // instead of a plain sentence.
   const loading =
     (view === 'fleet' && !fleet) ||
-    (view === 'session' && !session) ||
-    (view === 'code' && !edits) ||
+    (view === 'session' && (!session || !edits)) ||
     (view === 'security' && !security)
 
   return (
@@ -151,10 +168,7 @@ export default function App() {
               key={n.id}
               className="rail__item"
               aria-current={view === n.id ? 'page' : undefined}
-              disabled={
-                !n.ready ||
-                ((n.id === 'session' || n.id === 'code') && !runID && !fleet?.runs?.length)
-              }
+              disabled={!n.ready || (n.id === 'session' && !runID && !fleet?.runs?.length)}
               onClick={() => n.ready && selectNav(n.id)}
             >
               {n.label}
@@ -185,24 +199,25 @@ export default function App() {
           <Dashboard data={dashboard} dockOpen={dockOpen} onCloseDock={() => setDockOpen(false)} />
         )}
         {!error && view === 'fleet' && fleet && (
-          <Fleet data={fleet} onOpen={openSession} onStartTask={startTask} />
+          <Fleet
+            data={fleet}
+            onOpen={openSession}
+            onOpenFile={openSessionFile}
+            onStartTask={startTask}
+          />
         )}
-        {!error && view === 'session' && session && (
-          <Session session={session} onBack={() => setView('fleet')} />
-        )}
-        {!error && view === 'code' && edits && (
-          <>
-            <header className="view__head">
-              <div className="view__headrow">
-                <button className="back" onClick={() => setView('session')}>
-                  ← Session
-                </button>
-                <h1 className="view__title">Code</h1>
-              </div>
-              <p className="view__sub">What this run changed on disk.</p>
-            </header>
-            <Code runID={runID} edits={edits} />
-          </>
+        {!error && view === 'session' && session && edits && (
+          // Keyed by runId: a fresh mount per run resets tab/codeFile state
+          // instead of carrying over a Graph/Code selection from whatever run
+          // was open before, and lets initialTab/initialFile seed cleanly.
+          <Session
+            key={session.runId}
+            session={session}
+            edits={edits}
+            onBack={() => setView('fleet')}
+            initialTab={pendingFile ? 'code' : undefined}
+            initialFile={pendingFile}
+          />
         )}
         {!error && view === 'security' && security && (
           <ErrorBoundary label="Security">

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1260,6 +1260,13 @@ body {
 .gnode__label { fill: var(--hy-ink); font-family: var(--hy-font-mono); font-size: 11px; }
 .gnode__sub   { fill: var(--hy-dim); font-family: var(--hy-font-mono); font-size: 10px; }
 
+/* Only artifact (edit-target) nodes open something on click — a plain agent
+   node's label/sub already show everything known about it (#518). */
+.gnode-wrap--clickable { cursor: pointer; }
+.gnode-wrap--clickable:hover .gnode,
+.gnode-wrap--clickable:focus-visible .gnode { stroke: var(--hy-aqua); }
+.gnode-wrap--clickable:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; }
+
 .graph__legend { margin: 10px 0 0; font-size: 11px; color: var(--hy-dim); }
 
 /* ── Code view ─────────────────────────────────────────────────────────── */

--- a/desktop/frontend/src/views/Code.tsx
+++ b/desktop/frontend/src/views/Code.tsx
@@ -2,9 +2,28 @@ import { useEffect, useState } from 'react'
 import { GetDiff } from '../bindings'
 import type { Diff, Edit } from '../types'
 
-export function Code({ runID, edits }: { runID: string; edits: Edit[] }) {
+export function Code({
+  runID,
+  edits,
+  initialFile,
+}: {
+  runID: string
+  edits: Edit[]
+  /** Jump straight to this file — set when a graph node was clicked (#518)
+   *  rather than the tab reached on its own, which just wants index 0. */
+  initialFile?: string
+}) {
   const [selected, setSelected] = useState(0)
   const [diff, setDiff] = useState<Diff | null>(null)
+
+  // Re-selects on every new value, not just at mount — Session stays mounted
+  // across clicking different artifact nodes in the same run, so this has to
+  // react to initialFile changing, not just seed the initial state.
+  useEffect(() => {
+    if (!initialFile) return
+    const i = edits.findIndex((e) => e.file === initialFile)
+    if (i >= 0) setSelected(i)
+  }, [initialFile, edits])
 
   const current = edits[selected]
 

--- a/desktop/frontend/src/views/Fleet.tsx
+++ b/desktop/frontend/src/views/Fleet.tsx
@@ -6,10 +6,12 @@ import { RunGraph } from './RunGraph'
 export function Fleet({
   data,
   onOpen,
+  onOpenFile,
   onStartTask,
 }: {
   data: FleetData
   onOpen: (runID: string) => void
+  onOpenFile: (runID: string, file: string) => void
   onStartTask: () => void
 }) {
   return (
@@ -37,7 +39,13 @@ export function Fleet({
       ) : (
         <div className="runs">
           {data.runs.map((r) => (
-            <RunCard key={r.id} run={r} groupThreshold={data.groupThreshold} onOpen={onOpen} />
+            <RunCard
+              key={r.id}
+              run={r}
+              groupThreshold={data.groupThreshold}
+              onOpen={onOpen}
+              onOpenFile={onOpenFile}
+            />
           ))}
         </div>
       )}
@@ -49,10 +57,12 @@ function RunCard({
   run,
   groupThreshold,
   onOpen,
+  onOpenFile,
 }: {
   run: Run
   groupThreshold: number
   onOpen: (runID: string) => void
+  onOpenFile: (runID: string, file: string) => void
 }) {
   // Past the threshold a node-link graph is a hairball, not a picture (mirrors
   // Airflow's separate Grid view for large DAGs), so it collapses to a state
@@ -97,7 +107,9 @@ function RunCard({
           {/* Below the threshold: a single agent needs no graph, and 2..N draw
               the same dagre DAG SessionGraph uses, just smaller. At/above the
               threshold the toggle above reveals a heatmap grid instead. */}
-          {!large && <RunShape agents={run.agents} />}
+          {!large && (
+            <RunShape agents={run.agents} onOpenFile={(file) => onOpenFile(run.id, file)} />
+          )}
           {large && expanded && run.agents.length > 0 && <AgentGrid agents={run.agents} />}
         </>
       )}
@@ -106,7 +118,13 @@ function RunCard({
 }
 
 /** The 0/1/2..N shape for a run below GroupThreshold. */
-function RunShape({ agents }: { agents: Agent[] }) {
+function RunShape({
+  agents,
+  onOpenFile,
+}: {
+  agents: Agent[]
+  onOpenFile: (file: string) => void
+}) {
   if (agents.length === 0) return null
   // A single node is trivially linear — the same reasoning Session.tsx uses
   // to decide nonLinear (isNonLinear is false whenever there's nothing to
@@ -118,7 +136,7 @@ function RunShape({ agents }: { agents: Agent[] }) {
       </ul>
     )
   }
-  return <RunGraph agents={agents} />
+  return <RunGraph agents={agents} onOpenFile={onOpenFile} />
 }
 
 function StateBar({ run }: { run: Run }) {

--- a/desktop/frontend/src/views/RunGraph.tsx
+++ b/desktop/frontend/src/views/RunGraph.tsx
@@ -16,10 +16,18 @@ interface Placed {
   y: number
   label: string
   state: string
+  /** The file this node represents, when state is 'artifact' (#518). */
+  file?: string
 }
 
 /** Compact inline DAG for a run's agents — Fleet's 2..GroupThreshold tier. */
-export function RunGraph({ agents }: { agents: Agent[] }) {
+export function RunGraph({
+  agents,
+  onOpenFile,
+}: {
+  agents: Agent[]
+  onOpenFile?: (file: string) => void
+}) {
   const { nodes, lines, width, height } = useMemo(() => layout(agents), [agents])
 
   if (nodes.length === 0) return null
@@ -30,19 +38,40 @@ export function RunGraph({ agents }: { agents: Agent[] }) {
         {lines.map((l, i) => (
           <polyline key={i} points={l.points} className="edge" fill="none" />
         ))}
-        {nodes.map((n) => (
-          <g key={n.id} transform={`translate(${n.x - NODE_W / 2},${n.y - NODE_H / 2})`}>
-            <rect
-              width={NODE_W}
-              height={NODE_H}
-              rx={7}
-              className={`gnode gnode--${n.state}`}
-            />
-            <text x={8} y={17} className="gnode__label">
-              {n.label}
-            </text>
-          </g>
-        ))}
+        {nodes.map((n) => {
+          const clickable = n.file !== undefined && onOpenFile !== undefined
+          return (
+            <g
+              key={n.id}
+              transform={`translate(${n.x - NODE_W / 2},${n.y - NODE_H / 2})`}
+              className={clickable ? 'gnode-wrap--clickable' : undefined}
+              role={clickable ? 'button' : undefined}
+              tabIndex={clickable ? 0 : undefined}
+              aria-label={clickable ? `Open ${n.file}` : undefined}
+              onClick={clickable ? () => onOpenFile!(n.file!) : undefined}
+              onKeyDown={
+                clickable
+                  ? (e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        onOpenFile!(n.file!)
+                      }
+                    }
+                  : undefined
+              }
+            >
+              <rect
+                width={NODE_W}
+                height={NODE_H}
+                rx={7}
+                className={`gnode gnode--${n.state}`}
+              />
+              <text x={8} y={17} className="gnode__label">
+                {n.label}
+              </text>
+            </g>
+          )
+        })}
       </svg>
     </div>
   )
@@ -74,7 +103,15 @@ function layout(agents: Agent[]) {
   for (const p of placed) {
     const a = byID.get(p.id)
     if (!a) continue
-    nodes.push({ id: p.id, x: p.x, y: p.y, label: shortLabel(a), state: stateClass(a) })
+    const state = stateClass(a)
+    nodes.push({
+      id: p.id,
+      x: p.x,
+      y: p.y,
+      label: shortLabel(a),
+      state,
+      file: state === 'artifact' ? a.id : undefined,
+    })
   }
 
   return { nodes, lines, width, height }

--- a/desktop/frontend/src/views/Session.tsx
+++ b/desktop/frontend/src/views/Session.tsx
@@ -1,18 +1,31 @@
 import { useState } from 'react'
-import type { Session as SessionData, TimelineEntry } from '../types'
+import type { Edit, Session as SessionData, TimelineEntry } from '../types'
 import { clockTime, ms, pct, usdExact } from '../format'
 import { SessionGraph } from './SessionGraph'
+import { Code } from './Code'
 
 export function Session({
   session,
+  edits,
   onBack,
+  initialTab,
+  initialFile,
 }: {
   session: SessionData
+  edits: Edit[]
   onBack: () => void
+  /** Set when Session is opened by clicking an artifact node elsewhere (e.g.
+   *  Fleet's inline graph, #518) — App keys Session by runId, so this only
+   *  needs to seed initial state, not stay in sync afterward. */
+  initialTab?: 'code'
+  initialFile?: string
 }) {
   // Timeline is the default: most runs are linear, and a list is the right
   // shape for a linear thing.
-  const [tab, setTab] = useState<'timeline' | 'graph'>('timeline')
+  const [tab, setTab] = useState<'timeline' | 'code' | 'graph'>(initialTab ?? 'timeline')
+  // Consumed by Code, which re-selects whenever this changes — set once here,
+  // then updated by clicking further artifact nodes within the same session.
+  const [codeFile, setCodeFile] = useState<string | undefined>(initialFile)
 
   return (
     <>
@@ -46,17 +59,24 @@ export function Session({
             </p>
           )}
 
-          {/* The Graph tab appears only when a list genuinely cannot show the
-              shape. Drawing a graph of a straight line is worse than a list. */}
-          {session.nonLinear && (
-            <div className="tabs">
-              <button
-                className="tab"
-                aria-current={tab === 'timeline' ? 'page' : undefined}
-                onClick={() => setTab('timeline')}
-              >
-                Timeline
-              </button>
+          <div className="tabs">
+            <button
+              className="tab"
+              aria-current={tab === 'timeline' ? 'page' : undefined}
+              onClick={() => setTab('timeline')}
+            >
+              Timeline
+            </button>
+            <button
+              className="tab"
+              aria-current={tab === 'code' ? 'page' : undefined}
+              onClick={() => setTab('code')}
+            >
+              Code
+            </button>
+            {/* Graph appears only when a list genuinely cannot show the shape.
+                Drawing a graph of a straight line is worse than a list. */}
+            {session.nonLinear && (
               <button
                 className="tab"
                 aria-current={tab === 'graph' ? 'page' : undefined}
@@ -64,11 +84,23 @@ export function Session({
               >
                 Graph
               </button>
-            </div>
-          )}
+            )}
+          </div>
 
-          {tab === 'graph' && session.nonLinear ? (
-            <SessionGraph session={session} />
+          {tab === 'code' ? (
+            <Code
+              runID={session.runId}
+              edits={edits}
+              initialFile={codeFile}
+            />
+          ) : tab === 'graph' && session.nonLinear ? (
+            <SessionGraph
+              session={session}
+              onOpenFile={(file) => {
+                setCodeFile(file)
+                setTab('code')
+              }}
+            />
           ) : (
             <Timeline entries={session.timeline} />
           )}

--- a/desktop/frontend/src/views/SessionGraph.tsx
+++ b/desktop/frontend/src/views/SessionGraph.tsx
@@ -17,9 +17,18 @@ interface Placed {
   label: string
   sub: string
   state: string
+  /** The file this node represents, when state is 'artifact' — clicking it
+   *  opens that file rather than nothing (#518). */
+  file?: string
 }
 
-export function SessionGraph({ session }: { session: Session }) {
+export function SessionGraph({
+  session,
+  onOpenFile,
+}: {
+  session: Session
+  onOpenFile?: (file: string) => void
+}) {
   const { nodes, lines, width, height } = useMemo(() => layout(session), [session])
 
   if (nodes.length === 0) return null
@@ -35,22 +44,43 @@ export function SessionGraph({ session }: { session: Session }) {
             fill="none"
           />
         ))}
-        {nodes.map((n) => (
-          <g key={n.id} transform={`translate(${n.x - NODE_W / 2},${n.y - NODE_H / 2})`}>
-            <rect
-              width={NODE_W}
-              height={NODE_H}
-              rx={10}
-              className={`gnode gnode--${n.state}`}
-            />
-            <text x={11} y={19} className="gnode__label">
-              {n.label}
-            </text>
-            <text x={11} y={34} className="gnode__sub">
-              {n.sub}
-            </text>
-          </g>
-        ))}
+        {nodes.map((n) => {
+          const clickable = n.file !== undefined && onOpenFile !== undefined
+          return (
+            <g
+              key={n.id}
+              transform={`translate(${n.x - NODE_W / 2},${n.y - NODE_H / 2})`}
+              className={clickable ? 'gnode-wrap--clickable' : undefined}
+              role={clickable ? 'button' : undefined}
+              tabIndex={clickable ? 0 : undefined}
+              aria-label={clickable ? `Open ${n.file}` : undefined}
+              onClick={clickable ? () => onOpenFile!(n.file!) : undefined}
+              onKeyDown={
+                clickable
+                  ? (e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        onOpenFile!(n.file!)
+                      }
+                    }
+                  : undefined
+              }
+            >
+              <rect
+                width={NODE_W}
+                height={NODE_H}
+                rx={10}
+                className={`gnode gnode--${n.state}`}
+              />
+              <text x={11} y={19} className="gnode__label">
+                {n.label}
+              </text>
+              <text x={11} y={34} className="gnode__sub">
+                {n.sub}
+              </text>
+            </g>
+          )
+        })}
       </svg>
       <p className="graph__legend">
         solid = ownership · dashed = A2A handoff
@@ -88,6 +118,7 @@ function layout(session: Session) {
   for (const p of placed) {
     const a = byID.get(p.id)
     if (!a) continue
+    const state = stateClass(a)
     nodes.push({
       id: p.id,
       x: p.x,
@@ -97,7 +128,10 @@ function layout(session: Session) {
       sub: [a.tier > 0 ? `T${a.tier}` : null, a.state, a.durationMs > 0 ? `${a.durationMs}ms` : null]
         .filter(Boolean)
         .join(' · '),
-      state: stateClass(a),
+      state,
+      // An artifact node's own id IS the file path (see shortLabel's
+      // truncate-from-the-start case, which exists specifically for this).
+      file: state === 'artifact' ? a.id : undefined,
     })
   }
 


### PR DESCRIPTION
## Summary
Two related issues, one coherent change (splitting them would have meant
building #518 against the pre-#519 structure, then reworking it once #519
landed):

**#519 — Code folded into Session as a third tab**
- `Session.tsx` now has Timeline / Code / Graph tabs (Graph still only when
  `session.nonLinear`, Code always available)
- Removed `code` from App.tsx's top-level `NAV` and the `selectNav` run-guess
  fallback that existed solely to give Code something to look at
- `App.tsx` fetches `session` + `edits` together for the `session` view
  (`Promise.all`) since Code is now reachable from inside it

**#518 — clicking an artifact node opens that file**
- Artifact (edit-target) nodes in `SessionGraph`/`RunGraph` already carried
  the file path as their node id (see the existing `shortLabel` truncate-
  from-the-start case) — they just had no `onClick`. Added one, keyboard-
  accessible (`role="button"`, `tabIndex`, Enter/Space), only on artifact
  nodes — a real agent node has nowhere meaningful to jump to
- `Session` now tracks which tab + which file to preselect; clicking a node
  in its own graph switches to Code with that file selected
- Fleet's inline per-run graph gets the same click, threaded through a new
  `onOpenFile(runID, file)` on `Fleet` → `App.openSessionFile` → opens that
  run's Session already on the Code tab (`Session` is now keyed by `runId`
  so a fresh mount reads the initial tab/file cleanly, instead of carrying
  over tab state from whatever run was open before)

## Testing
- `npm run typecheck` / `npm run build` clean
- `go build ./...` clean (no Go changes; sanity check only)
- No frontend test framework exists in this repo (checked before writing —
  no vitest/jest, no existing `*.test.tsx` files), consistent with #513
- Not done: no live `wails dev` GUI smoke test — no display in this sandbox.
  Worth a manual pass before merge, especially the graph-node click and the
  Fleet → Session-on-Code-tab jump.

Closes #518
Closes #519