### PR TITLE
feat(mcp): trust scoring engine + version-bump automaton

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1301,10 +1301,10 @@ func cmdMCPRegistry() *cobra.Command {
 	var auditJSON bool
 	audit := &cobra.Command{
 		Use:   "audit",
-		Short: "Resolve installed MCP servers against the synced registry",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		Short: "Resolve installed MCP servers against the synced registry and score them",
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cwd, _ := os.Getwd()
-			rpt, err := mcpregistry.Audit(cwd)
+			rpt, err := mcpregistry.Audit(cmd.Context(), cwd)
 			if err != nil {
 				return err
 			}
@@ -1326,6 +1326,27 @@ func cmdMCPRegistry() *cobra.Command {
 					status = warnStyle.Render(status)
 				}
 				fmt.Printf("  %-9s %-16s %-8s %s\n", status, e.Client, e.Scope, e.Name)
+				if e.Score != nil {
+					fmt.Printf("             score %-20s state %-12s confidence %s\n",
+						mcpregistry.FormatScore(*e.Score), e.LifecycleState, mcpregistry.FormatConfidence(e.Score.Confidence))
+					for _, cat := range []struct {
+						name string
+						cs   mcpregistry.CategoryScore
+					}{
+						{"security", e.Score.SecurityImplementation},
+						{"repo health", e.Score.RepositoryHealth},
+						{"operational", e.Score.OperationalSecurity},
+						{"community", e.Score.CommunityGovernance},
+					} {
+						for _, sig := range cat.cs.Signals {
+							if sig.Available && sig.Detail != "" {
+								fmt.Printf("               %-11s %s\n", cat.name, dimStyle.Render(sig.Detail))
+							}
+						}
+					}
+				} else if e.NearestMatch != "" {
+					fmt.Printf("             %s\n", dimStyle.Render(fmt.Sprintf("nearest known identifier: %q (%d edits away) — verify this isn't a typosquat", e.NearestMatch, e.NearestDist)))
+				}
 			}
 			return nil
 		},

--- a/internal/mcpregistry/audit.go
+++ b/internal/mcpregistry/audit.go
@@ -3,6 +3,7 @@
 package mcpregistry
 
 import (
+	"context"
 	"os"
 	"time"
 )
@@ -23,11 +24,16 @@ const (
 	StatusUnresolved Status = "unresolved"
 )
 
-// AuditEntry is one installed server plus its Phase 1 resolution.
+// AuditEntry is one installed server plus its resolution, score (Phase 2,
+// resolved entries only), and lifecycle state.
 type AuditEntry struct {
 	InstalledServer
-	Status       Status `json:"status"`
-	RegistryName string `json:"registry_name,omitempty"`
+	Status         Status         `json:"status"`
+	RegistryName   string         `json:"registry_name,omitempty"`
+	NearestMatch   string         `json:"nearest_match,omitempty"`    // unresolved entries only: closest known identifier
+	NearestDist    int            `json:"nearest_distance,omitempty"` // edit distance to NearestMatch, -1 if not computed
+	Score          *Score         `json:"score,omitempty"`
+	LifecycleState LifecycleState `json:"lifecycle_state,omitempty"`
 }
 
 // AuditReport is the result of `hyctl mcp registry audit`.
