### PR TITLE
docs: describe the chat-first app instead of four views over a chat dock

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ For Ollama models, add a family pattern:
 | **Percolation-κ blast radius** — Molloy–Reed core detection weights hub files higher | ✅ Shipped |
 | **Rate-aware budget governor** — first-passage-time risk on `claude_pct`, escalates before a threshold | ✅ Shipped |
 | **Security posture** (`hyctl security`) — verdict, correlated incidents, risk register, OWASP LLM Top-10 coverage | ✅ Shipped |
-| **Native desktop app** — HUD Dashboard, Fleet workflow graph, Session, Code views over a persistent chat dock | ✅ Shipped |
+| **Native desktop app** — chat-first, with a pool-aware model picker and a routing/confidence pane; plus Dashboard, Fleet, Session and Security views | ✅ Shipped |
 | MCP server registry — central connection/authorization plane across every MCP server | 📋 [#9](https://github.com/ankit373/hydra/issues/9) |
 | Browser-based Web UI | 📋 [#12](https://github.com/ankit373/hydra/issues/12) |
 
@@ -689,11 +689,18 @@ hydra/
 
 ### The desktop app
 
-A native window over the same engine: **Dashboard** (HUD-style — arc gauges, glow chart, drill-down
-— spend, governor pressure, trust record, and a calibration leaderboard), **Fleet** (a dynamic
-workflow graph of runs in flight and the agents inside them), **Session** (one run's timeline, plus
-a layered graph when it fanned out), and **Code** (the file edits a run made, as diffs) — over a
-persistent chat dock.
+A native window over the same engine, opening on **Chat**: ask for work, and each reply says which
+model answered, at which tier, and what it cost — with the run's timeline narrated live rather than
+after the fact. The composer's model picker groups models by **token pool**, so it shows when a
+choice spends a quota another model shares (Opus and Sonnet draw from the same one). A companion
+pane beside the thread carries the active head, this run's confidence, per-model measured accuracy
+from the calibration record, and the files the run changed.
+
+Four more views sit behind an icon rail: **Dashboard** (HUD-style — arc gauges, glow chart,
+drill-down — spend, governor pressure, trust record, and a calibration leaderboard), **Fleet** (a
+dynamic workflow graph of runs in flight and the agents inside them), **Session** (one run's
+timeline, its file diffs, and a layered graph when it fanned out), and **Security** (OWASP LLM
+Top-10 coverage over the MCP ledger).
 
 It reads `~/.hydra/logs/` directly. No daemon, no telemetry, and its numbers are the CLI's numbers:
 Dashboard totals are asserted equal to `hyctl cost` and `hyctl stats` for the same data.

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,7 @@
       "Automatic fallback chains terminating at always-on local Qwen",
       "Local Ollama + cloud model hybrid — provider-neutral discovery",
       "Interactive TUI cockpit (hyctl tui) — chat, route work, and watch spend live",
-      "Desktop app (Wails v2) for macOS, Windows and Linux — Dashboard, Fleet, Session and Code views over a chat dock",
+      "Desktop app (Wails v2) for macOS, Windows and Linux — chat-first, with a pool-aware model picker, a routing and confidence pane, plus Dashboard, Fleet, Session and Security views",
       "Per-run event log — reconstruct any run's supervision tree, timeline and file edits",
       "Swarm dispatch — race, best, and all modes across multiple models simultaneously",
       "Token budget enforcement — per-model context window tracking with pressure modes",
@@ -822,10 +822,12 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
   <div class="klabel"><span>Hydra Desktop</span><b>ships with every release</b></div>
   <h2 class="big">Prefer to <span class="grad">watch</span> it rather than grep it?</h2>
   <p style="max-width:720px;color:var(--dim)">
-    Everything above is the CLI. The same control plane has a desktop app —
-    four views over the logs <code>hyctl</code> already writes: where the money
-    went, what is running now, why a run picked the head it did, and which files
-    it changed. No account, no server, nothing leaves the machine.
+    Everything above is the CLI. The same control plane has a desktop app that
+    opens on a chat: ask for work, and every reply says which model answered, at
+    which tier, and what it cost — beside a pane showing what the router knows.
+    Dashboard, Fleet, Session and Security sit behind it, over the logs
+    <code>hyctl</code> already writes. No account, no server, nothing leaves the
+    machine.
   </p>
 
   <div class="app-tease">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,7 @@
 
 - **10-tier routing**: Claude Opus (tier 1, complex reasoning) down to Qwen3 via Ollama (tier 10, free local)
 - **Interactive TUI cockpit**: `hyctl tui` opens an interactive cockpit — chat with your heads, route work, and watch spend live. Four views: chat+code, dashboard, agent-tree, and security (OWASP LLM Top-10 coverage). `hyctl tui --snapshot` renders one static frame for docs/previews
-- **Desktop app**: a Wails v2 GUI in `desktop/` with four views — Dashboard (spend, governor pressure, trust record), Fleet (runs in flight and the agents inside them), Session (one run's timeline, plus a layered graph when the run fanned out), Code (the file edits a run made, as diffs) — over a persistent chat dock. Every release ships a build for macOS (universal), Windows and Linux on the releases page. The builds are not code-signed yet, so macOS requires right-click → Open on first launch. Can also be built from source with `cd desktop && wails build`
+- **Desktop app**: a Wails v2 GUI in `desktop/` that opens on **Chat** — ask for work, and each reply says which model answered, at which tier, and what it cost, with the run's timeline narrated live as it happens. The composer's model picker is grouped by **token pool**, so it shows when a choice spends a quota another model shares. Beside the thread, a companion pane carries the active head, this run's confidence, per-model measured accuracy from the calibration record, and the files the run changed. Four more views sit behind an icon rail: Dashboard (spend, governor pressure, trust record), Fleet (runs in flight and the agents inside them), Session (one run's timeline, its file diffs, and a layered graph when the run fanned out), Security (OWASP LLM Top-10 coverage over the MCP ledger). Every release ships a build for macOS (universal), Windows and Linux on the releases page. The builds are not code-signed yet, so macOS requires right-click → Open on first launch. Can also be built from source with `cd desktop && wails build`
 - **Per-run event log**: every dispatch writes `~/.hydra/logs/runs/<run_id>.jsonl` — head selection, swarm attempts, SPRT samples with their running confidence, A2A handoffs, and file edits — which is what the cockpit's agent-tree and the desktop app reconstruct a run from. `HYDRA_RUN_ID` groups invocations an external orchestrator spawns into one run
 - **~1µs routing overhead**: the Go routing engine (policy eval + head selection + budget check) adds ~1,130 ns per dispatch — benchmarked on Apple M1 via `go test -bench=BenchmarkRoutingPath`
 - **Swarm dispatch**: fan a single prompt to multiple models simultaneously — race (fastest), best (LLM-judged quality), or all (aggregate)
@@ -87,7 +87,7 @@ Typical savings: 75-85% vs routing everything through Claude. Run `hyctl pricing
 ## Key Links
 
 - Homepage: https://hydra.uvansa.com/
-- Desktop app — the four views (Dashboard, Fleet, Session, Code), what each answers, and the platform downloads: https://hydra.uvansa.com/app.html
+- Desktop app — the views (Chat, Dashboard, Fleet, Session, Security), what each answers, and the platform downloads: https://hydra.uvansa.com/app.html
 - Documentation — every command (what it does, how it works, the logic/calculation, how to use): https://hydra.uvansa.com/docs.html
 - Pricing — free and open source (MIT); bring your own keys, pay providers directly. Custom builds on request: https://hydra.uvansa.com/pricing.html
 - Source code: https://github.com/ankit373/hydra

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
Docs catch-up for #552. I shipped four PRs of user-facing change and updated no docs,
which violates the mandatory docs-sync rule in CLAUDE.md and the "ship docs with the code,
never a later pass" convention. Fixing that.

## Changed
- `docs/llms.txt` — the desktop-app entry now describes what the app is: opens on Chat,
  replies name the model/tier/cost, the timeline narrates live, the picker groups by token
  pool, and a companion pane carries the routing detail. Four views behind an icon rail,
  Security included (it shipped and was never listed).
- `README.md` — same correction in prose, plus the feature-table row.
- `docs/index.html` — structured-data feature string and the "four views over the logs"
  paragraph.
- `docs/sitemap.xml` — root `lastmod` bumped with index.html, XML re-validated.

## On timing — checked, not assumed
CLAUDE.md says not to add features to `llms.txt` that have not shipped to `main`. None of
this epic has. I verified where the site is actually served from:

```
$ gh api repos/ankit373/hydra/pages --jq '.source'
{"branch": "main", "path": "/docs"}
```

So docs merged to `develop` go live only when the release carrying the features reaches
`main` — which is exactly the "no aspirational features" guarantee, and why this belongs
on develop now rather than held back.

## Deliberately excluded
`docs/app.html` — its whole value is a hand-coded simulation of the app, and that mock
still shows a `Code` nav item, no Chat, no Security, and a "Plus a chat dock" section.
Relabelling it while the simulated panels keep the old layout would read as more
trustworthy than it is, so it needs a rebuild: tracked in #567 with the specific list, and
deadlined to the next release since that is when it starts being wrong on the live site.

Closes #568