### PR TITLE
feat(desktop): expose the governor's burn rate and first-passage risk

### DIFF
--- a/desktop/api/dashboard.go
+++ b/desktop/api/dashboard.go
@@ -69,6 +69,25 @@ type GovernorPanel struct {
 	Known bool   `json:"known"`
 	Pct   int    `json:"pct"`
 	Mode  string `json:"mode"`
+
+	// EffectiveMode is what the router actually acts on: the level band raised
+	// by rate-driven risk when a fast burn would cross 80% before a static
+	// threshold catches it. Equals Mode when there is no rate signal.
+	EffectiveMode string `json:"effectiveMode"`
+
+	// BurnRatePct is the mean change in percentage points per observation, and
+	// Risk the probability of reaching the 80% emergency line within
+	// HorizonObs observations. Both are zero when Observations < 2 — that is
+	// "no rate signal", not "no risk", which is why Observations ships too: a
+	// bare 0 would read as a measurement.
+	BurnRatePct float64 `json:"burnRatePct"`
+	Risk        float64 `json:"risk"`
+
+	// Observations is how many points the trajectory estimate rests on, and
+	// HorizonObs the look-ahead Risk is computed over. Both are counts of
+	// claude_pct *updates*, not wall-clock time and not chat turns.
+	Observations int `json:"observations"`
+	HorizonObs   int `json:"horizonObs"`
 }
 
 // TrustPanel summarises the SPRT ensemble's record.
@@ -187,14 +206,28 @@ func governorPanel() GovernorPanel {
 	if err != nil {
 		return GovernorPanel{}
 	}
+	// One read for both: the level and the trajectory live in the same file,
+	// and dispatch already pairs them the same way (dispatch.go:375).
 	var s struct {
-		ClaudePct *int `json:"claude_pct"`
+		ClaudePct *int  `json:"claude_pct"`
+		History   []int `json:"claude_pct_history"`
 	}
 	if err := json.Unmarshal(raw, &s); err != nil || s.ClaudePct == nil {
 		return GovernorPanel{}
 	}
 	pct := *s.ClaudePct
-	return GovernorPanel{Known: true, Pct: pct, Mode: budget.ModeFor(pct).String()}
+
+	burn, risk := budget.RiskFromHistory(s.History)
+	return GovernorPanel{
+		Known:         true,
+		Pct:           pct,
+		Mode:          budget.ModeFor(pct).String(),
+		EffectiveMode: budget.EffectiveMode(pct, risk).String(),
+		BurnRatePct:   burn,
+		Risk:          risk,
+		Observations:  len(s.History),
+		HorizonObs:    int(budget.RiskHorizon),
+	}
 }
 
 func trustPanel() TrustPanel {

--- a/desktop/api/dashboard_test.go
+++ b/desktop/api/dashboard_test.go
@@ -541,3 +541,67 @@ func TestGetDashboard_ConcurrentCallsAreSafe(t *testing.T) {
 		}
 	}
 }
