### PR TITLE
fix(test): Sandbox doesn't block real Ollama, and two assertions crash on failure

### DIFF
--- a/internal/dispatch/identity_test.go
+++ b/internal/dispatch/identity_test.go
@@ -125,7 +125,10 @@ func TestLogDispatch_ExplicitBeatsEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	rows := readLog(t, home, "cost.jsonl")
-	if len(rows) != 1 || rows[0]["run_id"] != "explicit-run" {
+	if len(rows) != 1 {
+		t.Fatalf("cost.jsonl: got %d rows, want 1", len(rows))
+	}
+	if rows[0]["run_id"] != "explicit-run" {
 		t.Errorf("run_id = %v, want the explicit Options value to win over env", rows[0]["run_id"])
 	}
 }
@@ -143,7 +146,10 @@ func TestLogDispatch_EnvUsedWhenNoExplicit(t *testing.T) {
 		t.Fatal(err)
 	}
 	rows := readLog(t, home, "cost.jsonl")
-	if len(rows) != 1 || rows[0]["run_id"] != "orchestrator-run" {
+	if len(rows) != 1 {
+		t.Fatalf("cost.jsonl: got %d rows, want 1", len(rows))
+	}
+	if rows[0]["run_id"] != "orchestrator-run" {
 		t.Errorf("run_id = %v, want the env value", rows[0]["run_id"])
 	}
 }

--- a/internal/provider/port/provider_test.go
+++ b/internal/provider/port/provider_test.go
@@ -239,9 +239,12 @@ func TestDiscovery_ResolvesTheSameHostTheExecutorWill(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.env, func(t *testing.T) {
 			s := testutil.NewSandbox(t)
-			if tc.env != "" {
-				s.SetKey(t, "OLLAMA_HOST", tc.env)
-			}
+			// Explicit even for "", rather than relying on the sandbox's own
+			// baseline: NewSandbox points OLLAMA_HOST at a dead address by
+			// default so an unrelated test never discovers a real local
+			// Ollama server (#539), so "no override" has to be asserted here,
+			// not borrowed from whatever the sandbox happens to leave behind.
+			s.SetKey(t, "OLLAMA_HOST", tc.env)
 			got := provider.OllamaHost()
 			if got != tc.want {
 				t.Errorf("OllamaHost() = %q with OLLAMA_HOST=%q, want %q", got, tc.env, tc.want)

--- a/internal/testutil/sandbox.go
+++ b/internal/testutil/sandbox.go
@@ -194,8 +194,20 @@ func NewSandbox(t *testing.T) *Sandbox {
 		t.Setenv(v, "")
 	}
 	for _, v := range tuningVars {
-		if v == "HYDRA_HOME" {
+		switch v {
+		case "HYDRA_HOME":
 			continue // set above
+		case "OLLAMA_HOST":
+			// Clearing to "" falls back to the built-in localhost:11434
+			// default — indistinguishable from "no override" but not from
+			// "no Ollama". A machine that actually runs Ollama there (this
+			// is not hypothetical: it broke TestCLI_Dispatch_
+			// LocalOnlyRefusesWhenNothingIsLocal on a real laptop, #539) gets
+			// a genuine local head CI never sees. Point at a dead address —
+			// same convention as the package init()'s proxy blackhole below —
+			// so port discovery fails deterministically everywhere.
+			t.Setenv(v, "127.0.0.1:1")
+			continue
 		}
 		t.Setenv(v, "")
 	}


### PR DESCRIPTION
## Context

Found while investigating a reported `internal/dispatch` panic. That panic
turned out to be caused entirely by a stale `$HYDRA_HOME` export left in my
own `~/.zshrc` from an old debugging session — not a repo bug, fixed outside
this PR by removing the export. But two real, reproducible bugs surfaced
along the way.

## 1. `testutil.NewSandbox` doesn't actually block real Ollama discovery

The docstring promises: "a contributor with no Ollama, no API keys and no
agy on their machine gets byte-identical results to CI, and to a maintainer
whose laptop has all three." It didn't deliver that for port-based
discovery: it cleared `$OLLAMA_HOST` to `""`, which just falls back to the
hardcoded `localhost:11434` default — exactly where a real Ollama server
listens.

CI has no Ollama, so this was invisible there. On a machine that actually
runs Ollama (mine), `TestCLI_Dispatch_LocalOnlyRefusesWhenNothingIsLocal`
discovered a real local head and dispatched to it for real — correct
routing behavior, wrong test premise.

Fixed by pointing `OLLAMA_HOST` at `127.0.0.1:1` by default, the same
dead-address convention the package `init()` already uses to blackhole the
HTTP proxy. One existing test relied on the old `""` default to represent
"no override" — it now sets `""` explicitly, which is the more honest
assertion regardless.

## 2. Two assertions panic instead of failing cleanly

```go
if len(rows) != 1 || rows[0]["run_id"] != want {
    t.Errorf("run_id = %v, ...", rows[0]["run_id"])
}
```

`||` short-circuits the condition, but `Errorf`'s arguments are evaluated
unconditionally before the call — so a 0-row regression panics on the
empty-slice index instead of reporting a failure, crashing the whole
package and hiding every other test result in that run. Split into two
`if`s, matching the guard the other two tests in the same file already use.

## Verification

- Sabotaged the length guard on each fix in turn, confirmed a clean `FAIL`
  instead of a panic, reverted the sabotage.
- Full repo `go test -race ./...` green, with `$HYDRA_HOME` explicitly
  unset (not relying on my own env being clean).
- `gofmt`, `go vet`, `staticcheck` clean.

Closes #539
