### PR TITLE
docs: refresh README for v1.3.0 + fix mobile layout bugs on the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,42 +75,27 @@ Hydra discovers and routes to all of these automatically — no plugins, no manu
 
 ## Architecture
 
-```
-  ┌───────────────────────────────────────────────────────────────────────┐
-  │   hyctl dispatch  [--local | --swarm | --confidence 0.95]               │
-  └───────────────────────────────────┬─────────────────────────────────────┘
-                                       │
-                     ┌─────────────────▼─────────────────┐
-                     │  Policy Engine                     │  PII detection
-                     │  (blocks before any network call)  │  cost ceiling · local-only
-                     └─────────────────┬─────────────────┘
-                                       │
-                     ┌─────────────────▼─────────────────┐
-                     │  Router                            │  CapScore → tier
-                     │  score → tier → fallback chain     │  ~1.1 µs/dispatch
-                     └───┬───────────────┬───────────────┬─┘
-             single      │        swarm  │    confidence │  (SPRT)
-          ┌──────────────▼┐  ┌───────────▼──┐  ┌──────────▼───────────┐
-          │ best available│  │ race/best/all│  │ Trust Control Plane   │
-          │ head + fallbk │  │ + LLM judge  │  │ calibration → LLR/D    │
-          └──────┬────────┘  └──────┬───────┘  │ SPRT optimal-stopping  │
-                 │                  │          │ defect-cost model      │
-                 │                  │          └──────────┬────────────┘
-                 └──────────────────┴─────────────────────┘
-                                       │
-              ┌────────────────────────┼────────────────────────┐
-       ┌──────▼──────┐          ┌──────▼──────┐          ┌───────▼─────┐
-       │  CLI Heads  │          │  API Heads  │          │ Local Heads │
-       │ Claude Code │          │   OpenAI    │          │   Ollama    │
-       │   Codex     │          │  Anthropic  │          │  LM Studio  │
-       │  Cursor …   │          │  Groq … +12 │          │             │
-       └─────────────┘          └─────────────┘          └─────────────┘
-         score 60–95              score 70–95              score 50–72
-                                       │
-                     ┌─────────────────▼─────────────────┐
-                     │  Observability                     │  cost.jsonl (est/actual)
-                     │  cost + calibration + trust ledgers│  calibration.jsonl · trust.jsonl
-                     └────────────────────────────────────┘
+```mermaid
+flowchart TD
+    A["<b>hyctl dispatch</b><br/>--local · --swarm · --confidence 0.95"] --> B
+    B["<b>Policy Engine</b><br/>PII detection · cost ceiling · local-only<br/><i>blocks before any network call</i>"] --> C
+    C["<b>Router</b><br/>CapScore → tier → fallback chain<br/><i>~1.1 µs/dispatch</i>"]
+
+    C -->|single| E["best available head<br/>+ fallback chain"]
+    C -->|swarm| F["race / best / all<br/>+ LLM judge"]
+    C -->|confidence| G["<b>Trust Control Plane</b><br/>calibration → LLR/D<br/>SPRT optimal-stopping<br/>defect-cost model"]
+
+    subgraph Heads [" "]
+        direction LR
+        CLI["<b>CLI Heads</b><br/>Claude Code · Codex · Cursor …<br/>score 60–95"]
+        API["<b>API Heads</b><br/>OpenAI · Anthropic · Groq … +12<br/>score 70–95"]
+        LOC["<b>Local Heads</b><br/>Ollama · LM Studio<br/>score 50–72"]
+    end
+
+    E --> Heads
+    F --> Heads
+    G --> Heads
+    Heads --> J["<b>Observability</b><br/>cost.jsonl · calibration.jsonl · trust.jsonl<br/><i>est/actual labeled</i>"]
 ```
 
 Every executor is **native Go** — `agy`, Ollama, per-provider HTTP (OpenAI-compatible + Anthropic/Gemini/Cohere/Azure/Bedrock/Replicate), and generic CLI. No shell scripts in the hot path.
@@ -403,7 +388,7 @@ hyctl dispatch --confidence 0.90 --file internal/auth/token.go "rotate the signi
 
 In synthetic benchmarks this cuts model calls **~49% on easy tasks** and **~24% on a blended workload** at ≥98% accuracy — while deliberately sampling *more* than a fixed swarm on genuinely hard tasks, which a fixed-N ensemble cannot do. Calibration is cold-start conservative: with no history, sources are treated as uninformative and Hydra falls back to sampling broadly.
 
-> The SPRT ensemble, calibration engine, defect-cost model, graph-aware (blast-radius) routing, the local MCP accountability ledger, and verification oracles have all shipped. A central security agent and a web dashboard are on the [roadmap](#roadmap).
+> The SPRT ensemble, calibration engine, defect-cost model, graph-aware (blast-radius) routing, the local MCP accountability ledger, verification oracles, security posture assessment (`hyctl security`), and the native desktop app have all shipped. A browser-based Web UI and a central MCP server registry are on the [roadmap](#roadmap).
 
 ---
 
@@ -422,7 +407,8 @@ In synthetic benchmarks this cuts model calls **~49% on easy tasks** and **~24% 
 | Route to a **confidence of correctness** (SPRT) | ✅ | ❌ | ❌ | ❌ |
 | Per-source calibration (sensitivity / specificity / D) | ✅ | ❌ | ❌ | ❌ |
 | MCP accountability ledger | ✅ | ❌ | ❌ | ❌ |
-| Central security agent *(roadmap)* | 🔨 | ❌ | ❌ | ❌ |
+| Security posture + correlated incident detection (`hyctl security`) | ✅ | ❌ | ❌ | ❌ |
+| Native desktop app (Dashboard / Fleet / Session / Code) | ✅ | ❌ | ❌ | ❌ |
 
 ---
 
@@ -476,11 +462,10 @@ Every release builds `hyctl` for all six targets below. This table is kept in st
 
 Windows has no Homebrew; use npm, pip, `install.ps1`, or download the archive directly.
 
-The **desktop app** ships for macOS (universal), Windows x86-64 and Linux x86-64. Windows ARM64 and
-Linux ARM64 build on hosted ARM runners as of [#263](https://github.com/ankit373/hydra/issues/263),
-but were added after v1.2.0 was cut — the first release carrying them is the one after v1.2.0, and
-`install-app.sh` picks them up automatically once published. The CLI has covered ARM64 on all three
-OSes all along.
+The **desktop app** ships for macOS (universal), Windows x86-64/ARM64, and Linux x86-64/ARM64 — five
+targets total ([#263](https://github.com/ankit373/hydra/issues/263)), each built on a native runner
+(including two hosted ARM runners) and uploaded on every RC and stable release. `install-app.sh`
+resolves the right archive for your OS/arch automatically — nothing to configure per-arch.
 
 **From source** (Go 1.22+):
 ```bash
