### PR TITLE
fix(parallel): emit KindEdit run-log event for edit tasks

### DIFF
--- a/internal/editor/runlog.go
+++ b/internal/editor/runlog.go
@@ -3,47 +3,14 @@
 package editor
 
 import (
-	"fmt"
-	"sync/atomic"
-
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
 )
 
-// editSeq numbers snapshots within a process so two edits in one run cannot
-// overwrite each other's content. The run id keeps separate runs apart; this
-// keeps separate edits apart inside one.
-var editSeq atomic.Uint64
-
-// logEdit records one applied edit: the file and line counts on the event, the
-// before/after content in the run's side-file store.
-//
-// The content is never inlined. The run log's atomicity guarantee is per
-// write() call, so an entry carrying a whole file would break the property that
-// makes concurrent appends safe — hence Ref, pointing at content held beside
-// the log.
-//
-// Best-effort throughout: an edit that succeeded must not be reported as failed
-// because its observability record could not be written.
+// logEdit records one applied edit via runlog.LogEdit, resolving the run/task
+// identity the same way every other event on this edit does.
 func logEdit(req Request, before, after string, added, removed int) {
 	runID := runid.ResolveRun(req.RunID)
 	taskID := runid.ResolveTask(req.TaskID)
-	ref := fmt.Sprintf("%06d", editSeq.Add(1))
-
-	detail := fmt.Sprintf("+%d/-%d", added, removed)
-	if err := runlog.SaveEdit(runID, ref, []byte(before), []byte(after)); err != nil {
-		// The event still goes out. Losing it would hide that the file changed
-		// at all, which is worse than losing the diff — the reader can render
-		// "diff unavailable" from an unresolvable ref.
-		ref = ""
-		detail += " · snapshot unavailable"
-	}
-
-	_ = runlog.New(runID).Append(runlog.Event{
-		Kind:   runlog.KindEdit,
-		TaskID: taskID,
-		File:   req.File,
-		Ref:    ref,
-		Detail: detail,
-	})
+	runlog.LogEdit(runID, taskID, req.File, []byte(before), []byte(after), added, removed)
 }

--- a/internal/parallel/edit_test.go
+++ b/internal/parallel/edit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/ledger"
+	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/testutil"
 
 	// Providers register themselves in init(), and this package does not import