+
+// A single-point (or absent) history gives RiskFromHistory no rate signal, so
+// burn and risk come back zero. Observations must ship alongside them, or a UI
+// cannot tell "measured no risk" from "never measured" (#555).
+func TestGovernor_NoRateSignalIsDistinguishableFromNoRisk(t *testing.T) {
+	home := sandbox(t)
+	state := filepath.Join(home, ".hydra", "logs", "state.json")
+	if err := os.WriteFile(state, []byte(`{"claude_pct": 40, "claude_pct_history": [40]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := New().GetDashboard()
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := d.Governor
+	if g.BurnRatePct != 0 || g.Risk != 0 {
+		t.Errorf("burn=%v risk=%v; one observation cannot yield a rate", g.BurnRatePct, g.Risk)
+	}
+	if g.Observations != 1 {
+		t.Errorf("Observations = %d, want 1 — without it a zero risk reads as measured", g.Observations)
+	}
+	if g.HorizonObs <= 0 {
+		t.Errorf("HorizonObs = %d; the UI cannot state the horizon it is reporting", g.HorizonObs)
+	}
+	// With no rate signal the governor must fall back to the level band exactly.
+	if g.EffectiveMode != g.Mode {
+		t.Errorf("EffectiveMode = %q, Mode = %q; they must agree with no rate signal",
+			g.EffectiveMode, g.Mode)
+	}
+}
+
+// A climbing trajectory must produce a positive burn rate, and a fast climb must
+// be able to raise the effective mode above the static band — that escalation is
+// the entire point of the rate model.
+func TestGovernor_FastBurnRaisesEffectiveModeAboveTheBand(t *testing.T) {
+	home := sandbox(t)
+	state := filepath.Join(home, ".hydra", "logs", "state.json")
+	// Steady +8pp per observation, ending at 64: ModeFor(64) is "compact", but
+	// at this rate the 80% barrier is about two observations away.
+	body := `{"claude_pct": 64, "claude_pct_history": [24,32,40,48,56,64]}`
+	if err := os.WriteFile(state, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := New().GetDashboard()
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := d.Governor
+	if g.BurnRatePct <= 0 {
+		t.Errorf("BurnRatePct = %v on a monotonically climbing series", g.BurnRatePct)
+	}
+	if g.Risk <= 0 {
+		t.Errorf("Risk = %v; a fast climb toward 80%% must carry non-zero risk", g.Risk)
+	}
+	if g.Mode != "compact" {
+		t.Fatalf("Mode = %q, want compact — fixture no longer pins the band it means to", g.Mode)
+	}
+	if g.EffectiveMode == g.Mode {
+		t.Errorf("EffectiveMode = %q, same as the static band; the rate floor never applied",
+			g.EffectiveMode)
+	}
+}

--- a/desktop/api/typesparity_test.go
+++ b/desktop/api/typesparity_test.go
@@ -79,6 +79,7 @@ func TestTypesTS_MirrorsEveryFieldOnTheWire(t *testing.T) {
 		{"Model", Model{}},
 		{"Pool", Pool{}},
 		{"ModelRegistry", ModelRegistry{}},
+		{"GovernorPanel", GovernorPanel{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			ts := tsInterface(t, src, c.iface)
@@ -108,6 +109,7 @@ func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
 		{"Model", Model{}},
 		{"Pool", Pool{}},
 		{"ModelRegistry", ModelRegistry{}},
+		{"GovernorPanel", GovernorPanel{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			g := jsonFields(c.goVal)

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -17,6 +17,17 @@ export interface GovernorPanel {
   known: boolean
   pct: number
   mode: string
+  /** What the router acts on: the level band raised by rate-driven risk.
+   *  Equals `mode` when there is no rate signal. */
+  effectiveMode: string
+  /** Mean percentage-point change per observation, and the probability of
+   *  reaching 80% within `horizonObs`. Both zero when `observations` < 2 —
+   *  that is "no rate signal", not "no risk". */
+  burnRatePct: number
+  risk: number
+  /** Counts of claude_pct *updates* — not wall-clock time, not chat turns. */
+  observations: number
+  horizonObs: number
 }
 
 export interface TrustPanel {

--- a/internal/budget/risk.go
+++ b/internal/budget/risk.go
@@ -13,8 +13,13 @@ import "math"
 // an absorbing barrier; each recorded claude_pct observation is one step.
 const (
 	emergencyFrac = 0.80 // absorbing barrier b (matches ModeEmergency at 80%)
-	riskHorizon   = 3.0  // look-ahead in observations ("within the next ~3 claude_pct updates")
 	MaxPctHistory = 12   // bounded claude_pct series kept in state.json
+
+	// RiskHorizon is the look-ahead RiskFromHistory computes over, in
+	// observations ("within the next ~3 claude_pct updates") — not wall-clock
+	// time and not chat turns. Exported so a UI can state the horizon it is
+	// reporting instead of restating the number and drifting from it.
+	RiskHorizon = 3.0
 
 	// Risk floors: a high probability of hitting the 80% barrier within the
 	// horizon imposes a minimum mode regardless of the current level, so a fast
@@ -74,7 +79,7 @@ func RiskFromHistory(hist []int) (burnRatePct, risk float64) {
 	}
 
 	x := float64(hist[len(hist)-1]) / 100
-	risk = FirstPassageProb(emergencyFrac-x, mu, sigma, riskHorizon)
+	risk = FirstPassageProb(emergencyFrac-x, mu, sigma, RiskHorizon)
 	return mu * 100, risk
 }
 


### PR DESCRIPTION
Step 2 of #552. **Backend only — no UI changes.**

## Why
`budget.RiskFromHistory` has computed burn rate and the first-passage probability of
hitting the 80% line since the rate-aware governor landed, and `internal/dispatch`
acts on it (`dispatch.go:375`, feeding `EffectiveMode` tier downgrades). `GovernorPanel`
carried only `{Known, Pct, Mode}` — the level, never the trajectory. The usage modal in
#552 needs "how fast, and how close".

## What
`effectiveMode`, `burnRatePct`, `risk`, `observations`, `horizonObs`.

## Two things worth reviewing
**`observations` is load-bearing, not padding.** `RiskFromHistory` returns `0, 0` below
two points. Without the count, a UI cannot distinguish *"measured no risk"* from
*"never measured"* — the same failure as rendering `D=0.00` for an uncalibrated model.

**Exported `budget.RiskHorizon` rather than hardcoding `3` in the API.** One source of
truth for the look-ahead, so the UI can state the horizon it reports without drifting
from the value the math actually uses. Renamed from the unexported `riskHorizon`; the
single internal usage moved with it.

Both are documented as counts of claude_pct **updates** — not wall-clock time, not chat
turns. (The mockup on #520 said "~2 turns of headroom"; that was loose, and the field
docs now say what the number really means.)

## Testing
- New: a single-point history yields zero burn/risk *and* `observations: 1`, with
  `effectiveMode == mode` (no rate signal must fall back to the band exactly).
- New: a steady +8pp climb ending at 64 stays in the `compact` band but raises
  `effectiveMode` above it — pins that the rate floor actually fires, which is the
  whole point of the model.
- `GovernorPanel` added to the types-parity tests in both directions.
- `gofmt`/`go vet` clean; `go test ./api/ -race -count=1` clean; `internal/budget` clean.

**Pre-existing failure, not from this branch:** `TestLogDispatch_IdentityIsNeverEmpty`
and `TestLogDispatch_BothLogsShareOneIdentity` fail in my sandbox. I verified they fail
identically on unmodified `origin/develop` (network is proxy-blocked locally, so dispatch
logs no rows). CI has network and passes them.

Closes #556