### PR TITLE
feat(desktop): expose the model registry and per-pool spend via GetModels()

### DIFF
--- a/desktop/api/models.go
+++ b/desktop/api/models.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/cost"
+	"github.com/ankit373/hydra/registry"
+)
+
+// Model is one routable head as the registry declares it.
+//
+// Complexity is the band the registry assigns this model, and it is the honest
+// answer to "how hard can this one think" — Hydra has no thinking-depth dial;
+// depth is a property of which model you pick (Opus Thinking vs Sonnet
+// Thinking, Pro High vs Pro Low), so the band is what a picker should show.
+type Model struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Tier     int    `json:"tier"`
+	Provider string `json:"provider"`
+	Pool     string `json:"pool"`
+
+	ComplexityMin int `json:"complexityMin"`
+	ComplexityMax int `json:"complexityMax"`
+
+	// Qualitative registry labels ("slow", "very_high"), not measurements.
+	Speed    string `json:"speed"`
+	Accuracy string `json:"accuracy"`
+
+	ContextWindow int `json:"contextWindow"`
+
+	// Enabled false means the registry has it switched off — still listed, so a
+	// picker can show it greyed rather than pretending it does not exist.
+	Enabled bool `json:"enabled"`
+}
+
+// Pool is a shared quota and the models drawing from it.
+//
+// Members of a shared pool compete for one allocation: opus-thinking and
+// sonnet-thinking both draw from agy_claude, so choosing one spends what the
+// other will need. That consequence is the whole reason this type exists
+// instead of a flat model list (#553).
+type Pool struct {
+	Name string `json:"name"`
+	// Shared false means this pool has one member, or the members do not
+	// actually contend — spending here costs nothing elsewhere.
+	Shared bool   `json:"shared"`
+	Note   string `json:"note,omitempty"`
+
+	Models []Model `json:"models"`
+
+	// ObservedCalls/ObservedCostUSD are what Hydra itself logged against this
+	// pool, NOT a provider-reported balance. Hydra cannot see Antigravity's
+	// real remaining allocation, so these are named for what they are: our own
+	// spend, which is a floor on usage and never a quota reading.
+	ObservedCalls   int     `json:"observedCalls"`
+	ObservedCostUSD float64 `json:"observedCostUsd"`
+	ObservedTokens  int     `json:"observedTokens"`
+}
+
+// ModelRegistry is every pool, and anything the registry declared without one.
+type ModelRegistry struct {
+	// Found is false when models.yaml could not be read or parsed at all — an
+	// empty list then means "could not look", not "no models".
+	Found bool   `json:"found"`
+	Error string `json:"error,omitempty"`
+
+	Pools []Pool `json:"pools"`
+}
+
+// registryFile mirrors the parts of registry/models.yaml this needs. Declared
+// here rather than shared with internal/provider/agy because that one reads a
+// deliberately narrower set of fields for discovery; widening it would make
+// discovery depend on presentation concerns.
+type registryFile struct {
+	TokenPools map[string]struct {
+		Members []string `yaml:"members"`
+		Shared  bool     `yaml:"shared"`
+		Note    string   `yaml:"note"`
+	} `yaml:"token_pools"`
+
+	Models []struct {
+		Tier          int    `yaml:"tier"`
+		ID            string `yaml:"id"`
+		Name          string `yaml:"name"`
+		Provider      string `yaml:"provider"`
+		TokenPool     string `yaml:"token_pool"`
+		Enabled       bool   `yaml:"enabled"`
+		ContextWindow int    `yaml:"context_window"`
+		Speed         string `yaml:"speed"`
+		Accuracy      string `yaml:"accuracy"`
+		ComplexityMin int    `yaml:"complexity_min"`
+		ComplexityMax int    `yaml:"complexity_max"`
+	} `yaml:"models"`
+}
+
+// GetModels returns the model registry grouped by token pool, with the spend
+// Hydra has logged against each pool.
+//
+// Reads through registry.Read so an operator's $HYDRA_HOME/registry/models.yaml
+// wins over the embedded copy, same as every other consumer (#238).
+func (a *API) GetModels() ModelRegistry {
+	raw, err := registry.Read(config.ScriptHome(), "models.yaml")
+	if err != nil {
+		return ModelRegistry{Error: fmt.Sprintf("cannot read models.yaml: %v", err)}
+	}
+
+	var reg registryFile
+	if err := yaml.Unmarshal(raw, &reg); err != nil {
+		return ModelRegistry{Error: fmt.Sprintf("malformed models.yaml: %v", err)}
+	}
+
+	out := ModelRegistry{Found: true}
+
+	// Spend per pool. A missing or unreadable cost log is not an error here:
+	// a machine that has never dispatched still has a registry worth showing.
+	spend := map[string]cost.GroupRow{}
+	if rows, err := cost.ByPool(); err == nil {
+		for _, r := range rows {
+			spend[r.Key] = r
+		}
+	}
+
+	// Pool order follows the registry's own declaration order via the models
+	// list, so the strongest tiers lead — map iteration would shuffle it.
+	seen := map[string]int{}
+	for _, m := range reg.Models {
+		model := Model{
+			ID:            m.ID,
+			Name:          m.Name,
+			Tier:          m.Tier,
+			Provider:      m.Provider,
+			Pool:          m.TokenPool,
+			ComplexityMin: m.ComplexityMin,
+			ComplexityMax: m.ComplexityMax,
+			Speed:         m.Speed,
+			Accuracy:      m.Accuracy,
+			ContextWindow: m.ContextWindow,
+			Enabled:       m.Enabled,
+		}
+
+		key := m.TokenPool
+		if key == "" {
+			// A model with no declared pool draws from nothing shared. Group
+			// them together rather than dropping them.
+			key = "unpooled"
+		}
+
+		idx, ok := seen[key]
+		if !ok {
+			meta := reg.TokenPools[m.TokenPool]
+			s := spend[key]
+			out.Pools = append(out.Pools, Pool{
+				Name:            key,
+				Shared:          meta.Shared,
+				Note:            meta.Note,
+				ObservedCalls:   s.Calls,
+				ObservedCostUSD: s.EstCostUSD,
+				ObservedTokens:  s.PromptTokens + s.ResponseTokens,
+			})
+			idx = len(out.Pools) - 1
+			seen[key] = idx
+		}
+		out.Pools[idx].Models = append(out.Pools[idx].Models, model)
+	}
+
+	return out
+}