@@ -173,6 +174,70 @@ func writeLedgerPolicy(t *testing.T, p ledger.Policy) {
 	}
 	if err := os.WriteFile(path, raw, 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// A batch's edit task must leave the same KindEdit run-log trail a standalone
+// `hyctl edit` leaves for the same change (#531) — the agent-tree view,
+// blast.go's recent-edit signal, and the desktop live-code panel all key off
+// it, and runEditTask used to write the file but never emit the event.
+func TestEdit_EmitsAKindEditRunLogEvent(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}"))
+	file := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := Run(context.Background(), []Task{{
+		Label: "edit main", Enum: "MODERATE", File: file,
+		Prompt: "add an empty main", Validate: boolPtr(false),
+	}}, Options{RunID: "run-parallel-edit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got EditResult
+	if err := json.Unmarshal(results[0].raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "ok" {
+		t.Fatalf("status = %q, error %q", got.Status, got.Error)
+	}
+
+	events, err := runlog.Load("run-parallel-edit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var edit *runlog.Event
+	for i := range events {
+		if events[i].Kind == runlog.KindEdit {
+			edit = &events[i]
+			break
+		}
+	}
+	if edit == nil {
+		t.Fatalf("no KindEdit event in the run log: %+v", events)
+	}
+	if edit.File != file {
+		t.Errorf("edit.File = %q, want the file path %q — the same field hyctl edit keys the "+
+			"agent-tree node on", edit.File, file)
+	}
+	if edit.Ref == "" {
+		t.Error("the edit event carries no snapshot ref, so the diff cannot be rendered")
+	}
+	wantDetail := fmt.Sprintf("+%d/-%d", got.LinesAdded, got.LinesRemoved)
+	if edit.Detail != wantDetail {
+		t.Errorf("edit.Detail = %q, want %q — the same +N/-M format hyctl edit produces", edit.Detail, wantDetail)
+	}
+
+	before, after, err := runlog.LoadEdit("run-parallel-edit", edit.Ref)
+	if err != nil {
+		t.Fatalf("the snapshot the ref points at could not be loaded: %v", err)
+	}
+	if string(before) != "package main\n" {
+		t.Errorf("before snapshot = %q, want the file's original content", before)
+	}
+	if !strings.Contains(string(after), "func main() {}") {
+		t.Errorf("after snapshot = %q, want the model's content", after)
 	}
 }
 

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -223,8 +223,9 @@ func runTextTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 }
 
 // runEditTask performs an atomic file edit and returns the raw JSON result.
-// Self-contained port of the edit.sh flow so this package compiles on develop
-// before internal/editor merges. Once editor merges, this can delegate to editor.Edit.
+// Self-contained port of edit.sh — its tests target this package's own
+// extractContent/diffStats/rollback — but shares the KindEdit emission with
+// internal/editor via runlog.LogEdit rather than reimplementing it (#531).
 func runEditTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error, task Task, runID, taskID string) json.RawMessage {
 	file := task.File
 	if !filepath.IsAbs(file) {
@@ -383,6 +384,10 @@ func runEditTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 		}
 	}
 
+	// Same KindEdit shape hyctl edit produces (internal/editor/runlog.go), via
+	// the shared runlog.LogEdit — a parallel batch was writing files with no
+	// trace in the run log at all (#531).
+	runlog.LogEdit(runID, taskID, file, []byte(origContent), []byte(newContent+"\n"), added, removed)
 	return mustMarshal(EditResult{
 		Label: task.Label, Enum: task.Enum, Mode: "edit",
 		Status: "ok", File: file, Workspace: wsName, GitRoot: resolved.GitRoot,

--- a/internal/runlog/edits.go
+++ b/internal/runlog/edits.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 )
 
 // MaxSnapshotBytes caps one side of one edit snapshot.
@@ -58,6 +59,32 @@ func SaveEdit(runID, ref string, before, after []byte) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(dir, ref+".after"), after, 0o600)
+}
+
+// editSeq numbers snapshots across the process so two edits sharing one run
+// cannot overwrite each other's before/after content.
+var editSeq atomic.Uint64
+
+// LogEdit records one applied edit as a KindEdit event: content saved via
+// SaveEdit and referenced by Ref, Detail formatted as "+N/-M". Shared by every
+// edit path (hyctl edit, hyctl parallel) so they log one event shape (#531).
+//
+// Best-effort: a successful edit must not be reported as failed because its
+// observability record could not be written.
+func LogEdit(runID, taskID, file string, before, after []byte, added, removed int) {
+	ref := fmt.Sprintf("%06d", editSeq.Add(1))
+	detail := fmt.Sprintf("+%d/-%d", added, removed)
+	if err := SaveEdit(runID, ref, before, after); err != nil {
+		ref = ""
+		detail += " · snapshot unavailable"
+	}
+	_ = New(runID).Append(Event{
+		Kind:   KindEdit,
+		TaskID: taskID,
+		File:   file,
+		Ref:    ref,
+		Detail: detail,
+	})
 }
 
 // LoadEdit returns a stored edit's before/after content.


### PR DESCRIPTION
## Summary
- `hyctl parallel`'s `runEditTask` wrote files successfully but never emitted a `KindEdit` run-log event, unlike `hyctl edit`. The agent-tree TUI view, `internal/security/blast.go`'s recent-edit signal, and the desktop live-code panel all key off `KindEdit` and had a systematic blind spot for every file touched via `hyctl parallel`.
- Extracted the event-emission logic (`SaveEdit` + a `KindEdit` `Event`, `"+N/-M"` detail format) out of `internal/editor` into a new shared `runlog.LogEdit`, and call it from both `internal/editor` (unchanged behavior, now delegating) and `internal/parallel`'s `runEditTask` (the fix).
- Delegating `runEditTask` fully to `editor.Edit` was considered — there's no import cycle — but rejected: `internal/parallel`'s own test suite exercises this package's copies of `extractContent`, `diffStats`, `rollback`, `runValidate`, `tscTemplate` etc. directly, so full delegation would mean deleting that coverage. Sharing just the emission logic avoids the duplicate-logic problem without that tradeoff.

## Changes
- `internal/runlog/edits.go` — new exported `LogEdit(runID, taskID, file string, before, after []byte, added, removed int)`, moved from `internal/editor/runlog.go`'s private `logEdit`.
- `internal/editor/runlog.go` — `logEdit` now resolves run/task IDs and delegates to `runlog.LogEdit` (behavior unchanged, verified by existing `TestEdit_WritesTheModelsContentAndReportsTheDiff` / `TestLogEdit_IsBestEffort`).
- `internal/parallel/parallel.go` — `runEditTask` now calls `runlog.LogEdit` after a successful write, before returning the `ok` `EditResult`.
- `internal/parallel/edit_test.go` — new `TestEdit_EmitsAKindEditRunLogEvent`, which runs a real batch through `Run()`, then asserts the run log contains a `KindEdit` event with the correct file path (`Agent`), a resolvable snapshot `Ref` whose before/after content matches, and a `Detail` of `"+N/-M"` matching the result's own `LinesAdded`/`LinesRemoved`.

## Verification
- `go build ./...` and `go vet ./...` clean.
- `go test -race ./internal/parallel/... ./internal/editor/... ./internal/runlog/...` — all pass.
- Real repro: built the `hyctl` binary, ran a sandboxed `hyctl parallel --tasks tasks.json` batch with one edit task against a real git repo, and inspected the resulting run-log JSONL. It now contains:
  `{"kind":"edit","agent":"/.../main.go","ref":"000001","detail":"+2/-0"}`
  with a resolvable `.edits/000001.before` / `.after` snapshot pair on disk — it did not before this fix.

Closes #531