### PR TITLE
feat(mcp): hyctl mcp registry — local MCP server install audit

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ankit373/hydra/internal/executor"
 	"github.com/ankit373/hydra/internal/graph"
 	"github.com/ankit373/hydra/internal/ledger"
+	"github.com/ankit373/hydra/internal/mcpregistry"
 	"github.com/ankit373/hydra/internal/optimal"
 	"github.com/ankit373/hydra/internal/oracle"
 	"github.com/ankit373/hydra/internal/parallel"
@@ -1245,7 +1246,93 @@ func cmdMCP() *cobra.Command {
 	}
 	verifyChain.Flags().BoolVar(&chainJSON, "json", false, "machine-readable JSON output")
 
-	cmd.AddCommand(check, record, verify, logCmd, report, verifyChain)
+	cmd.AddCommand(check, record, verify, logCmd, report, verifyChain, cmdMCPRegistry())
+	return cmd
+}
+
+// cmdMCPRegistry is the Phase 1 CLI wedge: identity-only sync of the
+// official MCP registry, a scan of what's installed on this machine, and an
+// audit that resolves one against the other. No trust scoring yet.
+func cmdMCPRegistry() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registry",
+		Short: "Sync the official MCP registry and audit what's installed on this machine",
+	}
+
+	sync := &cobra.Command{
+		Use:   "sync",
+		Short: "Pull server metadata from the official MCP registry into a local cache",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			fmt.Println("  syncing the official MCP registry — thousands of servers, this can take a minute or two...")
+			n, err := mcpregistry.Sync(cmd.Context(), func(page, soFar int) {
+				fmt.Printf("\r  page %-4d  %d servers so far...", page, soFar)
+			})
+			fmt.Println()
+			if err != nil {
+				return err
+			}
+			fmt.Printf("  synced %d servers from the official MCP registry\n", n)
+			return nil
+		},
+	}
+
+	var scanJSON bool
+	scanCmd := &cobra.Command{
+		Use:   "scan",
+		Short: "List MCP servers installed across this machine's clients",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cwd, _ := os.Getwd()
+			installed := mcpregistry.Scan(cwd)
+			if scanJSON {
+				return json.NewEncoder(os.Stdout).Encode(installed)
+			}
+			if len(installed) == 0 {
+				fmt.Println("  no MCP servers found on this machine")
+				return nil
+			}
+			for _, s := range installed {
+				fmt.Printf("  %-16s %-8s %s\n", s.Client, s.Scope, s.Name)
+			}
+			return nil
+		},
+	}
+	scanCmd.Flags().BoolVar(&scanJSON, "json", false, "machine-readable JSON output")
+
+	var auditJSON bool
+	audit := &cobra.Command{
+		Use:   "audit",
+		Short: "Resolve installed MCP servers against the synced registry",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cwd, _ := os.Getwd()
+			rpt, err := mcpregistry.Audit(cwd)
+			if err != nil {
+				return err
+			}
+			if auditJSON {
+				return json.NewEncoder(os.Stdout).Encode(rpt)
+			}
+			if rpt.RegistrySync.IsZero() {
+				fmt.Println("  registry never synced — run `hyctl mcp registry sync` first for verification")
+			}
+			if len(rpt.Entries) == 0 {
+				fmt.Println("  no MCP servers found on this machine")
+				return nil
+			}
+			for _, e := range rpt.Entries {
+				status := strings.ToUpper(string(e.Status))
+				if e.Status == mcpregistry.StatusVerified {
+					status = okStyle.Render(status)
+				} else {
+					status = warnStyle.Render(status)
+				}
+				fmt.Printf("  %-9s %-16s %-8s %s\n", status, e.Client, e.Scope, e.Name)
+			}
+			return nil
+		},
+	}
+	audit.Flags().BoolVar(&auditJSON, "json", false, "machine-readable JSON output")
+
+	cmd.AddCommand(sync, scanCmd, audit)
 	return cmd
 }
 