--- a/desktop/api/models_test.go
+++ b/desktop/api/models_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The embedded registry is what every installed binary runs with (#238), so the
+// shipped default must produce a usable answer with no files on disk at all.
+func TestGetModels_EmbeddedRegistryIsUsable(t *testing.T) {
+	sandbox(t)
+
+	r := New().GetModels()
+	if !r.Found {
+		t.Fatalf("Found = false (%s); the embedded models.yaml must always parse", r.Error)
+	}
+	if len(r.Pools) == 0 {
+		t.Fatal("no pools; the embedded registry declares several")
+	}
+
+	var models int
+	for _, p := range r.Pools {
+		if p.Name == "" {
+			t.Error("a pool has no name")
+		}
+		models += len(p.Models)
+		for _, m := range p.Models {
+			if m.ID == "" {
+				t.Errorf("pool %q has a model with no id", p.Name)
+			}
+			if m.Tier == 0 {
+				t.Errorf("model %q has tier 0; every registry model declares a tier", m.ID)
+			}
+		}
+	}
+	if models == 0 {
+		t.Fatal("pools exist but contain no models")
+	}
+}
+
+// The complexity band is what a picker shows in place of a thinking-depth dial
+// Hydra does not have, so it has to survive the mapping rather than land as 0-0.
+func TestGetModels_CarriesComplexityBand(t *testing.T) {
+	sandbox(t)
+
+	for _, p := range New().GetModels().Pools {
+		for _, m := range p.Models {
+			if m.ComplexityMax == 0 {
+				t.Errorf("model %q has no complexity band; the picker would show 0-0", m.ID)
+			}
+			if m.ComplexityMin > m.ComplexityMax {
+				t.Errorf("model %q band is inverted: %d-%d", m.ID, m.ComplexityMin, m.ComplexityMax)
+			}
+		}
+	}
+}
+
+// Shared pools are the reason this groups by pool at all: opus and sonnet
+// contend for one allocation, so the UI must be able to say so.
+func TestGetModels_SharedPoolHasMultipleMembers(t *testing.T) {
+	sandbox(t)
+
+	shared := 0
+	for _, p := range New().GetModels().Pools {
+		if !p.Shared {
+			continue
+		}
+		shared++
+		if len(p.Models) < 2 {
+			t.Errorf("pool %q is marked shared but has %d member(s) — nothing to contend with",
+				p.Name, len(p.Models))
+		}
+	}
+	if shared == 0 {
+		t.Error("no shared pool found; the embedded registry declares several")
+	}
+}
+
+// A machine that has never dispatched still has a registry worth showing — a
+// missing cost log must not blank the model list.
+func TestGetModels_NoCostLogStillReturnsRegistry(t *testing.T) {
+	sandbox(t)
+
+	r := New().GetModels()
+	if !r.Found || len(r.Pools) == 0 {
+		t.Fatal("an absent cost.jsonl suppressed the registry")
+	}
+	for _, p := range r.Pools {
+		if p.ObservedCalls != 0 || p.ObservedCostUSD != 0 {
+			t.Errorf("pool %q reports spend with no cost log: %d calls, $%v",
+				p.Name, p.ObservedCalls, p.ObservedCostUSD)
+		}
+	}
+}
+
+// Pool spend comes from cost.jsonl's own `pool` field, which dispatch already
+// writes on every call. This pins that the join actually lands.
+func TestGetModels_AggregatesObservedSpendPerPool(t *testing.T) {
+	home := sandbox(t)
+
+	// Two calls against one real pool from the embedded registry, one against
+	// another, so a cross-pool leak would show up as the wrong total.
+	writeCostRows(t, home, []map[string]any{
+		{"ts": "2026-08-20T10:00:00Z", "pool": "agy_claude", "tier": 2,
+			"prompt_tokens": 100, "response_tokens": 50, "est_cost_usd": 0.10},
+		{"ts": "2026-08-20T10:01:00Z", "pool": "agy_claude", "tier": 3,
+			"prompt_tokens": 200, "response_tokens": 100, "est_cost_usd": 0.20},
+		{"ts": "2026-08-20T10:02:00Z", "pool": "agy_flash", "tier": 7,
+			"prompt_tokens": 10, "response_tokens": 5, "est_cost_usd": 0.01},
+	})
+
+	reg := New().GetModels()
+	var claude, flash *Pool
+	for i := range reg.Pools {
+		switch reg.Pools[i].Name {
+		case "agy_claude":
+			claude = &reg.Pools[i]
+		case "agy_flash":
+			flash = &reg.Pools[i]
+		}
+	}
+	if claude == nil {
+		t.Fatal("agy_claude pool missing from the registry")
+	}
+
+	if claude.ObservedCalls != 2 {
+		t.Errorf("agy_claude ObservedCalls = %d, want 2", claude.ObservedCalls)
+	}
+	if got := claude.ObservedTokens; got != 450 {
+		t.Errorf("agy_claude ObservedTokens = %d, want 450 (prompt+response)", got)
+	}
+	if claude.ObservedCostUSD < 0.29 || claude.ObservedCostUSD > 0.31 {
+		t.Errorf("agy_claude ObservedCostUSD = %v, want ~0.30", claude.ObservedCostUSD)
+	}
+	if flash != nil && flash.ObservedCalls != 1 {
+		t.Errorf("agy_flash ObservedCalls = %d, want 1 — spend leaked across pools",
+			flash.ObservedCalls)
+	}
+}
+
+// An operator's on-disk registry must win over the embedded copy, or retuning
+// routing without a rebuild (the whole point of registry.Read) silently fails.
+func TestGetModels_OnDiskRegistryOverridesEmbedded(t *testing.T) {
+	home := sandbox(t)
+
+	dir := filepath.Join(home, ".hydra", "registry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	yaml := `
+token_pools:
+  only_pool:
+    members: [just-one]
+    shared: false
+    note: "override marker"
+models:
+  - tier: 4
+    id: just-one
+    name: "Only Model"
+    provider: testing
+    token_pool: only_pool
+    enabled: true
+    context_window: 1234
+    complexity_min: 2
+    complexity_max: 3
+`
+	if err := os.WriteFile(filepath.Join(dir, "models.yaml"), []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := New().GetModels()
+	if !r.Found {
+		t.Fatalf("Found = false: %s", r.Error)
+	}
+	if len(r.Pools) != 1 || len(r.Pools[0].Models) != 1 {
+		t.Fatalf("got %d pool(s); the on-disk override declares exactly one", len(r.Pools))
+	}
+	m := r.Pools[0].Models[0]
+	if m.ID != "just-one" {
+		t.Errorf("model id = %q, want just-one — the embedded copy won", m.ID)
+	}
+	if m.ContextWindow != 1234 || m.ComplexityMax != 3 {
+		t.Errorf("override fields lost: ctx=%d band=%d-%d", m.ContextWindow, m.ComplexityMin, m.ComplexityMax)
+	}
+	if r.Pools[0].Note != "override marker" {
+		t.Errorf("pool note = %q, want the override's", r.Pools[0].Note)
+	}
+}
+
+// Unparseable YAML must say so rather than presenting "no models" as fact.
+func TestGetModels_MalformedRegistryReportsInsteadOfClaimingEmpty(t *testing.T) {
+	home := sandbox(t)
+
+	dir := filepath.Join(home, ".hydra", "registry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "models.yaml"),
+		[]byte("models: [this is not: valid: yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := New().GetModels()
+	if r.Found {
+		t.Error("Found = true on malformed YAML; an empty list would read as 'no models'")
+	}
+	if r.Error == "" {
+		t.Error("no Error explaining why the registry is empty")
+	}
+}

--- a/desktop/api/typesparity_test.go
+++ b/desktop/api/typesparity_test.go
@@ -76,6 +76,9 @@ func TestTypesTS_MirrorsEveryFieldOnTheWire(t *testing.T) {
 		{"Risk", security.Risk{}},
 		{"RiskRegister", security.RiskRegister{}},
 		{"Posture", security.Posture{}},
+		{"Model", Model{}},
+		{"Pool", Pool{}},
+		{"ModelRegistry", ModelRegistry{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			ts := tsInterface(t, src, c.iface)
@@ -102,6 +105,9 @@ func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
 		{"Attestation", security.Attestation{}},
 		{"BOMEntry", security.BOMEntry{}},
 		{"AgentPrivilege", security.AgentPrivilege{}},
+		{"Model", Model{}},
+		{"Pool", Pool{}},
+		{"ModelRegistry", ModelRegistry{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			g := jsonFields(c.goVal)

--- a/desktop/frontend/src/bindings.ts
+++ b/desktop/frontend/src/bindings.ts
@@ -14,6 +14,7 @@ import type {
   Fleet,
   HyctlStatus,
   InstallResult,
+  ModelRegistry,
   SecurityReport,
   Session,
   UpdateStatus,
@@ -38,6 +39,7 @@ interface WailsGo {
       CheckHyctl(): Promise<HyctlStatus>
       InstallHyctl(): Promise<InstallResult>
       GetSecurity(): Promise<SecurityReport>
+      GetModels(): Promise<ModelRegistry>
     }
   }
 }
@@ -72,3 +74,4 @@ export const TriggerUpgrade = (): Promise<UpgradeResult> => backend().TriggerUpg
 export const CheckHyctl = (): Promise<HyctlStatus> => backend().CheckHyctl()
 export const InstallHyctl = (): Promise<InstallResult> => backend().InstallHyctl()
 export const GetSecurity = (): Promise<SecurityReport> => backend().GetSecurity()
+export const GetModels = (): Promise<ModelRegistry> => backend().GetModels()

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -634,3 +634,45 @@ export interface ChatReply {
    *  showing a raw dispatch error. */
   needsProbe?: boolean
 }
+
+/** One routable head as registry/models.yaml declares it. */
+export interface Model {
+  id: string
+  name: string
+  tier: number
+  provider: string
+  pool: string
+  /** The registry's own band. Hydra has no thinking-depth dial — depth is which
+   *  model you pick, so this is what a picker shows in its place. */
+  complexityMin: number
+  complexityMax: number
+  /** Qualitative registry labels ("slow", "very_high"), not measurements. */
+  speed: string
+  accuracy: string
+  contextWindow: number
+  /** False means the registry switched it off — still listed, so a picker can
+   *  grey it rather than pretend it does not exist. */
+  enabled: boolean
+}
+
+/** A shared quota and the models drawing from it. */
+export interface Pool {
+  name: string
+  /** False means one member, or members that do not contend. */
+  shared: boolean
+  note?: string
+  models: Model[]
+  /** What Hydra logged against this pool — NOT a provider-reported balance.
+   *  A floor on usage, never a quota reading. */
+  observedCalls: number
+  observedCostUsd: number
+  observedTokens: number
+}
+
+export interface ModelRegistry {
+  /** False when models.yaml could not be read or parsed — an empty list then
+   *  means "could not look", not "no models". */
+  found: boolean
+  error?: string
+  pools: Pool[]
+}


### PR DESCRIPTION
First step of #552 (the approved chat-first cockpit design). **Backend + wiring only — no UI changes.**

## Why
`desktop/api` exposed `ChatEnums()` and nothing else about routing: no tiers, no model
names, no token pools, no complexity bands. The composer's model picker and the sidebar's
pool meter had nothing to read.

The decision-relevant fact was entirely invisible: `registry/models.yaml` defines **token
pools**, and members share one allocation — `opus-thinking` and `sonnet-thinking` both draw
from `agy_claude`. The registry's own note says "Prefer Sonnet for tasks that don't strictly
need Opus depth." Nothing in the app conveyed that picking one spends the other's budget.

## What
`GetModels() ModelRegistry` — pools, each with its members and observed spend.

- **Per model**: id, name, tier, provider, pool, `complexityMin/Max`, speed, accuracy,
  context window, enabled. Disabled models are still listed so a picker can grey them
  rather than pretend they don't exist.
- **Per pool**: name, `shared`, the registry's note, and observed calls / tokens / cost.

## Two deliberate calls
**Reused `cost.ByPool()` instead of writing aggregation.** It already existed, and
`cost.Entry.Pool` is already written on every dispatch (`dispatch.go:826`,
`swarm/cost.go:108`). No new logging, no duplicate grouping logic.

**Named the spend fields `Observed*`.** Hydra cannot see Antigravity's real remaining
allocation — this is our own logged spend, a floor on usage, never a quota reading. The
field names had to make that impossible to misread, since a "76% used" meter that actually
means "we logged this much" would be a lie in the UI.

## Testing
- 7 new tests: embedded registry parses (every installed binary depends on it, #238),
  complexity bands survive the mapping, shared pools really have multiple members, absent
  cost log still returns the registry, spend joins per-pool without leaking across pools,
  on-disk `$HYDRA_HOME/registry/models.yaml` overrides embedded, malformed YAML reports
  instead of presenting "no models" as fact.
- Added `Model`/`Pool`/`ModelRegistry` to the **types-parity tests** in both directions, so
  the Go DTO and the hand-written `types.ts` mirror cannot drift silently (the failure mode
  from #435).
- `gofmt`/`go vet` clean, `go test ./api/ -race -count=1` clean, `npm run typecheck` and
  `npm run build` clean.

Closes #553