@@ -41,7 +47,9 @@ type AuditReport struct {
 // against the last-synced registry dataset. Works with no prior sync (every
 // entry reports unresolved and RegistrySync is zero) — sync is what upgrades
 // the report from "here's what's installed" to "here's what's verified".
-func Audit(cwd string) (*AuditReport, error) {
+// Resolved entries additionally get a Phase 2 trust score and lifecycle
+// state, persisted across runs so a later version bump can be detected.
+func Audit(ctx context.Context, cwd string) (*AuditReport, error) {
 	installed := Scan(cwd)
 
 	report := &AuditReport{GeneratedAt: time.Now().UTC(), Entries: make([]AuditEntry, 0, len(installed))}
@@ -52,20 +60,51 @@ func Audit(cwd string) (*AuditReport, error) {
 	}
 
 	var index map[string]ServerRecord
+	var corpus []ServerRecord
 	if cache != nil {
 		report.RegistrySync = cache.FetchedAt
 		index = buildPackageIndex(cache.Servers)
+		corpus = cache.Servers
 	}
 
+	states, err := LoadStates()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	statesChanged := false
+
 	for _, s := range installed {
-		entry := AuditEntry{InstalledServer: s, Status: StatusUnresolved}
+		entry := AuditEntry{InstalledServer: s, Status: StatusUnresolved, NearestDist: -1}
 		if !s.Remote && s.Package != "" {
 			if match, ok := index[s.Package]; ok {
 				entry.Status = StatusVerified
 				entry.RegistryName = match.Name
+
+				score := ComputeScore(ctx, match, corpus)
+				entry.Score = &score
+
+				prev, hadPrev := states[match.Name]
+				var prevPtr *ServerState
+				if hadPrev {
+					prevPtr = &prev
+				}
+				next := Advance(prevPtr, match, score, now)
+				states[match.Name] = next
+				statesChanged = true
+				entry.LifecycleState = next.State
+			} else if corpus != nil {
+				nearest, dist := NearestIdentifier(s.Package, corpus)
+				entry.NearestMatch, entry.NearestDist = nearest, dist
 			}
 		}
 		report.Entries = append(report.Entries, entry)
+	}
+
+	if statesChanged {
+		if err := SaveStates(states); err != nil {
+			return nil, err
+		}
 	}
 	return report, nil
 }

--- a/internal/mcpregistry/audit_test.go
+++ b/internal/mcpregistry/audit_test.go
@@ -3,10 +3,36 @@
 package mcpregistry
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+// withStubbedScoringDeps points ComputeScore's external calls (OSV.dev,
+// GitHub) at local httptest servers returning empty/neutral responses, so
+// audit tests that resolve a server stay fast, offline, and deterministic —
+// scoring's own behavior is covered separately in score_test.go.
+func withStubbedScoringDeps(t *testing.T) {
+	t.Helper()
+	osv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(osv.Close)
+	origOSV := osvQueryURL
+	osvQueryURL = osv.URL
+	t.Cleanup(func() { osvQueryURL = origOSV })
+
+	gh := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // non-GitHub-shaped repo URLs in these fixtures; 404 is fine, just needs to not hang
+	}))
+	t.Cleanup(gh.Close)
+	origGH := githubAPIBase
+	githubAPIBase = gh.URL
+	t.Cleanup(func() { githubAPIBase = origGH })
+}
 
 func TestAudit_NeverSyncedReportsUnresolvedAndZeroSyncTime(t *testing.T) {
 	withTempHydraHome(t)
@@ -16,7 +42,7 @@ func TestAudit_NeverSyncedReportsUnresolvedAndZeroSyncTime(t *testing.T) {
 	writeJSON(t, filepath.Join(home, ".cursor", "mcp.json"),
 		`{"mcpServers": {"fetch": {"type":"stdio","command":"uvx","args":["mcp-server-fetch"]}}}`)
 
-	rpt, err := Audit("")
+	rpt, err := Audit(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,6 +56,7 @@ func TestAudit_NeverSyncedReportsUnresolvedAndZeroSyncTime(t *testing.T) {
 
 func TestAudit_MatchesInstalledPackageAgainstSyncedRegistry(t *testing.T) {
 	withTempHydraHome(t)
+	withStubbedScoringDeps(t)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
@@ -45,7 +72,7 @@ func TestAudit_MatchesInstalledPackageAgainstSyncedRegistry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rpt, err := Audit("")
+	rpt, err := Audit(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,6 +89,51 @@ func TestAudit_MatchesInstalledPackageAgainstSyncedRegistry(t *testing.T) {
 	if got.RegistryName != "io.github.modelcontextprotocol/fetch" {
 		t.Errorf("RegistryName = %q", got.RegistryName)
 	}
+	if got.Score == nil {
+		t.Fatal("expected a Score for a verified entry")
+	}
+	if got.LifecycleState != StateProvisional {
+		t.Errorf("LifecycleState = %q, want provisional (first time seen)", got.LifecycleState)
+	}
+
+	states, err := LoadStates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if states["io.github.modelcontextprotocol/fetch"].State != StateProvisional {
+		t.Error("lifecycle state should be persisted across the audit run")
+	}
+}
+
+func TestAudit_UnresolvedEntryGetsNearestMatchHint(t *testing.T) {
+	withTempHydraHome(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	writeJSON(t, filepath.Join(home, ".cursor", "mcp.json"),
+		`{"mcpServers": {"chrome": {"type":"stdio","command":"npx","args":["-y","chrome-mcp"]}}}`)
+
+	if err := writeCache(&registryCache{
+		FetchedAt: time.Now().UTC(),
+		Servers:   []ServerRecord{{Name: "x", Packages: []Package{{Identifier: "chrome-devtools-mcp"}}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rpt, err := Audit(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rpt.Entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(rpt.Entries))
+	}
+	got := rpt.Entries[0]
+	if got.Status != StatusUnresolved {
+		t.Fatalf("Status = %q, want unresolved", got.Status)
+	}
+	if got.NearestMatch != "chrome-devtools-mcp" || got.NearestDist < 0 {
+		t.Errorf("NearestMatch/NearestDist = %q/%d, want a hint toward chrome-devtools-mcp", got.NearestMatch, got.NearestDist)
+	}
 }
 
 func TestAudit_RemoteServerIsNeverMarkedVerified(t *testing.T) {
@@ -76,7 +148,7 @@ func TestAudit_RemoteServerIsNeverMarkedVerified(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rpt, err := Audit("")
+	rpt, err := Audit(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcpregistry/lifecycle.go
+++ b/internal/mcpregistry/lifecycle.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+)
+
+// LifecycleState is a server's position in the trust automaton (design doc
+// §9): every version bump costs a server its accumulated trust until it
+// re-earns a cooldown period — the direct, mechanical fix for the
+// postmark-mcp rug-pull pattern (15 clean versions, then a malicious one).
+type LifecycleState string
+
+const (
+	StateNew         LifecycleState = "new"
+	StateProvisional LifecycleState = "provisional"
+	StateTrusted     LifecycleState = "trusted"
+	StateFlagged     LifecycleState = "flagged"
+	StateQuarantined LifecycleState = "quarantined"
+	StateDelisted    LifecycleState = "delisted"
+)
+
+// provisionalCooldown is how long a server must hold a stable manifest hash
+// before graduating provisional -> trusted. A starting default, not a value
+// derived from a specific cited study (unlike the Cox hazard ratios in
+// score.go) — reasonable, not claimed as more rigorous than it is.
+const provisionalCooldown = 14 * 24 * time.Hour
+
+// ServerState is what's persisted per server between audit runs, keyed by
+// the server's registry Name.
+type ServerState struct {
+	State          LifecycleState `json:"state"`
+	ManifestHash   string         `json:"manifest_hash"`
+	FirstSeenAt    time.Time      `json:"first_seen_at"`
+	StateChangedAt time.Time      `json:"state_changed_at"`
+}
+
+// ManifestHash fingerprints the parts of a server record that matter for
+// re-verification: identity, version, and what it ships. Any change here —
+// not a statistically-detected anomaly — is what triggers re-review; the
+// design doc's research (§12) found the published defense for rug-pulls is
+// hash-pinning plus forced re-approval, not a learned changepoint detector.
+func ManifestHash(srv ServerRecord) string {
+	h := sha256.New()
+	h.Write([]byte(srv.Name))
+	h.Write([]byte("\x00"))
+	h.Write([]byte(srv.Version))
+	for _, p := range srv.Packages {
+		h.Write([]byte("\x00"))
+		h.Write([]byte(p.RegistryType))
+		h.Write([]byte(":"))
+		h.Write([]byte(p.Identifier))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// severeSecuritySignal reports whether score's Security Implementation
+// category carries a signal severe enough to force quarantine (a known-bad
+// match, or a flagged near-duplicate identifier) — the automaton's trigger
+// for NEW/PROVISIONAL -> QUARANTINED.
+func severeSecuritySignal(s Score) bool {
+	for _, sig := range s.SecurityImplementation.Signals {
+		if sig.Available && sig.Impact <= -40 {
+			return true
+		}
+	}
+	return false
+}
+
+// Advance computes a server's next lifecycle state. prev is nil the first
+// time a server is seen. now is passed in rather than read from time.Now()
+// so transition logic is deterministically testable.
+func Advance(prev *ServerState, srv ServerRecord, score Score, now time.Time) ServerState {
+	hash := ManifestHash(srv)
+	quarantineTriggered := severeSecuritySignal(score)
+
+	if prev == nil {
+		state := StateProvisional
+		if quarantineTriggered {
+			state = StateQuarantined
+		}
+		return ServerState{State: state, ManifestHash: hash, FirstSeenAt: now, StateChangedAt: now}
+	}
+
+	next := *prev
+	switch prev.State {
+	case StateTrusted:
+		switch {
+		case hash != prev.ManifestHash:
+			next.State = StateProvisional
+		case quarantineTriggered:
+			next.State = StateFlagged
+		}
+	case StateProvisional:
+		switch {
+		case quarantineTriggered:
+			next.State = StateQuarantined
+		case hash == prev.ManifestHash && now.Sub(prev.StateChangedAt) >= provisionalCooldown:
+			next.State = StateTrusted
+		}
+	case StateFlagged:
+		if !quarantineTriggered {
+			next.State = StateProvisional
+		}
+	case StateQuarantined, StateDelisted, StateNew:
+		// No automatic promotion out of quarantine/delisted — that's a
+		// manual-clear path (design doc §9's "false positive, manually
+		// cleared" edge), not something an audit run decides on its own.
+		// StateNew never persists (Advance always assigns Provisional or
+		// Quarantined on first sight) but is handled here defensively.
+	}
+	if next.State != prev.State {
+		next.StateChangedAt = now
+	}
+	next.ManifestHash = hash
+	return next
+}
+
+func statePath() string {
+	return filepath.Join(config.Dir(), "mcp_registry_state.json")
+}
+
+// LoadStates reads the persisted lifecycle-state map. A missing file yields
+// an empty map, not an error — the very first audit run has no history yet.
+func LoadStates() (map[string]ServerState, error) {
+	raw, err := os.ReadFile(statePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]ServerState{}, nil
+		}
+		return nil, err
+	}
+	var states map[string]ServerState
+	if err := json.Unmarshal(raw, &states); err != nil {
+		return nil, err
+	}
+	if states == nil {
+		states = map[string]ServerState{}
+	}
+	return states, nil
+}
+
+// SaveStates writes the lifecycle-state map atomically.
+func SaveStates(states map[string]ServerState) error {
+	raw, err := json.MarshalIndent(states, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := statePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	defer func() { _ = os.Remove(tmp) }()
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return os.WriteFile(path, raw, 0o600)
+	}
+	return nil
+}

--- a/internal/mcpregistry/lifecycle_test.go
+++ b/internal/mcpregistry/lifecycle_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"testing"
+	"time"
+)
+
+func srvV(name, version string) ServerRecord {
+	return ServerRecord{Name: name, Version: version, Packages: []Package{{RegistryType: "npm", Identifier: name}}}
+}
+
+func cleanScore() Score {
+	return Score{SecurityImplementation: CategoryScore{Confidence: ConfidenceHigh, Signals: []Signal{
+		{Name: "known-vulnerability match", Available: true, Impact: 0},
+	}}}
+}
+
+func badScore() Score {
+	return Score{SecurityImplementation: CategoryScore{Confidence: ConfidenceHigh, Signals: []Signal{
+		{Name: "known-vulnerability match", Available: true, Impact: -100},
+	}}}
+}
+
+func TestManifestHash_ChangesOnVersionBump(t *testing.T) {
+	a := ManifestHash(srvV("x", "1.0.0"))
+	b := ManifestHash(srvV("x", "1.0.1"))
+	if a == b {
+		t.Error("hash should differ when version changes")
+	}
+}
+
+func TestManifestHash_StableForIdenticalInput(t *testing.T) {
+	a := ManifestHash(srvV("x", "1.0.0"))
+	b := ManifestHash(srvV("x", "1.0.0"))
+	if a != b {
+		t.Error("hash should be stable for identical input")
+	}
+}
+
+func TestAdvance_NewCleanServerStartsProvisional(t *testing.T) {
+	next := Advance(nil, srvV("x", "1.0.0"), cleanScore(), time.Now())
+	if next.State != StateProvisional {
+		t.Errorf("State = %q, want provisional", next.State)
+	}
+}
+
+func TestAdvance_NewSevereServerStartsQuarantined(t *testing.T) {
+	next := Advance(nil, srvV("x", "1.0.0"), badScore(), time.Now())
+	if next.State != StateQuarantined {
+		t.Errorf("State = %q, want quarantined", next.State)
+	}
+}
+
+func TestAdvance_ProvisionalGraduatesAfterCooldownWithStableHash(t *testing.T) {
+	srv := srvV("x", "1.0.0")
+	now := time.Now()
+	prev := ServerState{State: StateProvisional, ManifestHash: ManifestHash(srv), StateChangedAt: now.Add(-provisionalCooldown - time.Hour)}
+	next := Advance(&prev, srv, cleanScore(), now)
+	if next.State != StateTrusted {
+		t.Errorf("State = %q, want trusted after cooldown", next.State)
+	}
+}
+
+func TestAdvance_ProvisionalDoesNotGraduateBeforeCooldown(t *testing.T) {
+	srv := srvV("x", "1.0.0")
+	now := time.Now()
+	prev := ServerState{State: StateProvisional, ManifestHash: ManifestHash(srv), StateChangedAt: now.Add(-time.Hour)}
+	next := Advance(&prev, srv, cleanScore(), now)
+	if next.State != StateProvisional {
+		t.Errorf("State = %q, want still provisional before cooldown elapses", next.State)
+	}
+}
+
+func TestAdvance_TrustedDropsToProvisionalOnVersionBump(t *testing.T) {
+	old := srvV("x", "1.0.0")
+	bumped := srvV("x", "1.0.1")
+	prev := ServerState{State: StateTrusted, ManifestHash: ManifestHash(old), StateChangedAt: time.Now().Add(-30 * 24 * time.Hour)}
+	next := Advance(&prev, bumped, cleanScore(), time.Now())
+	if next.State != StateProvisional {
+		t.Fatalf("State = %q, want provisional — this is the single edge that would have caught postmark-mcp", next.State)
+	}
+	if next.ManifestHash != ManifestHash(bumped) {
+		t.Error("ManifestHash should update to the new version's hash")
+	}
+}
+
+func TestAdvance_TrustedUnchangedStaysTrusted(t *testing.T) {
+	srv := srvV("x", "1.0.0")
+	prev := ServerState{State: StateTrusted, ManifestHash: ManifestHash(srv), StateChangedAt: time.Now().Add(-30 * 24 * time.Hour)}
+	next := Advance(&prev, srv, cleanScore(), time.Now())
+	if next.State != StateTrusted {
+		t.Errorf("State = %q, want still trusted when nothing changed", next.State)
+	}
+}
+
+func TestAdvance_TrustedFlaggedByPostHocCVE(t *testing.T) {
+	srv := srvV("x", "1.0.0")
+	prev := ServerState{State: StateTrusted, ManifestHash: ManifestHash(srv), StateChangedAt: time.Now().Add(-30 * 24 * time.Hour)}
+	next := Advance(&prev, srv, badScore(), time.Now())
+	if next.State != StateFlagged {
+		t.Errorf("State = %q, want flagged — same version, but a CVE was filed after the fact", next.State)
+	}
+}
+
+func TestAdvance_FlaggedReturnsToProvisionalOnceClean(t *testing.T) {
+	srv := srvV("x", "1.0.0")
+	prev := ServerState{State: StateFlagged, ManifestHash: ManifestHash(srv), StateChangedAt: time.Now()}
+	next := Advance(&prev, srv, cleanScore(), time.Now())
+	if next.State != StateProvisional {
+		t.Errorf("State = %q, want provisional (re-verification path)", next.State)
+	}
+}
+
+func TestAdvance_ProvisionalQuarantinedBySevereSignal(t *testing.T) {
+	srv := srvV("x", "1.0.0")
+	prev := ServerState{State: StateProvisional, ManifestHash: ManifestHash(srv), StateChangedAt: time.Now().Add(-time.Hour)}
+	next := Advance(&prev, srv, badScore(), time.Now())
+	if next.State != StateQuarantined {
+		t.Errorf("State = %q, want quarantined", next.State)
+	}
+}
+
+func TestAdvance_QuarantinedNeverAutoPromotes(t *testing.T) {
+	srv := srvV("x", "1.0.0")
+	prev := ServerState{State: StateQuarantined, ManifestHash: ManifestHash(srv), StateChangedAt: time.Now().Add(-365 * 24 * time.Hour)}
+	next := Advance(&prev, srv, cleanScore(), time.Now())
+	if next.State != StateQuarantined {
+		t.Errorf("State = %q, want to stay quarantined — no automatic path out, that's a manual-clear decision", next.State)
+	}
+}
+
+func TestAdvance_StateChangedAtOnlyUpdatesOnTransition(t *testing.T) {
+	srv := srvV("x", "1.0.0")
+	changedAt := time.Now().Add(-time.Hour)
+	prev := ServerState{State: StateTrusted, ManifestHash: ManifestHash(srv), StateChangedAt: changedAt}
+	next := Advance(&prev, srv, cleanScore(), time.Now())
+	if !next.StateChangedAt.Equal(changedAt) {
+		t.Errorf("StateChangedAt should be unchanged when the state doesn't transition")
+	}
+}
+
+func TestLoadStates_MissingFileYieldsEmptyMap(t *testing.T) {
+	withTempHydraHome(t)
+	states, err := LoadStates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 0 {
+		t.Errorf("expected an empty map, got %v", states)
+	}
+}
+
+func TestSaveLoadStates_RoundTrip(t *testing.T) {
+	withTempHydraHome(t)
+	want := map[string]ServerState{
+		"io.github.foo/bar": {State: StateTrusted, ManifestHash: "abc123", StateChangedAt: time.Now().UTC().Truncate(time.Second)},
+	}
+	if err := SaveStates(want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadStates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["io.github.foo/bar"].State != StateTrusted {
+		t.Errorf("round-tripped state = %+v", got["io.github.foo/bar"])
+	}
+}

--- a/internal/mcpregistry/mcpregistry.go
+++ b/internal/mcpregistry/mcpregistry.go
@@ -13,16 +13,44 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 )
 
+// EnvVar is one environment variable a package declares it needs, as
+// published in the registry's server.json. Identity/shape only — a
+// variable's name and whether it's secret-shaped, never a value — this is
+// registry metadata about what the package asks for, not a real config
+// file, so it carries none of the privacy risk scan.go's clientServerConfig
+// deliberately avoids.
+type EnvVar struct {
+	Name     string `json:"name"`
+	IsSecret bool   `json:"isSecret"`
+}
+
 // Package is one distribution channel a server ships through (npm, pypi,
 // docker, ...), as published in the registry's server.json.
 type Package struct {
-	RegistryType string `json:"registryType"`
-	Identifier   string `json:"identifier"`
+	RegistryType         string   `json:"registryType"`
+	Identifier           string   `json:"identifier"`
+	EnvironmentVariables []EnvVar `json:"environmentVariables"`
 }
 
 // Repository is the source repo a server's registry entry points at.
 type Repository struct {
 	URL string `json:"url"`
+}
+
+// RemoteHeader is one HTTP header a remote (URL-based) server declares it
+// needs — the registry's mechanism for a server to say "call me with this
+// auth header". IsSecret is what marks it as a credential rather than an
+// arbitrary header.
+type RemoteHeader struct {
+	Name     string `json:"name"`
+	IsSecret bool   `json:"isSecret"`
+}
+
+// Remote is one network endpoint a server exposes.
+type Remote struct {
+	Type    string         `json:"type"`
+	URL     string         `json:"url"`
+	Headers []RemoteHeader `json:"headers"`
 }
 
 // ServerRecord is one server as published by the official MCP registry.
@@ -34,6 +62,7 @@ type ServerRecord struct {
 	Version    string     `json:"version"`
 	Repository Repository `json:"repository"`
 	Packages   []Package  `json:"packages"`
+	Remotes    []Remote   `json:"remotes"`
 }
 
 // InstalledServer is one MCP server found configured on this machine.

--- a/internal/mcpregistry/score.go
+++ b/internal/mcpregistry/score.go
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Confidence states how much evidence backs a score. "Insufficient" is a
+// distinct third state from low/moderate/high — a server with no evidence
+// yet must never render the same as one found to be safe or unsafe (§10.2
+// of the design doc: this is a design requirement, not a rounding choice).
+type Confidence string
+
+const (
+	ConfidenceInsufficient Confidence = "insufficient_evidence"
+	ConfidenceLow          Confidence = "low"
+	ConfidenceModerate     Confidence = "moderate"
+	ConfidenceHigh         Confidence = "high"
+)
+
+// Signal is one piece of evidence behind a score. Always shown alongside the
+// number it feeds — a bare score with no signals is exactly what every
+// existing MCP directory already gets wrong (star/download counts with no
+// explanation). Impact ranges -100..100; Available false means the signal
+// couldn't be evaluated (network failure, unsupported ecosystem, non-GitHub
+// repo) rather than "evaluated and neutral".
+type Signal struct {
+	Name      string  `json:"name"`
+	Detail    string  `json:"detail"`
+	Impact    float64 `json:"impact"`
+	Available bool    `json:"available"`
+}
+
+// CategoryScore is one of the CSA MCP Selection Scorecard's four categories
+// (modelcontextprotocol-security.io/audit/scorecard.html) — Hydra automates
+// signal collection into a taxonomy the MCP Security Working Group already
+// endorsed, rather than inventing a competing one.
+type CategoryScore struct {
+	Value      float64    `json:"value"` // 0-100, meaningless if Confidence is insufficient
+	Confidence Confidence `json:"confidence"`
+	Signals    []Signal   `json:"signals"`
+}
+
+// Score is the Phase 2 trust score for one resolved server.
+type Score struct {
+	SecurityImplementation CategoryScore `json:"security_implementation"` // weight 0.35
+	RepositoryHealth       CategoryScore `json:"repository_health"`       // weight 0.25
+	OperationalSecurity    CategoryScore `json:"operational_security"`    // weight 0.25
+	CommunityGovernance    CategoryScore `json:"community_governance"`    // weight 0.15
+	Overall                float64       `json:"overall"`
+	Confidence             Confidence    `json:"confidence"`
+}
+
+const (
+	weightSecurityImplementation = 0.35
+	weightRepositoryHealth       = 0.25
+	weightOperationalSecurity    = 0.25
+	weightCommunityGovernance    = 0.15
+)
+
+// ComputeScore scores one resolved registry server. corpus is the full
+// synced dataset, used for the typosquat/near-duplicate check. A server with
+// no computable signals in a category returns that category at
+// ConfidenceInsufficient rather than a default-neutral number.
+func ComputeScore(ctx context.Context, srv ServerRecord, corpus []ServerRecord) Score {
+	var secSignals, repoSignals, opSignals, commSignals []Signal
+
+	for _, pkg := range srv.Packages {
+		secSignals = append(secSignals, knownBadSignal(ctx, pkg))
+	}
+	secSignals = append(secSignals, typosquatSignal(srv, corpus))
+
+	repoSignals = append(repoSignals, maintenanceSignal(ctx, srv.Repository.URL))
+
+	opSignals = append(opSignals, declaredAuthSignal(srv))
+
+	commSignals = append(commSignals, registryPresenceSignal())
+
+	sec := aggregate(secSignals)
+	repo := aggregate(repoSignals)
+	op := aggregate(opSignals)
+	comm := aggregate(commSignals)
+
+	overall := 0.0
+	weightSum := 0.0
+	for _, cs := range []struct {
+		score  CategoryScore
+		weight float64
+	}{
+		{sec, weightSecurityImplementation},
+		{repo, weightRepositoryHealth},
+		{op, weightOperationalSecurity},
+		{comm, weightCommunityGovernance},
+	} {
+		if cs.score.Confidence == ConfidenceInsufficient {
+			continue
+		}
+		overall += cs.score.Value * cs.weight
+		weightSum += cs.weight
+	}
+	if weightSum > 0 {
+		overall /= weightSum
+	}
+
+	return Score{
+		SecurityImplementation: sec,
+		RepositoryHealth:       repo,
+		OperationalSecurity:    op,
+		CommunityGovernance:    comm,
+		Overall:                overall,
+		Confidence:             overallConfidence(weightSum),
+	}
+}
+
+// aggregate turns a category's signals into a 0-100 value plus a confidence
+// derived from how many of the signals were actually available — the
+// "how many of the signals were computable" measure the design doc uses in
+// place of a borrowed calibration engine with no training data (§12/§13).
+func aggregate(signals []Signal) CategoryScore {
+	base := 70.0 // neutral starting point: no evidence either way
+	total := 0.0
+	available := 0
+	for _, s := range signals {
+		if s.Available {
+			total += s.Impact
+			available++
+		}
+	}
+	if available == 0 {
+		return CategoryScore{Confidence: ConfidenceInsufficient, Signals: signals}
+	}
+
+	value := base + total
+	if value < 0 {
+		value = 0
+	}
+	if value > 100 {
+		value = 100
+	}
+
+	conf := ConfidenceLow
+	switch {
+	case available >= len(signals) && len(signals) >= 2:
+		conf = ConfidenceHigh
+	case float64(available) >= float64(len(signals))*0.5:
+		conf = ConfidenceModerate
+	}
+	return CategoryScore{Value: value, Confidence: conf, Signals: signals}
+}
+
+func overallConfidence(weightSum float64) Confidence {
+	switch {
+	case weightSum <= 0:
+		return ConfidenceInsufficient
+	case weightSum < 0.5:
+		return ConfidenceLow
+	case weightSum < 0.85:
+		return ConfidenceModerate
+	default:
+		return ConfidenceHigh
+	}
+}
+
+// ── Security Implementation signals ─────────────────────────────────────
+
+var osvEcosystem = map[string]string{
+	"npm":    "npm",
+	"pypi":   "PyPI",
+	"docker": "", // OSV has no generic Docker-image ecosystem; skip, Available=false
+}
+
+var osvQueryURL = "https://api.osv.dev/v1/query"
+
+type osvVuln struct {
+	ID       string `json:"id"`
+	Summary  string `json:"summary"`
+	Severity []struct {
+		Score string `json:"score"`
+	} `json:"database_specific,omitempty"`
+}
+
+type osvResponse struct {
+	Vulns []osvVuln `json:"vulns"`
+}
+
+// knownBadSignal cross-references a package against OSV.dev's advisory
+// database — the highest-value signal per the design doc's evidence: OX
+// Security found 9 of 11 registries accept a known-malicious clone with zero
+// review. This is the check that would have caught it.
+func knownBadSignal(ctx context.Context, pkg Package) Signal {
+	eco, ok := osvEcosystem[pkg.RegistryType]
+	if !ok || eco == "" || pkg.Identifier == "" {
+		return Signal{Name: "known-vulnerability match", Available: false}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"package": map[string]string{"name": pkg.Identifier, "ecosystem": eco},
+	})
+	if err != nil {
+		return Signal{Name: "known-vulnerability match", Available: false}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, osvQueryURL, strings.NewReader(string(body)))
+	if err != nil {
+		return Signal{Name: "known-vulnerability match", Available: false}
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return Signal{Name: "known-vulnerability match", Available: false}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return Signal{Name: "known-vulnerability match", Available: false}
+	}
+
+	var out osvResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return Signal{Name: "known-vulnerability match", Available: false}
+	}
+	if len(out.Vulns) == 0 {
+		return Signal{Name: "known-vulnerability match", Detail: "no known advisories", Impact: 0, Available: true}
+	}
+	return Signal{
+		Name:      "known-vulnerability match",
+		Detail:    fmt.Sprintf("%d known advisory/advisories, e.g. %s", len(out.Vulns), out.Vulns[0].ID),
+		Impact:    -100,
+		Available: true,
+	}
+}
+
+// typosquatSignal flags a package identifier that's suspiciously close (edit
+// distance <=2) to a different, already-registered identifier — the exact
+// pattern OX Security proved works against real registries. There's no
+// popularity signal in the official registry's schema to compare against
+// (deliberately: §7 found popularity is actively misleading), so this
+// compares against the whole synced corpus rather than a "popular names"
+// list.
+func typosquatSignal(srv ServerRecord, corpus []ServerRecord) Signal {
+	for _, pkg := range srv.Packages {
+		if pkg.Identifier == "" {
+			continue
+		}
+		for _, other := range corpus {
+			if other.Name == srv.Name {
+				continue
+			}
+			for _, otherPkg := range other.Packages {
+				if otherPkg.Identifier == "" || otherPkg.Identifier == pkg.Identifier {
+					continue
+				}
+				d := levenshtein(pkg.Identifier, otherPkg.Identifier)
+				if d > 0 && d <= 2 && d < len(pkg.Identifier)/3+1 {
+					return Signal{
+						Name:      "near-duplicate identifier",
+						Detail:    fmt.Sprintf("%q is %d edit(s) from %q (published by a different entry) — verify this isn't a typosquat", pkg.Identifier, d, otherPkg.Identifier),
+						Impact:    -40,
+						Available: true,
+					}
+				}
+			}
+		}
+	}
+	return Signal{Name: "near-duplicate identifier", Detail: "no close match found", Impact: 0, Available: true}
+}
+
+// NearestIdentifier finds the closest package identifier in corpus to
+// candidate, for flagging an unresolved installed server that looks like a
+// near-miss of something in the registry rather than something wholly
+// unknown. Returns ("", -1) if corpus has no package identifiers at all.
+func NearestIdentifier(candidate string, corpus []ServerRecord) (string, int) {
+	best := ""
+	bestDist := -1
+	for _, srv := range corpus {
+		for _, pkg := range srv.Packages {
+			if pkg.Identifier == "" {
+				continue
+			}
+			d := levenshtein(candidate, pkg.Identifier)
+			if bestDist == -1 || d < bestDist {
+				bestDist = d
+				best = pkg.Identifier
+			}
+		}
+	}
+	return best, bestDist
+}
+
+// levenshtein computes edit distance with O(min(len(a),len(b))) space.
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	ra, rb := []rune(a), []rune(b)
+	if len(ra) > len(rb) {
+		ra, rb = rb, ra
+	}
+	prev := make([]int, len(ra)+1)
+	for i := range prev {
+		prev[i] = i
+	}
+	curr := make([]int, len(ra)+1)
+	for j := 1; j <= len(rb); j++ {
+		curr[0] = j
+		for i := 1; i <= len(ra); i++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[i] = min3(curr[i-1]+1, prev[i]+1, prev[i-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(ra)]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+// ── Repository Health signals ────────────────────────────────────────────
+
+var githubAPIBase = "https://api.github.com"
+
+type githubRepo struct {
+	PushedAt  time.Time `json:"pushed_at"`
+	Archived  bool      `json:"archived"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// maintenanceRecencyThreshold: no push in this long is treated as elevated
+// abandonment risk. Not a precise hazard-rate model (that needs contributor
+// counts and release cadence GitHub's single repo GET doesn't cheaply
+// provide — see design doc §12 for the Cox proportional-hazards research
+// this is informed by), but the same directional signal: staleness is real
+// and current popularity signals miss it.
+const maintenanceRecencyThreshold = 180 * 24 * time.Hour
+
+// maintenanceSignal fetches the repo's last-push date from GitHub. Best
+// effort: a non-GitHub repository, a rate-limited request, or any fetch
+// error all degrade to Available=false rather than failing the whole score.
+func maintenanceSignal(ctx context.Context, repoURL string) Signal {
+	owner, repo, ok := parseGitHubURL(repoURL)
+	if !ok {
+		return Signal{Name: "maintenance recency", Available: false}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/repos/%s/%s", githubAPIBase, owner, repo), nil)
+	if err != nil {
+		return Signal{Name: "maintenance recency", Available: false}
+	}
+	req.Header.Set("User-Agent", "hydra/1 (+https://github.com/ankit373/hydra)")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return Signal{Name: "maintenance recency", Available: false}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden && resp.Header.Get("X-RateLimit-Remaining") == "0" {
+		return Signal{Name: "maintenance recency", Detail: "GitHub API rate-limited", Available: false}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return Signal{Name: "maintenance recency", Available: false}
+	}
+
+	var gh githubRepo
+	if err := json.NewDecoder(resp.Body).Decode(&gh); err != nil {
+		return Signal{Name: "maintenance recency", Available: false}
+	}
+
+	if gh.Archived {
+		return Signal{Name: "maintenance recency", Detail: "repository is archived", Impact: -60, Available: true}
+	}
+
+	age := time.Since(gh.PushedAt)
+	if age > maintenanceRecencyThreshold {
+		days := int(age.Hours() / 24)
+		return Signal{
+			Name:      "maintenance recency",
+			Detail:    fmt.Sprintf("no push in %d days (threshold %d)", days, int(maintenanceRecencyThreshold.Hours()/24)),
+			Impact:    -30,
+			Available: true,
+		}
+	}
+	return Signal{
+		Name:      "maintenance recency",
+		Detail:    fmt.Sprintf("last push %s ago", age.Round(24*time.Hour)),
+		Impact:    0,
+		Available: true,
+	}
+}
+
+func parseGitHubURL(url string) (owner, repo string, ok bool) {
+	const prefix = "github.com/"
+	i := strings.Index(url, prefix)
+	if i == -1 {
+		return "", "", false
+	}
+	rest := strings.TrimSuffix(url[i+len(prefix):], ".git")
+	rest = strings.Trim(rest, "/")
+	parts := strings.SplitN(rest, "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// ── Operational Security signals ─────────────────────────────────────────
+
+// declaredAuthSignal checks whether a server exposing a remote (URL-based)
+// endpoint declares an auth header for it. Explicitly labeled "declared, not
+// verified" per the design doc's Goodhart's-law correction (§13.2): a
+// malicious server can trivially declare a header it doesn't enforce, so
+// this is weighted lower than an independently-checkable signal like a
+// known-vulnerability match, never presented as a verified guarantee.
+//
+// Only applies to remote servers — a stdio server runs locally under the
+// user's own OS permissions, so "remote auth posture" isn't a meaningful
+// question for it, and this correctly reports Available=false rather than
+// inventing a score for a question that doesn't apply.
+func declaredAuthSignal(srv ServerRecord) Signal {
+	if len(srv.Remotes) == 0 {
+		return Signal{Name: "declared remote auth (not independently verified)", Available: false}
+	}
+
+	for _, r := range srv.Remotes {
+		for _, h := range r.Headers {
+			if h.IsSecret {
+				return Signal{
+					Name:      "declared remote auth (not independently verified)",
+					Detail:    fmt.Sprintf("declares a credential header (%s) for its remote endpoint", h.Name),
+					Impact:    10,
+					Available: true,
+				}
+			}
+		}
+	}
+	return Signal{
+		Name:      "declared remote auth (not independently verified)",
+		Detail:    "remote endpoint declares no auth header — matches the pattern security research found in the large majority of exposed production MCP servers",
+		Impact:    -30,
+		Available: true,
+	}
+}
+
+// ── Community & Governance signals ───────────────────────────────────────
+
+// registryPresenceSignal is the baseline: this function is only called for
+// servers already resolved against the namespace-verified official
+// registry (Phase 1's StatusVerified), which is itself a weak-but-real
+// positive per §2 (identity is verified, safety is not).
+func registryPresenceSignal() Signal {
+	return Signal{Name: "namespace-verified registry presence", Detail: "publisher identity verified by the official registry", Impact: 10, Available: true}
+}
+
+// FormatConfidence renders a Confidence for CLI output.
+func FormatConfidence(c Confidence) string {
+	return strings.ReplaceAll(string(c), "_", " ")
+}
+
+// FormatScore renders an overall score as a rounded percentage string, or
+// "insufficient evidence" — never a bare number for a score with no signal.
+func FormatScore(s Score) string {
+	if s.Confidence == ConfidenceInsufficient {
+		return "insufficient evidence"
+	}
+	return strconv.Itoa(int(s.Overall+0.5)) + "/100"
+}

--- a/internal/mcpregistry/score_test.go
+++ b/internal/mcpregistry/score_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"", "abc", 3},
+		{"kitten", "sitting", 3},
+		{"mcp-server-postgres", "mcp-server-postgress", 1},
+		{"chrome-mcp", "chrome-devtools-mcp", 9},
+	}
+	for _, tt := range tests {
+		if got := levenshtein(tt.a, tt.b); got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestTyposquatSignal_FlagsCloseIdentifier(t *testing.T) {
+	target := ServerRecord{Name: "a", Packages: []Package{{Identifier: "mcp-server-postgres"}}}
+	corpus := []ServerRecord{
+		target,
+		{Name: "b", Packages: []Package{{Identifier: "mcp-server-postgress"}}}, // 1 edit away, different entry
+	}
+	sig := typosquatSignal(target, corpus)
+	if !sig.Available || sig.Impact >= 0 {
+		t.Fatalf("expected a negative-impact typosquat flag, got %+v", sig)
+	}
+}
+
+func TestTyposquatSignal_NoFlagWhenNothingClose(t *testing.T) {
+	target := ServerRecord{Name: "a", Packages: []Package{{Identifier: "totally-unique-name-xyz"}}}
+	corpus := []ServerRecord{
+		target,
+		{Name: "b", Packages: []Package{{Identifier: "completely-different-thing"}}},
+	}
+	sig := typosquatSignal(target, corpus)
+	if !sig.Available || sig.Impact != 0 {
+		t.Fatalf("expected no flag, got %+v", sig)
+	}
+}
+
+func TestNearestIdentifier(t *testing.T) {
+	corpus := []ServerRecord{
+		{Packages: []Package{{Identifier: "chrome-devtools-mcp"}}},
+		{Packages: []Package{{Identifier: "chrome-debugger-mcp"}}},
+	}
+	nearest, dist := NearestIdentifier("chrome-mcp", corpus)
+	if dist < 0 {
+		t.Fatalf("expected a distance to be found, got %d", dist)
+	}
+	if nearest != "chrome-devtools-mcp" && nearest != "chrome-debugger-mcp" {
+		t.Errorf("nearest = %q, want one of the two chrome candidates", nearest)
+	}
+}
+
+func TestNearestIdentifier_EmptyCorpus(t *testing.T) {
+	nearest, dist := NearestIdentifier("anything", nil)
+	if nearest != "" || dist != -1 {
+		t.Errorf("got (%q, %d), want (\"\", -1) for an empty corpus", nearest, dist)
+	}
+}
+
+func TestKnownBadSignal_UnsupportedEcosystemIsUnavailable(t *testing.T) {
+	sig := knownBadSignal(context.Background(), Package{RegistryType: "docker", Identifier: "x"})
+	if sig.Available {
+		t.Errorf("docker packages have no OSV ecosystem yet; expected Available=false, got %+v", sig)
+	}
+}
+
+func TestKnownBadSignal_ParsesVulnResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(osvResponse{Vulns: []osvVuln{{ID: "GHSA-test-1234"}}})
+	}))
+	defer srv.Close()
+	orig := osvQueryURL
+	osvQueryURL = srv.URL
+	defer func() { osvQueryURL = orig }()
+
+	sig := knownBadSignal(context.Background(), Package{RegistryType: "npm", Identifier: "evil-pkg"})
+	if !sig.Available || sig.Impact != -100 {
+		t.Fatalf("expected a severe known-bad flag, got %+v", sig)
+	}
+}
+
+func TestKnownBadSignal_NoVulnsIsNeutral(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(osvResponse{})
+	}))
+	defer srv.Close()
+	orig := osvQueryURL
+	osvQueryURL = srv.URL
+	defer func() { osvQueryURL = orig }()
+
+	sig := knownBadSignal(context.Background(), Package{RegistryType: "npm", Identifier: "fine-pkg"})
+	if !sig.Available || sig.Impact != 0 {
+		t.Fatalf("expected a neutral, available signal, got %+v", sig)
+	}
+}
+
+func TestParseGitHubURL(t *testing.T) {
+	tests := []struct {
+		url                 string
+		wantOwner, wantRepo string
+		wantOK              bool
+	}{
+		{"https://github.com/foo/bar", "foo", "bar", true},
+		{"https://github.com/foo/bar.git", "foo", "bar", true},
+		{"https://github.com/foo/bar/", "foo", "bar", true},
+		{"https://github.com/foo/bar/tree/main/subdir", "foo", "bar", true},
+		{"https://gitlab.com/foo/bar", "", "", false},
+		{"not a url", "", "", false},
+	}
+	for _, tt := range tests {
+		owner, repo, ok := parseGitHubURL(tt.url)
+		if ok != tt.wantOK || owner != tt.wantOwner || repo != tt.wantRepo {
+			t.Errorf("parseGitHubURL(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tt.url, owner, repo, ok, tt.wantOwner, tt.wantRepo, tt.wantOK)
+		}
+	}
+}
+
+func TestMaintenanceSignal_NonGitHubIsUnavailable(t *testing.T) {
+	sig := maintenanceSignal(context.Background(), "https://gitlab.com/foo/bar")
+	if sig.Available {
+		t.Errorf("expected Available=false for a non-GitHub repo, got %+v", sig)
+	}
+}
+
+func TestMaintenanceSignal_ArchivedIsPenalized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(githubRepo{Archived: true})
+	}))
+	defer srv.Close()
+	orig := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = orig }()
+
+	sig := maintenanceSignal(context.Background(), "https://github.com/foo/bar")
+	if !sig.Available || sig.Impact >= 0 {
+		t.Fatalf("expected a negative-impact archived flag, got %+v", sig)
+	}
+}
+
+func TestDeclaredAuthSignal_StdioIsNotApplicable(t *testing.T) {
+	sig := declaredAuthSignal(ServerRecord{})
+	if sig.Available {
+		t.Errorf("a server with no remotes should report Available=false, got %+v", sig)
+	}
+}
+
+func TestDeclaredAuthSignal_RemoteWithSecretHeaderIsPositive(t *testing.T) {
+	sig := declaredAuthSignal(ServerRecord{Remotes: []Remote{
+		{Type: "http", URL: "https://x", Headers: []RemoteHeader{{Name: "Authorization", IsSecret: true}}},
+	}})
+	if !sig.Available || sig.Impact <= 0 {
+		t.Fatalf("expected a positive declared-auth signal, got %+v", sig)
+	}
+}
+
+func TestDeclaredAuthSignal_RemoteWithNoAuthIsNegative(t *testing.T) {
+	sig := declaredAuthSignal(ServerRecord{Remotes: []Remote{{Type: "http", URL: "https://x"}}})
+	if !sig.Available || sig.Impact >= 0 {
+		t.Fatalf("expected a negative no-auth signal, got %+v", sig)
+	}
+}
+
+func TestAggregate_NoAvailableSignalsIsInsufficientEvidence(t *testing.T) {
+	cs := aggregate([]Signal{{Available: false}, {Available: false}})
+	if cs.Confidence != ConfidenceInsufficient {
+		t.Errorf("Confidence = %q, want insufficient_evidence", cs.Confidence)
+	}
+}
+
+func TestAggregate_ClampsToZeroAndHundred(t *testing.T) {
+	low := aggregate([]Signal{{Available: true, Impact: -1000}})
+	if low.Value != 0 {
+		t.Errorf("Value = %v, want clamped to 0", low.Value)
+	}
+	high := aggregate([]Signal{{Available: true, Impact: 1000}})
+	if high.Value != 100 {
+		t.Errorf("Value = %v, want clamped to 100", high.Value)
+	}
+}
+
+func TestComputeScore_InsufficientEvidenceOverallWhenNothingResolves(t *testing.T) {
+	// A server with an unsupported-ecosystem package, a non-GitHub repo, and
+	// no remotes has every signal come back unavailable except the baseline
+	// registry-presence signal (Community & Governance) — overall confidence
+	// should reflect that most categories are insufficient, not average them
+	// in as if they were neutral zeros.
+	srv := ServerRecord{
+		Name:       "x",
+		Packages:   []Package{{RegistryType: "docker", Identifier: "img"}},
+		Repository: Repository{URL: "https://gitlab.com/foo/bar"},
+	}
+	score := ComputeScore(context.Background(), srv, []ServerRecord{srv})
+	if score.SecurityImplementation.Confidence != ConfidenceInsufficient {
+		// typosquatSignal is always available (pure algorithm), so Security
+		// Implementation has partial evidence even though knownBadSignal
+		// isn't — that's correct, not a bug: assert on the categories that
+		// truly have nothing.
+		t.Logf("security implementation: %+v (expected partial evidence from typosquatSignal)", score.SecurityImplementation)
+	}
+	if score.RepositoryHealth.Confidence != ConfidenceInsufficient {
+		t.Errorf("RepositoryHealth.Confidence = %q, want insufficient_evidence (non-GitHub repo)", score.RepositoryHealth.Confidence)
+	}
+	if score.OperationalSecurity.Confidence != ConfidenceInsufficient {
+		t.Errorf("OperationalSecurity.Confidence = %q, want insufficient_evidence (no remotes)", score.OperationalSecurity.Confidence)
+	}
+	if score.CommunityGovernance.Confidence == ConfidenceInsufficient {
+		t.Errorf("CommunityGovernance should always have the baseline registry-presence signal available")
+	}
+}
+
+func TestFormatScore_InsufficientEvidence(t *testing.T) {
+	s := Score{Confidence: ConfidenceInsufficient}
+	if got := FormatScore(s); got != "insufficient evidence" {
+		t.Errorf("FormatScore = %q", got)
+	}
+}
+
+func TestFormatScore_Rounds(t *testing.T) {
+	s := Score{Overall: 72.6, Confidence: ConfidenceHigh}
+	if got := FormatScore(s); got != "73/100" {
+		t.Errorf("FormatScore = %q, want 73/100", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Phase 2 of the MCP registry: `hyctl mcp registry audit` now shows a real trust score, not just verified/unresolved.
- Score is shaped around the CSA MCP Selection Scorecard's four categories (automating an already-endorsed taxonomy, not inventing a competing one): Security Implementation 35%, Repository Health 25%, Operational Security 25%, Community & Governance 15%.
- Signals, all real and checkable: OSV.dev known-vulnerability cross-reference, edit-distance typosquat/near-duplicate detection against the full synced corpus, GitHub last-push/archived maintenance recency, declared (not verified) remote auth posture.
- A category with no computable signal renders "insufficient evidence" — never a fabricated number.
- New trust lifecycle automaton (new/provisional/trusted/flagged/quarantined/delisted), persisted per server. Every version bump (content-hash diff of the manifest) drops a server back to provisional — the direct fix for the `postmark-mcp` rug-pull pattern.

## Explicit scope corrections from the original design doc
- Dropped the originally-proposed tool-description entropy check: it would require executing the server to see its tool list, which contradicts the registry's own "no live probing" principle.
- Dropped provenance/SLSA as a bonus signal for now: real, but high implementation cost for uncertain value.
- Did **not** reuse `internal/trust`'s Beta-Bernoulli calibrator as originally planned: it calibrates a prediction source against recorded ground-truth outcomes over time, and no such feedback loop exists yet for MCP servers (that's Phase 6, gated on Phase 4). Used a simpler, honest "how many signals were actually computable" confidence measure instead.

## Changes
- `internal/mcpregistry/score.go` — scoring engine
- `internal/mcpregistry/lifecycle.go` — the trust automaton + persisted per-server state
- `internal/mcpregistry/mcpregistry.go` — extended `ServerRecord`/`Package` with `Remotes`/`EnvironmentVariables` (registry metadata only, never a real config value)
- `internal/mcpregistry/audit.go` — wires score + lifecycle into the audit report
- `cmd/hydra/main.go` — audit output now shows score, lifecycle state, and signal detail

## Test plan
- [x] `go test -race -count=1 ./internal/mcpregistry/... ./cmd/hydra/...` — 61+ tests, all pass
- [x] `go vet ./...`, `gofmt -l` clean
- [x] Live smoke test against the real registry: unresolved entries now surface real near-duplicate hints (e.g. flagged `chrome-mcp` as 2 edits from a real registered identifier)

Closes #558