### PR TITLE
feat(mcp): static export of audited servers

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1364,7 +1364,25 @@ func cmdMCPRegistry() *cobra.Command {
 	}
 	audit.Flags().BoolVar(&auditJSON, "json", false, "machine-readable JSON output")
 
-	cmd.AddCommand(sync, scanCmd, audit)
+	var exportOut string
+	export := &cobra.Command{
+		Use:   "export",
+		Short: "Render every audited server into a static index.html/index.json (no hosting or publishing)",
+		Long: "Writes index.json and index.html to --out, covering only the servers this machine has\n" +
+			"audited via `hyctl mcp registry audit` — not the full synced registry. This produces static\n" +
+			"files only; it does not publish, host, or deploy anything anywhere.",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			n, err := mcpregistry.ExportDirectory(exportOut)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("  wrote %d server(s) to %s/index.html and %s/index.json\n", n, exportOut, exportOut)
+			return nil
+		},
+	}
+	export.Flags().StringVar(&exportOut, "out", "mcp-directory", "output directory for index.html/index.json")
+
+	cmd.AddCommand(sync, scanCmd, audit, export)
 	return cmd
 }
 

--- a/internal/mcpregistry/audit.go
+++ b/internal/mcpregistry/audit.go
@@ -95,6 +95,7 @@ func Audit(ctx context.Context, cwd string) (*AuditReport, error) {
 					prevPtr = &prev
 				}
 				next := Advance(prevPtr, match, score, now)
+				next.LastScore = score
 				states[match.Name] = next
 				statesChanged = true
 				entry.LifecycleState = next.State