@@ -506,7 +491,9 @@ The wizard scans your machine, ranks every model it finds, walks you through pic
 hyctl init                              # first-run wizard
 hyctl probe                             # scan and display all available models
 hyctl status                            # live system state (heads, budget bars, burn-rate risk)
-hyctl tui                               # interactive cockpit — chat+code / dashboard / agent-tree / security (Tab cycles)
+hyctl tui                               # interactive cockpit — chat+code / dashboard / agent-tree (Tab cycles)
+hyctl version                           # version, commit, build info
+hyctl upgrade                           # self-update via install.sh (curl installs only; brew installs: `brew upgrade hyctl`)
 
 # Model registry (add a new model at runtime — no rebuild)
 hyctl models list                       # built-in + your models, by capability score
@@ -543,6 +530,7 @@ hyctl mcp check <tool> --agent A --resource R --action write  # gate + record an
 hyctl mcp check <tool> --content "$DATA" --action network      # PII auto-classified; policy can deny egress
 hyctl mcp check <tool> --params '{"amount":500}'               # bind a hash of the params to the decision
 hyctl mcp verify <tool> --resource R --params '{"amount":500}' # prove executed params == approved params
+hyctl mcp verify-chain                  # confirm the ledger's hash chain hasn't been tampered with
 hyctl mcp log --denied                  # what got blocked
 hyctl mcp report                        # allowed/denied by agent and tool
 hyctl security                          # what the agents did, and can the record be trusted
@@ -642,8 +630,10 @@ For Ollama models, add a family pattern:
 | **Runtime model registry** — `hyctl models add` merges a `~/.hydra/models.json` overlay, no rebuild | ✅ Shipped |
 | **Percolation-κ blast radius** — Molloy–Reed core detection weights hub files higher | ✅ Shipped |
 | **Rate-aware budget governor** — first-passage-time risk on `claude_pct`, escalates before a threshold | ✅ Shipped |
