### PR TITLE
feat(desktop): show how the router moved through tiers on a run

### DIFF
--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1746,3 +1746,47 @@ body {
   font-size: 12px; font-weight: 600;
   border: 1px solid var(--hy-aqua); background: var(--hy-aqua); color: #00251C;
 }
+
+/* ── Tier movement track ───────────────────────────────────────────────── */
+/* Renders only when the router actually changed tier, and never for swarm or
+   SPRT runs — see tierSteps for why a step line would misstate those. */
+
+.tt {
+  margin: 16px 0 0;
+  padding: 11px 14px 9px;
+  background: var(--hy-panel);
+  border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius);
+}
+.tt__head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 7px; }
+.tt__lbl {
+  font-family: var(--hy-font-mono);
+  font-size: 9px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--hy-faint);
+}
+.tt__sum { margin-left: auto; font-family: var(--hy-font-mono); font-size: 10px; color: var(--hy-dim); }
+/* The plot is the positioning context: the line is a stretched SVG, the dots are
+   HTML on top so they stay round (see TierTrack for why they cannot be circles
+   inside a non-uniformly scaled viewBox). */
+.tt__plot { position: relative; height: 44px; max-width: 560px; }
+.tt__svg { display: block; width: 100%; height: 100%; }
+.tt__line { fill: none; stroke: var(--hy-line-2); stroke-width: 1.2; vector-effect: non-scaling-stroke; }
+.tt__dot {
+  position: absolute;
+  width: 7px; height: 7px;
+  margin: -3.5px 0 0 -3.5px;   /* centre on its own point */
+  border-radius: 50%;
+  box-shadow: 0 0 0 1.5px var(--hy-bg-2);
+}
+.tt__dot--start { background: var(--hy-dim); }
+/* Escalation costs more, so it reads in the expensive colour; easing off reads
+   as the cheap one. Same semantic ramp the cost tables use. */
+.tt__dot--up   { background: var(--hy-expensive); }
+.tt__dot--down { background: var(--hy-cheap); }
+.tt__axis { display: flex; justify-content: space-between; margin-top: 3px; max-width: 560px; }
+.tt__tick { font-family: var(--hy-font-mono); font-size: 9px; font-variant-numeric: tabular-nums; }
+.tt__tick--start { color: var(--hy-dim); }
+.tt__tick--up    { color: var(--hy-expensive); }
+.tt__tick--down  { color: var(--hy-cheap); }

--- a/desktop/frontend/src/views/Session.tsx
+++ b/desktop/frontend/src/views/Session.tsx
@@ -3,6 +3,7 @@ import type { Edit, Session as SessionData, TimelineEntry } from '../types'
 import { clockTime, ms, pct, usdExact } from '../format'
 import { SessionGraph } from './SessionGraph'
 import { Code } from './Code'
+import { TierTrack } from './TierTrack'
 
 export function Session({
   session,
@@ -102,7 +103,10 @@ export function Session({
               }}
             />
           ) : (
-            <Timeline entries={session.timeline} />
+            <>
+              <TierTrack entries={session.timeline} />
+              <Timeline entries={session.timeline} />
+            </>
           )}
         </>
       )}