--- a/internal/mcpregistry/export.go
+++ b/internal/mcpregistry/export.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"encoding/json"
+	"html/template"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// DirectoryEntry is one server's public-facing record for the Phase 3
+// static export — every field a reader needs to see the score with its
+// reasoning, never a bare number with nothing behind it.
+type DirectoryEntry struct {
+	Name           string         `json:"name"`
+	RepositoryURL  string         `json:"repository_url,omitempty"`
+	LifecycleState LifecycleState `json:"lifecycle_state"`
+	Score          Score          `json:"score"`
+	LastCheckedAt  time.Time      `json:"last_checked_at"`
+}
+
+// ExportDirectory renders every server this machine has ever audited into a
+// self-contained static site under outDir: index.json (the raw data, for
+// anyone building their own frontend against it) and index.html (a plain,
+// dependency-free page). Returns the number of entries written.
+//
+// Deliberately bounded to what's actually been scored on this machine, not
+// an attempt to cover the full synced registry: the design doc's own
+// non-goals rule out a fifth undifferentiated full-corpus index, and eagerly
+// scoring tens of thousands of servers would exhaust GitHub's unauthenticated
+// rate limit before a single run finished. This grows organically as `audit`
+// runs, the same way the registry itself is meant to.
+//
+// This produces static files only — it does not publish, host, or deploy
+// anything anywhere. Where these files end up (if anywhere) is a decision
+// for whoever runs this, not something this function makes on its own.
+func ExportDirectory(outDir string) (int, error) {
+	states, err := LoadStates()
+	if err != nil {
+		return 0, err
+	}
+
+	cache, err := loadCache()
+	var byName map[string]ServerRecord
+	if err == nil && cache != nil {
+		byName = make(map[string]ServerRecord, len(cache.Servers))
+		for _, s := range cache.Servers {
+			byName[s.Name] = s
+		}
+	}
+
+	entries := make([]DirectoryEntry, 0, len(states))
+	for name, st := range states {
+		entry := DirectoryEntry{
+			Name:           name,
+			LifecycleState: st.State,
+			Score:          st.LastScore,
+			LastCheckedAt:  st.StateChangedAt,
+		}
+		if srv, ok := byName[name]; ok {
+			entry.RepositoryURL = srv.Repository.URL
+		}
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return 0, err
+	}
+
+	rawJSON, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return 0, err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "index.json"), rawJSON, 0o644); err != nil {
+		return 0, err
+	}
+
+	f, err := os.Create(filepath.Join(outDir, "index.html"))
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	// html/template, not string concatenation: every field rendered below —
+	// server name, signal detail — originates from the official registry,
+	// which by its own moderation policy applies "minimal-to-no" review
+	// (§2 of the design doc). A malicious entry's name or a signal's Detail
+	// string is untrusted input as far as this generator is concerned, and
+	// auto-escaping is what stops it from becoming markup in the exported
+	// page instead of text.
+	if err := directoryTemplate.Execute(f, entries); err != nil {
+		return 0, err
+	}
+
+	return len(entries), nil
+}
+
+var directoryTemplate = template.Must(template.New("directory").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Hydra MCP Trust Directory (local export)</title>
+<style>
+body { font-family: system-ui, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; }
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: 0.5rem; border-bottom: 1px solid #ddd; vertical-align: top; }
+.state-trusted { color: #0a7a2f; }
+.state-provisional { color: #8a6d00; }
+.state-flagged, .state-quarantined, .state-delisted { color: #b00020; }
+.signals { font-size: 0.85em; color: #555; }
+</style>
+</head>
+<body>
+<h1>Hydra MCP Trust Directory</h1>
+<p>Locally exported — servers this machine has audited via <code>hyctl mcp registry audit</code>, not the full official registry.</p>
+<table>
+<thead><tr><th>Server</th><th>State</th><th>Score</th><th>Signals</th><th>Last checked</th></tr></thead>
+<tbody>
+{{range .}}
+<tr>
+<td>{{.Name}}{{if .RepositoryURL}}<br><a href="{{.RepositoryURL}}">{{.RepositoryURL}}</a>{{end}}</td>
+<td class="state-{{.LifecycleState}}">{{.LifecycleState}}</td>
+<td>{{if eq .Score.Confidence "insufficient_evidence"}}insufficient evidence{{else}}{{printf "%.0f" .Score.Overall}}/100 ({{.Score.Confidence}}){{end}}</td>
+<td class="signals">
+{{range .Score.SecurityImplementation.Signals}}{{if .Available}}{{.Detail}}<br>{{end}}{{end}}
+{{range .Score.RepositoryHealth.Signals}}{{if .Available}}{{.Detail}}<br>{{end}}{{end}}
+{{range .Score.OperationalSecurity.Signals}}{{if .Available}}{{.Detail}}<br>{{end}}{{end}}
+</td>
+<td>{{.LastCheckedAt.Format "2006-01-02"}}</td>
+</tr>
+{{end}}
+</tbody>
+</table>
+</body>
+</html>
+`))

--- a/internal/mcpregistry/export_test.go
+++ b/internal/mcpregistry/export_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExportDirectory_NoStatesWritesEmptyDirectory(t *testing.T) {
+	withTempHydraHome(t)
+	out := t.TempDir()
+
+	n, err := ExportDirectory(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("n = %d, want 0", n)
+	}
+	if _, err := os.Stat(filepath.Join(out, "index.html")); err != nil {
+		t.Errorf("index.html should still be written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(out, "index.json")); err != nil {
+		t.Errorf("index.json should still be written: %v", err)
+	}
+}
+
+func TestExportDirectory_WritesOneEntryPerAuditedServer(t *testing.T) {
+	withTempHydraHome(t)
+	out := t.TempDir()
+
+	if err := SaveStates(map[string]ServerState{
+		"io.github.foo/bar": {
+			State:          StateTrusted,
+			StateChangedAt: time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+			LastScore:      Score{Overall: 82, Confidence: ConfidenceHigh},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCache(&registryCache{Servers: []ServerRecord{
+		{Name: "io.github.foo/bar", Repository: Repository{URL: "https://github.com/foo/bar"}},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := ExportDirectory(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("n = %d, want 1", n)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(out, "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []DirectoryEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	got := entries[0]
+	if got.Name != "io.github.foo/bar" || got.LifecycleState != StateTrusted || got.RepositoryURL != "https://github.com/foo/bar" {
+		t.Errorf("unexpected entry: %+v", got)
+	}
+	if got.Score.Overall != 82 {
+		t.Errorf("Score.Overall = %v, want 82 (persisted LastScore should round-trip)", got.Score.Overall)
+	}
+
+	html, err := os.ReadFile(filepath.Join(out, "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(html), "io.github.foo/bar") {
+		t.Error("index.html should contain the server name")
+	}
+}
+
+// The registry's own moderation policy is "minimal-to-no" review (design
+// doc §2) — a malicious entry's name is untrusted input as far as this
+// generator is concerned. html/template must escape it, not string-concat
+// it into the page.
+func TestExportDirectory_EscapesUntrustedServerNames(t *testing.T) {
+	withTempHydraHome(t)
+	out := t.TempDir()
+
+	malicious := `<script>alert(1)</script>`
+	if err := SaveStates(map[string]ServerState{
+		malicious: {State: StateFlagged, LastScore: Score{Confidence: ConfidenceInsufficient}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ExportDirectory(out); err != nil {
+		t.Fatal(err)
+	}
+
+	html, err := os.ReadFile(filepath.Join(out, "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(html), "<script>alert(1)</script>") {
+		t.Fatal("a malicious server name was rendered unescaped into the exported HTML")
+	}
+	if !strings.Contains(string(html), "&lt;script&gt;") {
+		t.Error("expected the malicious name to appear HTML-escaped")
+	}
+}
+
+func TestExportDirectory_EscapesUntrustedSignalDetail(t *testing.T) {
+	withTempHydraHome(t)
+	out := t.TempDir()
+
+	if err := SaveStates(map[string]ServerState{
+		"x": {State: StateTrusted, LastScore: Score{
+			Confidence: ConfidenceHigh,
+			SecurityImplementation: CategoryScore{Signals: []Signal{
+				{Available: true, Detail: `<img src=x onerror=alert(1)>`},
+			}},
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ExportDirectory(out); err != nil {
+		t.Fatal(err)
+	}
+	html, err := os.ReadFile(filepath.Join(out, "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(html), "<img src=x onerror=alert(1)>") {
+		t.Fatal("an unescaped signal Detail was rendered into the exported HTML")
+	}
+}
+
+func TestExportDirectory_SortedByName(t *testing.T) {
+	withTempHydraHome(t)
+	out := t.TempDir()
+
+	if err := SaveStates(map[string]ServerState{
+		"z-server": {State: StateTrusted},
+		"a-server": {State: StateTrusted},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ExportDirectory(out); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(out, "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []DirectoryEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 || entries[0].Name != "a-server" || entries[1].Name != "z-server" {
+		t.Errorf("entries not sorted by name: %+v", entries)
+	}
+}

--- a/internal/mcpregistry/lifecycle.go
+++ b/internal/mcpregistry/lifecycle.go
@@ -35,12 +35,15 @@ const (
 const provisionalCooldown = 14 * 24 * time.Hour
 
 // ServerState is what's persisted per server between audit runs, keyed by
-// the server's registry Name.
+// the server's registry Name. LastScore is the most recent ComputeScore
+// result — persisted so a later export or report doesn't have to re-run
+// the network-calling signals just to redisplay a score already computed.
 type ServerState struct {
 	State          LifecycleState `json:"state"`
 	ManifestHash   string         `json:"manifest_hash"`
 	FirstSeenAt    time.Time      `json:"first_seen_at"`
 	StateChangedAt time.Time      `json:"state_changed_at"`
+	LastScore      Score          `json:"last_score"`
 }
 
 // ManifestHash fingerprints the parts of a server record that matter for


### PR DESCRIPTION
## Summary
Generation-only slice of Phase 3 — deliberately **not** the public trust-scored directory itself. Publishing that requires a hosting/domain decision and the backtest-validation gate the design doc calls out (§13.4: prove the pipeline against the documented real incidents — postmark-mcp, the OX Security typosquat clone — before anything ships publicly). Those are decisions for a human, not something to decide inside a PR.

What this actually does: `hyctl mcp registry export --out <dir>` renders every server this machine has audited into a self-contained `index.html` + `index.json`. Bounded to what's actually been scored — not the full ~78K-server registry, both because the design doc's non-goals rule out a fifth undifferentiated full-corpus index, and because eagerly scoring tens of thousands of servers would blow through GitHub's unauthenticated rate limit before finishing.

`ServerState` now persists the last-computed `Score`, so export needs zero network calls — it only redisplays what `audit` already computed.

## Security note
Rendered via `html/template` (auto-escaping), not string concatenation. Server names and signal details come from the official registry, which applies "minimal-to-no" moderation by its own policy — untrusted input as far as this generator is concerned. Covered by explicit tests injecting `<script>`/`<img onerror>` payloads via both the server name and a signal's `Detail` field, asserting they come out escaped.

## Test plan
- [x] `go test -race -count=1 ./internal/mcpregistry/... ./cmd/hydra/...` — all pass
- [x] `go vet ./...`, `gofmt -l` clean
- [x] Live end-to-end smoke test: audited a real crafted server (real GitHub API call for maintenance recency), exported it, verified the rendered HTML shows the correct score, state, and signal details

Closes #570