-| MCP server registry + central security agent | 📋 [#9](https://github.com/ankit373/hydra/issues/9)/[#10](https://github.com/ankit373/hydra/issues/10) |
-| Web UI + real-time cost dashboard | 📋 [#11](https://github.com/ankit373/hydra/issues/11)/[#12](https://github.com/ankit373/hydra/issues/12) |
+| **Security posture** (`hyctl security`) — verdict, correlated incidents, risk register, OWASP LLM Top-10 coverage | ✅ Shipped |
+| **Native desktop app** — HUD Dashboard, Fleet workflow graph, Session, Code views over a persistent chat dock | ✅ Shipped |
+| MCP server registry — central connection/authorization plane across every MCP server | 📋 [#9](https://github.com/ankit373/hydra/issues/9) |
+| Browser-based Web UI | 📋 [#12](https://github.com/ankit373/hydra/issues/12) |
 
 See the full [Hydra Roadmap project board](https://github.com/users/ankit373/projects/2).
 
@@ -699,9 +689,10 @@ hydra/
 
 ### The desktop app
 
-A native window over the same engine: **Dashboard** (spend, governor pressure, trust record),
-**Fleet** (runs in flight and the agents inside them), **Session** (one run's timeline, plus a
-layered graph when it fanned out), and **Code** (the file edits a run made, as diffs) — over a
+A native window over the same engine: **Dashboard** (HUD-style — arc gauges, glow chart, drill-down
+— spend, governor pressure, trust record, and a calibration leaderboard), **Fleet** (a dynamic
+workflow graph of runs in flight and the agents inside them), **Session** (one run's timeline, plus
+a layered graph when it fanned out), and **Code** (the file edits a run made, as diffs) — over a
 persistent chat dock.
 
 It reads `~/.hydra/logs/` directly. No daemon, no telemetry, and its numbers are the CLI's numbers:

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -84,6 +84,15 @@ a{color:inherit;text-decoration:none;}
 .side{position:sticky;top:52px;align-self:start;height:calc(100vh - 52px);overflow-y:auto;
   padding:24px 14px 60px 24px;border-right:1px solid var(--line);}
 @media(max-width:960px){.side{position:static;height:auto;border-right:0;border-bottom:1px solid var(--line);}}
+.side-toggle{display:none;width:100%;text-align:left;background:rgba(150,140,255,.06);border:1px solid var(--line);
+  color:var(--ink);font-family:var(--mono);font-size:13px;padding:10px 14px;border-radius:9px;margin-bottom:14px;cursor:pointer;}
+.side-toggle .chev{float:right;transition:transform .15s;}
+.side-toggle[aria-expanded="true"] .chev{transform:rotate(180deg);}
+@media(max-width:960px){
+  .side-toggle{display:block;}
+  #toc{display:none;}
+  .side.open #toc{display:block;}
+}
 .search{width:100%;font-family:var(--mono);font-size:13px;color:var(--ink);background:rgba(20,22,44,.6);
   border:1px solid var(--line-2);border-radius:9px;padding:10px 12px;margin-bottom:18px;}
 .search::placeholder{color:var(--faint);}
@@ -256,6 +265,7 @@ footer a{color:var(--dim);} footer a:hover{color:var(--aqua);}
 
 <div class="shell">
   <aside class="side">
+    <button type="button" id="sideToggle" class="side-toggle" aria-expanded="false" aria-controls="toc">Menu <span class="chev">▾</span></button>
     <input id="q" class="search" type="search" placeholder="Search docs…  (press /)" aria-label="Search documentation">
     <nav id="toc">
       <div class="grp" data-grp>Start here</div>
@@ -796,6 +806,20 @@ hyctl models sync   <span class="c"># import the OpenRouter catalog</span></pre>
       docs=Array.prototype.slice.call(document.querySelectorAll('.doc'));
 
   var REDUCED = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // ── mobile nav: sidebar starts collapsed under 960px so the link list
+  //    doesn't push the actual doc content off the first screen ──
+  var sideToggle=document.getElementById('sideToggle'), side=document.querySelector('.side');
+  if(sideToggle && side){
+    sideToggle.addEventListener('click', function(){
+      var open=side.classList.toggle('open');
+      sideToggle.setAttribute('aria-expanded', open?'true':'false');
+    });
+    q.addEventListener('focus', function(){
+      side.classList.add('open');
+      sideToggle.setAttribute('aria-expanded','true');
+    });
+  }
 
   // ── copy-to-clipboard on command blocks (skip terminal renders) ──
   document.querySelectorAll('.content pre').forEach(function(pre){

--- a/docs/first-principles.html
+++ b/docs/first-principles.html
@@ -427,7 +427,6 @@ footer{border-top:1px solid var(--line);margin-top:40px;padding:44px 0 56px;}
       <a href="/docs.html">Docs</a>
       <a href="/pricing.html">Pricing</a>
       <a href="https://github.com/ankit373/hydra">GitHub</a>
-      <a href="/llms.txt">llms.txt</a>
     </nav>
   </div>
 </footer>

--- a/docs/index.html
+++ b/docs/index.html
@@ -429,7 +429,14 @@ h2.big{font-size:clamp(28px,4.4vw,46px);letter-spacing:-1px;font-weight:800;line
 .tile .mech code{font-family:var(--mono);font-size:12px;color:var(--ink);background:rgba(0,0,0,.4);padding:1px 6px;border-radius:4px;}
 
 /* ── section 6 · comparison ────────────────────────────────────────────── */
-.cmp-scroll{margin-top:34px;overflow-x:auto;border:1px solid var(--line);border-radius:14px;-webkit-overflow-scrolling:touch;}
+.cmp-scroll-wrap{position:relative;margin-top:34px;}
+.cmp-scroll{overflow-x:auto;border:1px solid var(--line);border-radius:14px;-webkit-overflow-scrolling:touch;}
+.cmp-swipe-hint{display:none;font-family:var(--mono);font-size:11px;letter-spacing:.5px;color:var(--faint);margin:0 0 8px;}
+@media (max-width:700px){
+  .cmp-swipe-hint{display:block;}
+  .cmp-scroll-wrap::after{content:"";position:absolute;top:1px;right:1px;bottom:1px;width:28px;pointer-events:none;
+    background:linear-gradient(to right,transparent,var(--bg));border-radius:0 13px 13px 0;}
+}
 table.cmp{border-collapse:collapse;width:100%;min-width:680px;font-size:14px;}
 table.cmp th,table.cmp td{padding:16px 18px;text-align:left;border-bottom:1px solid var(--line);}
 table.cmp thead th{font-family:var(--mono);font-size:12px;letter-spacing:.5px;color:var(--dim);font-weight:600;
@@ -781,6 +788,8 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
   <h2 class="big">Others route your traffic. <span class="grad">Hydra routes on your metal.</span></h2>
   <p class="lede">Cost routing and fallback are table stakes — most tools have them. The differentiators are the rows nobody else can check: local-first, confidence/trust routing, and an on-device accountability ledger.</p>
 
+  <div class="cmp-scroll-wrap">
+  <p class="cmp-swipe-hint">swipe to compare →</p>
   <div class="cmp-scroll">
     <table class="cmp">
       <colgroup><col><col class="hyctl"><col><col><col></colgroup>
@@ -803,6 +812,7 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
         <tr><th scope="row">Runs fully offline (0 network to route)</th><td class="hydcol"><span class="yes">✓</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td></tr>
       </tbody>
     </table>
+  </div>
   </div>
   <p class="cmp-note"><b>Every row checked above ships today</b> — <code>hyctl dispatch --confidence</code>, <code>hyctl graph blast</code>, <code>hyctl mcp</code>. The agent-tree cockpit (<code>hyctl tui</code>) now renders real runs from the per-run event log, and the desktop app ships as a download for macOS, Windows and Linux with every release — not yet code-signed, so macOS needs right-click → Open on first launch.</p>
 </section>
@@ -921,8 +931,6 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
         <h4>Resources</h4>
         <a href="/docs.html">Docs</a>
         <a href="https://github.com/ankit373/hydra">GitHub ★</a>
-        <a href="/llms.txt">llms.txt</a>
-        <a href="/pricing.md">pricing.md</a>
       </div>
     </div>
     <div class="foot-bottom">


### PR DESCRIPTION
## Summary
- README.md: replaced the misaligned ASCII architecture diagram with a Mermaid flowchart, fixed a roadmap/comparison mismatch and stale issue links, and corrected desktop-app/TUI copy that claimed develop-only features as if they shipped in v1.3.0 (verified directly against the `release/v1.3.0` branch).
- Website: fixed two real mobile bugs — the comparison table silently hid 3 of 5 columns with no scroll indicator, and docs.html's sidebar nav pushed real content 1557px down the page on phones. Also dropped the raw llms.txt/pricing.md footer links.

## Test plan
- [x] Diffed every new README claim against `release/v1.3.0` (not just `develop`) to confirm nothing unshipped is described as shipped
- [x] Verified `hyctl version`, `hyctl upgrade`, `hyctl mcp verify-chain`, and all 5 desktop build targets exist on `release/v1.3.0`
- [x] Headless-browser screenshots at 360x800 and 390x844 confirming the comparison table hint/fade and docs sidebar toggle work, and desktop (1280px) is unaffected by both
- [x] `go build`/`go vet` not applicable — docs/README only, no Go changes

Closes #541