### PR TITLE
feat(ledger): add an Ask verdict, and admit only Allow at the dispatch gates

### DIFF
--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -966,3 +966,37 @@ func TestTruncate(t *testing.T) {
 		t.Errorf("truncate(\"\") = %q", got)
 	}
 }
+
+// An Ask rule must withhold permission exactly like a deny does, until the
+// pause-and-resume path exists to act on it (#582).
+//
+// This is the regression that made #580 more than a new constant: this gate used
+// to test `decision == ledger.Deny`, so any other verdict fell straight through
+// and the head ran. A pending question would have been an approval.
+func TestDispatch_LedgerAskRuleDoesNotLetTheHeadRun(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	writeLedgerPolicy(t, ledger.Policy{Rules: []ledger.Rule{{Tool: "pending", Decision: ledger.Ask}}})
+
+	res, err := liveDispatcher(echoHead(t, s, "pending", 95), echoHead(t, s, "ok", 90)).
+		Dispatch(context.Background(), "go", Options{})
+	if err != nil {
+		t.Fatalf("dispatch gave up instead of falling back past the asked head: %v", err)
+	}
+	if res.Head.ID != "ok" {
+		t.Errorf("answered by %q, want the fallback head — an unanswered Ask must not run", res.Head.ID)
+	}
+
+	events, err := ledger.Load(ledger.DefaultPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawAsk bool
+	for _, e := range events {
+		if e.Tool == "pending" && e.Decision == ledger.Ask {
+			sawAsk = true
+		}
+	}
+	if !sawAsk {
+		t.Errorf("no ask event recorded for the pending head: %+v", events)
+	}
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -280,13 +280,18 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 			Head: h.ID, Model: h.Name, Tier: tier,
 			Detail: fmt.Sprintf("candidate %d of %d", i+1, len(candidates)),
 		})
-		// Fails closed like ledger.Check itself: a policy-check error (unreadable
+		// Proceeds only on an explicit Allow. Testing `== Deny` instead would
+		// let any other verdict through, which stopped being safe the moment
+		// Deny was not the only one that withholds permission — a pending
+		// ledger.Ask would have read as approval (#580).
+		//
+		// Fails closed the same way on error: a policy-check failure (unreadable
 		// policy file, ledger write failure) must deny, not silently let the
 		// candidate through just because the decision couldn't be computed.
 		// CheckAndRecordDispatch's LoadPolicy is itself mtime-cached, so trying
 		// every candidate against the same prompt no longer re-reads and
 		// re-parses the identical policy file from disk once per candidate.
