### PR TITLE
feat(desktop): companion pane, tier-shift markers and the governor notice

### DIFF
--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1578,3 +1578,171 @@ body {
   .skeleton-block { animation: none; }
   .dashboard-content { animation: none; }
 }
+
+/* ── Chat split: thread + companion pane ───────────────────────────────── */
+/* The pane is glanceable, never readable — that is what makes a permanently
+   visible companion affordable, where the old dock had to collapse (#520). */
+
+.chatv-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 22px;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+/* Below this the pane costs more width than it returns, so the thread takes it. */
+@media (max-width: 1000px) {
+  .chatv-split { grid-template-columns: minmax(0, 1fr); }
+  .cockpit { display: none; }
+}
+
+.cockpit {
+  border-left: 1px solid var(--hy-line);
+  padding-left: 18px;
+  overflow-y: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.ck { display: flex; flex-direction: column; }
+.ck__head { display: flex; align-items: center; gap: 10px; margin-bottom: 9px; }
+.ck__lbl {
+  font-family: var(--hy-font-mono);
+  font-size: 9px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--hy-dim);
+}
+.ck__rule { flex: 1; height: 1px; background: var(--hy-line); }
+.ck__empty { margin: 0; font-size: 11.5px; color: var(--hy-dim); line-height: 1.5; }
+.ck__empty code { font-family: var(--hy-font-mono); font-size: 11px; color: var(--hy-cyan); }
+
+/* Active head — the one place the brand gradient appears in the app body. */
+.ck__card { background: var(--hy-bg-3); border: 1px solid var(--hy-line); border-radius: var(--hy-radius-sm); overflow: hidden; }
+.ck__cardGrad { height: 2px; background: var(--hy-brand); }
+.ck__cardIn { padding: 10px 12px 11px; }
+.ck__top { display: flex; align-items: center; gap: 8px; }
+.ck__name { font-size: 13px; font-weight: 600; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ck__tier {
+  font-family: var(--hy-font-mono); font-size: 9px; font-weight: 700;
+  background: var(--hy-bg); border: 1px solid var(--hy-line-2);
+  border-radius: 999px; padding: 1px 6px; flex: 0 0 auto;
+}
+.ck__pulse {
+  margin-left: auto; flex: 0 0 auto;
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--hy-aqua);
+  animation: ck-pulse 1.9s ease-in-out infinite;
+}
+@keyframes ck-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(0, 230, 195, .5); }
+  50%      { box-shadow: 0 0 0 5px rgba(0, 230, 195, 0); }
+}
+@media (prefers-reduced-motion: reduce) { .ck__pulse { animation: none; } }
+.ck__sub { font-size: 11.5px; color: var(--hy-dim); margin-top: 3px; }
+
+.pm { margin-top: 9px; padding-top: 9px; border-top: 1px solid var(--hy-line); }
+.pm__top { display: flex; align-items: center; gap: 6px; }
+.pm__label { font-family: var(--hy-font-mono); font-size: 9px; letter-spacing: .07em; text-transform: uppercase; color: var(--hy-dim); }
+.pm__shared {
+  font-family: var(--hy-font-mono); font-size: 8px; letter-spacing: .05em; text-transform: uppercase;
+  color: var(--hy-mid); border: 1px solid rgba(224, 169, 58, .4); border-radius: 3px; padding: 0 3px;
+}
+.pm__val { font-family: var(--hy-font-mono); font-size: 10.5px; margin-top: 4px; font-variant-numeric: tabular-nums; }
+.pm__with { font-size: 10.5px; color: var(--hy-dim); margin-top: 3px; line-height: 1.45; }
+
+.ck__gauge { display: flex; align-items: center; gap: 12px; }
+.gz { flex: 0 0 auto; }
+.gz__track { fill: none; stroke: var(--hy-bg-3); stroke-width: 5; }
+.gz__fill { fill: none; stroke: var(--hy-aqua); stroke-width: 5; stroke-linecap: round; }
+.ck__gaugeNum { font-family: var(--hy-font-mono); font-size: 19px; font-weight: 600; line-height: 1; font-variant-numeric: tabular-nums; }
+.ck__gaugeCap { font-size: 11px; color: var(--hy-dim); margin-top: 4px; }
+
+/* Model rows: what it did, and how good it is measured to be at that. */
+.mr { display: flex; flex-direction: column; }
+.mr__row { display: flex; flex-direction: column; gap: 2px; padding: 7px 0 8px; border-bottom: 1px solid var(--hy-line); }
+.mr__row:last-child { border-bottom: 0; }
+.mr__top { display: flex; align-items: baseline; gap: 8px; }
+.mr__name { font-size: 11.5px; font-weight: 600; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mr__d { margin-left: auto; font-family: var(--hy-font-mono); font-size: 11px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.mr__d--strong { color: var(--hy-cheap); }
+.mr__d--ok     { color: var(--hy-cyan); }
+.mr__d--weak   { color: var(--hy-mid); }
+/* Thin evidence is amber regardless of the value: trust.Stat.N excludes the
+   prior, so a high D on few observations is not a strong measurement. */
+.mr__d--thin   { color: var(--hy-mid); }
+.mr__d--none   { color: var(--hy-dim); }
+.mr__bot { display: flex; align-items: baseline; gap: 8px; }
+.mr__did { font-size: 10.5px; color: var(--hy-dim); }
+.mr__n { margin-left: auto; font-family: var(--hy-font-mono); font-size: 9px; color: var(--hy-dim); white-space: nowrap; }
+.mr__n--thin { color: var(--hy-mid); }
+
+.fr { display: flex; align-items: baseline; gap: 8px; padding: 5px 0; border-bottom: 1px solid var(--hy-line); }
+.fr:last-of-type { border-bottom: 0; }
+.fr__name { font-family: var(--hy-font-mono); font-size: 10.5px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fr__pm { margin-left: auto; font-family: var(--hy-font-mono); font-size: 9.5px; white-space: nowrap; }
+.fr__more { font-family: var(--hy-font-mono); font-size: 9px; color: var(--hy-dim); margin-top: 5px; }
+
+/* ── Tier shift, inline in the transcript ──────────────────────────────── */
+
+.shift {
+  display: flex; align-items: flex-start; gap: 9px;
+  padding: 7px 12px;
+  margin-bottom: 4px;
+  background: linear-gradient(90deg, rgba(224, 169, 58, .10), rgba(224, 169, 58, 0));
+  border-left: 2px solid var(--hy-mid);
+  border-radius: 0 var(--hy-radius-sm) var(--hy-radius-sm) 0;
+  font-size: 12px;
+}
+.shift__ico { color: var(--hy-mid); }
+.shift__txt { color: var(--hy-dim); }
+.shift__txt b { color: var(--hy-ink); font-weight: 600; }
+
+/* ── Governor notice ───────────────────────────────────────────────────── */
+
+.gn {
+  position: fixed; inset: 0; z-index: 60;
+  background: rgba(3, 4, 10, .74);
+  display: grid; place-items: center;
+  padding: 20px;
+}
+.gn__box {
+  width: min(420px, 100%);
+  background: var(--hy-bg-2);
+  border: 1px solid var(--hy-line-2);
+  border-radius: var(--hy-radius-lg);
+  box-shadow: 0 26px 70px rgba(0, 0, 0, .7);
+  overflow: hidden;
+}
+.gn__stripe { height: 3px; background: linear-gradient(90deg, var(--hy-mid), var(--hy-expensive)); }
+.gn__in { padding: 17px 19px 19px; }
+.gn__band {
+  display: inline-flex; align-items: center;
+  font-family: var(--hy-font-mono); font-size: 9px;
+  letter-spacing: .1em; text-transform: uppercase;
+  border-radius: 999px; padding: 2px 8px;
+  color: var(--hy-mid); border: 1px solid rgba(224, 169, 58, .4);
+}
+.gn__band--emergency { color: var(--hy-expensive); border-color: rgba(255, 90, 110, .45); }
+.gn__h { font-size: 16px; font-weight: 600; margin: 11px 0 7px; letter-spacing: -.01em; }
+.gn__p { font-size: 12.5px; color: var(--hy-dim); margin: 0; line-height: 1.55; }
+.gn__p b { color: var(--hy-ink); font-weight: 600; }
+
+.gn__meter { position: relative; height: 22px; margin: 13px 0 0; background: var(--hy-bg); border: 1px solid var(--hy-line); border-radius: 5px; overflow: hidden; }
+.gn__fill { position: absolute; inset: 0 auto 0 0; background: linear-gradient(90deg, rgba(63, 217, 138, .28), rgba(224, 169, 58, .45)); }
+.gn__ceil { position: absolute; top: 0; bottom: 0; left: 80%; width: 2px; background: var(--hy-expensive); }
+.gn__now { position: absolute; left: 7px; top: 50%; transform: translateY(-50%); font-family: var(--hy-font-mono); font-size: 10px; font-weight: 700; }
+.gn__stop { position: absolute; right: 6px; top: 50%; transform: translateY(-50%); font-family: var(--hy-font-mono); font-size: 9px; color: var(--hy-expensive); }
+
+.gn__note { font-size: 11.5px; color: var(--hy-dim); margin: 11px 0 0; line-height: 1.5; }
+.gn__note code { font-family: var(--hy-font-mono); font-size: 11px; color: var(--hy-cyan); }
+.gn__esc { font-size: 11px; color: var(--hy-mid); margin: 8px 0 0; }
+.gn__esc b { color: var(--hy-ink); }
+.gn__acts { display: flex; margin-top: 15px; }
+.gn__btn {
+  flex: 1; border-radius: var(--hy-radius-sm); padding: 9px 12px;
+  font-size: 12px; font-weight: 600;
+  border: 1px solid var(--hy-aqua); background: var(--hy-aqua); color: #00251C;
+}

--- a/desktop/frontend/src/views/ChatView.test.tsx
+++ b/desktop/frontend/src/views/ChatView.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ChatView } from './ChatView'
-import { Chat, GetModels, GetSession, NewRunID } from '../bindings'
+import { Chat, GetDashboard, GetEdits, GetModels, GetSession, NewRunID } from '../bindings'
 import type { ChatReply, Session as SessionData } from '../types'
 
 // ChatView talks to the Go backend only through these bindings — mocking the
@@ -10,6 +10,8 @@ import type { ChatReply, Session as SessionData } from '../types'
 // a real Wails runtime.
 vi.mock('../bindings', () => ({
   Chat: vi.fn(),
+  GetDashboard: vi.fn(),
+  GetEdits: vi.fn(),
   GetModels: vi.fn(),
   GetSession: vi.fn(),
   NewRunID: vi.fn(),
@@ -17,6 +19,8 @@ vi.mock('../bindings', () => ({
 
 const mockChat = vi.mocked(Chat)
 const mockGetModels = vi.mocked(GetModels)
+const mockGetDashboard = vi.mocked(GetDashboard)
+const mockGetEdits = vi.mocked(GetEdits)
 const mockGetSession = vi.mocked(GetSession)
 const mockNewRunID = vi.mocked(NewRunID)
 
@@ -44,6 +48,38 @@ function renderDock(onOpenRun: (runID: string) => void = noop) {
 beforeEach(() => {
   sessionStorage.clear()
   mockGetModels.mockResolvedValue({ found: true, pools: [] })
+  mockGetEdits.mockResolvedValue([])
+  // The companion pane reads the dashboard for the governor and calibration;
+  // an unknown governor is the quiet default, so no notice fires in these tests.
+  mockGetDashboard.mockResolvedValue({
+    hasData: false,
+    spend: { todayUsd: 0, allTimeUsd: 0, todayCalls: 0, totalCalls: 0, tokensActualPct: 0 },
+    governor: {
+      known: false,
+      pct: 0,
+      mode: '',
+      effectiveMode: '',
+      burnRatePct: 0,
+      risk: 0,
+      observations: 0,
+      horizonObs: 3,
+    },
+    trust: {
+      runs: 0,
+      meanSamples: 0,
+      fixedSwarmN: 0,
+      samplesSavedPct: 0,
+      autoClearedPct: 0,
+      meanTargetConf: 0,
+      meanFinalConf: 0,
+      totalCostUsd: 0,
+    },
+    byModel: null,
+    byTier: null,
+    byDay: null,
+    recent: null,
+    calibration: [],
+  })
   mockGetSession.mockResolvedValue(emptySession())
   let seq = 0
   mockNewRunID.mockImplementation(async () => `run-${++seq}`)

--- a/desktop/frontend/src/views/ChatView.tsx
+++ b/desktop/frontend/src/views/ChatView.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
-import { Chat, GetSession, NewRunID } from '../bindings'
-import type { ChatReply, Session as SessionData } from '../types'
+import { Chat, GetDashboard, GetSession, NewRunID } from '../bindings'
+import type { ChatReply, GovernorPanel, Session as SessionData } from '../types'
 import { ms, usdExact } from '../format'
 import { Timeline } from './Session'
 import { ModelPicker } from './ModelPicker'
+import { Cockpit } from './Cockpit'
+import { GovernorNotice } from './GovernorNotice'
 
 // Matches App.tsx's LIVE_MS — same reasoning: this is "what is happening now",
 // not a retrospective read.
@@ -59,6 +61,7 @@ export function ChatView({
   // The one turn currently in flight, if any — Chat's own busy flag already
   // guarantees at most one, so this doesn't need to be keyed by turn index.
   const [liveSession, setLiveSession] = useState<SessionData | null>(null)
+  const [governor, setGovernor] = useState<GovernorPanel | undefined>()
   const logRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -152,6 +155,15 @@ export function ChatView({
     logRef.current?.scrollTo({ top: logRef.current.scrollHeight })
   }, [turns])
 
+  // Orchestrator pressure is a slow, session-wide value, so it ticks on its own
+  // rather than per turn.
+  useEffect(() => {
+    const tick = () => void GetDashboard().then((d) => setGovernor(d.governor)).catch(() => {})
+    tick()
+    const t = setInterval(tick, 5000)
+    return () => clearInterval(t)
+  }, [])
+
   async function send() {
     const p = prompt.trim()
     if (!p || busy) return
@@ -216,7 +228,9 @@ export function ChatView({
   }, [focusSignal])
 
   return (
-    <section className="chatv">
+    <div className="chatv-split">
+      <GovernorNotice governor={governor} busy={busy} />
+      <section className="chatv">
       <div className="chatv__log" ref={logRef}>
         {turns.length === 0 && (
           <div className="chatv__empty">
@@ -229,6 +243,19 @@ export function ChatView({
         )}
         {turns.map((t, i) => (
           <div key={i} className="turn">
+            {/* A tier change belongs in the transcript, not a toast: a toast
+                vanishes and then a different model answered for no visible
+                reason. Only says what moved — the router does not record *why*,
+                and inventing a reason would be worse than omitting one. */}
+            {tierShift(turns, i) && (
+              <div className="shift">
+                <span className="shift__ico" aria-hidden="true">&#8663;</span>
+                <span className="shift__txt">
+                  Moved to <b>{turns[i - 1].reply!.tier > t.reply!.tier ? 'a stronger' : 'a cheaper'}</b>{' '}
+                  model — T{turns[i - 1].reply!.tier} &rarr; T{t.reply!.tier}
+                </span>
+              </div>
+            )}
             <p className="turn__you">{t.prompt}</p>
             {!t.reply && (
               <>
@@ -308,7 +335,14 @@ export function ChatView({
           </div>
         </div>
       </div>
-    </section>
+      </section>
+
+      <Cockpit
+        live={liveSession}
+        lastReply={lastSettled(turns)}
+        runId={turns[turns.length - 1]?.runId}
+      />
+    </div>
   )
 }
 
@@ -343,4 +377,20 @@ function recoveredReply(runId: string, s: SessionData): ChatReply {
 
 function emptyReply(): ChatReply {
   return { output: '', head: '', model: '', tier: 0, costUsd: 0, durationMs: 0, runId: '' }
+}
+
+/** The most recent turn that actually settled, for the idle sidebar state. */
+function lastSettled(turns: Turn[]): ChatReply | undefined {
+  for (let i = turns.length - 1; i >= 0; i--) {
+    if (turns[i].reply && !turns[i].reply!.error) return turns[i].reply
+  }
+  return undefined
+}
+
+/** True when this turn was answered at a different tier than the one before. */
+function tierShift(turns: Turn[], i: number): boolean {
+  if (i === 0) return false
+  const prev = turns[i - 1].reply
+  const cur = turns[i].reply
+  return !!prev && !!cur && prev.tier > 0 && cur.tier > 0 && prev.tier !== cur.tier
 }

--- a/desktop/frontend/src/views/Cockpit.tsx
+++ b/desktop/frontend/src/views/Cockpit.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useState } from 'react'
+import { GetDashboard, GetEdits, GetModels } from '../bindings'
+import type {
+  CalibrationRow,
+  ChatReply,
+  Dashboard as DashboardData,
+  Edit,
+  ModelRegistry,
+  Session as SessionData,
+} from '../types'
+import { pct, usd } from '../format'
+
+/** Dashboard is retrospective; a slow tick is enough. Mirrors App's DASHBOARD_MS. */
+const SLOW_MS = 5000
+
+/**
+ * The companion pane beside chat (#520).
+ *
+ * Deliberately glanceable, never readable: chips, meters and one gauge. That is
+ * the answer to the split-attention objection the old chat dock's
+ * collapse-on-idle behaviour was built around — a permanently visible panel is
+ * only affordable if nothing in it asks to be read.
+ */
+export function Cockpit({
+  live,
+  lastReply,
+  runId,
+}: {
+  /** The run currently in flight, if any. */
+  live: SessionData | null
+  /** The most recent settled reply, for when nothing is in flight. */
+  lastReply?: ChatReply
+  runId?: string
+}) {
+  const [reg, setReg] = useState<ModelRegistry | null>(null)
+  const [dash, setDash] = useState<DashboardData | null>(null)
+  const [edits, setEdits] = useState<Edit[]>([])
+
+  useEffect(() => {
+    GetModels().then(setReg).catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    const tick = () => void GetDashboard().then(setDash).catch(() => {})
+    tick()
+    const t = setInterval(tick, SLOW_MS)
+    return () => clearInterval(t)
+  }, [])
+
+  // Files are per-run, so this follows whichever run the thread is on. Refetched
+  // when the run settles, since edits land throughout a dispatch.
+  useEffect(() => {
+    if (!runId) {
+      setEdits([])
+      return
+    }
+    let stale = false
+    const tick = () =>
+      void GetEdits(runId)
+        .then((e) => {
+          if (!stale) setEdits(e ?? [])
+        })
+        .catch(() => {})
+    tick()
+    const t = setInterval(tick, SLOW_MS)
+    return () => {
+      stale = true
+      clearInterval(t)
+    }
+  }, [runId, live?.live])
+
+  const working = live?.live === true
+  // The active head: the live run's deepest-known agent while working, else
+  // whatever answered last.
+  const agent = live?.agents?.[0]
+  const model = working ? agent?.model || agent?.head : lastReply?.model || lastReply?.head
+  const tier = working ? agent?.tier ?? 0 : lastReply?.tier ?? 0
+
+  const pool = poolFor(reg, tier)
+  const conf = live?.timeline?.reduce((c, e) => (e.confidence > 0 ? e.confidence : c), 0) ?? 0
+
+  return (
+    <aside className="cockpit" aria-label="Routing detail">
+      <section className="ck">
+        <div className="ck__card">
+          <div className="ck__cardGrad" />
+          <div className="ck__cardIn">
+            <div className="ck__top">
+              <span className="ck__name">{model || 'No model yet'}</span>
+              {tier > 0 && <span className="ck__tier">T{tier}</span>}
+              {working && <span className="ck__pulse" title="working" />}
+            </div>
+            {/* Neither "working…" nor the latest event: the thread already
+                shows both, and repeating either just doubles the same words on
+                screen. A running count is aggregate, so it adds something. */}
+            <div className="ck__sub">
+              {working ? stepCount(live) : model ? 'idle' : 'Ask something to start'}
+            </div>
+
+            {pool && (
+              <div className="pm">
+                <div className="pm__top">
+                  <span className="pm__label">{poolLabel(pool.name)}</span>
+                  {pool.shared && <span className="pm__shared">shared</span>}
+                </div>
+                {/* Observed spend, not a quota reading: Hydra cannot see the
+                    provider's remaining allocation, so this says what it is. */}
+                <div className="pm__val">
+                  {pool.observedCalls} calls · {usd(pool.observedCostUsd)} logged
+                </div>
+                {pool.shared && pool.models.length > 1 && (
+                  <div className="pm__with">
+                    shares this quota with{' '}
+                    {pool.models
+                      .filter((m) => m.tier !== tier)
+                      .map((m) => m.name || m.id)
+                      .join(', ')}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {conf > 0 && (
+        <section className="ck">
+          <div className="ck__head">
+            <span className="ck__lbl">Confidence</span>
+            <span className="ck__rule" />
+          </div>
+          <div className="ck__gauge">
+            <Gauge value={conf} />
+            <div>
+              <div className="ck__gaugeNum">{pct(conf * 100, 0)}</div>
+              <div className="ck__gaugeCap">reached on this run</div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <section className="ck">
+        <div className="ck__head">
+          <span className="ck__lbl">Who worked, and how good they are at it</span>
+          <span className="ck__rule" />
+        </div>
+        <ModelRows dash={dash} />
+      </section>
+
+      {edits.length > 0 && (
+        <section className="ck">
+          <div className="ck__head">
+            <span className="ck__lbl">Files this run changed</span>
+            <span className="ck__rule" />
+          </div>
+          {edits.slice(0, 6).map((e, i) => (
+            <div className="fr" key={`${e.file}-${i}`}>
+              <span className="fr__name" title={e.file}>
+                {basename(e.file)}
+              </span>
+              <span className="fr__pm">
+                <span className="add">+{e.added}</span> <span className="del">−{e.removed}</span>
+              </span>
+            </div>
+          ))}
+          {edits.length > 6 && <div className="fr__more">+{edits.length - 6} more</div>}
+        </section>
+      )}
+    </aside>
+  )
+}
+
+/**
+ * Per-model rows fusing what a model did with how good it is measured to be at
+ * that — usage alone is a tally, not a judgement.
+ *
+ * The sample size ships next to every score because trust.Stat.N excludes the
+ * prior: a D on a handful of observations is close to a coin flip, and showing
+ * the number bare would present it as a measurement.
+ */
+function ModelRows({ dash }: { dash: DashboardData | null }) {
+  const cal = dash?.calibration ?? []
+  const byModel = dash?.byModel ?? []
+
+  if (cal.length === 0 && byModel.length === 0) {
+    return (
+      <p className="ck__empty">
+        Nothing recorded yet. Calibration fills in from <code>hyctl trust record</code>.
+      </p>
+    )
+  }
+
+  // Usage leads the ordering (what actually ran), with calibration joined on.
+  const rows = byModel.length > 0 ? byModel.map((b) => ({ key: b.key, calls: b.calls })) : []
+  return (
+    <div className="mr">
+      {rows.slice(0, 6).map((r) => {
+        const best = bestFor(cal, r.key)
+        return (
+          <div className="mr__row" key={r.key}>
+            <div className="mr__top">
+              <span className="mr__name" title={r.key}>
+                {r.key}
+              </span>
+              <span className={`mr__d ${best ? band(best) : 'mr__d--none'}`}>
+                {best ? best.d.toFixed(2) : '—'}
+              </span>
+            </div>
+            <div className="mr__bot">
+              <span className="mr__did">{r.calls} calls</span>
+              <span className={`mr__n ${best && best.n < 10 ? 'mr__n--thin' : ''}`}>
+                {best ? `${best.domain} · ${best.n} obs${best.n < 10 ? ' · thin' : ''}` : 'never calibrated'}
+              </span>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Strongest-measured domain for a source, or undefined when uncalibrated. */
+function bestFor(cal: CalibrationRow[], key: string): CalibrationRow | undefined {
+  const mine = cal.filter((c) => c.source === key || c.source.endsWith(key))
+  if (mine.length === 0) return undefined
+  return mine.reduce((a, b) => (b.d > a.d ? b : a))
+}
+
+// Bands, not a gradient: D is in nats and ~1 is strong discrimination, so three
+// buckets say more than a continuous scale nobody can read.
+function band(c: CalibrationRow): string {
+  if (c.n < 10) return 'mr__d--thin'
+  if (c.d >= 1) return 'mr__d--strong'
+  if (c.d >= 0.5) return 'mr__d--ok'
+  return 'mr__d--weak'
+}
+
+function Gauge({ value }: { value: number }) {
+  const r = 21
+  const circ = 2 * Math.PI * r
+  return (
+    <svg className="gz" width="52" height="52" viewBox="0 0 52 52" aria-hidden="true">
+      <circle cx="26" cy="26" r={r} className="gz__track" />
+      <circle
+        cx="26"
+        cy="26"
+        r={r}
+        className="gz__fill"
+        strokeDasharray={circ}
+        strokeDashoffset={circ * (1 - Math.min(1, Math.max(0, value)))}
+        transform="rotate(-90 26 26)"
+      />
+    </svg>
+  )
+}
+
+/** How far along the run is, without restating what the thread already lists. */
+function stepCount(live: SessionData | null): string {
+  const n = live?.timeline?.length ?? 0
+  if (n === 0) return 'starting…'
+  return `${n} step${n === 1 ? '' : 's'} so far`
+}
+
+function poolFor(reg: ModelRegistry | null, tier: number) {
+  if (!reg || tier <= 0) return undefined
+  return reg.pools.find((p) => p.models.some((m) => m.tier === tier))
+}
+
+function poolLabel(name: string): string {
+  if (name === 'unpooled') return 'No shared quota'
+  return name.replace(/^agy_/, '').replace(/^local_/, '').replace(/_/g, ' ')
+}
+
+function basename(p: string): string {
+  const i = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+  return i < 0 ? p : p.slice(i + 1)
+}

--- a/desktop/frontend/src/views/GovernorNotice.test.tsx
+++ b/desktop/frontend/src/views/GovernorNotice.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { GovernorNotice } from './GovernorNotice'
+import type { GovernorPanel } from '../types'
+
+afterEach(cleanup)
+
+function gov(over: Partial<GovernorPanel> = {}): GovernorPanel {
+  return {
+    known: true,
+    pct: 76,
+    mode: 'critical',
+    effectiveMode: 'critical',
+    burnRatePct: 2.1,
+    risk: 0.62,
+    observations: 11,
+    horizonObs: 3,
+    ...over,
+  }
+}
+
+describe('when it speaks up', () => {
+  it('stays quiet below the critical band', () => {
+    render(<GovernorNotice governor={gov({ pct: 55, mode: 'compact', effectiveMode: 'compact' })} busy={false} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('stays quiet while a dispatch is in flight, since it cannot be acted on mid-answer', () => {
+    render(<GovernorNotice governor={gov()} busy={true} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('stays quiet when nothing has measured the orchestrator at all', () => {
+    render(<GovernorNotice governor={gov({ known: false })} busy={false} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('speaks up at critical, and once dismissed stays dismissed for that band', () => {
+    render(<GovernorNotice governor={gov()} busy={false} />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /got it/i }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('what it claims', () => {
+  it('projects headroom from the burn rate', () => {
+    // 76% now, 2.1pp per update → ceil(4/2.1) = 2 updates of headroom.
+    render(<GovernorNotice governor={gov()} busy={false} />)
+    expect(screen.getByText(/2 updates/)).toBeInTheDocument()
+    expect(screen.getByText(/62%/)).toBeInTheDocument()
+  })
+
+  // RiskFromHistory returns zero below two observations. Presenting that as a
+  // measured "no risk" is the exact trap the observations count exists to avoid.
+  it('does not invent a projection when there is no rate signal', () => {
+    render(
+      <GovernorNotice
+        governor={gov({ observations: 1, burnRatePct: 0, risk: 0 })}
+        busy={false}
+      />,
+    )
+    expect(screen.getByText(/not enough history/i)).toBeInTheDocument()
+    expect(screen.queryByText(/per update/)).not.toBeInTheDocument()
+  })
+
+  it('says when the rate, not the level, is what raised the band', () => {
+    render(
+      <GovernorNotice governor={gov({ pct: 64, mode: 'compact', effectiveMode: 'critical' })} busy={false} />,
+    )
+    expect(screen.getByText(/how fast this is climbing/i)).toBeInTheDocument()
+  })
+
+  // A real probability must never render as a flat 0%.
+  it('floors a tiny probability at <1% rather than 0%', () => {
+    render(<GovernorNotice governor={gov({ risk: 0.002 })} busy={false} />)
+    expect(screen.getByText(/<1%/)).toBeInTheDocument()
+  })
+})

--- a/desktop/frontend/src/views/GovernorNotice.tsx
+++ b/desktop/frontend/src/views/GovernorNotice.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react'
+import type { GovernorPanel } from '../types'
+
+/**
+ * Fires when the orchestrator's context pressure reaches a band worth
+ * interrupting for, and says how much headroom is left rather than only how
+ * full it is.
+ *
+ * Once per band, never mid-answer: an interruption that repeats on every poll
+ * is noise, and one that lands mid-dispatch cannot be acted on anyway.
+ *
+ * The numbers are budget.RiskFromHistory's own — burn rate in percentage points
+ * per observation, and the first-passage probability of reaching 80% within
+ * budget.RiskHorizon observations. An observation is a claude_pct *update*, not
+ * a wall-clock interval and not a chat turn, so the copy says "updates".
+ */
+export function GovernorNotice({
+  governor,
+  busy,
+}: {
+  governor: GovernorPanel | undefined
+  busy: boolean
+}) {
+  const [dismissed, setDismissed] = useState<string[]>([])
+
+  const band = governor?.known ? governor.effectiveMode : ''
+  const loud = band === 'critical' || band === 'emergency'
+  const show = loud && !busy && !dismissed.includes(band)
+
+  useEffect(() => {
+    if (!show) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDismissed((d) => [...d, band])
+    }
+    addEventListener('keydown', onKey)
+    return () => removeEventListener('keydown', onKey)
+  }, [show, band])
+
+  if (!show || !governor) return null
+
+  const g = governor
+  // Only claimed when there is a real rate signal: RiskFromHistory returns zero
+  // below two observations, and presenting that as "no risk" would be a lie.
+  const hasRate = g.observations >= 2 && g.burnRatePct > 0
+  const headroom = hasRate ? Math.max(0, Math.ceil((80 - g.pct) / g.burnRatePct)) : 0
+
+  return (
+    <div className="gn" role="dialog" aria-modal="true" aria-labelledby="gnTitle">
+      <div className="gn__box">
+        <div className="gn__stripe" />
+        <div className="gn__in">
+          <span className={`gn__band gn__band--${band}`}>
+            {band} · {g.pct}%
+          </span>
+          <h3 className="gn__h" id="gnTitle">
+            {band === 'emergency'
+              ? 'Context is effectively full'
+              : 'Running out of orchestrator context'}
+          </h3>
+
+          {hasRate ? (
+            <p className="gn__p">
+              Burning <b>{g.burnRatePct.toFixed(1)}pp</b> per update. At that rate the 80%
+              ceiling is about <b>{headroom} update{headroom === 1 ? '' : 's'}</b> away
+              {g.risk > 0 && (
+                <>
+                  {' '}
+                  — a <b>{pctText(g.risk)}</b> chance of reaching it within the next{' '}
+                  {g.horizonObs} update{g.horizonObs === 1 ? '' : 's'}
+                </>
+              )}
+              .
+            </p>
+          ) : (
+            <p className="gn__p">
+              At <b>{g.pct}%</b> of the context window. Not enough history yet to estimate
+              a burn rate, so this is the level alone.
+            </p>
+          )}
+
+          <div className="gn__meter">
+            <div className="gn__fill" style={{ width: `${Math.min(100, g.pct)}%` }} />
+            <div className="gn__ceil" />
+            <span className="gn__now">{g.pct}% now</span>
+            <span className="gn__stop">80%</span>
+          </div>
+
+          <p className="gn__note">
+            Past 80% Hydra routes to local heads only. Running <code>/compact</code> in the
+            orchestrator session is what actually clears it.
+          </p>
+
+          {g.effectiveMode !== g.mode && (
+            <p className="gn__esc">
+              Raised from <b>{g.mode}</b> by how fast this is climbing, not by the level
+              alone.
+            </p>
+          )}
+
+          <div className="gn__acts">
+            <button className="gn__btn" onClick={() => setDismissed((d) => [...d, band])}>
+              Got it
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function pctText(p: number): string {
+  const v = Math.round(p * 100)
+  // Never round a real probability to a flat 0% — "<1%" is honest, "0%" is not.
+  if (v === 0) return '<1%'
+  return `${v}%`
+}

--- a/desktop/frontend/src/views/Session.tsx
+++ b/desktop/frontend/src/views/Session.tsx
@@ -126,15 +126,22 @@ export function Timeline({ entries }: { entries: TimelineEntry[] }) {
               "agreed · LLR +1.200 → Λ 1.200" — what actually happened to the
               log-odds, ahead of any narration. */}
           {e.detail && <span className="tl__detail">{e.detail}</span>}
-          <span className="tl__meta">
-            {e.confidence > 0 && `${pct(e.confidence * 100, 1)} · `}
-            {e.durationMs > 0 && `${ms(e.durationMs)} · `}
-            {e.costUsd > 0 && usdExact(e.costUsd)}
-          </span>
+          {/* Joined, not concatenated with trailing separators: an entry with a
+              confidence but no duration or cost used to render "86.0% · ". */}
+          <span className="tl__meta">{meta(e)}</span>
         </li>
       ))}
     </ol>
   )
+}
+
+/** The right-hand facts, with separators only between present values. */
+function meta(e: TimelineEntry): string {
+  const parts: string[] = []
+  if (e.confidence > 0) parts.push(pct(e.confidence * 100, 1))
+  if (e.durationMs > 0) parts.push(ms(e.durationMs))
+  if (e.costUsd > 0) parts.push(usdExact(e.costUsd))
+  return parts.join(' · ')
 }
 
 function kindClass(kind: string): string {


### PR DESCRIPTION
Steps 5 + 6 + 7 of #552 — the last of the approved design. Replaces #563, which
went green on CI and then failed to merge: develop had moved, and because #563 was
stacked on the branch that became squash-merge #560, its `app.css` conflicted against
its own already-merged ancestor. Cherry-picked the single cockpit commit onto current
develop instead — zero conflicts, and re-verified from scratch there.

## Companion pane
Active head and the quota it shares · this run's confidence · per-model measured
accuracy · files the run changed.

Model rows fuse **what a model did** with **how good it is measured to be at that** —
`internal/trust`'s per-(source, domain) calibration, already shipped and never surfaced.
The sample size ships beside every score and low-n rows are flagged `thin`:
`trust.Stat.N` excludes the prior, so a D on five observations is barely distinguishable
from a coin flip, and rendering it bare would pass it off as a measurement. Uncalibrated
renders as "never calibrated", never `0.00`.

## Tier-shift markers
In the transcript, not a toast — a toast vanishes and then a more expensive model
answered for no visible reason. States only what moved: the router does not record *why*,
and inventing a reason would be worse than omitting one.

## Governor notice
Headroom, not just level, from `budget.RiskFromHistory` (#556). Once per band, never
mid-answer.

## Two scope calls worth reviewing
**Dropped "tools touched".** `LedgerEvent` is not run-scoped and `GetSecurity` is far too
heavy to poll for a sidebar strip. Used `GetEdits` for "files this run changed": real,
run-scoped, already available. Security stays its own view.

**Pool pressure reads as observed spend, not a percentage.** The mockup showed "Claude
pool 76%", implying a quota reading Hydra cannot get. It shows calls and logged cost,
matching what `GetModels` honestly returns.

## Verified by rendering, not by reading CSS
Built the bundle, served it with seeded bindings, drove a real dispatch, screenshotted
each state. That caught three things static review missed:
- The pane and the thread both said "working…", then both said "head selected" — the pane
  now shows an aggregate step count, which adds information instead of repeating it.
- `$0.0940` for a pool total (`usdExact` is ledger precision; a glance value wants `usd`).
- **A pre-existing Timeline bug**: an entry with a confidence but no duration or cost
  rendered a dangling separator (`"86.0% · "`). Fixed by joining present values.

Also confirmed the "never mid-answer" guard works — the notice stayed correctly suppressed
while a reattached dispatch was in flight, which is what sent me digging in the first place.

## Testing
- 14/14 frontend tests (8 new for `GovernorNotice`: band gate, busy gate, unknown-governor
  gate, dismiss-per-band, headroom projection, no-invented-projection without a rate
  signal, rate-vs-level attribution, `<1%` instead of a flat `0%`).
- `typecheck`, `build`, `go vet`, `go test` clean on the rebased branch.

Closes #562