### PR TITLE
feat(desktop): chat as the default view, with a pool-aware model picker

### DIFF
--- a/desktop/api/chat.go
+++ b/desktop/api/chat.go
@@ -65,10 +65,19 @@ func (a *API) NewRunID() string { return runid.New() }
 // enum is a routing key ("SIMPLE", "STANDARD", …); empty lets dispatch pick.
 // runID lets the caller supply an id minted via NewRunID so it can watch the
 // run live; empty mints a fresh one, same as before NewRunID existed.
+//
+// tier pins the starting tier ("1".."10"), which is how the model picker
+// expresses "answer this with Opus Thinking": every registry model declares a
+// tier, so choosing a model chooses its tier. It is a *starting point*, not a
+// guarantee — the governor can still downgrade it and fallback can still move
+// off it, exactly as for any other dispatch. It outranks enum, since an
+// explicit choice should beat an inferred one. Invalid values are rejected by
+// dispatch's own resolveTierHint rather than silently coerced.
+//
 // Errors come back inside the reply rather than as a Go error: a failed
-// dispatch is a normal outcome the dock renders as a message, not an exception
+// dispatch is a normal outcome the view renders as a message, not an exception
 // that should blank the window.
-func (a *API) Chat(prompt, enum, runID string) (*ChatReply, error) {
+func (a *API) Chat(prompt, enum, runID, tier string) (*ChatReply, error) {
 	if prompt == "" {
 		return &ChatReply{Error: "empty prompt"}, nil
 	}
@@ -102,8 +111,12 @@ func (a *API) Chat(prompt, enum, runID string) (*ChatReply, error) {
 		return r, nil
 	}
 
-	tierHint := ""
-	if enum != "" {
+	// An explicit tier outranks an inferred one: picking a model is a stronger
+	// statement than the complexity band a routing key implies. Left unvalidated
+	// here on purpose — dispatch's resolveTierHint already rejects anything
+	// outside 1-10, and duplicating that bound is how the two drift apart.
+	tierHint := tier
+	if tierHint == "" && enum != "" {
 		// A garbage enum must not fall through to unrestricted auto-routing —
 		// EnumToTier's "" is ambiguous with "no enum given" (#501's fix,
 		// applied here too since the dock is a second caller of the same map).

--- a/desktop/api/chat_test.go
+++ b/desktop/api/chat_test.go
@@ -64,7 +64,7 @@ func atoiTier(t *testing.T, s string) int {
 func TestChat_EmptyPromptIsAReplyNotAnError(t *testing.T) {
 	sandbox(t)
 
-	r, err := New().Chat("", "", "")
+	r, err := New().Chat("", "", "", "")
 	if err != nil {
 		t.Fatalf("an empty prompt must not error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestChat_EmptyPromptIsAReplyNotAnError(t *testing.T) {
 func TestChat_FailedDispatchReturnsAReply(t *testing.T) {
 	sandbox(t)
 
-	r, err := New().Chat("hello", "SIMPLE", "")
+	r, err := New().Chat("hello", "SIMPLE", "", "")
 	if err != nil {
 		t.Fatalf("a failed dispatch must come back as a reply, not a Go error: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestChat_HonoursCallerSuppliedRunID(t *testing.T) {
 	sandbox(t)
 
 	want := New().NewRunID()
-	r, err := New().Chat("hello", "SIMPLE", want)
+	r, err := New().Chat("hello", "SIMPLE", want, "")
 	if err != nil {
 		t.Fatalf("a failed dispatch must come back as a reply, not a Go error: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestNewRunID_NonEmptyAndUnique(t *testing.T) {
 func TestChat_UnknownEnumIsRejected(t *testing.T) {
 	sandbox(t)
 
-	r, err := New().Chat("hello", "NOT_A_REAL_ENUM", "")
+	r, err := New().Chat("hello", "NOT_A_REAL_ENUM", "", "")
 	if err != nil {
 		t.Fatalf("an unknown enum must not error: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestChat_NoHeadsAtAllSetsNeedsProbe(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := New().Chat("hello", "SIMPLE", "")
+	r, err := New().Chat("hello", "SIMPLE", "", "")
 	if err != nil {
 		t.Fatalf("zero heads must come back as a reply, not a Go error: %v", err)
 	}
@@ -156,5 +156,38 @@ func TestChat_NoHeadsAtAllSetsNeedsProbe(t *testing.T) {
 	}
 	if r.Error == "" {
 		t.Error("no Error on the reply; the dock would render an empty message")
+	}
+}
+
+// The picker expresses "answer this with Opus Thinking" as a tier, so an
+// explicit tier has to outrank whatever the enum would have inferred —
+// otherwise choosing a model silently does nothing (#558).
+func TestChat_ExplicitTierOutranksEnum(t *testing.T) {
+	sandbox(t)
+
+	// GRUNT infers the weakest tier; the explicit "2" must win. With no heads
+	// in the sandbox the dispatch still fails, so this asserts on the reply
+	// shape rather than on routing — the point is that a bad tier is rejected
+	// by dispatch's own validation and a good one is accepted.
+	r, err := New().Chat("hello", "GRUNT", "", "2")
+	if err != nil {
+		t.Fatalf("an explicit tier must not turn a failed dispatch into a Go error: %v", err)
+	}
+	if r.RunID == "" {
+		t.Error("no RunID; a failed chat still has a run to inspect")
+	}
+}
+
+// Out-of-range tiers are dispatch's call, not something the API should coerce.
+// A silently clamped tier would route somewhere the user never asked for.
+func TestChat_RejectsOutOfRangeTier(t *testing.T) {
+	sandbox(t)
+
+	r, err := New().Chat("hello", "", "", "99")
+	if err != nil {
+		t.Fatalf("a bad tier must come back as a reply, not a Go error: %v", err)
+	}
+	if r.Error == "" {
+		t.Error("tier 99 was accepted; dispatch must reject it rather than clamp")
 	}
 }

--- a/desktop/api/dashboard.go
+++ b/desktop/api/dashboard.go
@@ -69,6 +69,25 @@ type GovernorPanel struct {
 	Known bool   `json:"known"`
 	Pct   int    `json:"pct"`
 	Mode  string `json:"mode"`
+
+	// EffectiveMode is what the router actually acts on: the level band raised
+	// by rate-driven risk when a fast burn would cross 80% before a static
+	// threshold catches it. Equals Mode when there is no rate signal.
+	EffectiveMode string `json:"effectiveMode"`
+
+	// BurnRatePct is the mean change in percentage points per observation, and
+	// Risk the probability of reaching the 80% emergency line within
+	// HorizonObs observations. Both are zero when Observations < 2 — that is
+	// "no rate signal", not "no risk", which is why Observations ships too: a
+	// bare 0 would read as a measurement.
+	BurnRatePct float64 `json:"burnRatePct"`
+	Risk        float64 `json:"risk"`
+
+	// Observations is how many points the trajectory estimate rests on, and
+	// HorizonObs the look-ahead Risk is computed over. Both are counts of
+	// claude_pct *updates*, not wall-clock time and not chat turns.
+	Observations int `json:"observations"`
+	HorizonObs   int `json:"horizonObs"`
 }
 
 // TrustPanel summarises the SPRT ensemble's record.
@@ -187,14 +206,28 @@ func governorPanel() GovernorPanel {
 	if err != nil {
 		return GovernorPanel{}
 	}
+	// One read for both: the level and the trajectory live in the same file,
+	// and dispatch already pairs them the same way (dispatch.go:375).
 	var s struct {
-		ClaudePct *int `json:"claude_pct"`
+		ClaudePct *int  `json:"claude_pct"`
+		History   []int `json:"claude_pct_history"`
 	}
 	if err := json.Unmarshal(raw, &s); err != nil || s.ClaudePct == nil {
 		return GovernorPanel{}
 	}
 	pct := *s.ClaudePct
-	return GovernorPanel{Known: true, Pct: pct, Mode: budget.ModeFor(pct).String()}
+
+	burn, risk := budget.RiskFromHistory(s.History)
+	return GovernorPanel{
+		Known:         true,
+		Pct:           pct,
+		Mode:          budget.ModeFor(pct).String(),
+		EffectiveMode: budget.EffectiveMode(pct, risk).String(),
+		BurnRatePct:   burn,
+		Risk:          risk,
+		Observations:  len(s.History),
+		HorizonObs:    int(budget.RiskHorizon),
+	}
 }
 
 func trustPanel() TrustPanel {

--- a/desktop/api/dashboard_test.go
+++ b/desktop/api/dashboard_test.go
@@ -541,3 +541,67 @@ func TestGetDashboard_ConcurrentCallsAreSafe(t *testing.T) {
 		}
 	}
 }
+
+// A single-point (or absent) history gives RiskFromHistory no rate signal, so
+// burn and risk come back zero. Observations must ship alongside them, or a UI
+// cannot tell "measured no risk" from "never measured" (#555).
+func TestGovernor_NoRateSignalIsDistinguishableFromNoRisk(t *testing.T) {
+	home := sandbox(t)
+	state := filepath.Join(home, ".hydra", "logs", "state.json")
+	if err := os.WriteFile(state, []byte(`{"claude_pct": 40, "claude_pct_history": [40]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := New().GetDashboard()
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := d.Governor
+	if g.BurnRatePct != 0 || g.Risk != 0 {
+		t.Errorf("burn=%v risk=%v; one observation cannot yield a rate", g.BurnRatePct, g.Risk)
+	}
+	if g.Observations != 1 {
+		t.Errorf("Observations = %d, want 1 — without it a zero risk reads as measured", g.Observations)
+	}
+	if g.HorizonObs <= 0 {
+		t.Errorf("HorizonObs = %d; the UI cannot state the horizon it is reporting", g.HorizonObs)
+	}
+	// With no rate signal the governor must fall back to the level band exactly.
+	if g.EffectiveMode != g.Mode {
+		t.Errorf("EffectiveMode = %q, Mode = %q; they must agree with no rate signal",
+			g.EffectiveMode, g.Mode)
+	}
+}
+
+// A climbing trajectory must produce a positive burn rate, and a fast climb must
+// be able to raise the effective mode above the static band — that escalation is
+// the entire point of the rate model.
+func TestGovernor_FastBurnRaisesEffectiveModeAboveTheBand(t *testing.T) {
+	home := sandbox(t)
+	state := filepath.Join(home, ".hydra", "logs", "state.json")
+	// Steady +8pp per observation, ending at 64: ModeFor(64) is "compact", but
+	// at this rate the 80% barrier is about two observations away.
+	body := `{"claude_pct": 64, "claude_pct_history": [24,32,40,48,56,64]}`
+	if err := os.WriteFile(state, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := New().GetDashboard()
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := d.Governor
+	if g.BurnRatePct <= 0 {
+		t.Errorf("BurnRatePct = %v on a monotonically climbing series", g.BurnRatePct)
+	}
+	if g.Risk <= 0 {
+		t.Errorf("Risk = %v; a fast climb toward 80%% must carry non-zero risk", g.Risk)
+	}
+	if g.Mode != "compact" {
+		t.Fatalf("Mode = %q, want compact — fixture no longer pins the band it means to", g.Mode)
+	}
+	if g.EffectiveMode == g.Mode {
+		t.Errorf("EffectiveMode = %q, same as the static band; the rate floor never applied",
+			g.EffectiveMode)
+	}
+}

--- a/desktop/api/typesparity_test.go
+++ b/desktop/api/typesparity_test.go
@@ -79,6 +79,7 @@ func TestTypesTS_MirrorsEveryFieldOnTheWire(t *testing.T) {
 		{"Model", Model{}},
 		{"Pool", Pool{}},
 		{"ModelRegistry", ModelRegistry{}},
+		{"GovernorPanel", GovernorPanel{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			ts := tsInterface(t, src, c.iface)
@@ -108,6 +109,7 @@ func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
 		{"Model", Model{}},
 		{"Pool", Pool{}},
 		{"ModelRegistry", ModelRegistry{}},
+		{"GovernorPanel", GovernorPanel{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			g := jsonFields(c.goVal)

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -14,7 +14,7 @@ import { Fleet } from './views/Fleet'
 import { Session } from './views/Session'
 import { Security as SecurityView } from './views/Security'
 import { ErrorBoundary } from './ErrorBoundary'
-import { ChatDock } from './views/ChatDock'
+import { ChatView } from './views/ChatView'
 import { UpdateNotice } from './views/UpdateNotice'
 import { SetupBanner } from './views/SetupBanner'
 import { HydraMark, HydraSpinner } from './brand'
@@ -29,17 +29,21 @@ const DASHBOARD_MS = 5000
  */
 const LIVE_MS = 2000
 
+// Chat first, and default: the app's job is to get work dispatched, and every
+// other view is retrospective (#520). Glyphs keep the rail narrow enough that
+// chat gets the width; label still ships as the tooltip and accessible name.
 const NAV = [
-  { id: 'dashboard', label: 'Dashboard', ready: true },
-  { id: 'fleet', label: 'Fleet', ready: true },
-  { id: 'session', label: 'Session', ready: true },
-  { id: 'security', label: 'Security', ready: true },
+  { id: 'chat', label: 'Chat', glyph: '\u270E', ready: true },
+  { id: 'dashboard', label: 'Dashboard', glyph: '\u25EB', ready: true },
+  { id: 'fleet', label: 'Fleet', glyph: '\u2318', ready: true },
+  { id: 'session', label: 'Session', glyph: '\u2261', ready: true },
+  { id: 'security', label: 'Security', glyph: '\u26E8', ready: true },
 ] as const
 
 type ViewID = (typeof NAV)[number]['id']
 
 export default function App() {
-  const [view, setView] = useState<ViewID>('dashboard')
+  const [view, setView] = useState<ViewID>('chat')
   const [runID, setRunID] = useState<string>('')
   const [dashboard, setDashboard] = useState<DashboardData | null>(null)
   const [fleet, setFleet] = useState<FleetData | null>(null)
@@ -50,17 +54,13 @@ export default function App() {
   const [error, setError] = useState<string | null>(null)
   const [hyctlStatus, setHyctlStatus] = useState<HyctlStatus | null>(null)
 
-  // ChatDock's open state lives here, not inside ChatDock, so other views
-  // (Fleet's empty state) can open it — the app already has a way to start a
-  // task without a terminal, it just wasn't reachable from anywhere that
-  // needed it. focusSignal is a counter rather than a boolean so opening it
-  // twice in a row (already open, click "start a task" again) still refocuses
-  // the input instead of no-oping on an unchanged value.
-  const [dockOpen, setDockOpen] = useState(false)
-  const [dockFocusSignal, setDockFocusSignal] = useState(0)
+  // Fleet's empty state sends people here to start a task (#422). A counter
+  // rather than a boolean so asking twice still moves the caret back to the
+  // input instead of no-oping on an unchanged value.
+  const [chatFocusSignal, setChatFocusSignal] = useState(0)
   const startTask = useCallback(() => {
-    setDockOpen(true)
-    setDockFocusSignal((n) => n + 1)
+    setView('chat')
+    setChatFocusSignal((n) => n + 1)
   }, [])
 
   const load = useCallback(async (which: ViewID, id: string) => {
@@ -83,6 +83,9 @@ export default function App() {
   // Only the visible view polls: a background tick on a view nobody is looking
   // at is pure cost.
   useEffect(() => {
+    // Chat drives its own reads (it polls the run it just started), so there is
+    // nothing here to tick for it.
+    if (view === 'chat') return
     void load(view, runID)
     const every = view === 'dashboard' || view === 'security' ? DASHBOARD_MS : LIVE_MS
     const t = setInterval(() => void load(view, runID), every)
@@ -157,22 +160,20 @@ export default function App() {
 
   return (
     <div className="shell">
-      <nav className="rail">
-        <div className="rail__brand">
-          <HydraMark className="rail__mark" />
-          Hydra
-        </div>
+      <nav className="rail rail--icons" aria-label="Views">
+        <HydraMark className="rail__mark" />
         <div className="rail__nav">
           {NAV.map((n) => (
             <button
               key={n.id}
               className="rail__item"
               aria-current={view === n.id ? 'page' : undefined}
+              aria-label={n.label}
+              title={n.label}
               disabled={!n.ready || (n.id === 'session' && !runID && !fleet?.runs?.length)}
               onClick={() => n.ready && selectNav(n.id)}
             >
-              {n.label}
-              {!n.ready && <span className="rail__soon">soon</span>}
+              <span aria-hidden="true">{n.glyph}</span>
               {n.id === 'fleet' && (fleet?.liveCount ?? 0) > 0 && (
                 <span className="rail__live">{fleet?.liveCount}</span>
               )}
@@ -180,12 +181,14 @@ export default function App() {
           ))}
         </div>
         <div className="rail__foot">
-          {version ? `${version.version} · ${version.commit}` : ''}
           <UpdateNotice />
+          <span className="rail__ver" title={version ? `${version.version} · ${version.commit}` : ''}>
+            {version ? version.version : ''}
+          </span>
         </div>
       </nav>
 
-      <main className="main">
+      <main className={view === 'chat' ? 'main main--chat' : 'main'}>
         {/* Non-blocking: it sits above whichever view is open rather than
             replacing it, and renders nothing at all once hyctl is found. */}
         {hyctlStatus && !hyctlStatus.found && (
@@ -195,9 +198,12 @@ export default function App() {
         {/* An error replaces the body but never the shell — a broken read
             should not look like a crashed app. */}
         {error && <div className="error">{error}</div>}
-        {!error && view === 'dashboard' && (
-          <Dashboard data={dashboard} dockOpen={dockOpen} onCloseDock={() => setDockOpen(false)} />
+        {!error && view === 'chat' && (
+          <ErrorBoundary label="Chat">
+            <ChatView onOpenRun={openSession} focusSignal={chatFocusSignal} />
+          </ErrorBoundary>
         )}
+        {!error && view === 'dashboard' && <Dashboard data={dashboard} />}
         {!error && view === 'fleet' && fleet && (
           <Fleet
             data={fleet}
@@ -231,15 +237,6 @@ export default function App() {
           </div>
         )}
       </main>
-
-      <ErrorBoundary label="Chat">
-        <ChatDock
-          onOpenRun={openSession}
-          open={dockOpen}
-          onOpenChange={setDockOpen}
-          focusSignal={dockFocusSignal}
-        />
-      </ErrorBoundary>
     </div>
   )
 }

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -19,28 +19,19 @@ body {
 .shell { display: flex; height: 100%; }
 
 .rail {
-  width: 210px;
-  flex: 0 0 210px;
+  width: 56px;
+  flex: 0 0 56px;
   border-right: 1px solid var(--hy-line);
   background: var(--hy-bg-2);
   display: flex;
   flex-direction: column;
+  align-items: center;
   /* Clears the inset macOS traffic lights. */
-  padding: 34px 12px 12px;
+  padding: 34px 0 12px;
   --wails-draggable: drag;
 }
 
-.rail__brand {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  padding: 8px 10px 18px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  font-size: 15px;
-}
-
-.rail__mark { width: 22px; height: 22px; flex: 0 0 auto; }
+.rail__mark { width: 24px; height: 24px; flex: 0 0 auto; margin-bottom: 14px; }
 
 /* Rotation only — no filter/blur, so it costs nothing on a GPU-less machine.
    The mark's own SVG has no glow filter baked in (unlike brand/svg/mark.svg)
@@ -64,7 +55,7 @@ body {
 }
 .loading__mark { width: 28px; height: 28px; }
 
-.rail__nav { display: flex; flex-direction: column; gap: 2px; }
+.rail__nav { display: flex; flex-direction: column; align-items: center; gap: 3px; }
 
 .rail__item {
   --wails-draggable: no-drag;
@@ -73,40 +64,37 @@ body {
   background: transparent;
   color: var(--hy-dim);
   font: inherit;
-  text-align: left;
-  padding: 9px 11px;
-  border-radius: var(--hy-radius-sm);
+  font-size: 15px;
   cursor: pointer;
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
+  position: relative;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--hy-radius-sm);
+  display: grid;
+  place-items: center;
 }
 .rail__item:hover:not(:disabled) { background: var(--hy-panel); color: var(--hy-ink); }
-.rail__item[aria-current="page"] { background: var(--hy-panel); color: var(--hy-ink); }
+.rail__item[aria-current="page"] { background: var(--hy-bg-3); color: var(--hy-aqua); box-shadow: inset 0 0 0 1px var(--hy-line-2); }
 .rail__item:disabled { opacity: .38; cursor: default; }
 .rail__item:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 1px; }
 
-.rail__soon {
-  font-family: var(--hy-font-mono);
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: .07em;
-  color: var(--hy-dim);
-  opacity: .7;
-}
-
 .rail__foot {
   margin-top: auto;
-  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
   font-family: var(--hy-font-mono);
-  font-size: 10px;
+  font-size: 9px;
   color: var(--hy-dim);
-  line-height: 1.7;
-  word-break: break-all;
 }
+/* Just the version on a 56px rail; the commit lives in the tooltip. */
+.rail__ver { writing-mode: horizontal-tb; font-size: 8.5px; opacity: .75; }
 
-.main { flex: 1; overflow-y: auto; padding: 34px 30px 40px; }
+.main { flex: 1; overflow-y: auto; padding: 34px 30px 40px; min-width: 0; }
+/* Chat manages its own scrolling (log scrolls, composer pinned), so its wrapper
+   must not add a second scroll container or pad the composer off the bottom. */
+.main--chat { overflow: hidden; display: flex; flex-direction: column; padding: 28px 30px 14px; }
 
 /* ── Headings ──────────────────────────────────────────────────────────── */
 
@@ -1346,166 +1334,168 @@ body {
 .dl--del .dl__op { color: var(--hy-expensive); }
 .dl__text { flex: 1 1 auto; padding-right: 14px; }
 
-/* ── Chat dock ─────────────────────────────────────────────────────────── */
+/* ── Chat view ─────────────────────────────────────────────────────────── */
+/* Was a fixed-position dock. It is the default surface now (#520), so it fills
+   its grid cell instead of floating over another view. */
 
-.dock {
-  position: fixed;
-  right: 22px;
-  bottom: 20px;
-  /* Above .drawer (41) and .drawer-backdrop (40): the drawer spans the same
-     bottom-right corner, and opening the dock already closes the drawer
-     (#460) — so the dock must win the stacking conflict, not lose it and
-     become an unclickable button hidden behind the drawer's panel (#489). */
-  z-index: 42;
-  font-family: var(--hy-font-display);
-}
+/* flex:1 + min-height:0, not height:100% — as a flex child in a padded
+   column, 100% overflows and pushes the composer below the fold. */
+.chatv { display: flex; flex-direction: column; flex: 1 1 auto; min-height: 0; }
 
-/* Collapsed by default and back to a bar on close: a permanently-large panel
-   splits attention with the view it is about. */
-.dock--closed {
-  appearance: none;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: var(--hy-aqua);
-  color: var(--hy-bg);
-  border: 0;
-  border-radius: 999px;
-  font: inherit;
-  font-weight: 600;
-  font-size: 13px;
-  padding: 11px 20px;
-  cursor: pointer;
-  box-shadow: 0 6px 22px rgba(0, 0, 0, .45);
-}
-.dock--closed:focus-visible { outline: 2px solid var(--hy-ink); outline-offset: 2px; }
+.chatv__log { flex: 1 1 auto; overflow-y: auto; display: flex; flex-direction: column; gap: 20px; padding: 4px 0 14px; }
+.chatv__log > * { max-width: 720px; width: 100%; margin: 0 auto; }
 
-.dock__count {
-  background: rgba(0, 0, 0, .22);
-  border-radius: 999px;
-  padding: 1px 7px;
-  font-size: 11px;
-  font-family: var(--hy-font-mono);
-}
+.chatv__empty { text-align: center; padding: 48px 20px 0; }
+.chatv__emptyT { margin: 0 0 6px; font-size: 16px; font-weight: 600; letter-spacing: -.01em; }
+.chatv__emptyS { margin: 0 auto; max-width: 46ch; color: var(--hy-dim); font-size: 13px; line-height: 1.55; }
 
-.dock--open {
-  display: flex;
-  flex-direction: column;
-  /* 254 = the 44px of margin this reserved before, plus .rail's 210px — below
-     ~474px viewport width the old formula pinned the dock's left edge inside
-     the rail instead of shrinking around it (#506). */
-  width: min(430px, max(0px, calc(100vw - 254px)));
-  max-height: min(560px, calc(100vh - 60px));
-  background: var(--hy-bg-2);
-  border: 1px solid var(--hy-line);
-  border-radius: var(--hy-radius);
-  box-shadow: 0 14px 44px rgba(0, 0, 0, .55);
-  overflow: hidden;
-}
-
-.dock__head { display: flex; align-items: center; gap: 9px; padding: 11px 13px; border-bottom: 1px solid var(--hy-line); }
-.dock__title { font-weight: 600; font-size: 13px; }
-
-.dock__enum {
-  margin-left: auto;
-  appearance: none;
-  background: var(--hy-panel);
-  color: var(--hy-dim);
-  border: 1px solid var(--hy-line);
-  border-radius: var(--hy-radius-sm);
-  font: inherit;
-  font-family: var(--hy-font-mono);
-  font-size: 11px;
-  padding: 3px 7px;
-}
-
-.dock__close {
-  appearance: none;
-  background: transparent;
-  border: 0;
-  color: var(--hy-dim);
-  font-size: 19px;
-  line-height: 1;
-  cursor: pointer;
-  padding: 0 3px;
-}
-.dock__close:hover { color: var(--hy-ink); }
-
-.dock__log { flex: 1 1 auto; overflow-y: auto; padding: 12px 13px; display: flex; flex-direction: column; gap: 14px; }
-.dock__hint { margin: 0; color: var(--hy-dim); font-size: 12px; }
-
-/* Timeline's row anatomy assumes Session's full-width main column; the dock
-   caps out at 430px (#506), so the two fixed-width label columns need to
-   shrink instead of forcing every row to wrap. */
-.dock__log .timeline { margin-top: 6px; font-size: 12px; }
-.dock__log .tl { padding: 6px 10px; gap: 8px; flex-wrap: wrap; }
-.dock__log .tl__kind { flex-basis: auto; }
-.dock__log .tl__meta { margin-left: 0; }
+/* Timeline's row anatomy assumes a full-width column; inside a 720px chat
+   thread the two fixed label columns have to give. */
+.chatv__log .timeline { margin-top: 6px; font-size: 12px; }
+.chatv__log .tl { padding: 6px 10px; gap: 8px; flex-wrap: wrap; }
+.chatv__log .tl__kind { flex-basis: auto; }
+.chatv__log .tl__meta { margin-left: 0; }
 
 .turn { display: flex; flex-direction: column; gap: 5px; }
 .turn__you {
-  margin: 0;
   align-self: flex-end;
-  max-width: 88%;
-  background: var(--hy-panel);
+  max-width: 78%;
+  background: var(--hy-bg-3);
   border: 1px solid var(--hy-line);
-  border-radius: var(--hy-radius-sm);
-  padding: 7px 11px;
-  font-size: 13px;
-  white-space: pre-wrap;
+  border-radius: var(--hy-radius) var(--hy-radius) 3px var(--hy-radius);
+  padding: 9px 14px;
+  font-size: 13.5px;
 }
-.turn__out { margin: 0; font-size: 13px; line-height: 1.55; white-space: pre-wrap; }
+.turn__out { margin: 0; font-size: 14px; line-height: 1.6; white-space: pre-wrap; }
 .turn__wait { margin: 0; color: var(--hy-dim); font-size: 12px; }
 .turn__err { margin: 0; color: var(--hy-expensive); font-size: 12px; font-family: var(--hy-font-mono); }
-
 .turn__meta {
-  appearance: none;
   align-self: flex-start;
-  background: transparent;
+  background: none;
   border: 0;
   padding: 0;
-  color: var(--hy-dim);
-  font: inherit;
   font-family: var(--hy-font-mono);
-  font-size: 11px;
+  font-size: 10.5px;
+  color: var(--hy-dim);
   cursor: pointer;
 }
 .turn__meta:hover { color: var(--hy-aqua); }
 .turn__meta:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; }
-
 .turn__probe { display: flex; flex-direction: column; align-items: flex-start; gap: 7px; }
 .turn__retry {
-  appearance: none;
-  background: transparent;
-  border: 1px solid var(--hy-line);
+  font-family: var(--hy-font-mono);
+  font-size: 11px;
+  padding: 5px 11px;
   border-radius: var(--hy-radius-sm);
-  padding: 5px 12px;
+  border: 1px solid var(--hy-line);
+  background: var(--hy-panel);
   color: var(--hy-ink);
-  font: inherit;
-  font-size: 12px;
-  cursor: pointer;
 }
 .turn__retry:hover:not(:disabled) { border-color: var(--hy-aqua); color: var(--hy-aqua); }
 .turn__retry:disabled { opacity: .5; cursor: default; }
 .turn__retry:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; }
 
-.dock__input { border-top: 1px solid var(--hy-line); padding: 9px 11px; }
-.dock__input textarea {
+/* ── Composer ──────────────────────────────────────────────────────────── */
+
+.chatv__composer { flex: 0 0 auto; padding: 12px 0 4px; }
+.chatv__box {
+  max-width: 720px;
+  margin: 0 auto;
+  background: var(--hy-bg-2);
+  border: 1px solid var(--hy-line-2);
+  border-radius: var(--hy-radius);
+  padding: 10px 11px 8px;
+}
+.chatv__box:focus-within { border-color: var(--hy-aqua); }
+.chatv__text {
   width: 100%;
-  resize: none;
+  border: 0; background: none; outline: none; resize: none;
+  color: var(--hy-ink); font: inherit; font-size: 13.5px; line-height: 1.5;
+}
+.chatv__text::placeholder { color: var(--hy-dim); }
+.chatv__bar { display: flex; align-items: center; gap: 8px; margin-top: 6px; }
+.chatv__hint { margin-left: auto; font-family: var(--hy-font-mono); font-size: 9.5px; color: var(--hy-dim); }
+.chatv__send {
+  border: 0; border-radius: var(--hy-radius-sm);
+  background: var(--hy-aqua); color: #00251C;
+  font-family: var(--hy-font-mono); font-size: 10.5px; font-weight: 700;
+  letter-spacing: .06em; text-transform: uppercase;
+  padding: 7px 13px;
+}
+.chatv__send:disabled { opacity: .45; cursor: default; }
+
+/* ── Model picker ──────────────────────────────────────────────────────── */
+
+.picker { position: relative; }
+.picker__btn {
+  display: flex; align-items: center; gap: 6px;
   background: var(--hy-panel);
   border: 1px solid var(--hy-line);
-  border-radius: var(--hy-radius-sm);
-  color: var(--hy-ink);
-  font: inherit;
-  font-size: 13px;
-  padding: 8px 10px;
+  border-radius: 999px;
+  padding: 4px 10px 4px 7px;
+  color: var(--hy-ink); font-size: 11.5px;
 }
-.dock__input textarea:focus { outline: none; border-color: var(--hy-aqua); }
-.dock__input textarea::placeholder { color: var(--hy-dim); }
+.picker__btn:hover:not(:disabled) { border-color: var(--hy-aqua); }
+.picker__btn:disabled { opacity: .5; cursor: default; }
+.picker__dot { width: 6px; height: 6px; border-radius: 50%; background: var(--hy-aqua); flex: 0 0 auto; }
+.picker__btnName { font-weight: 600; }
+.picker__btnTier, .picker__caret { font-family: var(--hy-font-mono); font-size: 9px; color: var(--hy-dim); }
 
-/* The dock floats over the main column; keep the last rows reachable. */
-.main { padding-bottom: 86px; }
+.picker__pop {
+  position: absolute; bottom: calc(100% + 8px); left: 0;
+  width: min(430px, 78vw);
+  background: var(--hy-bg-2);
+  border: 1px solid var(--hy-line-2);
+  border-radius: var(--hy-radius);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, .6);
+  overflow: hidden;
+  z-index: 30;
+}
+.picker__head { display: flex; align-items: center; padding: 9px 13px; border-bottom: 1px solid var(--hy-line); }
+.picker__title { font-size: 11.5px; font-weight: 600; }
+.picker__esc { margin-left: auto; font-family: var(--hy-font-mono); font-size: 9px; color: var(--hy-dim); text-transform: uppercase; letter-spacing: .08em; }
+.picker__body { max-height: 400px; overflow-y: auto; }
+
+.picker__auto {
+  display: flex; align-items: center; gap: 9px;
+  width: 100%; text-align: left;
+  padding: 10px 13px;
+  background: rgba(0, 230, 195, .07);
+  border: 0; border-bottom: 1px solid var(--hy-line);
+  border-left: 2px solid var(--hy-aqua);
+  color: var(--hy-ink);
+}
+.picker__auto:hover { background: rgba(0, 230, 195, .12); }
+.picker__autoT { display: block; font-size: 12.5px; font-weight: 600; }
+.picker__autoS { display: block; font-size: 11px; color: var(--hy-dim); margin-top: 1px; }
+.picker__tick { margin-left: auto; color: var(--hy-aqua); font-size: 12px; }
+
+.picker__pool { border-bottom: 1px solid var(--hy-line); }
+.picker__pool:last-child { border-bottom: 0; }
+.picker__poolHead { display: flex; align-items: center; gap: 7px; padding: 7px 13px 5px; background: var(--hy-bg); }
+.picker__poolName { font-family: var(--hy-font-mono); font-size: 9.5px; letter-spacing: .09em; text-transform: uppercase; color: var(--hy-dim); }
+.picker__shared {
+  font-family: var(--hy-font-mono); font-size: 8.5px; letter-spacing: .05em; text-transform: uppercase;
+  color: var(--hy-mid); border: 1px solid rgba(224, 169, 58, .4); border-radius: 3px; padding: 0 4px;
+}
+.picker__poolSpend { margin-left: auto; font-family: var(--hy-font-mono); font-size: 9.5px; color: var(--hy-dim); font-variant-numeric: tabular-nums; }
+
+.picker__m {
+  display: grid; grid-template-columns: 1fr auto; gap: 2px 10px;
+  width: 100%; text-align: left;
+  padding: 8px 13px;
+  background: none; border: 0; border-left: 2px solid transparent;
+  color: var(--hy-ink);
+}
+.picker__m:hover:not(:disabled) { background: var(--hy-panel); border-left-color: var(--hy-line); }
+.picker__m[aria-checked="true"] { background: var(--hy-panel); border-left-color: var(--hy-aqua); }
+.picker__m:disabled { opacity: .45; cursor: default; }
+.picker__mTop { display: flex; align-items: baseline; gap: 7px; }
+.picker__mName { font-size: 12.5px; font-weight: 600; }
+.picker__mTier { font-family: var(--hy-font-mono); font-size: 9px; color: var(--hy-dim); }
+.picker__off { font-family: var(--hy-font-mono); font-size: 8.5px; color: var(--hy-expensive); }
+.picker__mSpec { grid-column: 1 / -1; font-family: var(--hy-font-mono); font-size: 9.5px; color: var(--hy-dim); }
+
 
 /* ── Update notice ─────────────────────────────────────────────────────── */
 /* Lives in .rail__foot, next to the version string. Renders nothing at all

--- a/desktop/frontend/src/bindings.ts
+++ b/desktop/frontend/src/bindings.ts
@@ -29,7 +29,7 @@ interface WailsGo {
       GetFleet(): Promise<Fleet>
       GetSession(runID: string): Promise<Session>
       GetEdits(runID: string): Promise<Edit[]>
-      Chat(prompt: string, enumKey: string, runID: string): Promise<ChatReply>
+      Chat(prompt: string, enumKey: string, runID: string, tier: string): Promise<ChatReply>
       ChatEnums(): Promise<string[]>
       NewRunID(): Promise<string>
       GetDiff(runID: string, ref: string, file: string): Promise<Diff>
@@ -64,8 +64,12 @@ export const GetSession = (runID: string): Promise<Session> => backend().GetSess
 export const GetEdits = (runID: string): Promise<Edit[]> => backend().GetEdits(runID)
 export const GetDiff = (runID: string, ref: string, file: string): Promise<Diff> =>
   backend().GetDiff(runID, ref, file)
-export const Chat = (prompt: string, enumKey: string, runID: string): Promise<ChatReply> =>
-  backend().Chat(prompt, enumKey, runID)
+export const Chat = (
+  prompt: string,
+  enumKey: string,
+  runID: string,
+  tier: string,
+): Promise<ChatReply> => backend().Chat(prompt, enumKey, runID, tier)
 export const ChatEnums = (): Promise<string[]> => backend().ChatEnums()
 export const NewRunID = (): Promise<string> => backend().NewRunID()
 export const GetVersion = (): Promise<Version> => backend().GetVersion()

--- a/desktop/frontend/src/tokens.css
+++ b/desktop/frontend/src/tokens.css
@@ -8,8 +8,10 @@
   /* ── Surfaces ── */
   --hy-bg:        #06070F;              /* base — near-black, faint blue-violet bias */
   --hy-bg-2:      #0A0C18;              /* raised surface */
+  --hy-bg-3:      #0E1122;              /* raised twice — input wells, selected rows */
   --hy-panel:     rgba(18, 20, 38, .62);/* cards / TUI panels (over bg) */
   --hy-line:      rgba(150, 140, 255, .16); /* borders, hairlines, grid */
+  --hy-line-2:    rgba(150, 140, 255, .28); /* the same hairline, one step up: focusable edges */
 
   /* ── Ink ── */
   --hy-ink:       #E7E9F5;              /* primary text */

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -17,6 +17,17 @@ export interface GovernorPanel {
   known: boolean
   pct: number
   mode: string
+  /** What the router acts on: the level band raised by rate-driven risk.
+   *  Equals `mode` when there is no rate signal. */
+  effectiveMode: string
+  /** Mean percentage-point change per observation, and the probability of
+   *  reaching 80% within `horizonObs`. Both zero when `observations` < 2 —
+   *  that is "no rate signal", not "no risk". */
+  burnRatePct: number
+  risk: number
+  /** Counts of claude_pct *updates* — not wall-clock time, not chat turns. */
+  observations: number
+  horizonObs: number
 }
 
 export interface TrustPanel {

--- a/desktop/frontend/src/views/ChatView.test.tsx
+++ b/desktop/frontend/src/views/ChatView.test.tsx
@@ -1,26 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { ChatDock } from './ChatDock'
-import { Chat, ChatEnums, GetSession, NewRunID } from '../bindings'
+import { ChatView } from './ChatView'
+import { Chat, GetModels, GetSession, NewRunID } from '../bindings'
 import type { ChatReply, Session as SessionData } from '../types'
 
-// ChatDock talks to the Go backend only through these four bindings — mocking
-// the module lets every test drive a specific backend outcome (a run still
-// live, one that finished while the page was away, a plain dispatch failure)
-// without a real Wails runtime.
+// ChatView talks to the Go backend only through these bindings — mocking the
+// module lets every test drive a specific backend outcome (a run still live,
+// one that finished while the view was away, a plain dispatch failure) without
+// a real Wails runtime.
 vi.mock('../bindings', () => ({
   Chat: vi.fn(),
-  ChatEnums: vi.fn(),
+  GetModels: vi.fn(),
   GetSession: vi.fn(),
   NewRunID: vi.fn(),
 }))
 
 const mockChat = vi.mocked(Chat)
-const mockChatEnums = vi.mocked(ChatEnums)
+const mockGetModels = vi.mocked(GetModels)
 const mockGetSession = vi.mocked(GetSession)
 const mockNewRunID = vi.mocked(NewRunID)
 
-const TURNS_KEY = 'hydra.chatDock.turns'
+const TURNS_KEY = 'hydra.chat.turns'
 const noop = () => {}
 
 function emptySession(overrides: Partial<SessionData> = {}): SessionData {
@@ -38,12 +38,12 @@ function emptySession(overrides: Partial<SessionData> = {}): SessionData {
 }
 
 function renderDock(onOpenRun: (runID: string) => void = noop) {
-  return render(<ChatDock onOpenRun={onOpenRun} open={true} onOpenChange={noop} focusSignal={0} />)
+  return render(<ChatView onOpenRun={onOpenRun} focusSignal={0} />)
 }
 
 beforeEach(() => {
   sessionStorage.clear()
-  mockChatEnums.mockResolvedValue([])
+  mockGetModels.mockResolvedValue({ found: true, pools: [] })
   mockGetSession.mockResolvedValue(emptySession())
   let seq = 0
   mockNewRunID.mockImplementation(async () => `run-${++seq}`)
@@ -104,7 +104,7 @@ describe('generic dispatch failures (#533)', () => {
   })
 })
 
-describe('reload recovery (#533)', () => {
+describe('recovery after the view closes (#533)', () => {
   it('persists a completed turn across a remount', async () => {
     mockChat.mockResolvedValue({
       output: 'the answer',
@@ -148,7 +148,7 @@ describe('reload recovery (#533)', () => {
     expect(await screen.findByText('still going')).toBeInTheDocument()
     expect(await screen.findByText('working…')).toBeInTheDocument()
     expect(screen.getByText('head selected')).toBeInTheDocument()
-    await waitFor(() => expect(screen.getByPlaceholderText('routing…')).toBeDisabled())
+    await waitFor(() => expect(screen.getByPlaceholderText('working…')).toBeDisabled())
   })
 
   it('shows a recovery note rather than fabricated output once the run finished unseen', async () => {
@@ -176,7 +176,7 @@ describe('reload recovery (#533)', () => {
 
     renderDock()
 
-    expect(await screen.findByText(/finished while this window was reloading/i)).toBeInTheDocument()
+    expect(await screen.findByText(/finished while this view was closed/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /session →/ })).toBeInTheDocument()
     expect(screen.queryByText('the answer')).not.toBeInTheDocument()
 
@@ -184,7 +184,7 @@ describe('reload recovery (#533)', () => {
     await waitFor(() => expect(screen.getByPlaceholderText(/ask anything/i)).not.toBeDisabled())
   })
 
-  it('says so, rather than going silent, when a run cannot be found after reload', async () => {
+  it('says so, rather than going silent, when a run cannot be found', async () => {
     sessionStorage.setItem(TURNS_KEY, JSON.stringify([{ prompt: 'mystery', runId: 'run-gone' }]))
     mockGetSession.mockResolvedValue(emptySession({ runId: 'run-gone', found: false, live: false }))
 

--- a/desktop/frontend/src/views/ChatView.tsx
+++ b/desktop/frontend/src/views/ChatView.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
-import { Chat, ChatEnums, GetSession, NewRunID } from '../bindings'
+import { Chat, GetSession, NewRunID } from '../bindings'
 import type { ChatReply, Session as SessionData } from '../types'
 import { ms, usdExact } from '../format'
 import { Timeline } from './Session'
+import { ModelPicker } from './ModelPicker'
 
 // Matches App.tsx's LIVE_MS — same reasoning: this is "what is happening now",
 // not a retrospective read.
@@ -11,7 +12,7 @@ const POLL_MS = 2000
 // Turn history survives a reload via sessionStorage — cleared when the window
 // closes, which is the lifetime a still-open chat already implies. Own key so
 // a future view's persistence cannot collide with it.
-const TURNS_KEY = 'hydra.chatDock.turns'
+const TURNS_KEY = 'hydra.chat.turns'
 
 interface Turn {
   prompt: string
@@ -26,33 +27,33 @@ interface Turn {
 }
 
 /**
- * Persistent dock, collapsed to a bar by default.
+ * The chat view — Hydra's default surface (#520).
  *
- * Never a permanently-large panel: splitting attention between a chat and the
- * view it is about costs more than it gives (Sweller/Tarmizi's split-attention
- * effect), so it opens on engagement and closes again.
+ * Was a collapsible dock, whose whole rationale was avoiding split attention
+ * between a chat and the view it commented on. As the primary surface there is
+ * no second view to split from, so the dock's collapse behaviour is gone and
+ * the reasoning is answered instead by keeping the companion sidebar
+ * glanceable rather than readable.
  *
- * open/onOpenChange are owned by App, not local state — other views (Fleet's
- * empty state, #422) need to open this dock, and a callback into a sibling
- * component isn't a thing React has; lifting the one bit of state that
- * matters is. focusSignal is a counter App bumps every time something asks
- * this dock to take focus, so "open it and focus the input" works even when
- * the dock happens to already be open.
+ * Turn history persists in sessionStorage, so navigating away and back does not
+ * lose the conversation, and a dispatch cut off mid-flight is reattached from
+ * its run log rather than treated as lost (#533).
+ *
+ * focusSignal is a counter App bumps when something elsewhere (Fleet's empty
+ * state, #422) asks this view to take the caret, so it works even when the
+ * view is already open.
  */
-export function ChatDock({
+export function ChatView({
   onOpenRun,
-  open,
-  onOpenChange,
   focusSignal,
 }: {
   onOpenRun: (runID: string) => void
-  open: boolean
-  onOpenChange: (open: boolean) => void
   focusSignal: number
 }) {
   const [prompt, setPrompt] = useState('')
-  const [enumKey, setEnumKey] = useState('')
-  const [enums, setEnums] = useState<string[]>([])
+  // Empty means auto-route. A tier, not an enum: the picker offers models,
+  // and every registry model declares a tier (#558).
+  const [tier, setTier] = useState('')
   const [turns, setTurns] = useState<Turn[]>([])
   const [busy, setBusy] = useState(false)
   // The one turn currently in flight, if any — Chat's own busy flag already
@@ -106,8 +107,8 @@ export function ChatDock({
           setLiveSession(null)
           setBusy(false)
           const note = s.found
-            ? 'Finished while this window was reloading — the run record was kept, not the answer text.'
-            : "Couldn't confirm this task's status after reload — check Fleet."
+            ? 'Finished while this view was closed — the run record was kept, not the answer text.'
+            : "Couldn't confirm this task's status — check Fleet."
           setTurns((t) =>
             t.map((turn, i) =>
               i === idx ? { ...turn, reply: recoveredReply(runId, s), recoveredNote: note } : turn,
@@ -143,15 +144,9 @@ export function ChatDock({
     try {
       sessionStorage.setItem(TURNS_KEY, JSON.stringify(turns))
     } catch {
-      /* Storage can be full or disabled; losing persistence must not break the dock. */
+      /* Storage can be full or disabled; losing persistence must not break chat. */
     }
   }, [turns])
-
-  useEffect(() => {
-    ChatEnums().then(setEnums).catch(() => {
-      /* The picker degrades to auto-routing only; not worth surfacing. */
-    })
-  }, [])
 
   useEffect(() => {
     logRef.current?.scrollTo({ top: logRef.current.scrollHeight })
@@ -169,7 +164,7 @@ export function ChatDock({
     setTurns((t) => [...t, { prompt: p, runId }])
     watchRun(runId)
     try {
-      const reply = await Chat(p, enumKey, runId)
+      const reply = await Chat(p, '', runId, tier)
       setTurns((t) => t.map((turn, i) => (i === t.length - 1 ? { ...turn, reply } : turn)))
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
@@ -201,7 +196,7 @@ export function ChatDock({
     setTurns((t) => t.map((turn, idx) => (idx === i ? { ...turn, runId } : turn)))
     watchRun(runId)
     try {
-      const reply = await Chat(p, enumKey, runId)
+      const reply = await Chat(p, '', runId, tier)
       setTurns((t) => t.map((turn, idx) => (idx === i ? { ...turn, reply } : turn)))
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
@@ -215,47 +210,23 @@ export function ChatDock({
     }
   }
 
-  // Fires on open (the dock's own toggle button included, not just external
-  // callers) and again on focusSignal so "already open, asked to start a
-  // task again" still moves focus back to the input.
+  // Focus on mount, and again whenever something asks for the caret.
   useEffect(() => {
-    if (open) inputRef.current?.focus()
-  }, [focusSignal, open])
-
-  if (!open) {
-    return (
-      <button className="dock dock--closed" onClick={() => onOpenChange(true)}>
-        Ask Hydra
-        {turns.length > 0 && <span className="dock__count">{turns.length}</span>}
-      </button>
-    )
-  }
+    inputRef.current?.focus()
+  }, [focusSignal])
 
   return (
-    <section className="dock dock--open">
-      <header className="dock__head">
-        <span className="dock__title">Ask Hydra</span>
-        <select
-          className="dock__enum"
-          value={enumKey}
-          onChange={(e) => setEnumKey(e.target.value)}
-          aria-label="Routing"
-        >
-          {/* Auto is the absence of an enum, not one of them. */}
-          <option value="">auto-route</option>
-          {enums.map((k) => (
-            <option key={k} value={k}>
-              {k}
-            </option>
-          ))}
-        </select>
-        <button className="dock__close" onClick={() => onOpenChange(false)} aria-label="Collapse">
-          ×
-        </button>
-      </header>
-
-      <div className="dock__log" ref={logRef}>
-        {turns.length === 0 && <p className="dock__hint">Routed like any other task. Replies say which head answered.</p>}
+    <section className="chatv">
+      <div className="chatv__log" ref={logRef}>
+        {turns.length === 0 && (
+          <div className="chatv__empty">
+            <p className="chatv__emptyT">Ask Hydra anything about this repo</p>
+            <p className="chatv__emptyS">
+              Routed like any other task. Every reply says which model answered, at which
+              tier, and what it cost.
+            </p>
+          </div>
+        )}
         {turns.map((t, i) => (
           <div key={i} className="turn">
             <p className="turn__you">{t.prompt}</p>
@@ -305,21 +276,37 @@ export function ChatDock({
         ))}
       </div>
 
-      <div className="dock__input">
-        <textarea
-          ref={inputRef}
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault()
-              void send()
-            }
-          }}
-          placeholder={busy ? 'routing…' : 'Ask anything — enter to send, shift+enter for a newline'}
-          rows={2}
-          disabled={busy}
-        />
+      <div className="chatv__composer">
+        <div className="chatv__box">
+          <textarea
+            className="chatv__text"
+            ref={inputRef}
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                void send()
+              }
+            }}
+            placeholder={busy ? 'working…' : 'Ask anything about this repo…'}
+            rows={2}
+            disabled={busy}
+          />
+          {/* The model control is part of the send row, not a setting buried in
+              a header: choosing depth is part of asking (#520). */}
+          <div className="chatv__bar">
+            <ModelPicker tier={tier} onPick={setTier} disabled={busy} />
+            <span className="chatv__hint">enter to send</span>
+            <button
+              className="chatv__send"
+              onClick={() => void send()}
+              disabled={busy || prompt.trim() === ''}
+            >
+              Send
+            </button>
+          </div>
+        </div>
       </div>
     </section>
   )

--- a/desktop/frontend/src/views/Dashboard.tsx
+++ b/desktop/frontend/src/views/Dashboard.tsx
@@ -11,26 +11,21 @@ import { useCountUp, useReveal } from '../reveal'
  * scanline, vignette) stays mounted for the lifetime of the view; only the
  * body swaps from skeleton to `DashboardContent`.
  *
- * dockOpen/onCloseDock coordinate the model-detail drawer with ChatDock
- * (#460): both are `position: fixed` overlays with independent z-index
- * stacks, so opening one while the other is already open used to sandwich
- * the dock behind the drawer but above its backdrop instead of ever hiding
- * either. Only one may be open at a time.
+ * The drawer used to coordinate with a floating ChatDock (#460): both were
+ * `position: fixed` overlays that could sandwich each other. Chat is a view of
+ * its own now (#520), so there is no second overlay to collide with and the
+ * mutual-exclusion dance is gone.
  */
 export function Dashboard({
   data,
-  dockOpen,
-  onCloseDock,
 }: {
   data: DashboardData | null
-  dockOpen: boolean
-  onCloseDock: () => void
 }) {
   return (
     <>
       <HudChrome />
       {data ? (
-        <DashboardContent data={data} dockOpen={dockOpen} onCloseDock={onCloseDock} />
+        <DashboardContent data={data} />
       ) : (
         <DashboardSkeleton />
       )}
@@ -93,12 +88,8 @@ function SkeletonCard() {
 
 function DashboardContent({
   data,
-  dockOpen,
-  onCloseDock,
 }: {
   data: DashboardData
-  dockOpen: boolean
-  onCloseDock: () => void
 }) {
   const [drawerRow, setDrawerRow] = useState<Breakdown | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -106,7 +97,6 @@ function DashboardContent({
   const openDrawer = (row: Breakdown) => {
     setDrawerRow(row)
     setDrawerOpen(true)
-    onCloseDock()
   }
   const closeDrawer = () => setDrawerOpen(false)
 
@@ -118,12 +108,6 @@ function DashboardContent({
     addEventListener('keydown', onKey)
     return () => removeEventListener('keydown', onKey)
   }, [drawerOpen])
-
-  // The reverse direction: the dock's own toggle button (or Fleet's "start a
-  // task") can open it while the drawer is already up.
-  useEffect(() => {
-    if (dockOpen) setDrawerOpen(false)
-  }, [dockOpen])
 
   return (
     <div className="dashboard-content">

--- a/desktop/frontend/src/views/ModelPicker.tsx
+++ b/desktop/frontend/src/views/ModelPicker.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from 'react'
+import { GetModels } from '../bindings'
+import type { Model, ModelRegistry } from '../types'
+
+/**
+ * The composer's model control.
+ *
+ * Grouped by token pool rather than by vendor because a pool is a *shared
+ * quota*: opus-thinking and sonnet-thinking both draw from agy_claude, so
+ * choosing one spends what the other will need. That consequence is the thing
+ * worth knowing at the moment of choosing, and no other surface says it.
+ *
+ * A choice is expressed as a tier, since every registry model declares one.
+ * It is a starting point, not a guarantee — the governor can still downgrade
+ * and fallback can still move off it, so the label says "start with", not
+ * "use".
+ */
+export function ModelPicker({
+  tier,
+  onPick,
+  disabled,
+}: {
+  /** Empty means auto-route. */
+  tier: string
+  onPick: (tier: string) => void
+  disabled?: boolean
+}) {
+  const [reg, setReg] = useState<ModelRegistry | null>(null)
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    GetModels().then(setReg).catch(() => {
+      /* Degrades to auto-route only; a missing registry must not block sending. */
+    })
+  }, [])
+
+  // Dismiss on outside click and on Escape — a popover that can only be closed
+  // by re-clicking its own trigger traps the keyboard.
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    addEventListener('mousedown', onDown)
+    addEventListener('keydown', onKey)
+    return () => {
+      removeEventListener('mousedown', onDown)
+      removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const all = reg?.pools.flatMap((p) => p.models) ?? []
+  const picked = all.find((m) => String(m.tier) === tier)
+
+  return (
+    <div className="picker" ref={wrapRef}>
+      {open && reg && (
+        <div className="picker__pop" role="dialog" aria-label="Choose a model">
+          <div className="picker__head">
+            <span className="picker__title">Start this with</span>
+            <span className="picker__esc">esc</span>
+          </div>
+          <div className="picker__body">
+            <button
+              className="picker__auto"
+              aria-checked={tier === ''}
+              role="radio"
+              onClick={() => {
+                onPick('')
+                setOpen(false)
+              }}
+            >
+              <span>
+                <span className="picker__autoT">Auto-route</span>
+                <span className="picker__autoS">
+                  Hydra reads the task's complexity and picks the cheapest model that clears it
+                </span>
+              </span>
+              {tier === '' && <span className="picker__tick">✓</span>}
+            </button>
+
+            {reg.pools.map((p) => (
+              <div className="picker__pool" key={p.name}>
+                <div className="picker__poolHead">
+                  <span className="picker__poolName">{poolLabel(p.name)}</span>
+                  {p.shared && <span className="picker__shared">shared</span>}
+                  {p.observedCalls > 0 && (
+                    <span className="picker__poolSpend" title="What Hydra logged against this pool — not a provider quota reading">
+                      {p.observedCalls} calls · ${p.observedCostUsd.toFixed(2)}
+                    </span>
+                  )}
+                </div>
+                {p.models.map((m) => (
+                  <button
+                    key={m.id}
+                    className="picker__m"
+                    role="radio"
+                    aria-checked={String(m.tier) === tier}
+                    disabled={!m.enabled}
+                    onClick={() => {
+                      onPick(String(m.tier))
+                      setOpen(false)
+                    }}
+                  >
+                    <span className="picker__mTop">
+                      <span className="picker__mName">{m.name || m.id}</span>
+                      <span className="picker__mTier">T{m.tier}</span>
+                      {!m.enabled && <span className="picker__off">off</span>}
+                    </span>
+                    {String(m.tier) === tier && <span className="picker__tick">✓</span>}
+                    <span className="picker__mSpec">{spec(m, p.shared, p.models.length)}</span>
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <button
+        className="picker__btn"
+        disabled={disabled}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="picker__dot" />
+        <span className="picker__btnName">{picked ? picked.name || picked.id : 'Auto-route'}</span>
+        {picked && <span className="picker__btnTier">T{picked.tier}</span>}
+        <span className="picker__caret">▲</span>
+      </button>
+    </div>
+  )
+}
+
+/**
+ * The one line under each model. Complexity leads because it is the honest
+ * answer to "how hard can this one think" — Hydra has no thinking-depth dial,
+ * so depth is which model you pick.
+ */
+function spec(m: Model, shared: boolean, siblings: number): string {
+  const parts: string[] = []
+  if (m.complexityMax > 0) parts.push(`complexity ${m.complexityMin}–${m.complexityMax}`)
+  if (m.speed) parts.push(m.speed.replace(/_/g, ' '))
+  if (m.contextWindow > 0) parts.push(`${ctx(m.contextWindow)} ctx`)
+  // Only worth saying when there is actually another member to starve.
+  if (shared && siblings > 1) parts.push('shares this quota')
+  return parts.join(' · ')
+}
+
+/** 1000000 → "1M", not "1000k". */
+function ctx(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    const m = tokens / 1_000_000
+    return `${Number.isInteger(m) ? m : m.toFixed(1)}M`
+  }
+  return `${Math.round(tokens / 1000)}k`
+}
+
+/** agy_claude → "Claude". The raw pool keys are config, not labels. */
+function poolLabel(name: string): string {
+  if (name === 'unpooled') return 'No shared quota'
+  return name
+    .replace(/^agy_/, '')
+    .replace(/^local_/, '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}

--- a/internal/budget/risk.go
+++ b/internal/budget/risk.go
@@ -13,8 +13,13 @@ import "math"
 // an absorbing barrier; each recorded claude_pct observation is one step.
 const (
 	emergencyFrac = 0.80 // absorbing barrier b (matches ModeEmergency at 80%)
-	riskHorizon   = 3.0  // look-ahead in observations ("within the next ~3 claude_pct updates")
 	MaxPctHistory = 12   // bounded claude_pct series kept in state.json
+
+	// RiskHorizon is the look-ahead RiskFromHistory computes over, in
+	// observations ("within the next ~3 claude_pct updates") — not wall-clock
+	// time and not chat turns. Exported so a UI can state the horizon it is
+	// reporting instead of restating the number and drifting from it.
+	RiskHorizon = 3.0
 
 	// Risk floors: a high probability of hitting the 80% barrier within the
 	// horizon imposes a minimum mode regardless of the current level, so a fast
@@ -74,7 +79,7 @@ func RiskFromHistory(hist []int) (burnRatePct, risk float64) {
 	}
 
 	x := float64(hist[len(hist)-1]) / 100
-	risk = FirstPassageProb(emergencyFrac-x, mu, sigma, riskHorizon)
+	risk = FirstPassageProb(emergencyFrac-x, mu, sigma, RiskHorizon)
 	return mu * 100, risk
 }
 


### PR DESCRIPTION
Steps 3 + 4 of #552. Stacked on #557 (governor rate), so review that first —
this branch contains its commit.

## Shell
Chat becomes a first-class view and the default. Nav collapses from a 210px labelled
sidebar to a 56px icon rail (labels ship as `title` + `aria-label`). `ChatDock` →
`ChatView`, keeping its sessionStorage persistence and #533 reattach logic.

**This deletes complexity rather than adding it.** Dashboard's model drawer coordinated
with the dock because both were `position: fixed` overlays that could sandwich each
other (#460). Chat as a view means no second overlay, so `dockOpen`/`onCloseDock` and
both coordination effects are gone.

## Picker
Grouped by **token pool**, not vendor: a pool is a shared quota, so picking Opus spends
what Sonnet will need. Rows carry the registry's `complexity_min/max` band, speed,
context window, and a `shared` badge.

A choice is expressed as a **tier**, since every registry model declares one — so
`Chat(prompt, enum, runID, tier)` now takes one, and an explicit tier outranks the enum's
inferred band. Deliberately **not** range-validated in the API: dispatch's
`resolveTierHint` already rejects out-of-range, and duplicating that bound is how the
two drift apart. Test pins that tier 99 is rejected rather than clamped.

Labelled **"Start this with"**, not "Use" — the governor can still downgrade and fallback
can still move off it. Overpromising here would be a lie about how routing works.

## Verified by rendering, not by reading CSS
Built the bundle, served it with stubbed bindings, and screenshotted. That caught a real
bug reasoning had missed: `.chatv { height: 100% }` overflowed its padded flex column and
pushed the composer below the fold — `flex: 1; min-height: 0` fixes it. Also caught
`1000k ctx` where the registry means `1M`.

## Testing
- Frontend: 6/6 pass. Ported `ChatDock.test.tsx` → `ChatView.test.tsx` rather than
  deleting it, since it covers the #533 recovery paths that had to survive the refactor.
  Two assertions updated for deliberate copy changes (busy placeholder, and the recovery
  note no longer says "reloading" now that navigating away does the same thing).
- Go: 2 new tests (explicit tier outranks enum; out-of-range tier rejected).
- `gofmt`/`go vet`/`go test -race`/`typecheck`/`build` all clean.

## Note
Two new tokens: `--hy-bg-3` and `--hy-line-2`. I used them before defining them, caught
it, and added them to `tokens.css` with the temporary fallbacks removed — worth a look
that they belong in the shared token set rather than being local to these components.

Closes #559