### PR TITLE
docs: add the MCP registry to index.html and README's feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,31 @@ assertions rather than measurements, defect cost is **per-occurrence and not
 annualised**, a file the dependency graph does not index is **unknown** and never
 "low-risk", and the attestation is **unsigned** because Hydra has no key management.
 
+### 🧩 MCP Server Trust Registry (`hyctl mcp registry`)
+
+The ledger above records what an agent *did*. This scores whether the MCP server it
+was talking to was ever safe to trust in the first place. Every existing MCP directory
+answers "does this server exist" — none answer "is it safe to run with my credentials
+right now," and star/download counts are actively misleading (the most-starred
+servers score worst on quality in independent research).
+
+```
+hyctl mcp registry sync       # pull the official MCP registry into a local cache
+hyctl mcp registry scan       # find servers installed across Claude Code/Desktop, Cursor, Windsurf, VS Code
+hyctl mcp registry audit      # resolve + score them, advance lifecycle state
+hyctl mcp registry backtest   # prove the pipeline still catches real incidents (postmark-mcp, CVE-2025-6514)
+```
+
+Scoring follows the CSA MCP Selection Scorecard's four categories — automating a
+taxonomy the MCP Security Working Group already endorsed, not inventing a competing
+one. Every version bump drops a server's trust state back to **provisional** until it
+re-earns it, detected via a content-hash diff of the manifest — the direct fix for a
+server that ships clean for months, then turns malicious in one release. `scan` never
+reads env-var or secret values from client configs, only server identity. Feeds back
+into the ledger: a flagged or quarantined server auto-classifies its own tool calls,
+the same mechanism PII is auto-detected from content, so a policy rule can gate on it
+without any extra configuration.
+
 ### 🧭 Confidence Routing (Trust Control Plane)
 
 Most routers optimize *cost*. Hydra is growing a second axis: **verified correctness**. Instead of always firing a fixed number of models, `--confidence` runs a **sequential probability ratio test (SPRT)** — it samples models adaptively, in most-diagnostic-per-dollar order, and stops the moment the calibrated log-odds cross the target confidence.

--- a/docs/index.html
+++ b/docs/index.html
@@ -735,6 +735,8 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
   <p class="cmp-note"><b>hyctl security --why</b> opens the whole programme underneath: a risk register on an SLA clock, crosswalked to OWASP LLM / NIST AI RMF / ISO 42001 / MITRE ATLAS / SOC 2 · OWASP LLM Top-10 coverage · a policy audit that finds rules which can <em>never</em> fire · PII exposure resolved against real heads, so a local model is not reported as a leak · control effectiveness, where a control that is configured but never applied reads as <b>inert</b> rather than as protection · head-binary integrity · edit blast radius.</p>
 
   <p class="cmp-note"><b>Honest about its own limits.</b> Framework mappings are marked <em>curated</em> assertions, not measurements. Defect cost is per-occurrence, not annualised. A file the dependency graph does not index is <em>unknown</em>, never “low-risk”. The attestation is unsigned, because Hydra has no key management and a signature without one is theatre.</p>
+
+  <p class="lede" style="margin-top:26px">The ledger records what an agent did. <b>hyctl mcp registry</b> scores whether the MCP server it was talking to was ever safe to trust in the first place — every existing MCP directory answers “does this exist”, none answer “is it safe to run with my credentials right now”, and star counts are actively misleading (the most-starred servers score worst on quality in independent research). <code>audit</code> resolves what's installed against the official registry and scores it; every trust state drops back to <em>provisional</em> on a version bump, the direct fix for a server that ships clean for months then turns malicious in one release.</p>
 </section>
 
 <!-- ══ 5 · CRAZY NUMBERS ════════════════════════════════════════════════════ -->
@@ -809,12 +811,13 @@ footer{border-top:1px solid var(--line);background:#05060C;font-family:var(--mon
         <tr><th scope="row">Spend logging &amp; cost reporting</th><td class="hydcol"><span class="yes">✓</span></td><td><span class="yes">✓</span></td><td><span class="yes">✓</span></td><td><span class="yes">✓</span></td></tr>
         <tr><th scope="row">Confidence / trust routing (calibrated + optimal-stopping)</th><td class="hydcol"><span class="yes">✓</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td></tr>
         <tr><th scope="row">On-device accountability ledger (PII / local-only policy)</th><td class="hydcol"><span class="yes">✓</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td></tr>
+        <tr><th scope="row">MCP server trust scoring (not just an index)</th><td class="hydcol"><span class="yes">✓</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td></tr>
         <tr><th scope="row">Runs fully offline (0 network to route)</th><td class="hydcol"><span class="yes">✓</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td><td><span class="no">—</span></td></tr>
       </tbody>
     </table>
   </div>
   </div>
-  <p class="cmp-note"><b>Every row checked above ships today</b> — <code>hyctl dispatch --confidence</code>, <code>hyctl graph blast</code>, <code>hyctl mcp</code>. The agent-tree cockpit (<code>hyctl tui</code>) now renders real runs from the per-run event log, and the desktop app ships as a download for macOS, Windows and Linux with every release — not yet code-signed, so macOS needs right-click → Open on first launch.</p>
+  <p class="cmp-note"><b>Every row checked above ships today</b> — <code>hyctl dispatch --confidence</code>, <code>hyctl graph blast</code>, <code>hyctl mcp</code>, <code>hyctl mcp registry</code>. The agent-tree cockpit (<code>hyctl tui</code>) now renders real runs from the per-run event log, and the desktop app ships as a download for macOS, Windows and Linux with every release — not yet code-signed, so macOS needs right-click → Open on first launch.</p>
 </section>
 
 <!-- ══ 6b · DESKTOP APP NUDGE ═══════════════════════════════════════════════ -->

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-08-20</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
Directly asked whether the website/README were fully updated for the MCP registry work (#551-#588). Checked instead of asserting — a real gap: `docs/docs.html` (CLI reference), `llms.txt`, and `CLAUDE.md` were updated across those PRs, but `docs/index.html`, the actual marketing landing page, never mentioned the feature at all.

## Changes
- `docs/index.html` — paragraph added to the existing Accountability section; new comparison-table row ("MCP server trust scoring (not just an index)") — a real differentiator none of OpenRouter/LiteLLM/Portkey have
- `README.md` — full feature section matching the Security Posture section's format
- `docs/sitemap.xml` — bumped lastmod

## Test plan
- [x] `go test ./cmd/hydra/... -run "TestDocs|TestReadme"` — pass
- [x] `go build ./...` clean

Closes #591