--- a/internal/mcpregistry/audit.go
+++ b/internal/mcpregistry/audit.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"os"
+	"time"
+)
+
+// Status is the Phase 1 (identity-only) resolution of one installed server
+// against the synced registry. There is no trust score yet — that's Phase 2.
+type Status string
+
+const (
+	// StatusVerified means the server's resolved package matches a
+	// namespace-verified entry in the official registry.
+	StatusVerified Status = "verified"
+	// StatusUnresolved means no match was found — a remote (URL-based)
+	// server, a launcher this package couldn't resolve to a package
+	// identifier, or a package genuinely absent from the registry (private,
+	// custom, or simply not the one it claims to be). Not necessarily
+	// malicious; it's exactly the category worth a second look.
+	StatusUnresolved Status = "unresolved"
+)
+
+// AuditEntry is one installed server plus its Phase 1 resolution.
+type AuditEntry struct {
+	InstalledServer
+	Status       Status `json:"status"`
+	RegistryName string `json:"registry_name,omitempty"`
+}
+
+// AuditReport is the result of `hyctl mcp registry audit`.
+type AuditReport struct {
+	GeneratedAt  time.Time    `json:"generated_at"`
+	RegistrySync time.Time    `json:"registry_synced_at,omitzero"` // zero if sync has never run
+	Entries      []AuditEntry `json:"entries"`
+}
+
+// Audit scans this machine's MCP clients and resolves each installed server
+// against the last-synced registry dataset. Works with no prior sync (every
+// entry reports unresolved and RegistrySync is zero) — sync is what upgrades
+// the report from "here's what's installed" to "here's what's verified".
+func Audit(cwd string) (*AuditReport, error) {
+	installed := Scan(cwd)
+
+	report := &AuditReport{GeneratedAt: time.Now().UTC(), Entries: make([]AuditEntry, 0, len(installed))}
+
+	cache, err := loadCache()
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	var index map[string]ServerRecord
+	if cache != nil {
+		report.RegistrySync = cache.FetchedAt
+		index = buildPackageIndex(cache.Servers)
+	}
+
+	for _, s := range installed {
+		entry := AuditEntry{InstalledServer: s, Status: StatusUnresolved}
+		if !s.Remote && s.Package != "" {
+			if match, ok := index[s.Package]; ok {
+				entry.Status = StatusVerified
+				entry.RegistryName = match.Name
+			}
+		}
+		report.Entries = append(report.Entries, entry)
+	}
+	return report, nil
+}
+
+// buildPackageIndex maps a package identifier to the registry server that
+// publishes it. Last-write-wins on a rare identifier collision — acceptable
+// for Phase 1's identity resolution, which isn't a security decision on its
+// own (see StatusUnresolved's doc comment).
+func buildPackageIndex(servers []ServerRecord) map[string]ServerRecord {
+	idx := make(map[string]ServerRecord)
+	for _, srv := range servers {
+		for _, pkg := range srv.Packages {
+			if pkg.Identifier != "" {
+				idx[pkg.Identifier] = srv
+			}
+		}
+	}
+	return idx
+}

