### PR TITLE
test(mcp): close mcpregistry coverage gaps; fix a real docker-heuristic bug

### DIFF
--- a/internal/mcpregistry/audit_test.go
+++ b/internal/mcpregistry/audit_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -140,6 +141,45 @@ func TestAudit_PersistsAliasesSoClassificationForToolWorksAfterward(t *testing.T
 	}
 	if _, flagged := ClassificationForTool("mcp__fetch__something"); flagged {
 		t.Error("a freshly-provisional server should not be flagged")
+	}
+}
+
+func TestAudit_CorruptCacheFileIsAnError(t *testing.T) {
+	withTempHydraHome(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if err := os.WriteFile(cachePath(), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Audit(context.Background(), ""); err == nil {
+		t.Fatal("a corrupt registry cache must fail the audit, not silently proceed with no registry data")
+	}
+}
+
+func TestAudit_CorruptStateFileIsAnError(t *testing.T) {
+	withTempHydraHome(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if err := os.WriteFile(statePath(), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Audit(context.Background(), ""); err == nil {
+		t.Fatal("a corrupt lifecycle-state file must fail the audit, not silently discard history")
+	}
+}
+
+func TestAudit_CorruptAliasesFileIsAnError(t *testing.T) {
+	withTempHydraHome(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	if err := os.WriteFile(aliasPath(), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Audit(context.Background(), ""); err == nil {
+		t.Fatal("a corrupt aliases file must fail the audit, not silently discard history")
 	}
 }
 

--- a/internal/mcpregistry/classify_test.go
+++ b/internal/mcpregistry/classify_test.go
@@ -2,7 +2,11 @@
 
 package mcpregistry
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestParseMCPToolName(t *testing.T) {
 	tests := []struct {
@@ -49,6 +53,62 @@ func TestSaveLoadAliases_RoundTrip(t *testing.T) {
 	}
 	if got["grafana"].RegistryName != "docker.io/grafana/mcp-grafana" {
 		t.Errorf("round-tripped alias = %+v", got["grafana"])
+	}
+}
+
+func TestLoadAliases_CorruptFileIsAnError(t *testing.T) {
+	withTempHydraHome(t)
+	path := aliasPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadAliases(); err == nil {
+		t.Fatal("a corrupt aliases file must surface as an error, not silently yield an empty map")
+	}
+}
+
+func TestClassificationForTool_DelistedServerIsClassifiedAsQuarantined(t *testing.T) {
+	withTempHydraHome(t)
+	if err := SaveAliases(map[string]aliasEntry{"gone": {RegistryName: "io.github.x/gone", Status: StatusVerified}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveStates(map[string]ServerState{"io.github.x/gone": {State: StateDelisted}}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := ClassificationForTool("mcp__gone__do_thing")
+	if !ok || got != ClassMCPQuarantined {
+		t.Errorf("got (%q, %v), want (%q, true) — delisted is grouped with quarantined", got, ok, ClassMCPQuarantined)
+	}
+}
+
+func TestClassificationForTool_CorruptAliasesFileFailsClosed(t *testing.T) {
+	withTempHydraHome(t)
+	path := aliasPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ClassificationForTool("mcp__anything__tool"); ok {
+		t.Error("a corrupt aliases file must fail closed (no classification), not error out of the ledger check path")
+	}
+}
+
+func TestClassificationForTool_CorruptStatesFileFailsClosed(t *testing.T) {
+	withTempHydraHome(t)
+	if err := SaveAliases(map[string]aliasEntry{"x": {RegistryName: "io.github.x/x", Status: StatusVerified}}); err != nil {
+		t.Fatal(err)
+	}
+	path := statePath()
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ClassificationForTool("mcp__x__tool"); ok {
+		t.Error("a corrupt states file must fail closed (no classification), not error out of the ledger check path")
 	}
 }
 

--- a/internal/mcpregistry/export_test.go
+++ b/internal/mcpregistry/export_test.go
@@ -56,6 +56,34 @@ func TestDirectory_MatchesWhatExportWrites(t *testing.T) {
 	}
 }
 
+func TestExportDirectory_PropagatesDirectoryError(t *testing.T) {
+	withTempHydraHome(t)
+	if err := os.WriteFile(statePath(), []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ExportDirectory(t.TempDir()); err == nil {
+		t.Fatal("a corrupt state file should fail the export, not silently write an empty directory")
+	}
+}
+
+// A file sitting where the output directory needs to go is a portable way
+// to make MkdirAll fail on every OS, without relying on permission bits
+// (which Windows doesn't enforce the same way — see internal/config's
+// equivalent test for the same reasoning).
+func TestExportDirectory_MkdirAllFailureIsAnError(t *testing.T) {
+	withTempHydraHome(t)
+	parent := t.TempDir()
+	blocked := filepath.Join(parent, "blocked")
+	if err := os.WriteFile(blocked, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// outDir itself is a file, so MkdirAll(outDir, ...) must fail: it can't
+	// turn a file into a directory.
+	if _, err := ExportDirectory(blocked); err == nil {
+		t.Fatal("expected an error when outDir already exists as a regular file")
+	}
+}
+
 func TestExportDirectory_NoStatesWritesEmptyDirectory(t *testing.T) {
 	withTempHydraHome(t)
 	out := t.TempDir()

--- a/internal/mcpregistry/lifecycle_test.go
+++ b/internal/mcpregistry/lifecycle_test.go
@@ -3,6 +3,8 @@
 package mcpregistry
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -138,6 +140,20 @@ func TestAdvance_StateChangedAtOnlyUpdatesOnTransition(t *testing.T) {
 	next := Advance(&prev, srv, cleanScore(), time.Now())
 	if !next.StateChangedAt.Equal(changedAt) {
 		t.Errorf("StateChangedAt should be unchanged when the state doesn't transition")
+	}
+}
+
+func TestLoadStates_CorruptFileIsAnError(t *testing.T) {
+	withTempHydraHome(t)
+	path := statePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadStates(); err == nil {
+		t.Fatal("a corrupt state file must surface as an error, not silently yield an empty map")
 	}
 }
 

--- a/internal/mcpregistry/scan.go
+++ b/internal/mcpregistry/scan.go
@@ -83,11 +83,18 @@ func claudeDesktopConfigPath() string {
 	if err != nil {
 		return ""
 	}
-	switch runtime.GOOS {
+	return claudeDesktopConfigPathFor(runtime.GOOS, home, os.Getenv("APPDATA"))
+}
+
+// claudeDesktopConfigPathFor is the pure, OS-parameterized core of
+// claudeDesktopConfigPath — split out so all three platform branches are
+// unit-testable on every CI runner, not just whichever OS happens to be
+// running the test (goos/appData wouldn't otherwise vary within one job).
+func claudeDesktopConfigPathFor(goos, home, appData string) string {
+	switch goos {
 	case "darwin":
 		return filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json")
 	case "windows":
-		appData := os.Getenv("APPDATA")
 		if appData == "" {
 			return ""
 		}
@@ -166,6 +173,11 @@ func toInstalledServers(servers map[string]clientServerConfig, client, scope str
 	return out
 }
 
+// dockerSubcommands are bare tokens that appear in a docker invocation but
+// are never the image — excluded so a config with only flags and no real
+// image argument doesn't misresolve one of these as if it were the image.
+var dockerSubcommands = map[string]bool{"run": true, "exec": true, "start": true}
+
 // resolvePackage makes a best-effort guess at the package identifier a
 // stdio launcher command runs, so it can be matched against the registry's
 // packages[].identifier. Deliberately conservative: an unresolved package
@@ -181,11 +193,14 @@ func resolvePackage(command string, args []string) string {
 		}
 	case "docker":
 		// Best-effort: the image is usually the last bare token that isn't
-		// a flag and doesn't look like an env-style KEY=VALUE pair passed
-		// to a preceding -e/--env flag.
+		// a flag, doesn't look like an env-style KEY=VALUE pair passed to a
+		// preceding -e/--env flag, and isn't the docker subcommand itself
+		// ("run"/"exec"/"start" are bare tokens too — a config with only
+		// flags and no real image argument would otherwise misresolve one
+		// of these as if it were the image).
 		for i := len(args) - 1; i >= 0; i-- {
 			a := args[i]
-			if strings.HasPrefix(a, "-") || strings.Contains(a, "=") {
+			if strings.HasPrefix(a, "-") || strings.Contains(a, "=") || dockerSubcommands[a] {
 				continue
 			}
 			return a

--- a/internal/mcpregistry/scan_files_test.go
+++ b/internal/mcpregistry/scan_files_test.go
@@ -56,6 +56,26 @@ func TestScanMCPServersFile_ParsesEntries(t *testing.T) {
 	}
 }
 
+func TestScanMCPServersFile_MalformedJSONIsNotAnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+	writeJSON(t, path, `{not valid json`)
+	out := scanMCPServersFile(path, "cursor", "user")
+	if out != nil {
+		t.Errorf("expected nil for a malformed config file, got %v", out)
+	}
+}
+
+func TestScanVSCodeFile_MalformedJSONIsNotAnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+	writeJSON(t, path, `{not valid json`)
+	out := scanVSCodeFile(path)
+	if out != nil {
+		t.Errorf("expected nil for a malformed config file, got %v", out)
+	}
+}
+
 func TestScanVSCodeFile_UsesServersKey(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mcp.json")
@@ -70,6 +90,38 @@ func TestScanVSCodeFile_UsesServersKey(t *testing.T) {
 	}
 	if out[0].Client != "vscode" {
 		t.Errorf("Client = %q, want vscode", out[0].Client)
+	}
+}
+
+func TestScan_ProjectScopedCwdIncludesCursorAndVSCodeProjectConfigs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	proj := t.TempDir()
+	writeJSON(t, filepath.Join(proj, ".cursor", "mcp.json"),
+		`{"mcpServers": {"proj-cursor": {"type":"stdio","command":"npx","args":["-y","proj-cursor-pkg"]}}}`)
+	writeJSON(t, filepath.Join(proj, ".vscode", "mcp.json"),
+		`{"servers": {"proj-vscode": {"type":"stdio","command":"npx","args":["-y","proj-vscode-pkg"]}}}`)
+
+	withCwd := Scan(proj)
+	withoutCwd := Scan("")
+
+	var sawCursor, sawVSCode bool
+	for _, s := range withCwd {
+		if s.Name == "proj-cursor" && s.Scope == "project" {
+			sawCursor = true
+		}
+		if s.Name == "proj-vscode" {
+			sawVSCode = true
+		}
+	}
+	if !sawCursor || !sawVSCode {
+		t.Errorf("expected project-scoped cursor and vscode entries when cwd is set, got %+v", withCwd)
+	}
+	for _, s := range withoutCwd {
+		if s.Name == "proj-cursor" || s.Name == "proj-vscode" {
+			t.Errorf("project-scoped entries must not appear when cwd is empty, got %+v", withoutCwd)
+		}
 	}
 }
 

--- a/internal/mcpregistry/scan_test.go
+++ b/internal/mcpregistry/scan_test.go
@@ -4,6 +4,7 @@ package mcpregistry
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 )
 
@@ -20,6 +21,7 @@ func TestResolvePackage(t *testing.T) {
 		{"npx only flags, no package", "npx", []string{"-y", "--silent"}, ""},
 		{"docker run with flags and image", "docker", []string{"run", "-i", "--rm", "-e", "API_KEY=secret", "mcp/fetch"}, "mcp/fetch"},
 		{"docker run image with tag", "docker", []string{"run", "--rm", "ghcr.io/foo/bar:latest"}, "ghcr.io/foo/bar:latest"},
+		{"docker with only flags, no image found", "docker", []string{"run", "-i", "--rm", "-e", "KEY=val"}, ""},
 		{"unknown launcher", "/usr/local/bin/my-server", []string{"--config", "x.json"}, ""},
 		{"absolute path to npx", "/usr/local/bin/npx", []string{"-y", "some-pkg"}, "some-pkg"},
 		{"no args at all", "npx", nil, ""},
@@ -28,6 +30,30 @@ func TestResolvePackage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := resolvePackage(tt.command, tt.args); got != tt.want {
 				t.Errorf("resolvePackage(%q, %v) = %q, want %q", tt.command, tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClaudeDesktopConfigPathFor_AllThreePlatforms(t *testing.T) {
+	// filepath.Join uses the test-running host's own separator regardless of
+	// the goos argument (it isn't itself GOOS-aware) — so "want" is computed
+	// with the same filepath.Join calls the function under test makes,
+	// rather than a hardcoded separator that would only be right on one host.
+	home, appData := "/Users/x", "/Users/x/AppData/Roaming"
+	tests := []struct {
+		name, goos, home, appData string
+		want                      string
+	}{
+		{"darwin", "darwin", home, "", filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json")},
+		{"windows with appdata", "windows", home, appData, filepath.Join(appData, "Claude", "claude_desktop_config.json")},
+		{"windows without appdata", "windows", home, "", ""},
+		{"linux/default", "linux", home, "", filepath.Join(home, ".config", "Claude", "claude_desktop_config.json")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := claudeDesktopConfigPathFor(tt.goos, tt.home, tt.appData); got != tt.want {
+				t.Errorf("claudeDesktopConfigPathFor(%q, %q, %q) = %q, want %q", tt.goos, tt.home, tt.appData, got, tt.want)
 			}
 		})
 	}

--- a/internal/mcpregistry/score_test.go
+++ b/internal/mcpregistry/score_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestLevenshtein(t *testing.T) {
@@ -53,6 +54,19 @@ func TestTyposquatSignal_NoFlagWhenNothingClose(t *testing.T) {
 	}
 }
 
+func TestTyposquatSignal_SkipsEmptyIdentifiersOnBothSides(t *testing.T) {
+	target := ServerRecord{Name: "a", Packages: []Package{{Identifier: ""}, {Identifier: "real-name"}}}
+	corpus := []ServerRecord{
+		target,
+		{Name: "b", Packages: []Package{{Identifier: ""}}},
+		{Name: "c", Packages: []Package{{Identifier: "totally-different-string"}}},
+	}
+	sig := typosquatSignal(target, corpus)
+	if !sig.Available || sig.Impact != 0 {
+		t.Fatalf("empty identifiers on either side must never be compared, got %+v", sig)
+	}
+}
+
 func TestNearestIdentifier(t *testing.T) {
 	corpus := []ServerRecord{
 		{Packages: []Package{{Identifier: "chrome-devtools-mcp"}}},
@@ -67,6 +81,17 @@ func TestNearestIdentifier(t *testing.T) {
 	}
 }
 
+func TestNearestIdentifier_SkipsEmptyIdentifiersInCorpus(t *testing.T) {
+	corpus := []ServerRecord{
+		{Packages: []Package{{Identifier: ""}}},
+		{Packages: []Package{{Identifier: "real-candidate"}}},
+	}
+	nearest, dist := NearestIdentifier("real-candidat", corpus)
+	if nearest != "real-candidate" || dist != 1 {
+		t.Errorf("got (%q, %d), want (\"real-candidate\", 1) — the empty identifier must never be returned as the nearest match", nearest, dist)
+	}
+}
+
 func TestNearestIdentifier_EmptyCorpus(t *testing.T) {
 	nearest, dist := NearestIdentifier("anything", nil)
 	if nearest != "" || dist != -1 {
@@ -78,6 +103,43 @@ func TestKnownBadSignal_UnsupportedEcosystemIsUnavailable(t *testing.T) {
 	sig := knownBadSignal(context.Background(), Package{RegistryType: "docker", Identifier: "x"})
 	if sig.Available {
 		t.Errorf("docker packages have no OSV ecosystem yet; expected Available=false, got %+v", sig)
+	}
+}
+
+func TestKnownBadSignal_EmptyIdentifierIsUnavailable(t *testing.T) {
+	sig := knownBadSignal(context.Background(), Package{RegistryType: "npm", Identifier: ""})
+	if sig.Available {
+		t.Errorf("an unresolved (empty) identifier has nothing to query; expected Available=false, got %+v", sig)
+	}
+}
+
+func TestKnownBadSignal_NonOKStatusIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	orig := osvQueryURL
+	osvQueryURL = srv.URL
+	defer func() { osvQueryURL = orig }()
+
+	sig := knownBadSignal(context.Background(), Package{RegistryType: "npm", Identifier: "x"})
+	if sig.Available {
+		t.Errorf("a 500 from OSV.dev must not be treated as evaluated evidence, got %+v", sig)
+	}
+}
+
+func TestKnownBadSignal_MalformedResponseIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+	orig := osvQueryURL
+	osvQueryURL = srv.URL
+	defer func() { osvQueryURL = orig }()
+
+	sig := knownBadSignal(context.Background(), Package{RegistryType: "npm", Identifier: "x"})
+	if sig.Available {
+		t.Errorf("a malformed response body must not be treated as evaluated evidence, got %+v", sig)
 	}
 }
 
@@ -185,6 +247,70 @@ func TestMaintenanceSignal_ArchivedIsPenalized(t *testing.T) {
 	}
 }
 
+func TestMaintenanceSignal_RateLimitedIsUnavailableWithDetail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	orig := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = orig }()
+
+	sig := maintenanceSignal(context.Background(), "https://github.com/foo/bar")
+	if sig.Available {
+		t.Errorf("a rate-limited response must not be treated as evaluated evidence, got %+v", sig)
+	}
+	if sig.Detail == "" {
+		t.Error("expected a detail explaining why this signal is unavailable")
+	}
+}
+
+func TestMaintenanceSignal_RecentPushIsNeutral(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(githubRepo{PushedAt: time.Now().Add(-24 * time.Hour)})
+	}))
+	defer srv.Close()
+	orig := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = orig }()
+
+	sig := maintenanceSignal(context.Background(), "https://github.com/foo/bar")
+	if !sig.Available || sig.Impact != 0 {
+		t.Fatalf("a recently-pushed, non-archived repo should be a neutral available signal, got %+v", sig)
+	}
+}
+
+func TestMaintenanceSignal_StalePushIsPenalized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(githubRepo{PushedAt: time.Now().Add(-365 * 24 * time.Hour)})
+	}))
+	defer srv.Close()
+	orig := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = orig }()
+
+	sig := maintenanceSignal(context.Background(), "https://github.com/foo/bar")
+	if !sig.Available || sig.Impact >= 0 {
+		t.Fatalf("a year-stale repo should be penalized, got %+v", sig)
+	}
+}
+
+func TestMaintenanceSignal_NonOKStatusIsUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	orig := githubAPIBase
+	githubAPIBase = srv.URL
+	defer func() { githubAPIBase = orig }()
+
+	sig := maintenanceSignal(context.Background(), "https://github.com/foo/bar")
+	if sig.Available {
+		t.Errorf("a 404 (e.g. deleted repo) must not be treated as evaluated evidence, got %+v", sig)
+	}
+}
+
 func TestDeclaredAuthSignal_StdioIsNotApplicable(t *testing.T) {
 	sig := declaredAuthSignal(ServerRecord{})
 	if sig.Available {
@@ -253,6 +379,27 @@ func TestComputeScore_InsufficientEvidenceOverallWhenNothingResolves(t *testing.
 	}
 	if score.CommunityGovernance.Confidence == ConfidenceInsufficient {
 		t.Errorf("CommunityGovernance should always have the baseline registry-presence signal available")
+	}
+}
+
+func TestOverallConfidence_AllFourBands(t *testing.T) {
+	tests := []struct {
+		weightSum float64
+		want      Confidence
+	}{
+		{0, ConfidenceInsufficient},
+		{-1, ConfidenceInsufficient},
+		{weightCommunityGovernance, ConfidenceLow},                                                          // 0.15
+		{weightSecurityImplementation, ConfidenceLow},                                                       // 0.35
+		{weightSecurityImplementation + weightCommunityGovernance, ConfidenceModerate},                      // 0.50
+		{weightSecurityImplementation + weightRepositoryHealth, ConfidenceModerate},                         // 0.60
+		{weightSecurityImplementation + weightRepositoryHealth + weightOperationalSecurity, ConfidenceHigh}, // 0.85
+		{1.0, ConfidenceHigh},
+	}
+	for _, tt := range tests {
+		if got := overallConfidence(tt.weightSum); got != tt.want {
+			t.Errorf("overallConfidence(%v) = %q, want %q", tt.weightSum, got, tt.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Directly asked whether test coverage was comprehensive. Checked with \`go tool cover\` rather than asserting it — it wasn't: 85.3%, with real gaps, not just cosmetic ones.

## What was actually missing
- \`overallConfidence\` — the low/moderate confidence bands were never exercised, only insufficient/high
- \`claudeDesktopConfigPath\` — an OS-dispatch function only checkable on whichever OS happened to run the test; extracted \`claudeDesktopConfigPathFor\` as a pure, parameterized core so all three platform branches (darwin/windows/linux) are tested in one run
- \`maintenanceSignal\`/\`knownBadSignal\` — rate-limit (403 + X-RateLimit-Remaining:0), non-200, and malformed-response paths never simulated
- \`LoadStates\`/\`LoadAliases\`/\`Audit\`/\`ExportDirectory\`/\`ClassificationForTool\` — corrupt-file and error-propagation paths untested; now confirms these fail closed/loud rather than silently discarding history
- \`typosquatSignal\`/\`NearestIdentifier\` — empty-identifier skip paths
- \`Scan\` — no direct test at all; only exercised indirectly through \`Audit\`, so project-scoped vs. user-scoped discovery had no dedicated coverage

## Found a real bug, not just closed a number
Writing the docker-heuristic edge case test caught this: \`docker run -i --rm -e KEY=val\` (all flags, no real image argument) resolved package identifier to \`"run"\` instead of \`""\` — the heuristic scans backward for the last bare token and didn't know to exclude the docker subcommand itself. Fixed by excluding known subcommands (\`run\`/\`exec\`/\`start\`) from the search.

## Honest about what's still open
92.0% now, up from 85.3%. What's left is almost entirely OS-permission-dependent and cross-device-rename fallback branches (the atomic-rename fallback in \`SaveStates\`/\`SaveAliases\`, \`os.UserHomeDir()\` failing) — can't be triggered portably across macOS/Linux/Windows CI without OS-conditional skips, the same category \`internal/config\`'s own tests already skip on Windows for the identical reason. These are simple \`if err != nil { return err }\` pass-throughs, not places a real logic bug could hide.

## Test plan
- [x] \`go test -race -count=1 ./internal/mcpregistry/... ./cmd/hydra/...\` — all pass
- [x] \`go vet ./...\`, \`gofmt -l\` clean
- [x] Coverage: 85.3% → 92.0%

Closes #587