--- a/desktop/frontend/src/views/TierTrack.test.tsx
+++ b/desktop/frontend/src/views/TierTrack.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { TierTrack, tierSteps } from './TierTrack'
+import type { TimelineEntry } from '../types'
+
+afterEach(cleanup)
+
+function e(kind: string, tier: number): TimelineEntry {
+  return { kind, ts: '', tier, costUsd: 0, durationMs: 0, confidence: 0 }
+}
+
+describe('when a track would mislead, it does not render', () => {
+  // A step line says "the router moved through these tiers in order". An SPRT
+  // ensemble runs sources in parallel, so drawing it that way states something
+  // false. Those get their own summary; this stays silent rather than lying.
+  it('renders nothing for an SPRT ensemble', () => {
+    expect(
+      tierSteps([e('head_selected', 3), e('sample', 2), e('sample', 6)]),
+    ).toBeNull()
+  })
+
+  it('renders nothing for a swarm fan-out', () => {
+    expect(
+      tierSteps([e('head_selected', 3), e('attempt', 2), e('attempt', 6)]),
+    ).toBeNull()
+  })
+
+  // Same reasoning Session already uses to hide its Graph tab on a linear run:
+  // a chart of a thing that did not move is noise.
+  it('renders nothing when the tier never changed', () => {
+    expect(tierSteps([e('head_selected', 6), e('dispatch_finished', 6)])).toBeNull()
+  })
+
+  it('renders nothing when no entry carries a tier', () => {
+    expect(tierSteps([e('run_started', 0), e('edit', 0)])).toBeNull()
+  })
+
+  it('mounts to nothing rather than an empty box', () => {
+    const { container } = render(<TierTrack entries={[e('head_selected', 6)]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('the sequence it extracts', () => {
+  it('collapses consecutive entries at the same tier into one step', () => {
+    const steps = tierSteps([
+      e('head_selected', 6),
+      e('dispatch_started', 6),
+      e('error', 6),
+      e('head_selected', 3),
+      e('dispatch_finished', 3),
+    ])
+    expect(steps).toEqual([
+      { tier: 6, held: 3 },
+      { tier: 3, held: 2 },
+    ])
+  })
+
+  it('keeps a return to an earlier tier as its own step, not a merge', () => {
+    const steps = tierSteps([e('head_selected', 6), e('head_selected', 3), e('head_selected', 6)])
+    expect(steps?.map((s) => s.tier)).toEqual([6, 3, 6])
+  })
+
+  it('ignores entries with no tier without breaking the run of one', () => {
+    const steps = tierSteps([e('head_selected', 6), e('edit', 0), e('dispatch_finished', 6)])
+    // The edit carries no tier, so tier 6 was never actually left.
+    expect(steps).toBeNull()
+  })
+})
+
+describe('what it says out loud', () => {
+  // Lower tier number is stronger, so 6 → 2 is an escalation, not a decrease.
+  it('calls a move to a stronger tier an escalation', () => {
+    render(<TierTrack entries={[e('head_selected', 6), e('head_selected', 2)]} />)
+    expect(screen.getByText(/escalated once · T6 → T2/)).toBeInTheDocument()
+  })
+
+  it('calls a move to a cheaper tier easing off', () => {
+    render(<TierTrack entries={[e('head_selected', 2), e('head_selected', 8)]} />)
+    expect(screen.getByText(/eased off once · T2 → T8/)).toBeInTheDocument()
+  })
+
+  it('does not claim a direction when it ended where it started', () => {
+    render(<TierTrack entries={[e('head_selected', 6), e('head_selected', 3), e('head_selected', 6)]} />)
+    expect(screen.getByText(/ended where it started/)).toBeInTheDocument()
+  })
+
+  it('counts multiple hops', () => {
+    render(
+      <TierTrack entries={[e('head_selected', 8), e('head_selected', 6), e('head_selected', 2)]} />,
+    )
+    expect(screen.getByText(/escalated 2 times/)).toBeInTheDocument()
+  })
+
+  it('gives the shape an accessible reading, not just a picture', () => {
+    render(<TierTrack entries={[e('head_selected', 6), e('head_selected', 2)]} />)
+    expect(screen.getByRole('img', { name: 'Tier movement: T6 then T2' })).toBeInTheDocument()
+  })
+})

--- a/desktop/frontend/src/views/TierTrack.tsx
+++ b/desktop/frontend/src/views/TierTrack.tsx
@@ -1,0 +1,135 @@
+import type { TimelineEntry } from '../types'
+
+/**
+ * Fewest tiers of vertical scale to draw, so a single one-tier hop does not
+ * fill the whole height and read as a dramatic swing.
+ */
+const MIN_SPAN = 3
+
+/**
+ * How the router moved through tiers across one run.
+ *
+ * Answers the question the Timeline cannot: did this escalate, or go straight to
+ * the tier it needed? The Timeline tags every row with its tier, but reading a
+ * *sequence* out of a list of rows is exactly the work this saves.
+ *
+ * Stronger tiers sit higher, because tier 1 is the strongest and a line that
+ * climbed reads as "this got harder" without a legend.
+ */
+export function TierTrack({ entries }: { entries: TimelineEntry[] }) {
+  const steps = tierSteps(entries)
+  if (steps === null) return null
+
+  const w = 100 // viewBox units; the SVG scales to its container
+  const h = 44
+  const pad = 7
+
+  // Scaled to the tiers this run actually used, not the full 1-10. Across a
+  // wide column the full range flattens a real escalation into a near-straight
+  // line. The trade-off: two runs' tracks are not comparable by height, which
+  // is why every point is labelled with its own tier below.
+  const tiers = steps.map((s) => s.tier)
+  const top = Math.min(...tiers)
+  const span = Math.max(Math.max(...tiers) - top, MIN_SPAN)
+  // Lower tier number is stronger, so it sits higher.
+  const y = (tier: number) => pad + ((tier - top) / span) * (h - pad * 2)
+  const x = (i: number) => (steps.length === 1 ? w / 2 : (i / (steps.length - 1)) * w)
+
+  // A step path, not a straight interpolation: the router held a tier and then
+  // jumped. Drawing a diagonal would imply it passed through the tiers between.
+  const d = steps
+    .map((s, i) => {
+      const px = x(i)
+      const py = y(s.tier)
+      if (i === 0) return `M ${px} ${py}`
+      return `L ${px} ${y(steps[i - 1].tier)} L ${px} ${py}`
+    })
+    .join(' ')
+
+  return (
+    <div className="tt">
+      <div className="tt__head">
+        <span className="tt__lbl">Tier movement</span>
+        <span className="tt__sum">{summary(steps)}</span>
+      </div>
+      {/* The line stretches with the column, so the SVG is non-uniformly
+          scaled. Circles cannot live in there — X scales ~10x and Y 1x, which
+          renders every dot as a wide smear. They go on top as HTML, positioned
+          in percent, so they stay round at any width. */}
+      <div className="tt__plot" role="img" aria-label={ariaLabel(steps)}>
+        <svg className="tt__svg" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" aria-hidden="true">
+          <path d={d} className="tt__line" />
+        </svg>
+        {steps.map((s, i) => (
+          <span
+            key={i}
+            className={`tt__dot tt__dot--${dir(steps, i)}`}
+            style={{ left: `${x(i)}%`, top: `${y(s.tier)}px` }}
+          />
+        ))}
+      </div>
+      <div className="tt__axis">
+        {steps.map((s, i) => (
+          <span key={i} className={`tt__tick tt__tick--${dir(steps, i)}`}>
+            T{s.tier}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface Step {
+  tier: number
+  /** How many timeline entries ran at this tier before it moved. */
+  held: number
+}
+
+/**
+ * The tier sequence, or null when a track would mislead rather than inform.
+ *
+ * Returns null for three distinct reasons, all deliberate:
+ *  - an SPRT ensemble (`sample`) or swarm (`attempt`) run, where heads run in
+ *    parallel: a step line implies the router moved through tiers in order, and
+ *    drawing parallel attempts that way would state something false. Those need
+ *    their own summary, which is a separate piece of work.
+ *  - fewer than two tiers: nothing moved, and a flat line is noise. Same
+ *    reasoning Session already uses to hide its Graph tab on a linear run.
+ *  - no tier data at all.
+ */
+export function tierSteps(entries: TimelineEntry[]): Step[] | null {
+  if (entries.some((e) => e.kind === 'sample' || e.kind === 'attempt')) return null
+
+  const steps: Step[] = []
+  for (const e of entries) {
+    if (!e.tier || e.tier <= 0) continue
+    const last = steps[steps.length - 1]
+    if (last && last.tier === e.tier) {
+      last.held++
+      continue
+    }
+    steps.push({ tier: e.tier, held: 1 })
+  }
+  return steps.length >= 2 ? steps : null
+}
+
+/** Whether this step was reached by escalating, easing off, or is the start. */
+function dir(steps: Step[], i: number): 'start' | 'up' | 'down' {
+  if (i === 0) return 'start'
+  // Lower tier number is stronger, so a decrease is an escalation.
+  return steps[i].tier < steps[i - 1].tier ? 'up' : 'down'
+}
+
+function summary(steps: Step[]): string {
+  const first = steps[0].tier
+  const last = steps[steps.length - 1].tier
+  const hops = steps.length - 1
+  const word = hops === 1 ? 'once' : `${hops} times`
+  if (last < first) return `escalated ${word} · T${first} → T${last}`
+  if (last > first) return `eased off ${word} · T${first} → T${last}`
+  return `moved ${word}, ended where it started · T${first}`
+}
+
+function ariaLabel(steps: Step[]): string {
+  return `Tier movement: ${steps.map((s) => `T${s.tier}`).join(' then ')}`
+}


### PR DESCRIPTION
Closes #521 — the "tiering movement" view from the original design feedback, built to the
direction settled on that issue: a sparkline that highlights where the tier changed, with
SPRT ensembles left to their own separate summary.

## What it answers
The Timeline already tags every row with its tier. What it cannot do is show a *sequence* —
whether a run escalated or went straight to the tier it needed. This states it in one line
("escalated 2 times · T8 → T2") and draws the shape above the rows it summarises.

## When it deliberately renders nothing
Three cases, each for its own reason:
- **SPRT (`sample`) or swarm (`attempt`) runs.** A step line asserts the router moved
  through tiers *in order*. Those run heads in parallel, so drawing them that way would
  state something false. This is the split you called for on the issue, and it is enforced
  in `tierSteps` rather than left to the caller.
- **The tier never changed.** A flat line is noise. Same reasoning Session already uses to
  hide its Graph tab on a linear run.
- **No entry carries a tier.**

## Two bugs only the screenshots caught
Tests passed and the values were right both times.

**Circles cannot live in a non-uniformly scaled viewBox.** With
`preserveAspectRatio="none"`, X scaled ~11× while Y stayed 1×, so every dot rendered as a
horizontal smear. `vector-effect: non-scaling-stroke` fixes strokes, not filled geometry.
The dots are now HTML positioned in percent over the stretched SVG, verified round by
measuring (`7x7` each).

**Mapping tiers 1–10 into a full-width strip flattens a real escalation.** 10 tiers across
34px is 2.7px per tier, invisible next to 1150px of width. It now scales to the tiers the
run actually used, with a `MIN_SPAN` floor so a single hop is not a full-height swing, and
the plot is width-capped because a 26:1 sparkline is a straight line no matter the data.
The trade-off, noted in the code: two runs' tracks are not comparable by height, which is
why each point carries its own tier label.

## Testing
14 new tests, 27/27 total. They cover the gating (ensemble, swarm, no movement, no tier
data, and that it mounts to nothing rather than an empty box), the sequence extraction
(collapsing consecutive same-tier entries, keeping a return to an earlier tier as its own
step, ignoring untiered entries without falsely breaking a run), and the wording —
including that a move to a *lower number* is called an escalation, since that is the easy
thing to get backwards.

`typecheck`, `build` clean.