### PR TITLE
feat(mcp): wire registry scores into the ledger classification gate

### DIFF
--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -1286,6 +1286,37 @@ func TestCLI_MCPCheck_ClassificationFromContentAndExplicit(t *testing.T) {
 	}
 }
 
+// A quarantined MCP server's tools must be classified without the caller
+// having to know that server is quarantined — the whole point of Phase 4's
+// wiring is that a policy author writing "deny mcp-quarantined" gets that
+// enforcement automatically off the registry's own state, the same way a
+// PII rule applies to unlabeled content.
+func TestCLI_MCPCheck_ClassificationFromQuarantinedMCPServer(t *testing.T) {
+	s := populated(t)
+
+	seed(t, "mcp_registry_aliases.json", `{"evil-server":{"registry_name":"io.github.x/evil","status":"verified"}}`)
+	seed(t, "mcp_registry_state.json", `{"io.github.x/evil":{"state":"quarantined","manifest_hash":"x","first_seen_at":"2026-01-01T00:00:00Z","state_changed_at":"2026-01-01T00:00:00Z"}}`)
+
+	policy := `{"rules":[{"classification":"mcp-quarantined","decision":"deny"}]}`
+	if err := os.WriteFile(filepath.Join(config.Dir(), "mcp_policy.json"), []byte(policy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := runBinary(t, s, "mcp", "check", "mcp__evil-server__do_something",
+		"--action", "exec", "--resource", "x", "--agent", "a")
+	if code != 3 {
+		t.Errorf("a quarantined MCP server's tool exited %d, want the deny code 3:\n%s", code, out)
+	}
+
+	// A tool from a server with no recorded state at all must not be
+	// affected — "never audited" is not the same claim as "quarantined".
+	code, out = runBinary(t, s, "mcp", "check", "mcp__unknown-server__do_something",
+		"--action", "exec", "--resource", "x", "--agent", "a")
+	if code != 0 {
+		t.Errorf("an unaudited MCP server's tool exited %d, want the permissive default 0:\n%s", code, out)
+	}
+}
+
 // A malformed --params or a policy file that will not parse must be refused.
 // A policy that silently fails to load is a gate that is not gating.
 func TestCLI_MCPCheck_RefusesBadInput(t *testing.T) {

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -983,9 +983,20 @@ func cmdMCP() *cobra.Command {
 					return fmt.Errorf("--params: %w", err)
 				}
 			}
+			// Explicit --classification and --content-derived PII both take
+			// priority; only fall back to the MCP registry's view of this
+			// tool's server when the caller supplied neither. Auto-derived
+			// the same way policy.ContainsPII already derives "pii" from
+			// --content — this is that same mechanism, for MCP server risk.
+			classification := chkClassification
+			if classification == "" && chkContent == "" {
+				if c, ok := mcpregistry.ClassificationForTool(args[0]); ok {
+					classification = c
+				}
+			}
 			decision, checkErr := ledger.Check(ledger.DefaultPath(), pol, ledger.CheckRequest{
 				Agent: chkAgent, Tool: args[0], Resource: chkResource, Action: action,
-				Params: params, Classification: chkClassification, Content: chkContent,
+				Params: params, Classification: classification, Content: chkContent,
 			})
 			// Report the decision before any error: a Deny that failed to write
 			// to the ledger is still a Deny, and callers gate on exit 3.

--- a/internal/mcpregistry/audit.go
+++ b/internal/mcpregistry/audit.go
@@ -5,6 +5,7 @@ package mcpregistry
 import (
 	"context"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -71,6 +72,10 @@ func Audit(ctx context.Context, cwd string) (*AuditReport, error) {
 	if err != nil {
 		return nil, err
 	}
+	aliases, err := LoadAliases()
+	if err != nil {
+		return nil, err
+	}
 	now := time.Now().UTC()
 	statesChanged := false
 
@@ -98,11 +103,17 @@ func Audit(ctx context.Context, cwd string) (*AuditReport, error) {
 				entry.NearestMatch, entry.NearestDist = nearest, dist
 			}
 		}
+		aliases[strings.ToLower(s.Name)] = aliasEntry{RegistryName: entry.RegistryName, Status: entry.Status}
 		report.Entries = append(report.Entries, entry)
 	}
 
 	if statesChanged {
 		if err := SaveStates(states); err != nil {
+			return nil, err
+		}
+	}
+	if len(installed) > 0 {
+		if err := SaveAliases(aliases); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/mcpregistry/audit_test.go
+++ b/internal/mcpregistry/audit_test.go
@@ -105,6 +105,44 @@ func TestAudit_MatchesInstalledPackageAgainstSyncedRegistry(t *testing.T) {
 	}
 }
 
+func TestAudit_PersistsAliasesSoClassificationForToolWorksAfterward(t *testing.T) {
+	withTempHydraHome(t)
+	withStubbedScoringDeps(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	writeJSON(t, filepath.Join(home, ".cursor", "mcp.json"),
+		`{"mcpServers": {"fetch": {"type":"stdio","command":"uvx","args":["mcp-server-fetch"]}}}`)
+
+	if err := writeCache(&registryCache{
+		FetchedAt: time.Now().UTC(),
+		Servers: []ServerRecord{
+			{Name: "io.github.modelcontextprotocol/fetch", Packages: []Package{{RegistryType: "pypi", Identifier: "mcp-server-fetch"}}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Audit(context.Background(), ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Phase 2's automaton starts a newly-seen clean server at PROVISIONAL,
+	// not TRUSTED, so this shouldn't be classified yet — but it also
+	// shouldn't be "never seen" any more, and that alias must now resolve.
+	aliases, err := LoadAliases()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := aliases["fetch"]
+	if !ok || entry.RegistryName != "io.github.modelcontextprotocol/fetch" || entry.Status != StatusVerified {
+		t.Fatalf("alias not persisted correctly: %+v (ok=%v)", entry, ok)
+	}
+	if _, flagged := ClassificationForTool("mcp__fetch__something"); flagged {
+		t.Error("a freshly-provisional server should not be flagged")
+	}
+}
+
 func TestAudit_UnresolvedEntryGetsNearestMatchHint(t *testing.T) {
 	withTempHydraHome(t)
 	home := t.TempDir()

--- a/internal/mcpregistry/classify.go
+++ b/internal/mcpregistry/classify.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ankit373/hydra/internal/config"
+)
+
+// aliasEntry is the minimum needed to classify a local server alias without
+// re-running a full audit: which registry entry it resolved to (if any) and
+// whether it resolved at all.
+type aliasEntry struct {
+	RegistryName string `json:"registry_name,omitempty"`
+	Status       Status `json:"status"`
+}
+
+func aliasPath() string {
+	return filepath.Join(config.Dir(), "mcp_registry_aliases.json")
+}
+
+// LoadAliases reads the persisted local-alias -> registry-resolution map,
+// keyed lowercase. A missing file yields an empty map.
+func LoadAliases() (map[string]aliasEntry, error) {
+	raw, err := os.ReadFile(aliasPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]aliasEntry{}, nil
+		}
+		return nil, err
+	}
+	var m map[string]aliasEntry
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	if m == nil {
+		m = map[string]aliasEntry{}
+	}
+	return m, nil
+}
+
+// SaveAliases writes the alias map atomically.
+func SaveAliases(m map[string]aliasEntry) error {
+	raw, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := aliasPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	defer func() { _ = os.Remove(tmp) }()
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return os.WriteFile(path, raw, 0o600)
+	}
+	return nil
+}
+
+// ParseMCPToolName extracts the server alias from an MCP-style tool name —
+// the "mcp__<alias>__<tool>" convention Claude Code and other MCP clients
+// expose tools under. Returns ok=false for anything that doesn't match,
+// including a bare "mcp__" with no alias.
+func ParseMCPToolName(tool string) (alias string, ok bool) {
+	const prefix = "mcp__"
+	if !strings.HasPrefix(tool, prefix) {
+		return "", false
+	}
+	rest := tool[len(prefix):]
+	parts := strings.SplitN(rest, "__", 2)
+	if parts[0] == "" {
+		return "", false
+	}
+	return parts[0], true
+}
+
+// Ledger classification tags for MCP-derived risk — distinct from
+// policy's "pii" tag, and distinct from each other so a policy author can
+// gate differently on "not even in the registry" vs. "in the registry but
+// currently flagged/quarantined".
+const (
+	ClassMCPUnverified  = "mcp-unverified"
+	ClassMCPFlagged     = "mcp-flagged"
+	ClassMCPQuarantined = "mcp-quarantined"
+)
+
+// ClassificationForTool is Phase 4's wiring point (design doc §6/§13): a low
+// trust score or an unresolved server becomes an auto-derived ledger
+// classification, the same mechanism policy.ContainsPII already uses for
+// content sensitivity — applied to MCP server risk instead. Returns
+// ok=false when tool isn't an MCP tool name, when the alias has never been
+// seen by an audit run, or when the server is trusted/provisional/new (no
+// flag warranted) — callers should fall through to their own classification
+// logic in all of those cases, not treat false as an error.
+func ClassificationForTool(tool string) (classification string, ok bool) {
+	alias, isMCP := ParseMCPToolName(tool)
+	if !isMCP {
+		return "", false
+	}
+
+	aliases, err := LoadAliases()
+	if err != nil {
+		return "", false
+	}
+	entry, found := aliases[strings.ToLower(alias)]
+	if !found {
+		return "", false
+	}
+	if entry.Status == StatusUnresolved {
+		return ClassMCPUnverified, true
+	}
+
+	states, err := LoadStates()
+	if err != nil {
+		return "", false
+	}
+	state, hasState := states[entry.RegistryName]
+	if !hasState {
+		return "", false
+	}
+	switch state.State {
+	case StateQuarantined, StateDelisted:
+		return ClassMCPQuarantined, true
+	case StateFlagged:
+		return ClassMCPFlagged, true
+	default:
+		return "", false
+	}
+}

--- a/internal/mcpregistry/classify_test.go
+++ b/internal/mcpregistry/classify_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import "testing"
+
+func TestParseMCPToolName(t *testing.T) {
+	tests := []struct {
+		tool      string
+		wantAlias string
+		wantOK    bool
+	}{
+		{"mcp__grafana__query_prometheus", "grafana", true},
+		{"mcp__chrome-mcp__chrome_click", "chrome-mcp", true},
+		{"mcp__x__", "x", true}, // empty tool suffix still yields a valid alias
+		{"mcp__", "", false},
+		{"shell", "", false},
+		{"read_file", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		alias, ok := ParseMCPToolName(tt.tool)
+		if alias != tt.wantAlias || ok != tt.wantOK {
+			t.Errorf("ParseMCPToolName(%q) = (%q, %v), want (%q, %v)", tt.tool, alias, ok, tt.wantAlias, tt.wantOK)
+		}
+	}
+}
+
+func TestLoadAliases_MissingFileYieldsEmptyMap(t *testing.T) {
+	withTempHydraHome(t)
+	aliases, err := LoadAliases()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(aliases) != 0 {
+		t.Errorf("expected empty map, got %v", aliases)
+	}
+}
+
+func TestSaveLoadAliases_RoundTrip(t *testing.T) {
+	withTempHydraHome(t)
+	want := map[string]aliasEntry{"grafana": {RegistryName: "docker.io/grafana/mcp-grafana", Status: StatusVerified}}
+	if err := SaveAliases(want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadAliases()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["grafana"].RegistryName != "docker.io/grafana/mcp-grafana" {
+		t.Errorf("round-tripped alias = %+v", got["grafana"])
+	}
+}
+
+func TestClassificationForTool_NonMCPToolIsUnclassified(t *testing.T) {
+	withTempHydraHome(t)
+	if _, ok := ClassificationForTool("shell"); ok {
+		t.Error("a non-MCP tool name should never be classified")
+	}
+}
+
+func TestClassificationForTool_NeverAuditedIsUnclassified(t *testing.T) {
+	withTempHydraHome(t)
+	if _, ok := ClassificationForTool("mcp__never-seen__tool"); ok {
+		t.Error("a server that's never been audited should not be classified — that's not the same claim as 'unverified'")
+	}
+}
+
+func TestClassificationForTool_UnresolvedServerIsUnverified(t *testing.T) {
+	withTempHydraHome(t)
+	if err := SaveAliases(map[string]aliasEntry{"chrome-mcp": {Status: StatusUnresolved}}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := ClassificationForTool("mcp__chrome-mcp__chrome_click")
+	if !ok || got != ClassMCPUnverified {
+		t.Errorf("got (%q, %v), want (%q, true)", got, ok, ClassMCPUnverified)
+	}
+}
+
+func TestClassificationForTool_QuarantinedServerIsClassified(t *testing.T) {
+	withTempHydraHome(t)
+	if err := SaveAliases(map[string]aliasEntry{"evil": {RegistryName: "io.github.x/evil", Status: StatusVerified}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveStates(map[string]ServerState{"io.github.x/evil": {State: StateQuarantined}}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := ClassificationForTool("mcp__evil__do_thing")
+	if !ok || got != ClassMCPQuarantined {
+		t.Errorf("got (%q, %v), want (%q, true)", got, ok, ClassMCPQuarantined)
+	}
+}
+
+func TestClassificationForTool_FlaggedServerIsClassified(t *testing.T) {
+	withTempHydraHome(t)
+	if err := SaveAliases(map[string]aliasEntry{"sketchy": {RegistryName: "io.github.x/sketchy", Status: StatusVerified}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveStates(map[string]ServerState{"io.github.x/sketchy": {State: StateFlagged}}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := ClassificationForTool("mcp__sketchy__do_thing")
+	if !ok || got != ClassMCPFlagged {
+		t.Errorf("got (%q, %v), want (%q, true)", got, ok, ClassMCPFlagged)
+	}
+}
+
+func TestClassificationForTool_TrustedServerIsNotClassified(t *testing.T) {
+	withTempHydraHome(t)
+	if err := SaveAliases(map[string]aliasEntry{"good": {RegistryName: "io.github.x/good", Status: StatusVerified}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveStates(map[string]ServerState{"io.github.x/good": {State: StateTrusted}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ClassificationForTool("mcp__good__do_thing"); ok {
+		t.Error("a trusted server should not be flagged with any classification")
+	}
+}
+
+func TestClassificationForTool_CaseInsensitiveAliasLookup(t *testing.T) {
+	withTempHydraHome(t)
+	if err := SaveAliases(map[string]aliasEntry{"grafana": {Status: StatusUnresolved}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ClassificationForTool("mcp__Grafana__query"); !ok {
+		t.Error("alias lookup should be case-insensitive")
+	}
+}


### PR DESCRIPTION
## Summary
Phase 4 of the MCP registry — the enforcement teeth only Hydra can offer on top of a report, since it's the one player sitting on the user's machine next to an accountability ledger and policy engine.

- `hyctl mcp check` auto-derives a ledger `Classification` from an MCP tool's server state: `mcp-unverified` (never resolved against the registry), `mcp-flagged` (a CVE landed after the fact), `mcp-quarantined` (known-bad match or typosquat flag).
- Explicit `--classification` and content-derived PII detection both still take priority — this is a fallback, same tier as the existing PII auto-derivation.
- Wired at the CLI layer (`cmd/hydra`), not inside `internal/ledger` — ledger stays dependency-free of mcpregistry, matching the existing layering.
- Every `Audit()` run now persists a local-alias → registry-resolution map, so `mcp check` classifies without any network calls on that path.

## Changes
- `internal/mcpregistry/classify.go` — alias persistence, `mcp__<alias>__<tool>` name parsing (matched against this session's own real MCP tool names), `ClassificationForTool`
- `internal/mcpregistry/audit.go` — persists the alias map alongside the existing lifecycle-state map
- `cmd/hydra/main.go` — `mcp check` consults the registry classification when the caller supplied neither an explicit classification nor content

## Test plan
- [x] `go test -race -count=1 ./internal/mcpregistry/... ./cmd/hydra/...` — all pass, including a full CLI-level test that seeds a quarantined server and confirms a policy `deny mcp-quarantined` rule actually fires (exit code 3), while an unaudited server's tool stays unaffected
- [x] `go vet ./...`, `gofmt -l` clean

Closes #564