### PR TITLE
fix(ci): rc.yml and edge.yml release tags point at the wrong commit

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Publish edge release
         run: |
           gh release create edge dist/*.tar.gz dist/*.zip dist/checksums.txt \
+            --target "${{ github.sha }}" \
             --title "Edge — ${{ steps.ver.outputs.version }}" \
             --notes "$(cat <<'EOF'
           > ⚠️ **This is an edge/nightly build** — built from the latest commit on \`develop\`.

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Publish RC release
         run: |
           gh release create "${{ steps.ver.outputs.tag }}" dist/*.tar.gz dist/*.zip dist/checksums.txt \
+            --target "${{ github.sha }}" \
             --title "RC — ${{ steps.ver.outputs.version }}" \
             --notes "$(cat <<'EOF'
           > 🧪 **This is a release candidate** — built from \`${{ github.ref_name }}\` for UAT testing.


### PR DESCRIPTION
## Summary
- Both rc.yml and edge.yml called `gh release create` with no `--target`, so new tags defaulted to main's HEAD instead of the commit each workflow actually ran on.
- This is what caused the v1.3.0 release mess: all 7 v1.3.0-rc.* releases pointed at v1.2.0's commit on main, and release-please's version scan picked up "v1.3.0-rc.7" as semver-higher than the 1.2.0 manifest, proposing 1.4.0-rc.7 instead of the correct next version. Had to delete all 7 releases to unblock.

## Fix
Add `--target ${{ github.sha }}` to both calls.

Closes #548