### PR TITLE
fix(dispatch): thread --a2a and --swarm-judge-tier consistently across all swarm/confidence paths

### DIFF
--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -319,6 +319,113 @@ func TestCLI_Dispatch_ConfidenceDryRunFiresNothing(t *testing.T) {
 	}
 }
 
+// #530: swarm.Options had no A2AFile field at all, so --a2a was silently
+// dropped the instant --swarm or --confidence was combined with it — a bad
+// handoff file must fail the run the same way it already does on plain
+// dispatch, in both --dry-run (Plan) and real (Run/RunSPRT) execution.
+func TestCLI_Dispatch_SwarmA2ABadFileRejectedIdenticallyDryRunAndReal(t *testing.T) {
+	for _, dryRun := range []bool{true, false} {
+		label := "real"
+		if dryRun {
+			label = "dry-run"
+		}
+		t.Run(label, func(t *testing.T) {
+			dispatchable(t, "answered")
+			bad := filepath.Join(t.TempDir(), "absent.json")
+			args := []string{"dispatch", "--swarm", "--swarm-mode", "all", "--tier", "6", "--a2a", bad, "x"}
+			if dryRun {
+				args = append(args, "--dry-run")
+			}
+			_, cobraOut, err := run(t, args...)
+			if err == nil {
+				t.Fatalf("a nonexistent --a2a file was accepted under --swarm (%s): %s", label, cobraOut)
+			}
+			if !strings.Contains(err.Error()+cobraOut, bad) {
+				t.Errorf("error = %v (%s), want it to name the offending path", err, cobraOut)
+			}
+		})
+	}
+}
+
+// Same contract on the --confidence (SPRT) path.
+func TestCLI_Dispatch_ConfidenceA2ABadFileRejectedIdenticallyDryRunAndReal(t *testing.T) {
+	for _, dryRun := range []bool{true, false} {
+		label := "real"
+		if dryRun {
+			label = "dry-run"
+		}
+		t.Run(label, func(t *testing.T) {
+			dispatchable(t, "answered")
+			bad := filepath.Join(t.TempDir(), "absent.json")
+			args := []string{"dispatch", "--confidence", "0.9", "--tier", "6", "--a2a", bad, "x"}
+			if dryRun {
+				args = append(args, "--dry-run")
+			}
+			_, cobraOut, err := run(t, args...)
+			if err == nil {
+				t.Fatalf("a nonexistent --a2a file was accepted under --confidence (%s): %s", label, cobraOut)
+			}
+			if !strings.Contains(err.Error()+cobraOut, bad) {
+				t.Errorf("error = %v (%s), want it to name the offending path", err, cobraOut)
+			}
+		})
+	}
+}
+
+// #530: only the real sw.Run() call set JudgeTierHint, so a bogus
+// --swarm-judge-tier quietly passed --dry-run and only failed for real —
+// defeating the "dry-run previews reality" contract #453 established.
+func TestCLI_Dispatch_SwarmJudgeTierBadValueRejectedIdenticallyDryRunAndReal(t *testing.T) {
+	for _, dryRun := range []bool{true, false} {
+		label := "real"
+		if dryRun {
+			label = "dry-run"
+		}
+		t.Run(label, func(t *testing.T) {
+			dispatchable(t, "answered")
+			args := []string{"dispatch", "--swarm", "--swarm-judge-tier", "99", "--tier", "6", "x"}
+			if dryRun {
+				args = append(args, "--dry-run")
+			}
+			_, cobraOut, err := run(t, args...)
+			if err == nil {
+				t.Fatalf("a bogus --swarm-judge-tier was accepted (%s): %s", label, cobraOut)
+			}
+			if !strings.Contains(err.Error()+cobraOut, "judge") {
+				t.Errorf("error = %v (%s), want it to name the judge tier as the problem", err, cobraOut)
+			}
+		})
+	}
+}
+
+// --swarm-judge-tier is not a no-op on --confidence: RunSPRT's behavioral
+// equivalence judge dispatches through it (sprt.go's judgeEquivalence), so
+// main.go wires it into that Options literal too instead of treating the
+// combination as meaningless. A bogus value must therefore be rejected the
+// same way in both dry-run (Plan) and real (RunSPRT) execution (#530).
+func TestCLI_Dispatch_ConfidenceSwarmJudgeTierBadValueRejectedIdenticallyDryRunAndReal(t *testing.T) {
+	for _, dryRun := range []bool{true, false} {
+		label := "real"
+		if dryRun {
+			label = "dry-run"
+		}
+		t.Run(label, func(t *testing.T) {
+			dispatchable(t, "answered")
+			args := []string{"dispatch", "--confidence", "0.9", "--swarm-judge-tier", "99", "--tier", "6", "x"}
+			if dryRun {
+				args = append(args, "--dry-run")
+			}
+			_, cobraOut, err := run(t, args...)
+			if err == nil {
+				t.Fatalf("a bogus --swarm-judge-tier under --confidence was accepted (%s): %s", label, cobraOut)
+			}
+			if !strings.Contains(err.Error()+cobraOut, "judge") {
+				t.Errorf("error = %v (%s), want it to name the judge tier as the problem", err, cobraOut)
+			}
+		})
+	}
+}
+
 // A swarm that actually runs must bill every head it fired, not just the winner.
 func TestCLI_Dispatch_SwarmBillsEveryHead(t *testing.T) {
 	dispatchable(t, "answered")

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -717,6 +717,10 @@ func cmdDispatch() *cobra.Command {
 					mode = swarm.ModeBest
 				}
 				sw := swarm.New(d, d.Heads(), d)
+				// Every field a real Run()/RunSPRT() call reads must appear here too,
+				// or --dry-run previews something other than what execution does
+				// (#167, #501, #530) — this literal backs both the --swarm and the
+				// --confidence dry-run preview.
 				planOpts := swarm.Options{
 					Mode:          mode,
 					TierHint:      tier,
@@ -725,6 +729,8 @@ func cmdDispatch() *cobra.Command {
 					MaxEstCostUSD: swarmMaxCost,
 					LocalOnly:     localOnly,
 					System:        system,
+					A2AFile:       a2aFile,
+					JudgeTierHint: swarmJudge,
 					Confidence:    effectiveConf,
 					Domain:        domain,
 				}
@@ -739,12 +745,20 @@ func cmdDispatch() *cobra.Command {
 			if effectiveConf > 0 {
 				sw := swarm.New(d, d.Heads(), d)
 				res, err := sw.RunSPRT(ctx, prompt, swarm.Options{
-					TierHint:       tier,
-					HeadIDs:        headIDs,
-					MaxHeads:       swarmMaxHeads,
-					MaxEstCostUSD:  swarmMaxCost,
-					LocalOnly:      localOnly,
-					System:         system,
+					TierHint:      tier,
+					HeadIDs:       headIDs,
+					MaxHeads:      swarmMaxHeads,
+					MaxEstCostUSD: swarmMaxCost,
+					LocalOnly:     localOnly,
+					System:        system,
+					A2AFile:       a2aFile,
+					// JudgeTierHint is not a no-op here: RunSPRT's behavioral
+					// equivalence judge (judgeEquivalence) dispatches through it to
+					// decide whether two candidate answers agree. It just isn't a
+					// ModeBest-style answer-picker, so it is wired in and validated
+					// like every other tier hint rather than rejected as
+					// inapplicable (#530).
+					JudgeTierHint:  swarmJudge,
 					Confidence:     effectiveConf,
 					Domain:         domain,
 					RunID:          runID,
@@ -774,6 +788,7 @@ func cmdDispatch() *cobra.Command {
 					MaxEstCostUSD:  swarmMaxCost,
 					LocalOnly:      localOnly,
 					System:         system,
+					A2AFile:        a2aFile,
 					JudgeTierHint:  swarmJudge,
 					RunID:          runID,
 					TaskID:         taskID,

--- a/internal/a2a/a2a.go
+++ b/internal/a2a/a2a.go
@@ -8,6 +8,7 @@ package a2a
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -140,6 +141,22 @@ func Load(path string) (*Handoff, error) {
 		return nil, err
 	}
 	return &h, nil
+}
+
+// Inject reads a handoff JSON file at path and prepends its structured context
+// to prompt. Unlike Load's "missing file = no prior handoff" contract for
+// other callers, path here always comes from an explicit --a2a flag, so a
+// missing or malformed file is a mistake the caller needs to hear about
+// rather than something to silently skip (#450, #530).
+func Inject(path, prompt string) (string, error) {
+	h, err := Load(path)
+	if err != nil {
+		return prompt, fmt.Errorf("malformed handoff file %s: %w", path, err)
+	}
+	if h == nil {
+		return prompt, fmt.Errorf("handoff file not found: %s", path)
+	}
+	return h.PromptBlock(prompt) + "\n\nADDITIONAL INSTRUCTION:\n" + prompt, nil
 }
 
 // Save writes the handoff atomically-ish (dir created, 0600).

--- a/internal/a2a/coverage_test.go
+++ b/internal/a2a/coverage_test.go
@@ -3,8 +3,10 @@
 package a2a
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -44,6 +46,46 @@ func TestLoad_MissingFileIsNilNilNotAnError(t *testing.T) {
 	}
 	if h != nil {
 		t.Errorf("a missing handoff returned %+v", h)
+	}
+}
+
+// Inject's handoff context must reach the prompt when the file is valid, and a
+// missing or corrupt handoff file must fail loudly (#450, #530) rather than
+// letting a caller (dispatch, swarm, RunSPRT) silently proceed without it.
+func TestInject(t *testing.T) {
+	dir := t.TempDir()
+
+	h := Handoff{From: "agent-1", Task: "earlier task", PriorOutput: "earlier output"}
+	raw, err := json.Marshal(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "handoff.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Inject(path, "new instruction")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"agent-1", "earlier output", "new instruction", "ADDITIONAL INSTRUCTION"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("injected prompt is missing %q:\n%s", want, got)
+		}
+	}
+
+	// --a2a always names a file the caller explicitly asked for, so a missing
+	// file must be an error, not silently treated as "no handoff".
+	if _, err := Inject(filepath.Join(dir, "absent.json"), "unchanged"); err == nil {
+		t.Error("a missing handoff file did not produce an error")
+	}
+
+	if err := os.WriteFile(path, []byte("{truncated"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Inject(path, "unchanged"); err == nil {
+		t.Error("a malformed handoff file did not produce an error")
 	}
 }
 

--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -556,46 +556,6 @@ func TestDispatch_NoHeadsErrorIsMatchableAndPhrasesAnEmptyTierClearly(t *testing
 	}
 }
 
-// A2A injection: the handoff's context must reach the prompt when the file is
-// valid, and a missing or corrupt handoff file must fail loudly (#450) rather
-// than silently dispatching without the context the user asked for.
-func TestInjectA2A(t *testing.T) {
-	dir := t.TempDir()
-
-	h := a2a.Handoff{From: "agent-1", Task: "earlier task", PriorOutput: "earlier output"}
-	raw, err := json.Marshal(h)
-	if err != nil {
-		t.Fatal(err)
-	}
-	path := filepath.Join(dir, "handoff.json")
-	if err := os.WriteFile(path, raw, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := injectA2A(path, "new instruction")
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, want := range []string{"agent-1", "earlier output", "new instruction", "ADDITIONAL INSTRUCTION"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("injected prompt is missing %q:\n%s", want, got)
-		}
-	}
-
-	// --a2a always names a file the user explicitly asked for, so a missing
-	// file must be an error, not silently treated as "no handoff".
-	if _, err := injectA2A(filepath.Join(dir, "absent.json"), "unchanged"); err == nil {
-		t.Error("a missing --a2a file did not produce an error")
-	}
-
-	if err := os.WriteFile(path, []byte("{truncated"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := injectA2A(path, "unchanged"); err == nil {
-		t.Error("a malformed --a2a file did not produce an error")
-	}
-}
-
 // A dispatch given a bad --a2a path must fail clearly instead of silently
 // running without the handoff context the user explicitly asked for (#450).
 func TestDispatch_BadA2AFileFailsTheRun(t *testing.T) {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -217,7 +217,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 	// user explicitly asked for, so a read/parse failure must fail the dispatch
 	// rather than silently running without the handoff context (#450).
 	if opts.A2AFile != "" {
-		injected, err := injectA2A(opts.A2AFile, prompt)
+		injected, err := a2a.Inject(opts.A2AFile, prompt)
 		if err != nil {
 			return nil, fmt.Errorf("--a2a %s: %w", opts.A2AFile, err)
 		}
@@ -452,21 +452,6 @@ func asIntSlice(v any) []int {
 		out = append(out, asInt(e))
 	}
 	return out
-}
-
-// injectA2A reads a handoff JSON file and prepends a structured block to the prompt.
-// The path always comes from the user-supplied --a2a flag, so unlike a2a.Load's
-// "missing file = no prior handoff" contract for its other (auto-load) callers,
-// a missing or malformed file here is a mistake the user needs to hear about.
-func injectA2A(path, prompt string) (string, error) {
-	h, err := a2a.Load(path)
-	if err != nil {
-		return prompt, fmt.Errorf("a2a: malformed handoff file %s: %w", path, err)
-	}
-	if h == nil {
-		return prompt, fmt.Errorf("a2a: handoff file not found: %s", path)
-	}
-	return h.PromptBlock(prompt) + "\n\nADDITIONAL INSTRUCTION:\n" + prompt, nil
 }
 
 // writeHandoff saves last_handoff.json after a successful dispatch, advancing

--- a/internal/swarm/run_test.go
+++ b/internal/swarm/run_test.go
@@ -4,11 +4,13 @@ package swarm
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/ankit373/hydra/internal/a2a"
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/cost"
 	"github.com/ankit373/hydra/internal/dispatch"
@@ -93,6 +95,48 @@ func TestRun_ModeAllRunsEveryHeadAndRanksThem(t *testing.T) {
 	}
 	if res.Mode != ModeAll || res.Prompt != "the question" {
 		t.Errorf("result did not carry the request back: %+v", res)
+	}
+}
+
+// writeHandoffFile writes a minimal valid A2A handoff to a fresh temp file
+// and returns its path, for tests exercising Options.A2AFile.
+func writeHandoffFile(t *testing.T) string {
+	t.Helper()
+	h := a2a.Handoff{From: "agent-1", Task: "earlier task", PriorOutput: "prior output"}
+	raw, err := json.Marshal(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "handoff.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// #530: a valid --a2a file must actually reach the heads Run fires, not just
+// pass validation — swarm.Options carrying an A2AFile field is only half the
+// fix if the injected content never makes it into the executed prompt.
+func TestRun_A2AFileInjectsHandoffIntoPrompt(t *testing.T) {
+	withTempConfig(t)
+	capturing := &capturingExecutor{}
+	withStubExecutor(t, capturing)
+
+	s := New(nil, []provider.Head{registryHead("h1", "H1", 90)}, fakePricing{per: 0.01})
+	if _, err := s.Run(context.Background(), "new instruction", Options{
+		Mode: ModeAll, A2AFile: writeHandoffFile(t),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	seen := capturing.seen()
+	if len(seen) != 1 {
+		t.Fatalf("executor ran %d times, want 1", len(seen))
+	}
+	for _, want := range []string{"agent-1", "prior output", "new instruction"} {
+		if !strings.Contains(seen[0], want) {
+			t.Errorf("executed prompt is missing %q:\n%s", want, seen[0])
+		}
 	}
 }
 
@@ -424,6 +468,38 @@ func TestRunSPRT_EmptyDomainDefaults(t *testing.T) {
 	}
 	if res.Domain == "" {
 		t.Error("Domain is empty; calibration would be recorded against no domain at all")
+	}
+}
+
+// #530: RunSPRT must honor --a2a exactly like Run does — the handoff's
+// context has to reach every sampled head's prompt, not just pass Options
+// validation.
+func TestRunSPRT_A2AFileInjectsHandoffIntoPrompt(t *testing.T) {
+	withTempConfig(t)
+	capturing := &capturingExecutor{}
+	withStubExecutor(t, capturing)
+
+	s := New(nil, []provider.Head{registryHead("h1", "H1", 90)}, fakePricing{per: 0.01})
+	res, err := s.RunSPRT(context.Background(), "new instruction", Options{
+		Confidence: 0.6, A2AFile: writeHandoffFile(t),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := capturing.seen()
+	if len(seen) == 0 {
+		t.Fatal("no prompts were executed")
+	}
+	for _, p := range seen {
+		for _, want := range []string{"agent-1", "prior output", "new instruction"} {
+			if !strings.Contains(p, want) {
+				t.Errorf("executed prompt is missing %q:\n%s", want, p)
+			}
+		}
+	}
+	if !strings.Contains(res.Prompt, "prior output") {
+		t.Errorf("SPRTResult.Prompt = %q, want it to reflect the injected handoff", res.Prompt)
 	}
 }
 

--- a/internal/swarm/runner_test.go
+++ b/internal/swarm/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -101,6 +102,27 @@ func withStubExecutor(t *testing.T, e executor.Executor) {
 	orig := executorFor
 	executorFor = func(provider.Head) executor.Executor { return e }
 	t.Cleanup(func() { executorFor = orig })
+}
+
+// capturingExecutor records the prompt every head actually ran with, so a test
+// can prove content (like an injected A2A handoff) reached execution instead
+// of only checking that Run/RunSPRT returned success.
+type capturingExecutor struct {
+	mu      sync.Mutex
+	prompts []string
+}
+
+func (c *capturingExecutor) Execute(_ context.Context, req executor.Request) (*executor.Response, error) {
+	c.mu.Lock()
+	c.prompts = append(c.prompts, req.Prompt)
+	c.mu.Unlock()
+	return &executor.Response{Output: "ok"}, nil
+}
+
+func (c *capturingExecutor) seen() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.prompts...)
 }
 
 // A hung head must degrade to a clean StatusTimeout — not block wg.Wait forever.

--- a/internal/swarm/sprt.go
+++ b/internal/swarm/sprt.go
@@ -43,6 +43,10 @@ func (s *Swarm) RunSPRT(ctx context.Context, prompt string, opts Options) (*SPRT
 	if err := validateSwarmTiers(cfg, opts); err != nil {
 		return nil, err
 	}
+	prompt, err = injectA2A(prompt, opts)
+	if err != nil {
+		return nil, err
+	}
 
 	selected, err := resolveSelector(opts, cfg).Select(s.heads, opts)
 	if err != nil {

--- a/internal/swarm/swarm.go
+++ b/internal/swarm/swarm.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/ankit373/hydra/internal/a2a"
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/policy"
@@ -48,6 +49,14 @@ type Options struct {
 	// Prompt parameters.
 	System    string
 	MaxTokens int
+
+	// A2AFile is a path to an A2A handoff JSON file (--a2a): its structured
+	// context is prepended to the prompt before any head fires. Mirrors the
+	// fail-loudly contract dispatch.Options.A2AFile gives plain dispatch — a
+	// missing or malformed file fails Plan/Run/RunSPRT instead of silently
+	// dropping the handoff, which is what happened before this field existed
+	// at all (#530).
+	A2AFile string
 
 	// Judge (ModeBest only).
 	JudgeTierHint string        // "" → use config.Cortex head
@@ -148,6 +157,10 @@ func (s *Swarm) Plan(prompt string, opts Options) (heads []provider.Head, estUSD
 	if err := validateSwarmTiers(cfg, opts); err != nil {
 		return nil, 0, err
 	}
+	prompt, err = injectA2A(prompt, opts)
+	if err != nil {
+		return nil, 0, err
+	}
 	selected, err := resolveSelector(opts, cfg).Select(s.heads, opts)
 	if err != nil {
 		return nil, 0, err
@@ -176,6 +189,10 @@ func (s *Swarm) Run(ctx context.Context, prompt string, opts Options) (*SwarmRes
 	// are fired or judged — never silently widen to CapScoreSelector's top-N
 	// fan-out (#501).
 	if err := validateSwarmTiers(cfg, opts); err != nil {
+		return nil, err
+	}
+	prompt, err = injectA2A(prompt, opts)
+	if err != nil {
 		return nil, err
 	}
 
@@ -279,6 +296,23 @@ func validateSwarmTiers(cfg *config.Config, opts Options) error {
 		return fmt.Errorf("swarm: judge tier: %w", err)
 	}
 	return nil
+}
+
+// injectA2A prepends opts.A2AFile's handoff context to prompt when set, using
+// the identical fail-loudly contract dispatch.Dispatch applies to --a2a. Plan,
+// Run and RunSPRT all call this so a bad handoff file is rejected the same way
+// regardless of mode — before this, swarm.Options had no A2AFile field at all,
+// so --a2a was silently dropped the moment --swarm or --confidence was
+// combined with it (#530).
+func injectA2A(prompt string, opts Options) (string, error) {
+	if opts.A2AFile == "" {
+		return prompt, nil
+	}
+	injected, err := a2a.Inject(opts.A2AFile, prompt)
+	if err != nil {
+		return prompt, fmt.Errorf("swarm: --a2a %s: %w", opts.A2AFile, err)
+	}
+	return injected, nil
 }
 
 func buildJudge(d *dispatch.Dispatcher, opts Options, cfg *config.Config) Judge {

--- a/internal/swarm/swarm_test.go
+++ b/internal/swarm/swarm_test.go
@@ -522,3 +522,30 @@ func TestPlan_RejectsUnknownModeLikeRun(t *testing.T) {
 		}
 	}
 }
+
+// #530: swarm.Options had no A2AFile field at all, so --a2a was silently
+// dropped the instant --swarm or --confidence was combined with it — a bad
+// handoff file must be rejected by Plan (the --dry-run path), Run and
+// RunSPRT alike, exactly as it already was on plain dispatch.
+func TestPlanRunRunSPRT_RejectBadA2AFileIdentically(t *testing.T) {
+	withTempConfig(t)
+	all := []provider.Head{registryHead("h1", "H1", 90)}
+	s := New(nil, all, fakePricing{per: 0.01})
+	bad := filepath.Join(t.TempDir(), "missing.json")
+
+	if _, _, err := s.Plan("p", Options{A2AFile: bad}); err == nil {
+		t.Error("Plan accepted a nonexistent --a2a file")
+	} else if !strings.Contains(err.Error(), bad) {
+		t.Errorf("Plan error = %v, want it to name the offending path", err)
+	}
+	if _, err := s.Run(context.Background(), "p", Options{A2AFile: bad}); err == nil {
+		t.Error("Run accepted a nonexistent --a2a file")
+	} else if !strings.Contains(err.Error(), bad) {
+		t.Errorf("Run error = %v, want it to name the offending path", err)
+	}
+	if _, err := s.RunSPRT(context.Background(), "p", Options{A2AFile: bad, Confidence: 0.9}); err == nil {
+		t.Error("RunSPRT accepted a nonexistent --a2a file")
+	} else if !strings.Contains(err.Error(), bad) {
+		t.Errorf("RunSPRT error = %v, want it to name the offending path", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two related bugs, both about `swarm.Options{}` being built inconsistently across the four call sites in `cmdDispatch` (`cmd/hydra/main.go`) — the same bug shape already fixed once for PII local-only enforcement (#500).

**Bug 1 — `--a2a` silently dropped on `--swarm`/`--confidence`.** `swarm.Options` had no `A2AFile` field, and the SPRT/swarm branches never injected the handoff. `hyctl dispatch --a2a bad.json --confidence 0.5 "x"` (or `--swarm`) used to exit 0 with the handoff silently skipped, while plain dispatch correctly errored.

- Moved the injection logic out of `internal/dispatch` (unexported `injectA2A`) into `a2a.Inject` — a shared, exported helper — so `dispatch.Dispatch`, `swarm.Plan`, `swarm.Run`, and `swarm.RunSPRT` all use the identical fail-loudly contract instead of three copies of the same logic.
- Added `Options.A2AFile` to `swarm.Options` and a small `injectA2A(prompt, opts)` wrapper in `internal/swarm` that all three entry points (`Plan`, `Run`, `RunSPRT`) call before selecting/firing any head.
- A missing or malformed handoff file now errors identically across plain dispatch, `--swarm`, and `--confidence`, in both `--dry-run` and real execution.

**Bug 2 — `--swarm-judge-tier` inconsistently wired.** Only the real (non-dry-run) `sw.Run()` call set `JudgeTierHint`; the dry-run `Plan()` call and the `RunSPRT()` call never did. `--swarm --swarm-judge-tier bogus --dry-run` used to succeed silently while the same command without `--dry-run` correctly errored.

- `JudgeTierHint` is now set in all three `swarm.Options{}` literals `cmdDispatch` builds (dry-run `Plan`, real `RunSPRT`, real `Run` — `Run` already had it).
- Decision on the `--confidence` combination: `RunSPRT`'s behavioral equivalence judge (`judgeEquivalence` in `internal/swarm/sprt.go`) genuinely dispatches through `opts.JudgeTierHint` to decide whether two candidate answers agree — it isn't a ModeBest-style answer-picker, but it is not a no-op either. So rather than rejecting `--swarm-judge-tier` + `--confidence` as an invalid combination, it's wired in and validated the same way as every other tier hint (`validateSwarmTiers`, shared by `Plan`/`Run`/`RunSPRT`). A bogus value now errors identically in dry-run and real execution on both the `--swarm` and `--confidence` paths.

## Changes

- `internal/a2a/a2a.go` — new exported `Inject(path, prompt) (string, error)`, moved from `dispatch.injectA2A`.
- `internal/dispatch/dispatch.go` — `Dispatch` now calls `a2a.Inject`; old private `injectA2A` removed.
- `internal/swarm/swarm.go` — `Options.A2AFile` field; `injectA2A` helper; wired into `Plan` and `Run`.
- `internal/swarm/sprt.go` — `RunSPRT` now calls `injectA2A` too.
- `cmd/hydra/main.go` — all three `swarm.Options{}` literals in `cmdDispatch` now set `A2AFile` and `JudgeTierHint` consistently.
- Tests: `internal/a2a/coverage_test.go` (moved `TestInject`), `internal/swarm/swarm_test.go`, `internal/swarm/run_test.go`, `internal/swarm/runner_test.go` (new `capturingExecutor`), `cmd/hydra/cli_success_test.go` (CLI-level dry-run/real parity tests for both bugs).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./internal/a2a/... ./internal/dispatch/... ./internal/swarm/...` — clean
- [x] `go test -race -count=1 ./cmd/hydra/...` — clean except `TestCLI_Dispatch_LocalOnlyRefusesWhenNothingIsLocal`, which fails identically on unmodified `develop` on this machine because it has a real local Ollama server running on the default port (a pre-existing gap already called out in a comment on the neighboring `TestCLI_Dispatch_PIIPolicyForcesLocalOnlyOnTheSPRTPath` test) — unrelated to this change, confirmed via `git stash`.
- [x] `go test ./...` (full repo) — same result.
- [x] New unit tests assert the A2A handoff error surfaces identically across plain/`--swarm`/`--confidence`, in both dry-run and real modes, and that `--swarm-judge-tier` validation is consistent between dry-run and real, including under `--confidence`.

Closes #530