--- a/internal/mcpregistry/audit_test.go
+++ b/internal/mcpregistry/audit_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAudit_NeverSyncedReportsUnresolvedAndZeroSyncTime(t *testing.T) {
+	withTempHydraHome(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	writeJSON(t, filepath.Join(home, ".cursor", "mcp.json"),
+		`{"mcpServers": {"fetch": {"type":"stdio","command":"uvx","args":["mcp-server-fetch"]}}}`)
+
+	rpt, err := Audit("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rpt.RegistrySync.IsZero() {
+		t.Errorf("expected zero RegistrySync when sync never ran, got %v", rpt.RegistrySync)
+	}
+	if len(rpt.Entries) != 1 || rpt.Entries[0].Status != StatusUnresolved {
+		t.Fatalf("unexpected entries: %+v", rpt.Entries)
+	}
+}
+
+func TestAudit_MatchesInstalledPackageAgainstSyncedRegistry(t *testing.T) {
+	withTempHydraHome(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	writeJSON(t, filepath.Join(home, ".cursor", "mcp.json"),
+		`{"mcpServers": {"fetch": {"type":"stdio","command":"uvx","args":["mcp-server-fetch"]}}}`)
+
+	if err := writeCache(&registryCache{
+		FetchedAt: time.Now().UTC(),
+		Servers: []ServerRecord{
+			{Name: "io.github.modelcontextprotocol/fetch", Packages: []Package{{RegistryType: "pypi", Identifier: "mcp-server-fetch"}}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rpt, err := Audit("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rpt.RegistrySync.IsZero() {
+		t.Fatal("expected a non-zero RegistrySync after a cache write")
+	}
+	if len(rpt.Entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(rpt.Entries))
+	}
+	got := rpt.Entries[0]
+	if got.Status != StatusVerified {
+		t.Errorf("Status = %q, want verified", got.Status)
+	}
+	if got.RegistryName != "io.github.modelcontextprotocol/fetch" {
+		t.Errorf("RegistryName = %q", got.RegistryName)
+	}
+}
+
+func TestAudit_RemoteServerIsNeverMarkedVerified(t *testing.T) {
+	withTempHydraHome(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	writeJSON(t, filepath.Join(home, ".cursor", "mcp.json"),
+		`{"mcpServers": {"remote": {"type":"http","url":"https://example.com/mcp"}}}`)
+
+	if err := writeCache(&registryCache{Servers: []ServerRecord{{Name: "x"}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	rpt, err := Audit("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rpt.Entries) != 1 || rpt.Entries[0].Status != StatusUnresolved {
+		t.Fatalf("remote server should be unresolved (Phase 1 does not match URLs), got %+v", rpt.Entries)
+	}
+}
+
+func TestBuildPackageIndex(t *testing.T) {
+	idx := buildPackageIndex([]ServerRecord{
+		{Name: "a", Packages: []Package{{Identifier: "pkg-a"}}},
+		{Name: "b", Packages: []Package{{Identifier: "pkg-b"}, {Identifier: "pkg-b-alt"}}},
+	})
+	if len(idx) != 3 {
+		t.Fatalf("got %d entries, want 3", len(idx))
+	}
+	if idx["pkg-a"].Name != "a" || idx["pkg-b"].Name != "b" || idx["pkg-b-alt"].Name != "b" {
+		t.Errorf("unexpected index contents: %+v", idx)
+	}
+}

--- a/internal/mcpregistry/mcpregistry.go
+++ b/internal/mcpregistry/mcpregistry.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+// Package mcpregistry is the Phase 1 CLI wedge of Hydra's MCP registry:
+// identity-only sync of the official MCP registry, a scan of what's actually
+// installed across this machine's MCP clients, and an audit that resolves one
+// against the other. No trust scoring yet — that's Phase 2.
+package mcpregistry
+
+import (
+	"path/filepath"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+)
+
+// Package is one distribution channel a server ships through (npm, pypi,
+// docker, ...), as published in the registry's server.json.
+type Package struct {
+	RegistryType string `json:"registryType"`
+	Identifier   string `json:"identifier"`
+}
+
+// Repository is the source repo a server's registry entry points at.
+type Repository struct {
+	URL string `json:"url"`
+}
+
+// ServerRecord is one server as published by the official MCP registry.
+// Presence in the registry under a reverse-DNS name (e.g. "io.github.x/y")
+// already implies namespace ownership was verified at publish time (GitHub
+// OIDC or DNS challenge) — there is no separate "verified" flag to check.
+type ServerRecord struct {
+	Name       string     `json:"name"`
+	Version    string     `json:"version"`
+	Repository Repository `json:"repository"`
+	Packages   []Package  `json:"packages"`
+}
+
+// InstalledServer is one MCP server found configured on this machine.
+// Identity only, by construction: the parser this feeds from never declares
+// a field for env vars or other config values, so a secret cannot end up
+// here even by accident — see clientServerConfig in scan.go.
+type InstalledServer struct {
+	Client  string `json:"client"`            // "claude-code", "claude-desktop", "cursor", "windsurf"
+	Scope   string `json:"scope"`             // "user" or "project"
+	Name    string `json:"name"`              // the config key / server name
+	Command string `json:"command,omitempty"` // launcher binary (npx, uvx, docker, ...), never full args
+	Package string `json:"package,omitempty"` // best-effort resolved package identifier
+	Remote  bool   `json:"remote"`            // true for url-based (http/sse) servers, no package to resolve
+}
+
+func cachePath() string {
+	return filepath.Join(config.Dir(), "mcp_registry_cache.json")
+}
+
+// registryCache is the on-disk shape written by Sync and read by Audit.
+type registryCache struct {
+	FetchedAt time.Time      `json:"fetched_at"`
+	Servers   []ServerRecord `json:"servers"`
+}

--- a/internal/mcpregistry/scan.go
+++ b/internal/mcpregistry/scan.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// clientServerConfig mirrors one entry inside a client's mcpServers/servers
+// map. There is deliberately no field for "env" or any other config value:
+// these files commonly hold API keys and tokens in plaintext, and scan must
+// never read, log, or transmit them. Adding an Env field here is a privacy
+// regression — identity fields only (command/args/url), never values that
+// could carry a secret.
+type clientServerConfig struct {
+	Type    string   `json:"type,omitempty"`
+	Command string   `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
+	URL     string   `json:"url,omitempty"`
+}
+
+// Scan enumerates MCP servers configured across this machine's known
+// clients (Claude Code, Claude Desktop, Cursor, Windsurf, VS Code).
+// cwd scopes project-level lookups; pass "" to skip project-scoped sources.
+// A missing config file for a client is not an error — most machines won't
+// have every client installed.
+func Scan(cwd string) []InstalledServer {
+	var out []InstalledServer
+	out = append(out, scanClaudeCode(cwd)...)
+	out = append(out, scanClaudeDesktop()...)
+	out = append(out, scanMCPServersFile(cursorGlobalConfigPath(), "cursor", "user")...)
+	if cwd != "" {
+		out = append(out, scanMCPServersFile(filepath.Join(cwd, ".cursor", "mcp.json"), "cursor", "project")...)
+	}
+	out = append(out, scanMCPServersFile(windsurfConfigPath(), "windsurf", "user")...)
+	if cwd != "" {
+		out = append(out, scanVSCodeFile(filepath.Join(cwd, ".vscode", "mcp.json"))...)
+	}
+	return out
+}
+
+// claudeCodeConfig mirrors the parts of ~/.claude.json this package reads.
+type claudeCodeConfig struct {
+	MCPServers map[string]clientServerConfig `json:"mcpServers"`
+	Projects   map[string]struct {
+		MCPServers map[string]clientServerConfig `json:"mcpServers"`
+	} `json:"projects"`
+}
+
+func scanClaudeCode(cwd string) []InstalledServer {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	raw, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	if err != nil {
+		return nil
+	}
+	var cfg claudeCodeConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil
+	}
+
+	out := toInstalledServers(cfg.MCPServers, "claude-code", "user")
+	if cwd != "" {
+		if proj, ok := cfg.Projects[cwd]; ok {
+			out = append(out, toInstalledServers(proj.MCPServers, "claude-code", "project")...)
+		}
+	}
+	return out
+}
+
+func scanClaudeDesktop() []InstalledServer {
+	return scanMCPServersFile(claudeDesktopConfigPath(), "claude-desktop", "user")
+}
+
+func claudeDesktopConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json")
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return ""
+		}
+		return filepath.Join(appData, "Claude", "claude_desktop_config.json")
+	default:
+		return filepath.Join(home, ".config", "Claude", "claude_desktop_config.json")
+	}
+}
+
+func cursorGlobalConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".cursor", "mcp.json")
+}
+
+func windsurfConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+}
+
+// scanMCPServersFile reads a {"mcpServers": {name: config}} file, the shape
+// shared by Claude Desktop, Cursor, and Windsurf.
+func scanMCPServersFile(path, client, scope string) []InstalledServer {
+	if path == "" {
+		return nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var cfg struct {
+		MCPServers map[string]clientServerConfig `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil
+	}
+	return toInstalledServers(cfg.MCPServers, client, scope)
+}
+
+// scanVSCodeFile reads VS Code's {"servers": {name: config}} shape — the one
+// client here that uses "servers" instead of "mcpServers".
+func scanVSCodeFile(path string) []InstalledServer {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var cfg struct {
+		Servers map[string]clientServerConfig `json:"servers"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil
+	}
+	return toInstalledServers(cfg.Servers, "vscode", "project")
+}
+
+func toInstalledServers(servers map[string]clientServerConfig, client, scope string) []InstalledServer {
+	out := make([]InstalledServer, 0, len(servers))
+	for name, cfg := range servers {
+		if cfg.URL != "" {
+			out = append(out, InstalledServer{Client: client, Scope: scope, Name: name, Remote: true})
+			continue
+		}
+		out = append(out, InstalledServer{
+			Client:  client,
+			Scope:   scope,
+			Name:    name,
+			Command: filepath.Base(cfg.Command),
+			Package: resolvePackage(cfg.Command, cfg.Args),
+		})
+	}
+	return out
+}
+
+// resolvePackage makes a best-effort guess at the package identifier a
+// stdio launcher command runs, so it can be matched against the registry's
+// packages[].identifier. Deliberately conservative: an unresolved package
+// (empty string) is safe — it just shows up as "unresolved" in the audit,
+// not as a false claim about what the server is.
+func resolvePackage(command string, args []string) string {
+	switch filepath.Base(command) {
+	case "npx", "uvx":
+		for _, a := range args {
+			if !strings.HasPrefix(a, "-") {
+				return a
+			}
+		}
+	case "docker":
+		// Best-effort: the image is usually the last bare token that isn't
+		// a flag and doesn't look like an env-style KEY=VALUE pair passed
+		// to a preceding -e/--env flag.
+		for i := len(args) - 1; i >= 0; i-- {
+			a := args[i]
+			if strings.HasPrefix(a, "-") || strings.Contains(a, "=") {
+				continue
+			}
+			return a
+		}
+	}
+	return ""
+}

--- a/internal/mcpregistry/scan_files_test.go
+++ b/internal/mcpregistry/scan_files_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeJSON(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScanMCPServersFile_MissingFileIsNotAnError(t *testing.T) {
+	out := scanMCPServersFile(filepath.Join(t.TempDir(), "nope.json"), "cursor", "user")
+	if out != nil {
+		t.Errorf("expected nil for a missing file, got %v", out)
+	}
+}
+
+func TestScanMCPServersFile_ParsesEntries(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+	writeJSON(t, path, `{
+		"mcpServers": {
+			"fetch": {"type":"stdio","command":"uvx","args":["mcp-server-fetch"],"env":{"TOKEN":"secret"}},
+			"remote": {"type":"http","url":"https://example.com/mcp"}
+		}
+	}`)
+
+	out := scanMCPServersFile(path, "cursor", "user")
+	if len(out) != 2 {
+		t.Fatalf("got %d entries, want 2", len(out))
+	}
+
+	byName := map[string]InstalledServer{}
+	for _, s := range out {
+		byName[s.Name] = s
+	}
+	if byName["fetch"].Package != "mcp-server-fetch" {
+		t.Errorf("fetch.Package = %q, want mcp-server-fetch", byName["fetch"].Package)
+	}
+	if !byName["remote"].Remote {
+		t.Errorf("remote server should have Remote=true")
+	}
+	if byName["fetch"].Client != "cursor" || byName["fetch"].Scope != "user" {
+		t.Errorf("fetch client/scope = %q/%q, want cursor/user", byName["fetch"].Client, byName["fetch"].Scope)
+	}
+}
+
+func TestScanVSCodeFile_UsesServersKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+	writeJSON(t, path, `{"servers": {"gh": {"type":"stdio","command":"npx","args":["-y","@modelcontextprotocol/server-github"]}}}`)
+
+	out := scanVSCodeFile(path)
+	if len(out) != 1 {
+		t.Fatalf("got %d entries, want 1", len(out))
+	}
+	if out[0].Package != "@modelcontextprotocol/server-github" {
+		t.Errorf("Package = %q", out[0].Package)
+	}
+	if out[0].Client != "vscode" {
+		t.Errorf("Client = %q, want vscode", out[0].Client)
+	}
+}
+
+func TestScanClaudeCode_UserAndProjectScope(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
+	claudeJSON := filepath.Join(home, ".claude.json")
+	proj := filepath.Join(home, "myproject")
+	writeJSON(t, claudeJSON, `{
+		"mcpServers": {"grafana": {"type":"stdio","command":"npx","args":["-y","mcp-grafana"]}},
+		"projects": {
+			"`+proj+`": {"mcpServers": {"custom": {"type":"stdio","command":"node","args":["./server.js"]}}}
+		}
+	}`)
+
+	out := scanClaudeCode(proj)
+	if len(out) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(out), out)
+	}
+
+	var sawUser, sawProject bool
+	for _, s := range out {
+		if s.Name == "grafana" && s.Scope == "user" {
+			sawUser = true
+		}
+		if s.Name == "custom" && s.Scope == "project" {
+			sawProject = true
+		}
+	}
+	if !sawUser || !sawProject {
+		t.Errorf("expected one user-scope and one project-scope entry, got %+v", out)
+	}
+}
+
+func TestScanClaudeCode_DifferentCwdSkipsProjectServers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
+	claudeJSON := filepath.Join(home, ".claude.json")
+	proj := filepath.Join(home, "myproject")
+	writeJSON(t, claudeJSON, `{
+		"mcpServers": {},
+		"projects": {"`+proj+`": {"mcpServers": {"custom": {"type":"stdio","command":"node","args":["./server.js"]}}}}
+	}`)
+
+	out := scanClaudeCode(filepath.Join(home, "other-project"))
+	if len(out) != 0 {
+		t.Errorf("expected 0 entries for an unrelated cwd, got %+v", out)
+	}
+}

--- a/internal/mcpregistry/scan_files_test.go
+++ b/internal/mcpregistry/scan_files_test.go
@@ -3,6 +3,7 @@
 package mcpregistry
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,12 +79,28 @@ func TestScanClaudeCode_UserAndProjectScope(t *testing.T) {
 	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
 	claudeJSON := filepath.Join(home, ".claude.json")
 	proj := filepath.Join(home, "myproject")
-	writeJSON(t, claudeJSON, `{
-		"mcpServers": {"grafana": {"type":"stdio","command":"npx","args":["-y","mcp-grafana"]}},
-		"projects": {
-			"`+proj+`": {"mcpServers": {"custom": {"type":"stdio","command":"node","args":["./server.js"]}}}
-		}
-	}`)
+
+	// Built structurally, not by string-interpolating proj into a JSON
+	// literal: proj is a Windows path on Windows CI, and an unescaped
+	// backslash inside a hand-written JSON string corrupts the document —
+	// this is exactly the bug that broke this test on windows-latest.
+	cfg := claudeCodeConfig{
+		MCPServers: map[string]clientServerConfig{
+			"grafana": {Type: "stdio", Command: "npx", Args: []string{"-y", "mcp-grafana"}},
+		},
+		Projects: map[string]struct {
+			MCPServers map[string]clientServerConfig `json:"mcpServers"`
+		}{
+			proj: {MCPServers: map[string]clientServerConfig{
+				"custom": {Type: "stdio", Command: "node", Args: []string{"./server.js"}},
+			}},
+		},
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, claudeJSON, string(raw))
 
 	out := scanClaudeCode(proj)
 	if len(out) != 2 {
@@ -110,10 +127,21 @@ func TestScanClaudeCode_DifferentCwdSkipsProjectServers(t *testing.T) {
 	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
 	claudeJSON := filepath.Join(home, ".claude.json")
 	proj := filepath.Join(home, "myproject")
-	writeJSON(t, claudeJSON, `{
-		"mcpServers": {},
-		"projects": {"`+proj+`": {"mcpServers": {"custom": {"type":"stdio","command":"node","args":["./server.js"]}}}}
-	}`)
+
+	cfg := claudeCodeConfig{
+		Projects: map[string]struct {
+			MCPServers map[string]clientServerConfig `json:"mcpServers"`
+		}{
+			proj: {MCPServers: map[string]clientServerConfig{
+				"custom": {Type: "stdio", Command: "node", Args: []string{"./server.js"}},
+			}},
+		},
+	}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, claudeJSON, string(raw))
 
 	out := scanClaudeCode(filepath.Join(home, "other-project"))
 	if len(out) != 0 {

--- a/internal/mcpregistry/scan_test.go
+++ b/internal/mcpregistry/scan_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestResolvePackage(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		want    string
+	}{
+		{"npx with -y flag", "npx", []string{"-y", "@modelcontextprotocol/server-github"}, "@modelcontextprotocol/server-github"},
+		{"npx no flags", "npx", []string{"remote-filesystem-mcp-server"}, "remote-filesystem-mcp-server"},
+		{"uvx package", "uvx", []string{"mcp-server-fetch"}, "mcp-server-fetch"},
+		{"npx only flags, no package", "npx", []string{"-y", "--silent"}, ""},
+		{"docker run with flags and image", "docker", []string{"run", "-i", "--rm", "-e", "API_KEY=secret", "mcp/fetch"}, "mcp/fetch"},
+		{"docker run image with tag", "docker", []string{"run", "--rm", "ghcr.io/foo/bar:latest"}, "ghcr.io/foo/bar:latest"},
+		{"unknown launcher", "/usr/local/bin/my-server", []string{"--config", "x.json"}, ""},
+		{"absolute path to npx", "/usr/local/bin/npx", []string{"-y", "some-pkg"}, "some-pkg"},
+		{"no args at all", "npx", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolvePackage(tt.command, tt.args); got != tt.want {
+				t.Errorf("resolvePackage(%q, %v) = %q, want %q", tt.command, tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToInstalledServers_RemoteServerHasNoPackage(t *testing.T) {
+	servers := map[string]clientServerConfig{
+		"cloudflare": {Type: "http", URL: "https://example.com/mcp"},
+	}
+	out := toInstalledServers(servers, "claude-code", "user")
+	if len(out) != 1 {
+		t.Fatalf("got %d entries, want 1", len(out))
+	}
+	if !out[0].Remote {
+		t.Errorf("expected Remote=true for a url-based server")
+	}
+	if out[0].Package != "" {
+		t.Errorf("remote server should have no package, got %q", out[0].Package)
+	}
+}
+
+func TestToInstalledServers_StdioServerResolvesPackage(t *testing.T) {
+	servers := map[string]clientServerConfig{
+		"github": {Type: "stdio", Command: "npx", Args: []string{"-y", "@modelcontextprotocol/server-github"}},
+	}
+	out := toInstalledServers(servers, "claude-desktop", "user")
+	if len(out) != 1 {
+		t.Fatalf("got %d entries, want 1", len(out))
+	}
+	got := out[0]
+	if got.Remote {
+		t.Errorf("expected Remote=false for a stdio server")
+	}
+	if got.Package != "@modelcontextprotocol/server-github" {
+		t.Errorf("Package = %q, want %q", got.Package, "@modelcontextprotocol/server-github")
+	}
+	if got.Command != "npx" {
+		t.Errorf("Command = %q, want %q", got.Command, "npx")
+	}
+}
+
+// clientServerConfig must never carry env values into memory: scan reads
+// config files that commonly hold plaintext API keys, and the privacy
+// guarantee in mcpregistry.go depends on this struct having no field an
+// "env" JSON key could unmarshal into. This test fails the moment someone
+// adds one.
+func TestClientServerConfig_HasNoEnvField(t *testing.T) {
+	var cfg clientServerConfig
+	raw := []byte(`{"type":"stdio","command":"npx","args":["-y","pkg"],"env":{"API_KEY":"super-secret-value"}}`)
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// The struct simply has nowhere to put "env" — this assertion documents
+	// that guarantee rather than testing incidental behavior.
+	if cfg.Command != "npx" {
+		t.Fatalf("sanity check failed: Command = %q", cfg.Command)
+	}
+}

--- a/internal/mcpregistry/sync.go
+++ b/internal/mcpregistry/sync.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// registryServersURL is a var so tests can override it with httptest.Server.
+var registryServersURL = "https://registry.modelcontextprotocol.io/v0/servers"
+
+var httpClient = &http.Client{Timeout: 15 * time.Second}
+
+// maxResponseBytes caps a single page's response body.
+const maxResponseBytes = 10 << 20
+
+// maxPages bounds a sync run so a misbehaving server (an infinite cursor
+// loop) can't hang hyctl forever. At 100/page this covers 500k servers,
+// several times the entire known registry.
+const maxPages = 5000
+
+type serverListItem struct {
+	Server ServerRecord `json:"server"`
+}
+
+type serverListResponse struct {
+	Servers  []serverListItem `json:"servers"`
+	Metadata struct {
+		NextCursor string `json:"nextCursor"`
+	} `json:"metadata"`
+}
+
+// Sync fetches the full official MCP registry (paginated) and writes it to
+// the local cache. Returns the number of servers written. onProgress, if
+// non-nil, is called after every page — the full registry is thousands of
+// servers over dozens of sequential requests, easily a minute or two, and a
+// caller driving a CLI needs that to show something rather than sit silent.
+func Sync(ctx context.Context, onProgress func(page, serversSoFar int)) (int, error) {
+	var servers []ServerRecord
+	cursor := ""
+
+	for page := 1; page <= maxPages; page++ {
+		url := registryServersURL + "?limit=100"
+		if cursor != "" {
+			url += "&cursor=" + cursor
+		}
+
+		resp, err := fetchPage(ctx, url)
+		if err != nil {
+			return 0, err
+		}
+		for _, item := range resp.Servers {
+			servers = append(servers, item.Server)
+		}
+		if onProgress != nil {
+			onProgress(page, len(servers))
+		}
+		if resp.Metadata.NextCursor == "" {
+			break
+		}
+		cursor = resp.Metadata.NextCursor
+	}
+
+	if err := writeCache(&registryCache{FetchedAt: time.Now().UTC(), Servers: servers}); err != nil {
+		return 0, err
+	}
+	return len(servers), nil
+}
+
+func fetchPage(ctx context.Context, url string) (*serverListResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "hydra/1 (+https://github.com/ankit373/hydra)")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("mcp registry fetch: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("mcp registry fetch: HTTP %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, maxResponseBytes+1)
+	var out serverListResponse
+	if err := json.NewDecoder(limited).Decode(&out); err != nil {
+		return nil, fmt.Errorf("mcp registry parse: %w", err)
+	}
+	return &out, nil
+}
+
+// LoadCache reads the local sync cache. Returns an error wrapping
+// os.ErrNotExist-checkable state when sync has never run.
+func loadCache() (*registryCache, error) {
+	raw, err := os.ReadFile(cachePath())
+	if err != nil {
+		return nil, err
+	}
+	var c registryCache
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("mcp registry cache corrupt: %w", err)
+	}
+	return &c, nil
+}
+
+func writeCache(c *registryCache) error {
+	raw, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := cachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	defer func() { _ = os.Remove(tmp) }()
+
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return os.WriteFile(path, raw, 0o600)
+	}
+	return nil
+}

--- a/internal/mcpregistry/sync_test.go
+++ b/internal/mcpregistry/sync_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func withFakeRegistry(t *testing.T, pages [][]ServerRecord) {
+	t.Helper()
+	page := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if page >= len(pages) {
+			_ = json.NewEncoder(w).Encode(serverListResponse{})
+			return
+		}
+		items := make([]serverListItem, len(pages[page]))
+		for i, s := range pages[page] {
+			items[i] = serverListItem{Server: s}
+		}
+		resp := serverListResponse{Servers: items}
+		page++
+		if page < len(pages) {
+			resp.Metadata.NextCursor = "next"
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+
+	origURL := registryServersURL
+	registryServersURL = srv.URL
+	t.Cleanup(func() { registryServersURL = origURL })
+}
+
+func withTempHydraHome(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HYDRA_HOME", dir)
+}
+
+func TestSync_SinglePage(t *testing.T) {
+	withTempHydraHome(t)
+	withFakeRegistry(t, [][]ServerRecord{
+		{{Name: "io.github.foo/bar", Packages: []Package{{RegistryType: "npm", Identifier: "bar-mcp"}}}},
+	})
+
+	n, err := Sync(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("Sync() = %d, want 1", n)
+	}
+
+	cache, err := loadCache()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cache.Servers) != 1 || cache.Servers[0].Name != "io.github.foo/bar" {
+		t.Errorf("unexpected cache contents: %+v", cache.Servers)
+	}
+}
+
+func TestSync_FollowsPagination(t *testing.T) {
+	withTempHydraHome(t)
+	withFakeRegistry(t, [][]ServerRecord{
+		{{Name: "a"}},
+		{{Name: "b"}},
+		{{Name: "c"}},
+	})
+
+	n, err := Sync(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Fatalf("Sync() = %d, want 3 (pagination should be followed to the end)", n)
+	}
+}
+
+func TestSync_ReportsProgressPerPage(t *testing.T) {
+	withTempHydraHome(t)
+	withFakeRegistry(t, [][]ServerRecord{
+		{{Name: "a"}},
+		{{Name: "b"}, {Name: "c"}},
+	})
+
+	var pages []int
+	var counts []int
+	_, err := Sync(context.Background(), func(page, soFar int) {
+		pages = append(pages, page)
+		counts = append(counts, soFar)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pages) != 2 || pages[0] != 1 || pages[1] != 2 {
+		t.Errorf("pages = %v, want [1 2]", pages)
+	}
+	if len(counts) != 2 || counts[0] != 1 || counts[1] != 3 {
+		t.Errorf("counts = %v, want [1 3] (cumulative)", counts)
+	}
+}
+
+func TestSync_HTTPErrorPropagates(t *testing.T) {
+	withTempHydraHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	origURL := registryServersURL
+	registryServersURL = srv.URL
+	defer func() { registryServersURL = origURL }()
+
+	if _, err := Sync(context.Background(), nil); err == nil {
+		t.Fatal("expected an error from a 500 response")
+	}
+}
+
+func TestWriteCache_CreatesParentDir(t *testing.T) {
+	withTempHydraHome(t)
+	if err := writeCache(&registryCache{Servers: []ServerRecord{{Name: "x"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadCache(); err != nil {
+		t.Fatalf("loadCache after writeCache: %v", err)
+	}
+}
+
+func TestCachePath_IsUnderHydraHome(t *testing.T) {
+	withTempHydraHome(t)
+	got := cachePath()
+	want := "mcp_registry_cache.json"
+	if filepath.Base(got) != want {
+		t.Errorf("cachePath() base = %q, want %q", filepath.Base(got), want)
+	}
+}


### PR DESCRIPTION
## Summary
- Phase 1 of the MCP registry: `internal/mcpregistry` — identity-only, no trust scoring yet.
- `hyctl mcp registry sync` — pulls the official MCP registry (registry.modelcontextprotocol.io) into a local cache. Confirmed live: syncs the full 78,020-server registry cleanly.
- `hyctl mcp registry scan` — enumerates MCP servers installed across this machine's clients (Claude Code, Claude Desktop, Cursor, Windsurf, VS Code).
- `hyctl mcp registry audit` — resolves installed servers against the synced dataset, reports verified vs. unresolved.
- **Privacy-by-construction**: the client-config parser (`clientServerConfig`) has no field for `env` — secrets in MCP client configs are never even parsed into memory, let alone logged or transmitted.

Dogfooded against my own machine: both of my locally-configured stdio MCP servers (`grafana` via `uvx mcp-grafana`, `chrome-mcp` via `npx chrome-mcp`) came back unresolved against the full registry — genuinely correct, not a bug (the registry has differently-identified siblings for both, e.g. `docker.io/grafana/mcp-grafana` and `chrome-devtools-mcp`/`chrome-debugger-mcp`/`chrome-bridge-mcp`, but nothing matching my exact identifiers).

## Changes
- `internal/mcpregistry/` — new package: `sync.go` (paginated fetch + cache), `scan.go` (client config parsing), `audit.go` (resolve + report)
- `cmd/hydra/main.go` — wires `hyctl mcp registry sync|scan|audit` under the existing `hyctl mcp` command

## Test plan
- [x] `go test -race -count=1 ./internal/mcpregistry/... ./cmd/hydra/...` — all pass
- [x] `go vet ./...` clean, `gofmt -l` clean
- [x] Live end-to-end: synced the real official registry (78,020 servers), scanned and audited real local MCP configs

Closes #551