### PR TITLE
fix(provider): exclude embedding-only Ollama models from dispatch candidates

### DIFF
--- a/internal/provider/port/provider.go
+++ b/internal/provider/port/provider.go
@@ -118,7 +118,8 @@ func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]pro
 
 	var payload struct {
 		Models []struct {
-			Name string `json:"name"`
+			Name         string   `json:"name"`
+			Capabilities []string `json:"capabilities"`
 		} `json:"models"`
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
@@ -127,6 +128,9 @@ func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]pro
 
 	heads := make([]provider.Head, 0, len(payload.Models))
 	for _, m := range payload.Models {
+		if !completionCapable(m.Capabilities) {
+			continue // embedding-only etc.: reports capabilities but no completion, so it fails every dispatch (#532)
+		}
 		heads = append(heads, provider.Head{
 			ID:       "ollama/" + m.Name,
 			Name:     m.Name + " (Ollama)",
@@ -143,6 +147,23 @@ func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]pro
 		})
 	}
 	return heads, nil
+}
+
+// completionCapable reports whether an Ollama model can serve a text-completion
+// request. An empty list means an older server or a model type that never
+// populates the field — treated as capable, since we have no positive signal
+// either way. A non-empty list lacking "completion" (e.g. embedding-only) is
+// the one case we can rule out (#532).
+func completionCapable(caps []string) bool {
+	if len(caps) == 0 {
+		return true
+	}
+	for _, c := range caps {
+		if c == "completion" {
+			return true
+		}
+	}
+	return false
 }
 
 // ── LM Studio ─────────────────────────────────────────────────────────────────

--- a/internal/provider/port/provider_test.go
+++ b/internal/provider/port/provider_test.go
@@ -93,6 +93,48 @@ func TestLMStudio_DiscoversModelsOnANonDefaultAddress(t *testing.T) {
 	}
 }
 
+// Embedding-only models report capabilities but never "completion", so they
+// were discovered as normal routable heads and failed every dispatch (#532).
+// The fix must exclude only the positively-non-completion case and keep every
+// other shape — including no capabilities field at all, for older servers.
+func TestOllama_ExcludesEmbeddingOnlyModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"models":[
+			{"name":"qwen3:0.6b","capabilities":["completion"]},
+			{"name":"nomic-embed-text:latest","capabilities":["embedding"]},
+			{"name":"llama3.2:3b"},
+			{"name":"qwen2.5-coder:7b","capabilities":["completion","tools","insert"]}
+		]}`))
+	}))
+	defer srv.Close()
+
+	heads, err := (&ollamaService{base: srv.URL}).probe(context.Background(), caps(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids := make(map[string]bool, len(heads))
+	for _, h := range heads {
+		ids[h.ID] = true
+	}
+
+	for _, want := range []string{"ollama/qwen3:0.6b", "ollama/llama3.2:3b", "ollama/qwen2.5-coder:7b"} {
+		if !ids[want] {
+			t.Errorf("missing expected head %q among %+v", want, ids)
+		}
+	}
+	if ids["ollama/nomic-embed-text:latest"] {
+		t.Error("nomic-embed-text is embedding-only and must not be offered as a dispatch candidate")
+	}
+	if len(heads) != 3 {
+		t.Errorf("got %d heads, want 3 (embedding-only excluded): %+v", len(heads), heads)
+	}
+}
+
 // A server that answers but not with what we asked for is not a head. Returning
 // one anyway is the #248 failure: advertising something dispatch cannot use.
 func TestProbe_NonOKStatusYieldsNoHeads(t *testing.T) {


### PR DESCRIPTION
## Summary
- Ollama's `/api/tags` response includes a per-model `capabilities` array that discovery was ignoring — only `name` was read.
- Embedding-only models (e.g. `nomic-embed-text`) were therefore discovered as normal, fully-routable local heads and appeared in `hyctl probe`, tier-10 dry-run plans, and swarm fan-outs, then failed every time they were actually dispatched to.
- Fixed by decoding `capabilities` and skipping any model whose list is present but does not include `"completion"`. A model with no `capabilities` field at all (older Ollama servers, or a model type that never populates it) is left unaffected — only a positive non-completion signal excludes.

## Changes
- `internal/provider/port/provider.go` — decode `capabilities` in the `/api/tags` struct; add `completionCapable` helper; skip embedding-only models in `ollamaService.probe`.
- `internal/provider/port/provider_test.go` — new `TestOllama_ExcludesEmbeddingOnlyModels` covering: `capabilities:["completion"]` (included), `capabilities:["embedding"]` (excluded), no `capabilities` field (included, backward-compat), and multiple capabilities including completion (included).

## Verification
- `go build ./...`, `go vet ./...` clean.
- `go test -race -count=1 ./internal/provider/port/...` — all pass, including the new test.
- Ollama is installed and running on this machine with a live `nomic-embed-text:latest` embedding model. Built binaries from before/after this change and confirmed live:
  - `hyctl probe`: `nomic-embed-text:latest (Ollama)` disappears from discovered heads after the fix; the two completion-capable Ollama models remain.
  - `hyctl dispatch --dry-run --tier 10 --local "..."`: before, `nomic-embed-text:latest` appears in the fallback chain; after, it's gone.
  - `hyctl dispatch --dry-run --swarm --swarm-mode all --local "..."`: same before/after result for the swarm candidate list.

Closes #532