### PR TITLE
feat(mcp): hyctl mcp registry list — audited servers as a capability list

### DIFF
--- a/cmd/hydra/cli_success_test.go
+++ b/cmd/hydra/cli_success_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/mcpregistry"
 	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/testutil"
 )
@@ -1314,6 +1315,46 @@ func TestCLI_MCPCheck_ClassificationFromQuarantinedMCPServer(t *testing.T) {
 		"--action", "exec", "--resource", "x", "--agent", "a")
 	if code != 0 {
 		t.Errorf("an unaudited MCP server's tool exited %d, want the permissive default 0:\n%s", code, out)
+	}
+}
+
+func TestCLI_MCPRegistryList_ShowsAuditedServersByScore(t *testing.T) {
+	populated(t)
+
+	seed(t, "mcp_registry_state.json", `{
+		"io.github.x/good": {"state":"trusted","manifest_hash":"a","first_seen_at":"2026-01-01T00:00:00Z","state_changed_at":"2026-01-01T00:00:00Z","last_score":{"security_implementation":{},"repository_health":{},"operational_security":{},"community_governance":{},"overall":91,"confidence":"high"}},
+		"io.github.x/bad": {"state":"quarantined","manifest_hash":"b","first_seen_at":"2026-01-01T00:00:00Z","state_changed_at":"2026-01-01T00:00:00Z","last_score":{"security_implementation":{},"repository_health":{},"operational_security":{},"community_governance":{},"overall":5,"confidence":"high"}}
+	}`)
+
+	out, cobraOut, err := run(t, "mcp", "registry", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	combined := out + cobraOut
+	if !strings.Contains(combined, "io.github.x/good") || !strings.Contains(combined, "io.github.x/bad") {
+		t.Errorf("both audited servers should be listed:\n%s", combined)
+	}
+	if !strings.Contains(combined, "trusted") || !strings.Contains(combined, "quarantined") {
+		t.Errorf("lifecycle states should be shown:\n%s", combined)
+	}
+
+	jsonOut, _, err := run(t, "mcp", "registry", "list", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []mcpregistry.DirectoryEntry
+	if err := json.Unmarshal([]byte(jsonOut), &entries); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, jsonOut)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+}
+
+func TestCLI_MCPRegistryList_EmptyIsNotAnError(t *testing.T) {
+	populated(t)
+	if _, _, err := run(t, "mcp", "registry", "list"); err != nil {
+		t.Fatalf("an empty registry list should not error: %v", err)
 	}
 }
 

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -1429,7 +1429,42 @@ func cmdMCPRegistry() *cobra.Command {
 	}
 	backtest.Flags().BoolVar(&backtestJSON, "json", false, "machine-readable JSON output")
 
-	cmd.AddCommand(sync, scanCmd, audit, export, backtest)
+	var listJSON bool
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List every MCP server this machine has audited, by trust score",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			entries, err := mcpregistry.Directory()
+			if err != nil {
+				return err
+			}
+			if listJSON {
+				return json.NewEncoder(os.Stdout).Encode(entries)
+			}
+			if len(entries) == 0 {
+				fmt.Println("  no audited servers yet — run `hyctl mcp registry audit` first")
+				return nil
+			}
+			fmt.Printf("\n  %-40s %-12s %6s  %s\n", "SERVER", "STATE", "SCORE", "CONFIDENCE")
+			fmt.Println("  " + strings.Repeat("─", 78))
+			for _, e := range entries {
+				state := string(e.LifecycleState)
+				switch e.LifecycleState {
+				case mcpregistry.StateTrusted:
+					state = okStyle.Render(state)
+				case mcpregistry.StateFlagged, mcpregistry.StateQuarantined, mcpregistry.StateDelisted:
+					state = warnStyle.Render(state)
+				}
+				fmt.Printf("  %-40.40s %-12s %6s  %s\n", e.Name, state,
+					mcpregistry.FormatScore(e.Score), mcpregistry.FormatConfidence(e.Score.Confidence))
+			}
+			fmt.Println()
+			return nil
+		},
+	}
+	list.Flags().BoolVar(&listJSON, "json", false, "machine-readable JSON output")
+
+	cmd.AddCommand(sync, scanCmd, audit, export, backtest, list)
 	return cmd
 }
 

--- a/internal/mcpregistry/export.go
+++ b/internal/mcpregistry/export.go
@@ -22,25 +22,18 @@ type DirectoryEntry struct {
 	LastCheckedAt  time.Time      `json:"last_checked_at"`
 }
 
