### PR TITLE
feat(mcp): backtest against known real incidents (finds and fixes a live scoring bug)

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1382,7 +1382,54 @@ func cmdMCPRegistry() *cobra.Command {
 	}
 	export.Flags().StringVar(&exportOut, "out", "mcp-directory", "output directory for index.html/index.json")
 
-	cmd.AddCommand(sync, scanCmd, audit, export)
+	var backtestJSON bool
+	backtest := &cobra.Command{
+		Use:   "backtest",
+		Short: "Validate the scoring pipeline against known real MCP-security incidents",
+		Long: "Checks whether the live pipeline still catches the documented real incidents that\n" +
+			"justified building it — the gate this repo's design doc names before a public directory\n" +
+			"(Phase 3) can go live. Re-run before any launch decision; this is a point-in-time proof,\n" +
+			"not a permanent guarantee.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			known := mcpregistry.Backtest(cmd.Context())
+			typo := mcpregistry.BacktestTyposquat()
+			if backtestJSON {
+				return json.NewEncoder(os.Stdout).Encode(map[string]any{"known_incidents": known, "typosquat_pairs": typo})
+			}
+			allPassed := true
+			fmt.Println("  known-vulnerability match (live OSV.dev check):")
+			for _, r := range known {
+				status := okStyle.Render("CAUGHT")
+				if !r.Caught {
+					status = warnStyle.Render("MISSED")
+					allPassed = false
+				}
+				fmt.Printf("    %-8s %s\n", status, r.Incident.Name)
+				fmt.Printf("             %s\n", dimStyle.Render(r.Incident.Description))
+				if r.Detail != "" {
+					fmt.Printf("             %s\n", dimStyle.Render(r.Detail))
+				}
+			}
+			fmt.Println("  typosquat detector (constructed pairs, not a live-registry probe):")
+			for _, r := range typo {
+				status := okStyle.Render("CAUGHT")
+				if !r.Detected {
+					status = warnStyle.Render("MISSED")
+					allPassed = false
+				}
+				fmt.Printf("    %-8s %s vs %s (%d edits)\n", status, r.Pair.Registered, r.Pair.Typosquat, r.Distance)
+			}
+			if !allPassed {
+				fmt.Println("\n  backtest FAILED — do not treat the pipeline as launch-ready")
+				os.Exit(1)
+			}
+			fmt.Println("\n  backtest passed")
+			return nil
+		},
+	}
+	backtest.Flags().BoolVar(&backtestJSON, "json", false, "machine-readable JSON output")
+
+	cmd.AddCommand(sync, scanCmd, audit, export, backtest)
 	return cmd
 }
 

--- a/internal/mcpregistry/backtest.go
+++ b/internal/mcpregistry/backtest.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import "context"
+
+// KnownIncident is one documented, real MCP-security incident used to prove
+// the scoring pipeline actually catches what it was built to catch — the
+// design doc's §13.4 gate: don't publish a public score (Phase 3) until this
+// passes. Each entry here has an independently-verifiable source; this list
+// is not a general threat-intel feed and isn't meant to grow into one.
+type KnownIncident struct {
+	Name         string
+	RegistryType string
+	Identifier   string
+	Description  string
+}
+
+// KnownIncidents is intentionally short: each entry is a specific, checkable
+// real-world event, hand-verified against OSV.dev at the time it was added
+// here (registered by `MAL-2025-47604` and `CVE-2025-6514` respectively) —
+// not a scraped or speculative list.
+var KnownIncidents = []KnownIncident{
+	{
+		Name:         "postmark-mcp rug-pull",
+		RegistryType: "npm",
+		Identifier:   "postmark-mcp",
+		Description:  "ran clean for 15 npm versions, then v1.0.16 silently BCC'd every outgoing email to an attacker domain (Sept 2025) — the incident that motivated this registry's version-bump automaton",
+	},
+	{
+		Name:         "mcp-remote OS command injection",
+		RegistryType: "npm",
+		Identifier:   "mcp-remote",
+		Description:  "CVE-2025-6514: a crafted authorization_endpoint redirect from an untrusted MCP server achieves OS command injection",
+	},
+}
+
+// BacktestResult is one incident's outcome against the live pipeline.
+type BacktestResult struct {
+	Incident KnownIncident `json:"incident"`
+	Caught   bool          `json:"caught"`
+	Detail   string        `json:"detail"`
+}
+
+// Backtest runs every KnownIncident's package through the real
+// knownBadSignal check and reports whether today's pipeline still flags it.
+// This is a point-in-time proof, not a guarantee — OSV.dev's data could
+// change — which is exactly why this is a command to re-run before a launch
+// decision, not a one-time claim to trust forever.
+func Backtest(ctx context.Context) []BacktestResult {
+	results := make([]BacktestResult, 0, len(KnownIncidents))
+	for _, inc := range KnownIncidents {
+		sig := knownBadSignal(ctx, Package{RegistryType: inc.RegistryType, Identifier: inc.Identifier})
+		results = append(results, BacktestResult{
+			Incident: inc,
+			Caught:   sig.Available && sig.Impact < 0,
+			Detail:   sig.Detail,
+		})
+	}
+	return results
+}
+
+// TyposquatBacktestPair is the OX Security-style near-duplicate pattern this
+// validates: an existing registered identifier and a plausible typosquat of
+// it. Modeled on the real published attack (OX Security's "Malicious Trial
+// Balloon": a typosquatted clone of a Postgres MCP server accepted by 9 of
+// 11 public registries with zero review) — not a claim that this exact pair
+// is live in the production registry today, which isn't something to probe.
+type TyposquatBacktestPair struct {
+	Registered string
+	Typosquat  string
+}
+
+var typosquatBacktestPairs = []TyposquatBacktestPair{
+	{Registered: "mcp-server-postgres", Typosquat: "mcp-server-postgress"},
+	{Registered: "mcp-server-github", Typosquat: "mcp-server-githup"},
+}
+
+// TyposquatBacktestResult is one pair's outcome against the edit-distance
+// detector.
+type TyposquatBacktestResult struct {
+	Pair     TyposquatBacktestPair `json:"pair"`
+	Detected bool                  `json:"detected"`
+	Distance int                   `json:"distance"`
+}
+
+// BacktestTyposquat validates the near-duplicate detector algorithm itself
+// against pairs modeled on the real published attack pattern, using a
+// constructed two-entry corpus rather than the live registry.
+func BacktestTyposquat() []TyposquatBacktestResult {
+	results := make([]TyposquatBacktestResult, 0, len(typosquatBacktestPairs))
+	for _, pair := range typosquatBacktestPairs {
+		target := ServerRecord{Name: "candidate", Packages: []Package{{Identifier: pair.Typosquat}}}
+		corpus := []ServerRecord{
+			target,
+			{Name: "registered", Packages: []Package{{Identifier: pair.Registered}}},
+		}
+		sig := typosquatSignal(target, corpus)
+		results = append(results, TyposquatBacktestResult{
+			Pair:     pair,
+			Detected: sig.Available && sig.Impact < 0,
+			Distance: levenshtein(pair.Registered, pair.Typosquat),
+		})
+	}
+	return results
+}