-		if decision, lerr := ledger.CheckAndRecordDispatch("hydra-dispatch", h.ID, opts.Resource, prompt, class); lerr != nil || decision == ledger.Deny {
+		if decision, lerr := ledger.CheckAndRecordDispatch("hydra-dispatch", h.ID, opts.Resource, prompt, class); lerr != nil || decision != ledger.Allow {
 			detail := "denied by ledger policy"
 			if lerr != nil {
 				detail = "ledger policy check failed: " + lerr.Error()

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -43,6 +43,15 @@ type Decision string
 const (
 	Allow Decision = "allow"
 	Deny  Decision = "deny"
+
+	// Ask means the access needs a human's confirmation before it happens: not
+	// permitted, not refused, pending. It is never a fallback — only an explicit
+	// rule match produces it, because a failure path that returned Ask would
+	// turn a policy bug into a prompt instead of a block (#580).
+	//
+	// Callers must treat it as "do not proceed". Every gate here admits only
+	// Allow, so an unanswered Ask can never read as consent.
+	Ask Decision = "ask"
 )
 
 // ParseAction normalizes and validates an action string. Matching is exact, so
@@ -61,16 +70,16 @@ func ParseAction(s string) (Action, error) {
 }
 
 // ParseDecision normalizes and validates a decision string. An unrecognized
-// value is rejected because callers gate on Deny exactly: a decision of "DENY"
-// or "block" would print like a denial while comparing unequal to Deny.
+// value is rejected because callers gate on the exact value: a decision of
+// "DENY" or "block" would print like a denial while comparing unequal to Deny.
 func ParseDecision(s string) (Decision, error) {
 	switch d := Decision(strings.ToLower(strings.TrimSpace(s))); d {
-	case Allow, Deny:
+	case Allow, Deny, Ask:
 		return d, nil
 	case "":
-		return "", fmt.Errorf("decision is required (allow|deny)")
+		return "", fmt.Errorf("decision is required (allow|deny|ask)")
 	default:
-		return "", fmt.Errorf("unknown decision %q (want allow|deny)", s)
+		return "", fmt.Errorf("unknown decision %q (want allow|deny|ask)", s)
 	}
 }
 
@@ -666,8 +675,11 @@ var (
 // the accountability gate. It returns the decision.
 //
 // Check fails closed: if the request's parameters cannot be hashed, it returns
-// Deny (and records that denial) rather than a zero Decision, so a caller that
-// only tests `decision == Deny` can never be tricked into proceeding.
+// Deny (and records that denial) rather than a zero Decision.
+//
+// Callers must gate on `decision != Allow`, not `== Deny`. Deny is no longer
+// the only verdict that withholds permission — Ask does too — so testing for
+// Deny alone would let a pending question through as if it were approval.
 func Check(path string, p Policy, req CheckRequest) (Decision, error) {
 	classification := NormalizeClassification(req.Classification)
 	piiTypes := req.PIITypes

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -1014,3 +1014,64 @@ func TestRecord_SanitizesFreeTextFieldsAtIngest(t *testing.T) {
 		})
 	}
 }
+
+// Ask is a real verdict a policy file can carry, so it has to survive parsing
+// and normalisation the same way allow/deny do (#580).
+func TestParseDecision_AcceptsAskAndNormalisesCase(t *testing.T) {
+	for _, in := range []string{"ask", "ASK", " Ask "} {
+		got, err := ParseDecision(in)
+		if err != nil {
+			t.Fatalf("ParseDecision(%q) errored: %v", in, err)
+		}
+		if got != Ask {
+			t.Errorf("ParseDecision(%q) = %q, want %q", in, got, Ask)
+		}
+	}
+	if _, err := ParseDecision("maybe"); err == nil {
+		t.Error("an unknown decision was accepted; rules gate on the exact value")
+	}
+}
+
+// The whole point of Ask is that it is NOT approval. LatestBound is what finds
+// the approval a later execution is verified against, and it admits Allow only.
+// If that ever loosened, an unanswered question would become consent.
+func TestLatestBound_AskIsNotAnApproval(t *testing.T) {
+	hash, err := HashParams(map[string]any{"file": "/etc/hosts"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := []Event{{
+		Agent: "a", Tool: "read_file", Resource: "/etc/hosts", Action: Read,
+		Decision: Ask, ParametersHash: hash,
+	}}
+
+	if _, ok := LatestBound(events, "read_file", "/etc/hosts"); ok {
+		t.Fatal("an Ask event was returned as the binding approval — a pending question read as consent")
+	}
+
+	// Control: the same event as an Allow is found, so the test is proving the
+	// decision filter and not something incidental about the fixture.
+	events[0].Decision = Allow
+	if _, ok := LatestBound(events, "read_file", "/etc/hosts"); !ok {
+		t.Fatal("an Allow event was not found; the fixture is wrong, not the filter")
+	}
+}
+
+// Ask must never come out of a failure path. Unhashable params still deny, so a
+// policy or plumbing bug cannot degrade into an interactive prompt.
+func TestCheck_UnhashableParamsStillDeniesNeverAsks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ledger.jsonl")
+
+	// A channel cannot be marshalled, so HashParams fails.
+	got, err := Check(path, Policy{Default: Ask}, CheckRequest{
+		Agent: "a", Tool: "t", Resource: "r", Action: Read,
+		Params: map[string]any{"bad": make(chan int)},
+	})
+	if err == nil {
+		t.Fatal("expected an error for unhashable params")
+	}
+	if got != Deny {
+		t.Errorf("Check = %q on unhashable params, want %q — a failure path must not ask", got, Deny)
+	}
+}

--- a/internal/swarm/runner.go
+++ b/internal/swarm/runner.go
@@ -45,11 +45,14 @@ func executeHead(ctx context.Context, h provider.Head, prompt string, opts Optio
 		StartedAt: time.Now(),
 	}
 
-	// Fails closed like ledger.Check itself: a policy-check error must deny,
-	// not silently let the head run just because the decision couldn't be computed.
+	// Proceeds only on an explicit Allow — see the same gate in dispatch.go for
+	// why `== Deny` is not sufficient now that Ask also withholds permission.
+	//
+	// Fails closed the same way on error: a policy-check failure must deny, not
+	// silently let the head run because the decision couldn't be computed.
 	// opts.Classification is resolved once by Run/RunSPRT before any head fires,
 	// so concurrent calls here reuse it instead of each re-scanning prompt (#522).
-	if decision, err := ledger.CheckAndRecordDispatch("hydra-swarm", h.ID, "", prompt, opts.Classification); err != nil || decision == ledger.Deny {
+	if decision, err := ledger.CheckAndRecordDispatch("hydra-swarm", h.ID, "", prompt, opts.Classification); err != nil || decision != ledger.Allow {
 		a.FinishedAt = time.Now()
 		a.Duration = a.FinishedAt.Sub(a.StartedAt)
 		a.Status = StatusFailed


### PR DESCRIPTION
Closes #580. Part 1 of 3 for #517 (then #582, #583).

## The finding that made this bigger than a new constant
`Ask` itself is four lines. The real work was what I found checking its callers:

Both gates that consume a ledger verdict tested `decision == ledger.Deny` and proceeded
otherwise — `internal/dispatch/dispatch.go` and `internal/swarm/runner.go`. That was only
ever safe because `Deny` was the *sole* non-Allow value. Land `Ask` without touching them
and **a pending question falls through as approval and the head runs**. That is precisely
the "unanswered question becomes a silent yes" failure I flagged when filing the issue,
sitting one constant away from being real.

Both now proceed on an explicit `Allow` and nothing else. That is the correct posture for a
security gate regardless of this feature, and it hardens them against any verdict added
later.

## Kept intact
- **`Ask` is never a fallback.** The unhashable-params path still hardcodes `Deny`, so a
  policy or plumbing bug cannot degrade into an interactive prompt.
- **`LatestBound` still admits `Allow` only** — an `Ask` event is not the binding approval
  a later execution verifies against. Tested with an Allow control alongside, so the test
  proves the decision filter rather than something incidental about the fixture.

## Inert on its own
Nothing pauses yet. An `ask` rule currently withholds permission and dispatch falls through
to the next candidate, exactly like a deny. #582 teaches dispatch to park the task instead;
#583 surfaces the question. Landing the verdict alone keeps each piece reviewable and leaves
no window where `Ask` means "proceed".

## Verified the regression test is load-bearing
A test that passes with and without the fix proves nothing, so I reverted the gate to
`== Deny` and re-ran:

```
--- FAIL: TestDispatch_LedgerAskRuleDoesNotLetTheHeadRun
    answered by "pending", want the fallback head — an unanswered Ask must not run
```

The asked head ran. Restored, it passes.

## Testing
`gofmt`, `go vet`, and `-race -count=1` clean on ledger, dispatch, swarm and security.

**Pre-existing failure, not from this branch:** `TestPlanRunRunSPRT_RejectBadA2AFileIdentically`
fails in my sandbox on config.toml path text. Confirmed identical on unmodified
`origin/develop`; it is a `$TMPDIR` artifact and CI passes it.