### PR TITLE
fix(desktop): put calibration bars on an absolute scale and floor cost colour

### DIFF
--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -687,8 +687,9 @@ body {
 }
 .cal__domain { margin-left: 6px; font-size: 10px; color: var(--hy-faint); }
 
-/* Not `overflow: hidden` — the halo below deliberately bleeds past the track,
-   the same way SpendTrend's SVG halo bleeds HALO_PAD past its crisp bar. */
+/* Not `overflow: hidden` — the halo bleeds vertically past the track, the same
+   way SpendTrend's SVG halo bleeds HALO_PAD past its crisp bar. Horizontally
+   it cannot: calBarWidths lays the pair out inside the track less the bleed. */
 .cal__track {
   position: relative;
   height: 8px;
@@ -709,19 +710,42 @@ body {
 .cal__halo.grown, .cal__fill.grown { transform: scaleX(1); }
 
 /* Width/height/inset (the halo's HALO_PAD bleed) are set inline per row from
-   the D-relative fraction; only the reveal grow-in is CSS. */
+   the absolute nat scale; only the reveal grow-in is CSS. */
 .cal__fill { opacity: .95; }
 .cal__halo { opacity: .3; }
+
+/* Under ten observations D is a guess, so the bar is drawn as provisional
+   rather than left to look like a measurement (#593). */
+.cal__fill--thin { opacity: .38; }
+.cal__halo--thin { opacity: .12; }
 
 .cal__fill--oracle, .cal__halo--oracle { background: linear-gradient(90deg, rgba(0, 230, 195, .5), var(--hy-aqua)); }
 .cal__fill--model,  .cal__halo--model  { background: linear-gradient(90deg, rgba(139, 92, 246, .5), var(--hy-violet)); }
 
 .cal__value {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: 9px;
   font-family: var(--hy-font-mono);
   font-size: 12px;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
+
+/* Words, not just nats: the band reads without knowing what a nat is. Fixed
+   width so the D column stays aligned down the list. Same colour ramp as the
+   Cockpit's per-model D. */
+.cal__strength {
+  min-width: 98px;
+  text-align: right;
+  font-size: 10px;
+  letter-spacing: .02em;
+}
+.cal__strength--strong   { color: var(--hy-cheap); }
+.cal__strength--moderate { color: var(--hy-cyan); }
+.cal__strength--weak     { color: var(--hy-mid); }
+.cal__strength--thin     { color: var(--hy-dim); }
 
 .cal-legend {
   display: flex;
@@ -740,6 +764,7 @@ body {
 }
 .cal-legend__dot--oracle { background: var(--hy-aqua); }
 .cal-legend__dot--model  { background: var(--hy-violet); }
+.cal-legend__scale { margin-left: auto; color: var(--hy-faint); }
 
 /* ── Dashboard: HUD chrome ─────────────────────────────────────────────── */
 /* Corner brackets + scanline + vignette, the same frame language as
@@ -1668,7 +1693,7 @@ body {
 .mr__name { font-size: 11.5px; font-weight: 600; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mr__d { margin-left: auto; font-family: var(--hy-font-mono); font-size: 11px; font-weight: 700; font-variant-numeric: tabular-nums; }
 .mr__d--strong { color: var(--hy-cheap); }
-.mr__d--ok     { color: var(--hy-cyan); }
+.mr__d--moderate { color: var(--hy-cyan); }
 .mr__d--weak   { color: var(--hy-mid); }
 /* Thin evidence is amber regardless of the value: trust.Stat.N excludes the
    prior, so a high D on few observations is not a strong measurement. */

--- a/desktop/frontend/src/format.test.ts
+++ b/desktop/frontend/src/format.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { calibrationLabel, calibrationStrength, calibrationWidthPct, costBand } from './format'
+
+describe('costBand does not alarm about sub-cent spend', () => {
+  // The real defect (#594): $0.0009 was the largest figure in the table, so
+  // share-of-max alone painted a tenth of a cent red and $0.0000 green.
+  it('does not call a tenth of a cent expensive, even as the set maximum', () => {
+    expect(costBand(0.0009, 0.0009)).toBe('cheap')
+  })
+
+  it('holds the whole sub-cent range at cheap', () => {
+    for (const v of [0.0001, 0.0009, 0.002, 0.0099]) {
+      expect(costBand(v, 0.0099)).toBe('cheap')
+    }
+  })
+
+  it('still reports free for nothing spent', () => {
+    expect(costBand(0, 0.0009)).toBe('free')
+  })
+
+  it('keeps the share ramp once the amounts are real', () => {
+    expect(costBand(1, 1)).toBe('expensive')
+    expect(costBand(0.7, 1)).toBe('expensive')
+    expect(costBand(0.3, 1)).toBe('mid')
+    expect(costBand(0.05, 1)).toBe('cheap')
+  })
+
+  // Security's CountBars/ByHead reuse this ramp for integer counts, where any
+  // non-zero row is already above a floor expressed in dollars.
+  it('leaves the integer-count reuse untouched', () => {
+    expect(costBand(5, 5)).toBe('expensive')
+    expect(costBand(2, 5)).toBe('mid')
+    expect(costBand(1, 9)).toBe('cheap')
+  })
+})
+
+describe('calibration bars are on an absolute scale', () => {
+  // The real defect (#593): every top row sat at D=0.28 nats and, normalised
+  // against the set, drew as a full bar. D=0 is a coin flip.
+  it('draws D=0.28 nats as a sliver, not a full bar', () => {
+    const w = calibrationWidthPct(0.28, 40)
+    expect(w).toBeGreaterThan(0)
+    expect(w).toBeLessThan(15)
+  })
+
+  it('is independent of the other rows', () => {
+    expect(calibrationWidthPct(0.28, 40)).toBe(calibrationWidthPct(0.28, 4000))
+  })
+
+  it('never exceeds the track, however diagnostic the source', () => {
+    for (const d of [2.9, 3, 12, 1e6]) expect(calibrationWidthPct(d, 100)).toBeLessThanOrEqual(100)
+    expect(calibrationWidthPct(1e6, 100)).toBe(100)
+  })
+
+  it('reaches full width only at the LLR that buys 95% on its own', () => {
+    expect(calibrationWidthPct(Math.log(0.95 / 0.05), 100)).toBeCloseTo(100, 6)
+    expect(calibrationWidthPct(1, 100)).toBeCloseTo(33.96, 1)
+  })
+
+  it('keeps a sliver for a measured coin flip, and nothing for no data', () => {
+    expect(calibrationWidthPct(0, 12)).toBe(2)
+    expect(calibrationWidthPct(0, 0)).toBe(0)
+  })
+
+  it('rises with D', () => {
+    const ws = [0.1, 0.5, 1, 2].map((d) => calibrationWidthPct(d, 100))
+    expect(ws).toEqual([...ws].sort((a, b) => a - b))
+    expect(new Set(ws).size).toBe(4)
+  })
+})
+
+describe('calibration strength says in words what the nats mean', () => {
+  it('bands on the thresholds the Cockpit already used', () => {
+    expect(calibrationStrength(0.28, 40)).toBe('weak')
+    expect(calibrationStrength(0.49, 40)).toBe('weak')
+    expect(calibrationStrength(0.5, 40)).toBe('moderate')
+    expect(calibrationStrength(0.99, 40)).toBe('moderate')
+    expect(calibrationStrength(1, 40)).toBe('strong')
+  })
+
+  it('calls thin evidence thin whatever D says', () => {
+    expect(calibrationStrength(4, 9)).toBe('thin')
+    expect(calibrationStrength(4, 10)).toBe('strong')
+  })
+
+  it('reads as plain language', () => {
+    expect(calibrationLabel('weak')).toBe('weak evidence')
+    expect(calibrationLabel('thin')).toBe('too few samples')
+  })
+})

--- a/desktop/frontend/src/format.ts
+++ b/desktop/frontend/src/format.ts
@@ -65,14 +65,54 @@ export function toSecurityCSV(
   return ['id,name,status,gap_age_days,detail', ...rows].join('\n')
 }
 
-/** Cost ramp for a per-row figure, relative to the largest row in its table. */
+const COST_FLOOR_USD = 0.01
+
+/** Cost ramp relative to the largest row, floored: sub-cent spend earns no
+ * mid/expensive colour, because `usd()` already prints it "<$0.01" and the
+ * biggest tenth of a cent is not expensive. */
 export function costBand(v: number, max: number): 'free' | 'cheap' | 'mid' | 'expensive' {
   if (v <= 0) return 'free'
-  if (max <= 0) return 'cheap'
+  if (max <= 0 || v < COST_FLOOR_USD) return 'cheap'
   const share = v / max
   if (share >= 0.6) return 'expensive'
   if (share >= 0.25) return 'mid'
   return 'cheap'
+}
+
+/** internal/trust's D is expected |LLR| in nats — 0 is a coin flip. ln(.95/.05)
+ * is what one verdict must carry to move a 50/50 prior to the 95% the SPRT
+ * ensemble targets, so it is the honest full scale for a bar. */
+const CAL_FULL_SCALE_NATS = Math.log(0.95 / 0.05)
+
+/** A source with observations but no diagnostic power keeps a sliver: the row
+ * is real even when the measurement says coin flip. */
+const CAL_SLIVER_PCT = 2
+
+/** Absolute, never share-of-max: a leaderboard of weak sources must look weak.
+ * At D=0.28 nats this is ~10% of the track, not the 100% a set-relative scale
+ * gave the best of a bad field. */
+export function calibrationWidthPct(d: number, n: number): number {
+  if (d <= 0) return n > 0 ? CAL_SLIVER_PCT : 0
+  return Math.min(100, Math.max(CAL_SLIVER_PCT, (d / CAL_FULL_SCALE_NATS) * 100))
+}
+
+export type CalStrength = 'thin' | 'weak' | 'moderate' | 'strong'
+
+/** The bands Cockpit's per-model rows already read D by, in one place. n is
+ * trust.Stat.N, which excludes the Laplace prior — under ten observations the
+ * number is a guess whatever it says, so that outranks the value. */
+export function calibrationStrength(d: number, n: number): CalStrength {
+  if (n < 10) return 'thin'
+  if (d >= 1) return 'strong'
+  if (d >= 0.5) return 'moderate'
+  return 'weak'
+}
+
+/** Plain words for the band. A nat figure is unreadable to anyone who has not
+ * read internal/trust; the bar and the number both lean on this. */
+export function calibrationLabel(s: CalStrength): string {
+  if (s === 'thin') return 'too few samples'
+  return `${s} evidence`
 }
 
 /** internal/trust calibration keys are "verifier:go-test" / "model:claude-sonnet"

--- a/desktop/frontend/src/views/Cockpit.tsx
+++ b/desktop/frontend/src/views/Cockpit.tsx
@@ -8,7 +8,7 @@ import type {
   ModelRegistry,
   Session as SessionData,
 } from '../types'
-import { pct, usd } from '../format'
+import { calibrationStrength, pct, usd } from '../format'
 
 /** Dashboard is retrospective; a slow tick is enough. Mirrors App's DASHBOARD_MS. */
 const SLOW_MS = 5000
@@ -202,7 +202,7 @@ function ModelRows({ dash }: { dash: DashboardData | null }) {
               <span className="mr__name" title={r.key}>
                 {r.key}
               </span>
-              <span className={`mr__d ${best ? band(best) : 'mr__d--none'}`}>
+              <span className={`mr__d ${best ? `mr__d--${calibrationStrength(best.d, best.n)}` : 'mr__d--none'}`}>
                 {best ? best.d.toFixed(2) : '—'}
               </span>
             </div>
@@ -224,15 +224,6 @@ function bestFor(cal: CalibrationRow[], key: string): CalibrationRow | undefined
   const mine = cal.filter((c) => c.source === key || c.source.endsWith(key))
   if (mine.length === 0) return undefined
   return mine.reduce((a, b) => (b.d > a.d ? b : a))
-}
-
-// Bands, not a gradient: D is in nats and ~1 is strong discrimination, so three
-// buckets say more than a continuous scale nobody can read.
-function band(c: CalibrationRow): string {
-  if (c.n < 10) return 'mr__d--thin'
-  if (c.d >= 1) return 'mr__d--strong'
-  if (c.d >= 0.5) return 'mr__d--ok'
-  return 'mr__d--weak'
 }
 
 function Gauge({ value }: { value: number }) {

--- a/desktop/frontend/src/views/Dashboard.test.tsx
+++ b/desktop/frontend/src/views/Dashboard.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { CalibrationLeaderboard, calBarWidths } from './Dashboard'
+import type { CalibrationRow } from '../types'
+
+afterEach(cleanup)
+
+const BLEED = 6
+
+function row(d: number, n = 40, source = 'model:claude-sonnet'): CalibrationRow {
+  return { source, domain: 'go', d, se: 0.6, sp: 0.6, n }
+}
+
+/** Resolves a bar's calc() against a concrete track width, the way the browser
+ * does — the "cannot overflow" claim is arithmetic, not CSS to be trusted. */
+function resolve(expr: string, trackPx: number): number {
+  if (expr === '0px') return 0
+  const m = /^calc\((?:(\d+)px \+ )?([\d.]+) \* \(100% - (\d+)px\)(?: \+ (\d+)px)?\)$/.exec(expr)
+  if (!m) throw new Error(`unparsed width: ${expr}`)
+  const [, leadPx, scale, sub, tailPx] = m
+  return Number(scale) * (trackPx - Number(sub)) + Number(leadPx ?? tailPx ?? 0)
+}
+
+describe('a calibration bar cannot exceed its track', () => {
+  // The released geometry was `calc(${widthPct}% + 6px)` with `left: -3px`,
+  // which at 100% is 6px wider than the track it sits in.
+  it('lands the full-width halo exactly on the track edge', () => {
+    const { fill, halo } = calBarWidths(100)
+    for (const trackPx of [40, 200, 900]) {
+      expect(resolve(halo, trackPx)).toBe(trackPx)
+      expect(resolve(fill, trackPx) + BLEED).toBe(trackPx)
+    }
+  })
+
+  it('stays inside the track at every width', () => {
+    for (let pct = 0; pct <= 100; pct += 2.5) {
+      const { fill, halo } = calBarWidths(pct)
+      expect(resolve(halo, 200)).toBeLessThanOrEqual(200)
+      expect(resolve(fill, 200) + BLEED).toBeLessThanOrEqual(200)
+    }
+  })
+
+  it('clamps a width that overshoots rather than trusting its caller', () => {
+    expect(resolve(calBarWidths(140).halo, 200)).toBe(200)
+    expect(calBarWidths(0).halo).toBe('0px')
+  })
+})
+
+describe('the leaderboard reads correctly on weak real data', () => {
+  const weak = [row(0.28, 40, 'verifier:go-test'), row(0.28, 40), row(0.24, 40, 'model:qwen3')]
+
+  it('draws three rows of D=0.28 as slivers, not three full bars', () => {
+    const { container } = render(<CalibrationLeaderboard rows={weak} />)
+    const fills = [...container.querySelectorAll<HTMLElement>('.cal__fill')]
+    expect(fills).toHaveLength(3)
+    for (const f of fills) {
+      const w = resolve(f.style.width, 200)
+      expect(w).toBeGreaterThan(0)
+      expect(w).toBeLessThan(0.15 * 200)
+    }
+  })
+
+  it('says in words that the evidence is weak', () => {
+    render(<CalibrationLeaderboard rows={weak} />)
+    expect(screen.getAllByText('weak evidence')).toHaveLength(3)
+    expect(screen.queryByText('strong evidence')).toBeNull()
+  })
+
+  it('overflows nothing it renders', () => {
+    const { container } = render(<CalibrationLeaderboard rows={[...weak, row(9, 400)]} />)
+    for (const el of container.querySelectorAll<HTMLElement>('.cal__fill, .cal__halo')) {
+      expect(resolve(el.style.width, 200)).toBeLessThanOrEqual(200)
+    }
+  })
+
+  it('marks a high D on few observations as provisional, not strong', () => {
+    const { container } = render(<CalibrationLeaderboard rows={[row(2.4, 3)]} />)
+    expect(screen.getByText('too few samples')).toBeTruthy()
+    expect(container.querySelector('.cal__fill--thin')).toBeTruthy()
+  })
+
+  it('states the scale the bar is drawn against', () => {
+    render(<CalibrationLeaderboard rows={weak} />)
+    expect(screen.getByText(/full bar = one verdict enough for 95%/)).toBeTruthy()
+  })
+
+  it('renders the empty state rather than an empty track', () => {
+    render(<CalibrationLeaderboard rows={[]} />)
+    expect(screen.getByText('No calibration recorded yet')).toBeTruthy()
+  })
+})

--- a/desktop/frontend/src/views/Dashboard.tsx
+++ b/desktop/frontend/src/views/Dashboard.tsx
@@ -1,6 +1,20 @@
 import { useEffect, useRef, useState } from 'react'
 import type { Breakdown, CalibrationRow, Dashboard as DashboardData, TrustPanel } from '../types'
-import { clockTime, costBand, govBand, ms, pct, sourceKind, sourceLabel, tokens, usd, usdExact } from '../format'
+import {
+  calibrationLabel,
+  calibrationStrength,
+  calibrationWidthPct,
+  clockTime,
+  costBand,
+  govBand,
+  ms,
+  pct,
+  sourceKind,
+  sourceLabel,
+  tokens,
+  usd,
+  usdExact,
+} from '../format'
 import { ArcGauge, Sparkline, SpendTrend, TrustArc } from './DashboardCharts'
 import { useCountUp, useReveal } from '../reveal'
 
@@ -333,13 +347,15 @@ function RankedBars({
  * Which sources actually earn their stated confidence — one row per
  * (source, domain), sorted by D descending (the order internal/trust's
  * Calibrator.Report already returns, same as `hyctl trust calibration`).
- * Bars use the SpendTrend halo treatment (#414) turned sideways: a fainter
- * halo layered behind a crisp fill, both growing in via `transform: scaleX`
- * once `useReveal` fires, never `filter: blur`. Independent of `hasData` —
+ * Bars are on an absolute nat scale, never share-of-max (#593): "who to
+ * trust" has to draw a weak field as weak, and the strongest of three coin
+ * flips is still a coin flip. They use the SpendTrend halo treatment (#414)
+ * turned sideways: a fainter halo behind a crisp fill, both growing in via
+ * `transform: scaleX` once `useReveal` fires. Independent of `hasData` —
  * calibration history comes from `hyctl trust record`, not the cost log, so
  * it can be populated (or empty) regardless of whether anything dispatched.
  */
-function CalibrationLeaderboard({ rows }: { rows: CalibrationRow[] }) {
+export function CalibrationLeaderboard({ rows }: { rows: CalibrationRow[] }) {
   const revealed = useReveal(rows.length > 0)
 
   if (rows.length === 0) {
@@ -356,14 +372,13 @@ function CalibrationLeaderboard({ rows }: { rows: CalibrationRow[] }) {
     )
   }
 
-  const maxD = Math.max(...rows.map((r) => r.d))
   return (
     <section>
       <h2 className="section__title">Calibration leaderboard · who to trust</h2>
       <div className="table__wrap">
         <div className="rank">
           {rows.map((r) => (
-            <CalibrationBar key={`${r.source} ${r.domain}`} row={r} maxD={maxD} revealed={revealed} />
+            <CalibrationBar key={`${r.source}\u0000${r.domain}`} row={r} revealed={revealed} />
           ))}
         </div>
         <div className="cal-legend">
@@ -375,6 +390,7 @@ function CalibrationLeaderboard({ rows }: { rows: CalibrationRow[] }) {
             <span className="cal-legend__dot cal-legend__dot--model" />
             model's own answer
           </span>
+          <span className="cal-legend__scale">full bar = one verdict enough for 95% on its own</span>
         </div>
       </div>
     </section>
@@ -385,11 +401,22 @@ function CalibrationLeaderboard({ rows }: { rows: CalibrationRow[] }) {
 // matches SpendTrend's HALO_PAD.
 const CAL_HALO_PAD = 3
 
-function CalibrationBar({ row, maxD, revealed }: { row: CalibrationRow; maxD: number; revealed: boolean }) {
+/** Both bars sit inside the track minus the halo's bleed, so a full-width
+ * bar's halo lands on the track edge. The old `calc(100% + 6px)` could not be
+ * contained at any pad; this cannot exceed the track at any width. */
+export function calBarWidths(widthPct: number): { fill: string; halo: string } {
+  const bleed = CAL_HALO_PAD * 2
+  const s = Math.min(1, Math.max(0, widthPct / 100))
+  return {
+    fill: `calc(${s} * (100% - ${bleed}px))`,
+    halo: s > 0 ? `calc(${s} * (100% - ${bleed}px) + ${bleed}px)` : '0px',
+  }
+}
+
+function CalibrationBar({ row, revealed }: { row: CalibrationRow; revealed: boolean }) {
   const kind = sourceKind(row.source)
-  // A source with real observations but zero diagnostic power (a coin flip)
-  // still gets a sliver — the row itself is informative even at D=0.
-  const widthPct = maxD > 0 ? (row.d / maxD) * 100 : row.n > 0 ? 4 : 0
+  const strength = calibrationStrength(row.d, row.n)
+  const { fill, halo } = calBarWidths(calibrationWidthPct(row.d, row.n))
   const grown = revealed ? ' grown' : ''
   return (
     <div className="cal__row">
@@ -399,17 +426,21 @@ function CalibrationBar({ row, maxD, revealed }: { row: CalibrationRow; maxD: nu
       </span>
       <span className="cal__track">
         <span
-          className={`cal__halo cal__halo--${kind}${grown}`}
+          className={`cal__halo cal__halo--${kind} cal__halo--${strength}${grown}`}
           style={{
-            width: `calc(${widthPct}% + ${CAL_HALO_PAD * 2}px)`,
+            width: halo,
             height: `calc(100% + ${CAL_HALO_PAD * 2}px)`,
-            left: -CAL_HALO_PAD,
+            left: 0,
             top: -CAL_HALO_PAD,
           }}
         />
-        <span className={`cal__fill cal__fill--${kind}${grown}`} style={{ width: `${widthPct}%` }} />
+        <span
+          className={`cal__fill cal__fill--${kind} cal__fill--${strength}${grown}`}
+          style={{ width: fill, left: CAL_HALO_PAD }}
+        />
       </span>
       <span className="cal__value" title={`Se ${row.se.toFixed(2)} · Sp ${row.sp.toFixed(2)} · n=${row.n}`}>
+        <span className={`cal__strength cal__strength--${strength}`}>{calibrationLabel(strength)}</span>
         {row.d.toFixed(2)}
       </span>
     </div>


### PR DESCRIPTION
Two dashboard panels on the released build stated the opposite of their own numbers. Both are arithmetic, so here is the arithmetic.

## Bug 1 - the calibration leaderboard drew near-worthless D as a full bar

`CalibrationBar` normalised against the set:

```ts
const maxD = Math.max(...rows.map((r) => r.d))
const widthPct = maxD > 0 ? (row.d / maxD) * 100 : row.n > 0 ? 4 : 0
```

With the reported data (rows at D = 0.28, 0.28, 0.24, 0.11 nats) that is `0.28/0.28 = 100%`, `0.28/0.28 = 100%`, `0.24/0.28 = 85.7%`, `0.11/0.28 = 39.3%`. D is `internal/trust.Calibrator.D` - expected |LLR| in nats, always >= 0 and exactly 0 when `se + sp = 1`, i.e. the source carries no information. So a panel headed "who to trust" drew "excellent, excellent, very good" over numbers that say "coin flip". The best row was 100% wide whatever it was worth; the scale said nothing.

Width is now absolute, against `ln(.95/.05) = 2.944` nats - what a single verdict must carry to move a 50/50 prior to the 95% the SPRT ensemble targets. So D = 0.28 draws at `0.28/2.944 = 9.5%`, D = 1.0 at 34%, and only a source that would clear 95% on its own fills the track. The legend states that scale in the panel, and each row carries its band in words ("weak evidence" / "moderate evidence" / "strong evidence" / "too few samples") - the point is that a non-expert reads it right without knowing what a nat is.

The bands are the ones `Cockpit.tsx` had already established for the same number (D >= 1 strong, >= 0.5 moderate, else weak, with n < 10 outranking the value because `trust.Stat.N` excludes the Laplace prior). They now live once in `format.ts` and both call sites read them from there, rather than a second copy of the same threshold table. A high D on a handful of observations also draws its bar muted, so it cannot read as a measurement.

## Bug 1b - the halo could not be contained

```ts
width: `calc(${widthPct}% + ${CAL_HALO_PAD * 2}px)`   // with left: -3px
```

At `widthPct = 100` that is `100% + 6px` starting 3px left of the track, so the halo's right edge sits 3px past the track's. Measured in a real browser on the released build: `haloRight - trackRight = +3.0px` on every full-width row.

`calBarWidths` now lays fill and halo out inside the track less that bleed - `calc(s * (100% - 6px))` for the fill at `left: 3px`, plus `6px` for the halo at `left: 0` - so at `s = 1` the halo is exactly the track width. Measured after the fix: overhang `0.0px` at 1440px wide, at 900px wide, and at every width in between, with `scrollWidth - clientWidth = 0` on the enclosing `.table__wrap`.

One correction to the diagnosis: it does not visibly clip. The 3px overhang lands in the 10px grid gap between the track and the value column, well inside `.table__wrap`'s padding, so no scrollbar appears and nothing is cut off. What it does is make the widest bar read as wider than 100% of its own scale and encroach on the gutter. Still wrong, still fixed, but the symptom was geometric rather than a clip.

`RankedBars` does **not** share this bug: its fill is a plain `width: ${pct}%` inside an `overflow: hidden` track, with no halo at all. Left alone, as asked, including its share-of-max normalisation.

## Bug 2 - cost colour was meaningless at small magnitudes

`costBand` banded purely on `v / max`, so in a sub-cent log `$0.0009 / $0.0009 = 1.0 >= 0.6` gives `expensive` (red) while `$0.0000` gives `free` (green). Confirmed on the released build: `claude-sonnet $0.0009 [expensive] | qwen3-coder $0.0004 [mid] | gemini-flash $0.0001 [cheap]`.

Nothing under one cent can now be `mid` or `expensive`. One cent is not arbitrary: it is the same boundary `usd()` in the same file already uses to print `<$0.01`, so the colour and the text now agree about what counts as an amount. Above the floor the share ramp is untouched - verified live: `$1.4200 [expensive] | $0.3800 [mid] | $0.0200 [cheap]`.

Every `costBand` caller was checked. `Security.tsx`'s `CountBars` and `ByHead` reuse the ramp for integer counts, where any non-zero row is already >= 1 and therefore above a floor expressed in dollars - their banding is unchanged, and a test pins that.

## Also in here

`Dashboard.tsx` contained a **raw NUL byte** inside a React key template literal, between `r.source` and `r.domain`. It is the only NUL in any tracked text file in the repo, and it made the entire file read as binary to grep: `grep -n Calibration Dashboard.tsx` returned nothing, silently, which is how a 537-line view hid from search. Replaced with the equivalent `` escape - identical key, no control byte in the source.

## Screenshots

Rendered from the real `dist` build with stubbed Wails bindings, fed the reported data (calibration rows at D = 0.28 and a whole cost log under a cent), driven headless, and measured in the live DOM rather than reasoned about from the CSS.

Calibration, **before** - two full bars and an 86% bar over the numbers 0.28, 0.28, 0.24, with a 39% bar at 0.11. Reads as a strong panel. **After** - four short slivers (9.4%, 9.4%, 8.1%, 3.7%), each labelled "weak evidence" in amber, with "full bar = one verdict enough for 95% on its own" in the legend. Reads as what it is.

Across the full range after the fix: D = 3.40 fills the track (halo overhang 0.0px), D = 1.42 gives 47.9% "strong evidence", D = 0.71 gives 23.9% "moderate evidence", D = 0.28 gives 9.4% "weak evidence", and D = 2.41 on n = 4 draws muted as "too few samples".

Cost, **before**: `$0.0009` red, `$0.0004` amber, `$0.0001` green in By model and By tier, and the Spend-by-day chart the same - one sub-cent day painted red among green ones. **After**: every sub-cent row and every bar green, while bar *lengths* stay ranked by share, so "who spent most" is unchanged.

## Verification

- `npm test` - 50 tests across 5 files, green. New: `src/format.test.ts` (the sub-cent-as-set-maximum case, the whole sub-cent range, the share ramp above the floor, the integer-count reuse, D = 0.28 not near-full, independence from the rest of the set, the 100% clamp, the band boundaries) and `src/views/Dashboard.test.tsx` (renders the leaderboard on the reported data, then resolves each bar's `calc()` against concrete track widths the way the browser does and asserts nothing exceeds the track at any width from 0 to 100, including an overshooting input).
- `npm run typecheck` and `npm run build` - clean.
- `go test -race -count=1 ./...` in the repo root and in `desktop/` - all green, `go vet` clean. Worth noting: the two failures flagged as expected-in-a-sandbox (`TestPlanRunRunSPRT_RejectBadA2AFileIdentically` and the `TestLogDispatch_*` identity tests) did **not** fail here. Every package reported `ok`, on this branch, so there was no pre-existing failure to dismiss.

Closes #593
Closes #594