--- a/internal/mcpregistry/backtest_test.go
+++ b/internal/mcpregistry/backtest_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+
+package mcpregistry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The test suite stubs OSV.dev rather than depending on the network — the
+// real API was hand-verified live while building this (postmark-mcp:
+// MAL-2025-47604, mcp-remote: CVE-2025-6514) — see KnownIncidents' doc
+// comment. This test proves the plumbing (Backtest calls knownBadSignal
+// correctly and reports Caught accurately), not that OSV.dev's data hasn't
+// changed since — that's what re-running the real command before a launch
+// decision is for.
+func TestBacktest_ReportsCaughtWhenOSVHasAnAdvisory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Package struct{ Name string } `json:"package"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Package.Name == "postmark-mcp" {
+			_ = json.NewEncoder(w).Encode(osvResponse{Vulns: []osvVuln{{ID: "MAL-2025-47604"}}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(osvResponse{})
+	}))
+	defer srv.Close()
+	orig := osvQueryURL
+	osvQueryURL = srv.URL
+	defer func() { osvQueryURL = orig }()
+
+	results := Backtest(context.Background())
+	if len(results) != len(KnownIncidents) {
+		t.Fatalf("got %d results, want %d", len(results), len(KnownIncidents))
+	}
+
+	byName := map[string]BacktestResult{}
+	for _, r := range results {
+		byName[r.Incident.Name] = r
+	}
+	if !byName["postmark-mcp rug-pull"].Caught {
+		t.Error("postmark-mcp should be Caught when OSV.dev has an advisory for it")
+	}
+	if byName["mcp-remote OS command injection"].Caught {
+		t.Error("mcp-remote should not be Caught when the stub returns no advisory for it")
+	}
+}
+
+func TestBacktest_ReportsMissedWhenOSVHasNothing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(osvResponse{})
+	}))
+	defer srv.Close()
+	orig := osvQueryURL
+	osvQueryURL = srv.URL
+	defer func() { osvQueryURL = orig }()
+
+	for _, r := range Backtest(context.Background()) {
+		if r.Caught {
+			t.Errorf("%s: Caught=true with no advisory data available", r.Incident.Name)
+		}
+	}
+}
+
+func TestBacktestTyposquat_DetectsKnownPatternPairs(t *testing.T) {
+	for _, r := range BacktestTyposquat() {
+		if !r.Detected {
+			t.Errorf("%s vs %s (%d edits): expected the typosquat detector to flag this pair", r.Pair.Registered, r.Pair.Typosquat, r.Distance)
+		}
+		if r.Distance > 3 {
+			t.Errorf("%s vs %s: distance %d is suspiciously large for a claimed typosquat pair — check the fixture", r.Pair.Registered, r.Pair.Typosquat, r.Distance)
+		}
+	}
+}
+
+func TestKnownIncidents_TableIsWellFormed(t *testing.T) {
+	if len(KnownIncidents) == 0 {
+		t.Fatal("KnownIncidents must not be empty — an empty backtest silently reports nothing")
+	}
+	for _, inc := range KnownIncidents {
+		if inc.Name == "" || inc.Identifier == "" || inc.RegistryType == "" || inc.Description == "" {
+			t.Errorf("incomplete KnownIncident entry: %+v", inc)
+		}
+	}
+}

--- a/internal/mcpregistry/score.go
+++ b/internal/mcpregistry/score.go
@@ -179,11 +179,8 @@ var osvEcosystem = map[string]string{
 var osvQueryURL = "https://api.osv.dev/v1/query"
 
 type osvVuln struct {
-	ID       string `json:"id"`
-	Summary  string `json:"summary"`
-	Severity []struct {
-		Score string `json:"score"`
-	} `json:"database_specific,omitempty"`
+	ID      string `json:"id"`
+	Summary string `json:"summary"`
 }
 
 type osvResponse struct {

--- a/internal/mcpregistry/score_test.go
+++ b/internal/mcpregistry/score_test.go
@@ -96,6 +96,36 @@ func TestKnownBadSignal_ParsesVulnResponse(t *testing.T) {
 	}
 }
 
+// A real OSV.dev response's database_specific field is an OBJECT
+// (malicious-packages-origins, severity, cwe_ids, ...), not the array an
+// earlier version of osvVuln mistakenly declared it as — which made
+// json.Decode fail on every real advisory carrying that field, silently
+// turning the single highest-value signal in this whole scoring engine into
+// a permanent no-op. This test uses the real shape (verbatim from a live
+// query against postmark-mcp) precisely so that regression can't recur
+// silently: TestKnownBadSignal_ParsesVulnResponse alone couldn't catch it
+// because its synthetic fixture never included the field the real API does.
+func TestKnownBadSignal_ToleratesRealOSVResponseShape(t *testing.T) {
+	const realWorldShape = `{"vulns":[{"id":"MAL-2025-47604","summary":"Malicious code in postmark-mcp (npm)",
+		"details":"turned malicious in v1.0.16","modified":"2025-09-26T04:14:45Z","published":"2025-09-26T04:14:45Z",
+		"database_specific":{"malicious-packages-origins":[{"modified_time":"2025-09-26T04:14:45Z",
+		"ranges":[{"events":[{"introduced":"1.0.16"}],"type":"SEMVER"}],"source":"google-open-source-security"}]},
+		"references":[{"type":"ARTICLE","url":"https://example.com"}],"schema_version":"1.7.3"}]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(realWorldShape))
+	}))
+	defer srv.Close()
+	orig := osvQueryURL
+	osvQueryURL = srv.URL
+	defer func() { osvQueryURL = orig }()
+
+	sig := knownBadSignal(context.Background(), Package{RegistryType: "npm", Identifier: "postmark-mcp"})
+	if !sig.Available || sig.Impact != -100 {
+		t.Fatalf("real-shaped OSV response should still be caught as severe, got %+v", sig)
+	}
+}
+
 func TestKnownBadSignal_NoVulnsIsNeutral(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(osvResponse{})


### PR DESCRIPTION
## Summary
`hyctl mcp registry backtest` is design doc §13.4's launch-readiness gate made real: proves the scoring pipeline still catches the documented incidents that justified building it, before a public directory (Phase 3) is considered launch-ready.

- Live OSV.dev check for `postmark-mcp` (the rug-pull that motivated the version-bump automaton) and `mcp-remote` (CVE-2025-6514) — both independently hand-verified against the real API.
- Self-contained check that the edit-distance typosquat detector flags near-duplicate pairs modeled on the OX Security pattern — constructed pairs, deliberately not a probe against the live production registry.

## This found a real bug
Running the live check for the first time returned MISSED on both known incidents. Root cause: `osvVuln.Severity` was tagged `json:"database_specific"` with the wrong type — an array, when OSV's real `database_specific` is always an object. Every real advisory carrying that field (nearly all of them) failed to decode, so `knownBadSignal` — the single highest-value signal in the whole scoring engine per the design doc's own evidence — silently returned `Available: false` for every real hit since Phase 2 (#561) shipped. The unit test never caught it because its synthetic fixture never included the field the real API always sends.

Fixed by removing the unused, mistyped field, and locked in with a new test (`TestKnownBadSignal_ToleratesRealOSVResponseShape`) using the real response shape verbatim from a live query against postmark-mcp.

## Test plan
- [x] `go test -race -count=1 ./internal/mcpregistry/... ./cmd/hydra/...` — all pass
- [x] `go vet ./...`, `gofmt -l` clean
- [x] Live re-run of `hyctl mcp registry backtest` after the fix: both incidents now CAUGHT, both typosquat pairs CAUGHT, exit code 0

Closes #572