### PR TITLE
fix(trust): reject misaligned calibration snapshot offsets, fall back to full replay

### DIFF
--- a/internal/trust/calibration.go
+++ b/internal/trust/calibration.go
@@ -112,7 +112,7 @@ func (c *Calibrator) load() error {
 	}
 
 	var startOffset int64
-	if snap, offset, ok := loadSnapshot(snapshotPath(c.path), info.Size()); ok {
+	if snap, offset, ok := loadSnapshot(snapshotPath(c.path), f, info.Size()); ok {
 		c.store = snap
 		startOffset = offset
 	}

--- a/internal/trust/calibration_snapshot.go
+++ b/internal/trust/calibration_snapshot.go
@@ -36,9 +36,9 @@ func snapshotPath(jsonlPath string) string {
 	return jsonlPath + ".snapshot"
 }
 
-// loadSnapshot never errors — missing/corrupt/stale-offset just means "no
-// usable checkpoint," so load() falls back to a full replay.
-func loadSnapshot(path string, jsonlSize int64) (store map[calibKey]*confusion, offset int64, ok bool) {
+// loadSnapshot never errors — missing/corrupt/out-of-bounds/misaligned offset
+// just means "no usable checkpoint," so load() falls back to a full replay.
+func loadSnapshot(path string, jsonl *os.File, jsonlSize int64) (store map[calibKey]*confusion, offset int64, ok bool) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, 0, false
@@ -49,6 +49,14 @@ func loadSnapshot(path string, jsonlSize int64) (store map[calibKey]*confusion, 
 	}
 	if snap.Schema != snapshotSchema || snap.Offset < 0 || snap.Offset > jsonlSize {
 		return nil, 0, false
+	}
+	// A valid checkpoint must land exactly on a line boundary; otherwise
+	// load() would seek mid-line and silently drop the split record.
+	if snap.Offset > 0 {
+		var b [1]byte
+		if _, err := jsonl.ReadAt(b[:], snap.Offset-1); err != nil || b[0] != '\n' {
+			return nil, 0, false
+		}
 	}
 	store = make(map[calibKey]*confusion, len(snap.Entries))
 	for _, e := range snap.Entries {

--- a/internal/trust/calibration_snapshot_test.go
+++ b/internal/trust/calibration_snapshot_test.go
@@ -119,6 +119,42 @@ func TestSnapshot_OffsetPastFileSizeIsRejected(t *testing.T) {
 	}
 }
 
+// A schema-valid, in-bounds offset that lands mid-line (not on a JSONL line
+// boundary) must be rejected, not seeked-to — otherwise the split first line
+// silently drops a real record instead of triggering a full replay.
+func TestSnapshot_MisalignedOffsetFallsBackToFullReplay(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "calibration.jsonl")
+
+	c1, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed(t, c1, "model:good", "go", 150, 50, 0, 0)
+	want := c1.D("model:good", "go")
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A few bytes short of EOF lands inside the last line's JSON, not on a
+	// newline — schema-valid and in-bounds, but not a real line boundary.
+	if err := saveSnapshot(snapshotPath(path), map[calibKey]*confusion{}, info.Size()-5); err != nil {
+		t.Fatal(err)
+	}
+
+	c2, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := c2.D("model:good", "go")
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("D after rejecting a misaligned snapshot = %.6f, want %.6f (a record was silently dropped)", got, want)
+	}
+	if n := c2.Report()[0].N; n != 200 {
+		t.Errorf("observations after rejecting a misaligned snapshot = %v, want 200 (a record was silently dropped)", n)
+	}
+}
+
 // Below snapshotThreshold, load() must not write a snapshot file at all.
 func TestSnapshot_NotWrittenBelowThreshold(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "calibration.jsonl")


### PR DESCRIPTION
## Problem

`internal/trust/calibration_snapshot.go`'s `loadSnapshot` validated `snap.Schema == 1` and `0 <= snap.Offset <= jsonlSize`, but never checked that `Offset` actually landed on a JSONL line boundary in `calibration.jsonl`.

A schema-valid, in-bounds, but byte-misaligned offset caused `Calibrator.load()` to seek mid-line. The resulting first fragment failed `json.Unmarshal`, and the "skip malformed rows" logic silently ate one real observation — instead of recognizing the snapshot itself was untrustworthy and falling back to a full replay (which already correctly happens for garbage bytes, bad schema, truncated files, and out-of-bounds offsets).

This was dangerous because it was silent: `hyctl trust calibration`'s se/sp/D numbers (which feed `hyctl dispatch --confidence`'s SPRT ensemble) could be quietly wrong by exactly the discarded record, with no error surfaced anywhere.

## Fix

`loadSnapshot` now also verifies that the byte immediately before a nonzero `Offset` is a newline (`\n`) in the jsonl file, using the already-open file handle from `Calibrator.load()`. A misaligned offset now takes the same fallback path as every other invalid-snapshot case: reject the checkpoint, do a full replay, and self-heal by writing a fresh, correctly-aligned snapshot on the next threshold crossing.

## Changes
- `internal/trust/calibration_snapshot.go` — `loadSnapshot` takes the open jsonl `*os.File` and rejects offsets that don't land on a line boundary
- `internal/trust/calibration.go` — updated the one call site
- `internal/trust/calibration_snapshot_test.go` — new regression test `TestSnapshot_MisalignedOffsetFallsBackToFullReplay`

## Verification
- `go build ./...`, `go vet ./...` clean
- `go test -race -count=1 ./internal/trust/...` passes, including the new test
- Confirmed the new test fails without the fix (temporarily reverted the check: it panics/reports wrong D and dropped observations)
- Real repro with built binaries, mirroring the issue exactly:
  - 250 `hyctl trust record` calls cross `snapshotThreshold=200`, producing a real checkpoint at `offset=19600`
  - Hand-edited the `.snapshot` file's offset to `19610` (misaligned, still in-bounds)
  - Pre-fix binary: `hyctl trust calibration --json` → `n=249` (silent drop, bug reproduced)
  - Post-fix binary against the identical misaligned snapshot: `hyctl trust calibration --json` → `n=250` (matches full replay)

Closes #529