-// ExportDirectory renders every server this machine has ever audited into a
-// self-contained static site under outDir: index.json (the raw data, for
-// anyone building their own frontend against it) and index.html (a plain,
-// dependency-free page). Returns the number of entries written.
-//
-// Deliberately bounded to what's actually been scored on this machine, not
-// an attempt to cover the full synced registry: the design doc's own
-// non-goals rule out a fifth undifferentiated full-corpus index, and eagerly
-// scoring tens of thousands of servers would exhaust GitHub's unauthenticated
-// rate limit before a single run finished. This grows organically as `audit`
-// runs, the same way the registry itself is meant to.
-//
-// This produces static files only — it does not publish, host, or deploy
-// anything anywhere. Where these files end up (if anywhere) is a decision
-// for whoever runs this, not something this function makes on its own.
-func ExportDirectory(outDir string) (int, error) {
+// Directory gathers every server this machine has ever audited (via
+// `hyctl mcp registry audit`) into the display shape both the static export
+// and `hyctl mcp registry list` use — one source of truth for "what has
+// this machine scored," sorted by name. Deliberately bounded to what's
+// actually been scored, not an attempt to cover the full synced registry:
+// the design doc's own non-goals rule out a fifth undifferentiated
+// full-corpus index, and eagerly scoring tens of thousands of servers would
+// exhaust GitHub's unauthenticated rate limit before a single run finished.
+func Directory() ([]DirectoryEntry, error) {
 	states, err := LoadStates()
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	cache, err := loadCache()
@@ -66,6 +59,22 @@ func ExportDirectory(outDir string) (int, error) {
 		entries = append(entries, entry)
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	return entries, nil
+}
+
+// ExportDirectory renders Directory() into a self-contained static site
+// under outDir: index.json (the raw data, for anyone building their own
+// frontend against it) and index.html (a plain, dependency-free page).
+// Returns the number of entries written.
+//
+// This produces static files only — it does not publish, host, or deploy
+// anything anywhere. Where these files end up (if anywhere) is a decision
+// for whoever runs this, not something this function makes on its own.
+func ExportDirectory(outDir string) (int, error) {
+	entries, err := Directory()
+	if err != nil {
+		return 0, err
+	}
 
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return 0, err

--- a/internal/mcpregistry/export_test.go
+++ b/internal/mcpregistry/export_test.go
@@ -11,6 +11,51 @@ import (
 	"time"
 )
 
+func TestDirectory_NoStatesIsEmptyNotNil(t *testing.T) {
+	withTempHydraHome(t)
+	entries, err := Directory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("got %d entries, want 0", len(entries))
+	}
+}
+
+func TestDirectory_MatchesWhatExportWrites(t *testing.T) {
+	withTempHydraHome(t)
+	if err := SaveStates(map[string]ServerState{
+		"io.github.foo/bar": {State: StateTrusted, LastScore: Score{Overall: 91, Confidence: ConfidenceHigh}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	viaDirectory, err := Directory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := t.TempDir()
+	n, err := ExportDirectory(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(viaDirectory) {
+		t.Errorf("ExportDirectory wrote %d entries, Directory() returned %d — they should agree", n, len(viaDirectory))
+	}
+
+	raw, err := os.ReadFile(filepath.Join(out, "index.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var exported []DirectoryEntry
+	if err := json.Unmarshal(raw, &exported); err != nil {
+		t.Fatal(err)
+	}
+	if len(exported) != 1 || exported[0].Name != viaDirectory[0].Name || exported[0].Score.Overall != viaDirectory[0].Score.Overall {
+		t.Errorf("exported = %+v, Directory() = %+v — should be the same data", exported, viaDirectory)
+	}
+}
+
 func TestExportDirectory_NoStatesWritesEmptyDirectory(t *testing.T) {
 	withTempHydraHome(t)
 	out := t.TempDir()


### PR DESCRIPTION
## Scope note
This is the well-specified half of Phase 5 (Option D in MCP_REGISTRY_SCOPE.md) — surfacing known/audited MCP servers as a capability list, the same shape as `internal/capabilities/data.json` for models. It does **not** implement "route dispatch to MCP tools as heads": that's a materially bigger, still-underspecified architectural question spanning `internal/dispatch`/`executor`/`provider` that the design doc itself left unscoped. Inventing that on the fly would be exactly the premature-design problem this repo's Karpathy rule warns against — it needs its own design pass, not an improvisation here.

## Changes
- `hyctl mcp registry list` — every audited server by trust score, mirroring `hyctl models list`'s table/JSON shape
- Extracted `mcpregistry.Directory()` out of `ExportDirectory` so `list` and `export` share one source of truth instead of duplicating the entry-gathering logic

## Test plan
- [x] `go test -race -count=1 ./internal/mcpregistry/... ./cmd/hydra/...` — all pass
- [x] `go vet ./...`, `gofmt -l` clean
- [x] Live smoke test against a crafted audited server — output matches expected table format

Closes #576