### PR TITLE
feat(desktop): six-view vocabulary, and the Models view the registry never had

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,5 +1,13 @@
-import { useCallback, useEffect, useState } from 'react'
-import { CheckHyctl, GetDashboard, GetEdits, GetFleet, GetSecurity, GetSession, GetVersion } from './bindings'
+import { useCallback, useEffect, useState } from "react";
+import {
+  CheckHyctl,
+  GetDashboard,
+  GetEdits,
+  GetFleet,
+  GetSecurity,
+  GetSession,
+  GetVersion,
+} from "./bindings";
 import type {
   Dashboard as DashboardData,
   Edit,
@@ -8,155 +16,156 @@ import type {
   SecurityReport,
   Session as SessionData,
   Version,
-} from './types'
-import { Dashboard } from './views/Dashboard'
-import { Fleet } from './views/Fleet'
-import { Session } from './views/Session'
-import { Security as SecurityView } from './views/Security'
-import { ErrorBoundary } from './ErrorBoundary'
-import { ChatView } from './views/ChatView'
-import { UpdateNotice } from './views/UpdateNotice'
-import { SetupBanner } from './views/SetupBanner'
-import { HydraMark, HydraSpinner } from './brand'
+} from "./types";
+import { Dashboard } from "./views/Dashboard";
+import { Fleet } from "./views/Fleet";
+import { Session } from "./views/Session";
+import { Security as SecurityView } from "./views/Security";
+import { Models } from "./views/Models";
+import { ErrorBoundary } from "./ErrorBoundary";
+import { ChatView } from "./views/ChatView";
+import { UpdateNotice } from "./views/UpdateNotice";
+import { SetupBanner } from "./views/SetupBanner";
+import { HydraMark, HydraSpinner } from "./brand";
 
 /** Dashboard is retrospective — a slow refresh is enough and costs nothing. */
-const DASHBOARD_MS = 5000
+const DASHBOARD_MS = 5000;
 
 /**
  * Fleet and an open Session poll faster because they answer "what is happening
  * now", and runlog.StaleAfter is 10s — a slower tick than half that would let a
  * run look live for seconds after it died.
  */
-const LIVE_MS = 2000
+const LIVE_MS = 2000;
 
 // Chat first, and default: the app's job is to get work dispatched, and every
 // other view is retrospective (#520). Glyphs keep the rail narrow enough that
 // chat gets the width; label still ships as the tooltip and accessible name.
+/**
+ * Industry vocabulary, from the signed-off design: Chat, Models, Activity,
+ * Usage, Audit. The old labels were Hydra's internal names (dispatch, fleet,
+ * governor), which is why the released build read as jargon.
+ *
+ * Agents is deliberately absent until it has real content: its headline group
+ * is "waiting on you", which needs the pending-question path (#583). A nav
+ * item that is always empty is exactly the hollowness this replaces.
+ */
 const NAV = [
-  { id: 'chat', label: 'Chat', glyph: '\u270E', ready: true },
-  { id: 'dashboard', label: 'Dashboard', glyph: '\u25EB', ready: true },
-  { id: 'fleet', label: 'Fleet', glyph: '\u2318', ready: true },
-  { id: 'session', label: 'Session', glyph: '\u2261', ready: true },
-  { id: 'security', label: 'Security', glyph: '\u26E8', ready: true },
-] as const
+  { id: "chat", label: "Chat", glyph: "\u270E", ready: true },
+  { id: "models", label: "Models", glyph: "\u2318", ready: true },
+  { id: "activity", label: "Activity", glyph: "\u2261", ready: true },
+  { id: "usage", label: "Usage", glyph: "\u25EB", ready: true },
+  { id: "audit", label: "Audit", glyph: "\u26E8", ready: true },
+] as const;
 
-type ViewID = (typeof NAV)[number]['id']
+/** Session is reached by opening one from Activity, never from the rail. */
+type ViewID = (typeof NAV)[number]["id"] | "session";
 
 export default function App() {
-  const [view, setView] = useState<ViewID>('chat')
-  const [runID, setRunID] = useState<string>('')
-  const [dashboard, setDashboard] = useState<DashboardData | null>(null)
-  const [fleet, setFleet] = useState<FleetData | null>(null)
-  const [session, setSession] = useState<SessionData | null>(null)
-  const [edits, setEdits] = useState<Edit[] | null>(null)
-  const [security, setSecurity] = useState<SecurityReport | null>(null)
-  const [version, setVersion] = useState<Version | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [hyctlStatus, setHyctlStatus] = useState<HyctlStatus | null>(null)
+  const [view, setView] = useState<ViewID>("chat");
+  const [runID, setRunID] = useState<string>("");
+  const [dashboard, setDashboard] = useState<DashboardData | null>(null);
+  const [fleet, setFleet] = useState<FleetData | null>(null);
+  const [session, setSession] = useState<SessionData | null>(null);
+  const [edits, setEdits] = useState<Edit[] | null>(null);
+  const [security, setSecurity] = useState<SecurityReport | null>(null);
+  const [version, setVersion] = useState<Version | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [hyctlStatus, setHyctlStatus] = useState<HyctlStatus | null>(null);
 
   // Fleet's empty state sends people here to start a task (#422). A counter
   // rather than a boolean so asking twice still moves the caret back to the
   // input instead of no-oping on an unchanged value.
-  const [chatFocusSignal, setChatFocusSignal] = useState(0)
+  const [chatFocusSignal, setChatFocusSignal] = useState(0);
   const startTask = useCallback(() => {
-    setView('chat')
-    setChatFocusSignal((n) => n + 1)
-  }, [])
+    setView("chat");
+    setChatFocusSignal((n) => n + 1);
+  }, []);
 
   const load = useCallback(async (which: ViewID, id: string) => {
     try {
-      if (which === 'fleet') setFleet(await GetFleet())
+      if (which === "activity") setFleet(await GetFleet());
       // Code is a tab inside Session now (#519), not its own view — fetch
       // both together so switching tabs never has to wait on a second load.
-      else if (which === 'session') {
-        const [s, e] = await Promise.all([GetSession(id), GetEdits(id)])
-        setSession(s)
-        setEdits(e)
-      } else if (which === 'security') setSecurity(await GetSecurity())
-      else setDashboard(await GetDashboard())
-      setError(null)
+      else if (which === "session") {
+        const [s, e] = await Promise.all([GetSession(id), GetEdits(id)]);
+        setSession(s);
+        setEdits(e);
+      } else if (which === "audit") setSecurity(await GetSecurity());
+      else if (which === "usage") setDashboard(await GetDashboard());
+      setError(null);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
+      setError(e instanceof Error ? e.message : String(e));
     }
-  }, [])
+  }, []);
 
   // Only the visible view polls: a background tick on a view nobody is looking
   // at is pure cost.
   useEffect(() => {
-    // Chat drives its own reads (it polls the run it just started), so there is
-    // nothing here to tick for it.
-    if (view === 'chat') return
-    void load(view, runID)
-    const every = view === 'dashboard' || view === 'security' ? DASHBOARD_MS : LIVE_MS
-    const t = setInterval(() => void load(view, runID), every)
-    return () => clearInterval(t)
-  }, [load, view, runID])
+    // Chat and Models drive their own reads, so there is nothing to tick here
+    // for them.
+    if (view === "chat" || view === "models") return;
+    void load(view, runID);
+    const every = view === "usage" || view === "audit" ? DASHBOARD_MS : LIVE_MS;
+    const t = setInterval(() => void load(view, runID), every);
+    return () => clearInterval(t);
+  }, [load, view, runID]);
 
   useEffect(() => {
-    GetVersion().then(setVersion).catch(() => {
-      /* Version is decoration; failing to read it must not blank the window. */
-    })
-  }, [])
+    GetVersion()
+      .then(setVersion)
+      .catch(() => {
+        /* Version is decoration; failing to read it must not blank the window. */
+      });
+  }, []);
 
   // One-shot, not polled: this is a first-run check (#383), not a live value.
   // A machine with hyctl already on PATH — the common case — never shows
   // anything, since the banner below renders only when Found is false.
   useEffect(() => {
-    CheckHyctl().then(setHyctlStatus).catch(() => {
-      /* Same as GetVersion: decoration, not worth blanking the window over. */
-    })
-  }, [])
+    CheckHyctl()
+      .then(setHyctlStatus)
+      .catch(() => {
+        /* Same as GetVersion: decoration, not worth blanking the window over. */
+      });
+  }, []);
 
   // Set alongside runID when a caller wants Session to open straight on the
   // Code tab at a specific file (an artifact-node click, #518) rather than
   // its own default. Session is keyed by runId below, so a fresh mount reads
   // this once as initial state — plain opens must clear it, or a later
   // no-file open of a different run would wrongly inherit it.
-  const [pendingFile, setPendingFile] = useState<string | undefined>()
+  const [pendingFile, setPendingFile] = useState<string | undefined>();
 
   const openSession = useCallback((id: string) => {
-    setRunID(id)
+    setRunID(id);
     // Don't show the previous run's data under a new id.
-    setSession(null)
-    setEdits(null)
-    setPendingFile(undefined)
-    setView('session')
-  }, [])
+    setSession(null);
+    setEdits(null);
+    setPendingFile(undefined);
+    setView("session");
+  }, []);
 
   const openSessionFile = useCallback((id: string, file: string) => {
-    setRunID(id)
-    setSession(null)
-    setEdits(null)
-    setPendingFile(file)
-    setView('session')
-  }, [])
+    setRunID(id);
+    setSession(null);
+    setEdits(null);
+    setPendingFile(file);
+    setView("session");
+  }, []);
 
   // Session is reachable by drilling in from Fleet; selecting it with no run
   // chosen opens the most recent one, which is what "Session" means with no
   // further qualification.
-  const selectNav = useCallback(
-    (id: ViewID) => {
-      if (id === 'session' && !runID) {
-        const first = fleet?.runs?.[0]?.id
-        if (!first) return
-        setRunID(first)
-        setSession(null)
-        setEdits(null)
-        setView(id)
-        return
-      }
-      setView(id)
-    },
-    [fleet, runID],
-  )
+  const selectNav = useCallback((id: ViewID) => setView(id), []);
 
   // Dashboard handles its own loading state (a skeleton, not this fallback
   // text) so its first-load window can look like the rest of the view
   // instead of a plain sentence.
   const loading =
-    (view === 'fleet' && !fleet) ||
-    (view === 'session' && (!session || !edits)) ||
-    (view === 'security' && !security)
+    (view === "activity" && !fleet) ||
+    (view === "session" && (!session || !edits)) ||
+    (view === "audit" && !security);
 
   return (
     <div className="shell">
@@ -167,14 +176,14 @@ export default function App() {
             <button
               key={n.id}
               className="rail__item"
-              aria-current={view === n.id ? 'page' : undefined}
+              aria-current={view === n.id ? "page" : undefined}
               aria-label={n.label}
               title={n.label}
-              disabled={!n.ready || (n.id === 'session' && !runID && !fleet?.runs?.length)}
+              disabled={!n.ready}
               onClick={() => n.ready && selectNav(n.id)}
             >
               <span aria-hidden="true">{n.glyph}</span>
-              {n.id === 'fleet' && (fleet?.liveCount ?? 0) > 0 && (
+              {n.id === "activity" && (fleet?.liveCount ?? 0) > 0 && (
                 <span className="rail__live">{fleet?.liveCount}</span>
               )}
             </button>
@@ -182,13 +191,16 @@ export default function App() {
         </div>
         <div className="rail__foot">
           <UpdateNotice />
-          <span className="rail__ver" title={version ? `${version.version} · ${version.commit}` : ''}>
-            {version ? version.version : ''}
+          <span
+            className="rail__ver"
+            title={version ? `${version.version} · ${version.commit}` : ""}
+          >
+            {version ? version.version : ""}
           </span>
         </div>
       </nav>
 
-      <main className={view === 'chat' ? 'main main--chat' : 'main'}>
+      <main className={view === "chat" ? "main main--chat" : "main"}>
         {/* Non-blocking: it sits above whichever view is open rather than
             replacing it, and renders nothing at all once hyctl is found. */}
         {hyctlStatus && !hyctlStatus.found && (
@@ -198,21 +210,32 @@ export default function App() {
         {/* An error replaces the body but never the shell — a broken read
             should not look like a crashed app. */}
         {error && <div className="error">{error}</div>}
-        {!error && view === 'chat' && (
+        {!error && view === "chat" && (
           <ErrorBoundary label="Chat">
             <ChatView onOpenRun={openSession} focusSignal={chatFocusSignal} />
           </ErrorBoundary>
         )}
-        {!error && view === 'dashboard' && <Dashboard data={dashboard} />}
-        {!error && view === 'fleet' && fleet && (
-          <Fleet
-            data={fleet}
-            onOpen={openSession}
-            onOpenFile={openSessionFile}
-            onStartTask={startTask}
-          />
+        {!error && view === "models" && (
+          <ErrorBoundary label="Models">
+            <Models />
+          </ErrorBoundary>
         )}
-        {!error && view === 'session' && session && edits && (
+        {!error && view === "usage" && (
+          <ErrorBoundary label="Usage">
+            <Dashboard data={dashboard} />
+          </ErrorBoundary>
+        )}
+        {!error && view === "activity" && fleet && (
+          <ErrorBoundary label="Activity">
+            <Fleet
+              data={fleet}
+              onOpen={openSession}
+              onOpenFile={openSessionFile}
+              onStartTask={startTask}
+            />
+          </ErrorBoundary>
+        )}
+        {!error && view === "session" && session && edits && (
           // Keyed by runId: a fresh mount per run resets tab/codeFile state
           // instead of carrying over a Graph/Code selection from whatever run
           // was open before, and lets initialTab/initialFile seed cleanly.
@@ -220,12 +243,12 @@ export default function App() {
             key={session.runId}
             session={session}
             edits={edits}
-            onBack={() => setView('fleet')}
-            initialTab={pendingFile ? 'code' : undefined}
+            onBack={() => setView("activity")}
+            initialTab={pendingFile ? "code" : undefined}
             initialFile={pendingFile}
           />
         )}
-        {!error && view === 'security' && security && (
+        {!error && view === "audit" && security && (
           <ErrorBoundary label="Security">
             <SecurityView data={security} />
           </ErrorBoundary>
@@ -238,5 +261,5 @@ export default function App() {
         )}
       </main>
     </div>
-  )
+  );
 }

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1815,3 +1815,87 @@ body {
 .tt__tick--start { color: var(--hy-dim); }
 .tt__tick--up    { color: var(--hy-expensive); }
 .tt__tick--down  { color: var(--hy-cheap); }
+
+/* ── Models ────────────────────────────────────────────────────────────── */
+/* The registry shipped in #553 and fed only the composer picker; this is the
+   first surface that shows what the machine can actually route to. */
+
+.models { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: 18px; align-items: start; }
+@media (max-width: 900px) { .models { grid-template-columns: 1fr; } }
+
+.models__tree { display: flex; flex-direction: column; gap: 16px; min-width: 0; }
+
+.pool-g { display: flex; flex-direction: column; }
+.pool-g__head { display: flex; align-items: baseline; gap: 9px; padding: 0 0 6px; }
+.pool-g__name {
+  font-family: var(--hy-font-mono); font-size: 10px; letter-spacing: .09em;
+  text-transform: uppercase; color: var(--hy-dim);
+}
+.pool-g__shared {
+  font-family: var(--hy-font-mono); font-size: 8.5px; letter-spacing: .05em; text-transform: uppercase;
+  color: var(--hy-mid); border: 1px solid rgba(224,169,58,.4); border-radius: 3px; padding: 0 4px;
+}
+.pool-g__spend {
+  margin-left: auto; font-family: var(--hy-font-mono); font-size: 9.5px;
+  color: var(--hy-faint); font-variant-numeric: tabular-nums;
+}
+
+.mrow {
+  display: grid; grid-template-columns: 9px minmax(0,1fr) 34px 84px 46px;
+  gap: 10px; align-items: center;
+  width: 100%; text-align: left;
+  padding: 8px 10px; border: 1px solid transparent; border-radius: var(--hy-radius-sm);
+  background: none; color: var(--hy-ink); font: inherit; font-size: 13px; cursor: pointer;
+}
+.mrow:hover { background: var(--hy-panel); }
+.mrow[aria-current="true"] { background: var(--hy-panel); border-color: var(--hy-line-2); }
+.mrow:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 1px; }
+.mrow__dot { width: 7px; height: 7px; border-radius: 50%; }
+.mrow__dot--on { background: var(--hy-cheap); }
+.mrow__dot--off { background: var(--hy-faint); }
+.mrow__name { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mrow__tier, .mrow__band, .mrow__cost {
+  font-family: var(--hy-font-mono); font-size: 10.5px; font-variant-numeric: tabular-nums;
+}
+.mrow__tier { color: var(--hy-faint); }
+.mrow__band { color: var(--hy-dim); }
+.mrow__cost { text-align: right; font-weight: 700; }
+.mrow__cost--free { color: var(--hy-cheap); }
+.mrow__cost--low  { color: var(--hy-cheap); }
+.mrow__cost--mid  { color: var(--hy-mid); }
+.mrow__cost--high { color: var(--hy-expensive); }
+
+.scard {
+  background: var(--hy-panel); border: 1px solid var(--hy-line);
+  border-radius: var(--hy-radius); padding: 15px 16px;
+  display: flex; flex-direction: column; gap: 7px;
+}
+.scard__name { font-size: 14.5px; font-weight: 600; letter-spacing: -.01em; }
+.scard__sub { font-size: 11.5px; color: var(--hy-dim); }
+.scard__hl { color: var(--hy-aqua); font-family: var(--hy-font-mono); }
+.scard__off { color: var(--hy-expensive); }
+.scard__rule { height: 1px; background: var(--hy-line); margin: 4px 0 2px; }
+.scard__lbl {
+  font-family: var(--hy-font-mono); font-size: 9.5px; letter-spacing: .09em;
+  text-transform: uppercase; color: var(--hy-faint);
+}
+.scard__line { display: flex; align-items: baseline; gap: 10px; font-size: 12px; }
+.scard__k { color: var(--hy-dim); }
+.scard__v { margin-left: auto; font-family: var(--hy-font-mono); font-size: 11.5px; }
+.scard__none { margin: 2px 0 0; font-size: 11.5px; color: var(--hy-dim); line-height: 1.5; }
+
+.scard__cal { display: flex; flex-direction: column; gap: 1px; padding: 5px 0; border-bottom: 1px solid var(--hy-line); }
+.scard__cal:last-child { border-bottom: none; }
+.scard__calTop { display: flex; align-items: baseline; gap: 8px; }
+.scard__calDom { font-family: var(--hy-font-mono); font-size: 11.5px; }
+.scard__calD {
+  margin-left: auto; font-family: var(--hy-font-mono); font-size: 13px;
+  font-weight: 700; font-variant-numeric: tabular-nums;
+}
+.scard__calD--strong   { color: var(--hy-cheap); }
+.scard__calD--moderate { color: var(--hy-mid); }
+.scard__calD--weak     { color: var(--hy-expensive); }
+/* Muted, not coloured: a score on too few outcomes must not read as a finding. */
+.scard__calD--thin     { color: var(--hy-faint); }
+.scard__calSub { font-family: var(--hy-font-mono); font-size: 9.5px; color: var(--hy-faint); }
+.scard__thin { color: var(--hy-mid); }

--- a/desktop/frontend/src/views/Dashboard.tsx
+++ b/desktop/frontend/src/views/Dashboard.tsx
@@ -65,8 +65,8 @@ function HudChrome() {
 function DashboardHeader() {
   return (
     <header className="view__head">
-      <h1 className="view__title view__title--brand">Dashboard</h1>
-      <p className="view__sub">Spend, governor pressure, and the trust ensemble's record.</p>
+      <h1 className="view__title view__title--brand">Usage</h1>
+      <p className="view__sub">What you spent, how much context budget is left, and which models earned their answers.</p>
     </header>
   )
 }
@@ -152,7 +152,7 @@ function SpendCard({ data }: { data: DashboardData }) {
       <div className="card">
         <div className="card__label">Spend today</div>
         <div className="card__value card__value--unknown">no data yet</div>
-        <div className="card__note">Nothing has dispatched on this machine.</div>
+        <div className="card__note">No requests on this machine yet.</div>
       </div>
     )
   }
@@ -559,7 +559,7 @@ function RecentTable({ data }: { data: DashboardData }) {
 function EmptyState() {
   return (
     <div className="empty" style={{ marginTop: 26 }}>
-      <p className="empty__title">Nothing has dispatched yet</p>
+      <p className="empty__title">No requests yet</p>
       <p>
         Run <code>hyctl dispatch --enum SIMPLE "…"</code> and this fills in.
       </p>

--- a/desktop/frontend/src/views/Fleet.tsx
+++ b/desktop/frontend/src/views/Fleet.tsx
@@ -17,18 +17,18 @@ export function Fleet({
   return (
     <>
       <header className="view__head">
-        <h1 className="view__title">Fleet</h1>
+        <h1 className="view__title">Activity</h1>
         <p className="view__sub">
           {data.liveCount > 0
-            ? `${data.liveCount} run${data.liveCount === 1 ? '' : 's'} in flight`
-            : 'Nothing running right now.'}
+            ? `${data.liveCount} request${data.liveCount === 1 ? '' : 's'} running now`
+            : 'Every request this machine has handled, newest first.'}
         </p>
       </header>
 
       {!data.hasRuns ? (
         <div className="empty">
-          <p className="empty__title">No runs yet</p>
-          <p>Start one from here, or run it from a terminal instead:</p>
+          <p className="empty__title">Nothing has run yet</p>
+          <p>Ask for something in Chat, or run it from a terminal instead:</p>
           <button className="empty__cta" onClick={onStartTask}>
             Start a task
           </button>

--- a/desktop/frontend/src/views/Models.test.tsx
+++ b/desktop/frontend/src/views/Models.test.tsx
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { Models } from './Models'
+import { GetDashboard, GetModels } from '../bindings'
+import type { CalibrationRow, Model, ModelRegistry } from '../types'
+
+vi.mock('../bindings', () => ({ GetModels: vi.fn(), GetDashboard: vi.fn() }))
+const mockModels = vi.mocked(GetModels)
+const mockDash = vi.mocked(GetDashboard)
+
+function model(over: Partial<Model> = {}): Model {
+  return {
+    id: 'sonnet-thinking',
+    name: 'Claude Sonnet (Thinking)',
+    tier: 3,
+    provider: 'antigravity',
+    pool: 'agy_claude',
+    complexityMin: 6,
+    complexityMax: 7,
+    speed: 'medium_slow',
+    accuracy: 'high',
+    contextWindow: 200000,
+    enabled: true,
+    ...over,
+  }
+}
+
+function registry(over: Partial<ModelRegistry> = {}): ModelRegistry {
+  return {
+    found: true,
+    pools: [
+      {
+        name: 'agy_claude',
+        shared: true,
+        models: [model(), model({ id: 'opus-thinking', name: 'Claude Opus (Thinking)', tier: 2 })],
+        observedCalls: 12,
+        observedCostUsd: 0.094,
+        observedTokens: 4000,
+      },
+    ],
+    ...over,
+  }
+}
+
+function cal(over: Partial<CalibrationRow> = {}): CalibrationRow {
+  return { source: 'model:sonnet-thinking', domain: 'go', d: 1.42, se: 0.8, sp: 0.7, n: 62, ...over }
+}
+
+beforeEach(() => {
+  mockModels.mockResolvedValue(registry())
+  mockDash.mockResolvedValue({ calibration: [] } as never)
+})
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('the model list', () => {
+  it('groups by shared quota and says when a quota is shared', async () => {
+    render(<Models />)
+    // agy_claude -> "Claude"; the raw pool key is config, not a label.
+    expect(await screen.findByText('Claude')).toBeInTheDocument()
+    expect(screen.getByText('shared quota')).toBeInTheDocument()
+  })
+
+  it('does not claim a quota is shared when it has one member', async () => {
+    mockModels.mockResolvedValue(
+      registry({
+        pools: [
+          {
+            name: 'local_ollama',
+            shared: true,
+            models: [model({ id: 'qwen', name: 'Qwen', tier: 10 })],
+            observedCalls: 0,
+            observedCostUsd: 0,
+            observedTokens: 0,
+          },
+        ],
+      }),
+    )
+    render(<Models />)
+    // Twice by design: the list row, and the scorecard for the selected model.
+    expect(await screen.findAllByText('Qwen')).toHaveLength(2)
+    // Flagged shared, but with nothing to contend against, so saying so would mislead.
+    expect(screen.queryByText('shared quota')).not.toBeInTheDocument()
+  })
+
+  // Observed spend is Hydra's own log, not a provider balance. The wording and
+  // the tooltip both have to stop short of implying otherwise.
+  it('labels pool spend as logged, never as remaining quota', async () => {
+    render(<Models />)
+    const spend = await screen.findByTitle(/not a reading of the provider/i)
+    expect(spend.textContent).toMatch(/12 requests/)
+    expect(spend.textContent).toMatch(/logged/)
+  })
+
+  // usdExact renders 0 as an em-dash, which turned "no cost" into "- logged".
+  it('says a free pool costs nothing rather than printing a dash', async () => {
+    mockModels.mockResolvedValue(
+      registry({
+        pools: [
+          {
+            name: 'local_ollama',
+            shared: false,
+            models: [model({ id: 'qwen', name: 'Qwen', tier: 10 })],
+            observedCalls: 9,
+            observedCostUsd: 0,
+            observedTokens: 120,
+          },
+        ],
+      }),
+    )
+    render(<Models />)
+    const spend = await screen.findByTitle(/not a reading of the provider/i)
+    expect(spend.textContent).toMatch(/9 requests/)
+    expect(spend.textContent).toMatch(/no cost/)
+    expect(spend.textContent).not.toMatch(/logged/)
+  })
+
+  it('shows a disabled model rather than hiding it', async () => {
+    mockModels.mockResolvedValue(
+      registry({
+        pools: [
+          {
+            name: 'agy_claude',
+            shared: false,
+            models: [model({ enabled: false })],
+            observedCalls: 0,
+            observedCostUsd: 0,
+            observedTokens: 0,
+          },
+        ],
+      }),
+    )
+    render(<Models />)
+    expect(await screen.findAllByText('Claude Sonnet (Thinking)')).toHaveLength(2)
+    expect(screen.getByText(/switched off/)).toBeInTheDocument()
+  })
+})
+
+describe('the scorecard never states a score it cannot support', () => {
+  it('says nothing is measured rather than showing a zero', async () => {
+    render(<Models />)
+    expect(await screen.findByText(/absence of evidence, not a low score/i)).toBeInTheDocument()
+  })
+
+  it('always prints the outcome count beside the evidence weight', async () => {
+    mockDash.mockResolvedValue({ calibration: [cal()] } as never)
+    render(<Models />)
+    expect(await screen.findByText('1.42')).toBeInTheDocument()
+    expect(screen.getByText(/62 outcomes/)).toBeInTheDocument()
+  })
+
+  // The trap from #593: a high D on a handful of samples is not a measurement.
+  it('flags a strong-looking score built on too few outcomes', async () => {
+    mockDash.mockResolvedValue({ calibration: [cal({ d: 2.41, n: 4 })] } as never)
+    render(<Models />)
+    const score = await screen.findByText('2.41')
+    expect(screen.getByText(/too few to trust/i)).toBeInTheDocument()
+    // Muted, not green: it must not read as a finding.
+    expect(score.className).toMatch(/--thin/)
+    expect(score.className).not.toMatch(/--strong/)
+  })
+
+  it('grades a genuinely strong record as strong', async () => {
+    mockDash.mockResolvedValue({ calibration: [cal({ d: 1.42, n: 62 })] } as never)
+    render(<Models />)
+    expect((await screen.findByText('1.42')).className).toMatch(/--strong/)
+  })
+
+  it('grades a weak record as weak even with plenty of outcomes', async () => {
+    mockDash.mockResolvedValue({ calibration: [cal({ d: 0.28, n: 40 })] } as never)
+    render(<Models />)
+    expect((await screen.findByText('0.28')).className).toMatch(/--weak/)
+  })
+})
+
+describe('when the registry cannot be read', () => {
+  it('says it could not look, rather than showing an empty list as fact', async () => {
+    mockModels.mockResolvedValue({ found: false, error: 'malformed models.yaml', pools: [] })
+    render(<Models />)
+    expect(await screen.findByText(/Couldn't read the model registry/i)).toBeInTheDocument()
+    expect(screen.getByText(/malformed models.yaml/)).toBeInTheDocument()
+  })
+
+  it('renders nothing at all before the first read resolves', async () => {
+    let release: (r: ModelRegistry) => void = () => {}
+    mockModels.mockReturnValue(new Promise<ModelRegistry>((r) => (release = r)))
+    const { container } = render(<Models />)
+    expect(container).toBeEmptyDOMElement()
+    release(registry())
+    await waitFor(() => expect(container).not.toBeEmptyDOMElement())
+  })
+})

--- a/desktop/frontend/src/views/Models.tsx
+++ b/desktop/frontend/src/views/Models.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useMemo, useState } from 'react'
+import { GetDashboard, GetModels } from '../bindings'
+import type { CalibrationRow, Model, ModelRegistry, Pool } from '../types'
+import { sourceLabel, usdExact } from '../format'
+
+/** Retrospective, like the other reference views. Mirrors App's DASHBOARD_MS. */
+const SLOW_MS = 5000
+
+/**
+ * What this machine can route to, and how well each one has actually done.
+ *
+ * The registry has shipped since #553 and until now fed nothing but the
+ * composer's picker, so the app could route to twelve models and show you none
+ * of them. Grouped by shared quota rather than by vendor, because the quota is
+ * what a choice actually spends.
+ */
+export function Models() {
+  const [reg, setReg] = useState<ModelRegistry | null>(null)
+  const [cal, setCal] = useState<CalibrationRow[]>([])
+  const [selected, setSelected] = useState<string>('')
+
+  useEffect(() => {
+    const load = () => {
+      void GetModels().then(setReg).catch(() => {})
+      void GetDashboard()
+        .then((d) => setCal(d.calibration ?? []))
+        .catch(() => {})
+    }
+    load()
+    const t = setInterval(load, SLOW_MS)
+    return () => clearInterval(t)
+  }, [])
+
+  const all = useMemo(() => reg?.pools.flatMap((p) => p.models) ?? [], [reg])
+  const current = all.find((m) => m.id === selected) ?? all[0]
+
+  if (!reg) return null
+
+  if (!reg.found) {
+    return (
+      <>
+        <Head />
+        <div className="empty">
+          <p className="empty__title">Couldn't read the model registry</p>
+          <p>{reg.error || 'models.yaml could not be parsed.'}</p>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Head />
+      <div className="models">
+        <div className="models__tree">
+          {reg.pools.map((p) => (
+            <PoolGroup
+              key={p.name}
+              pool={p}
+              selected={current?.id ?? ''}
+              onSelect={setSelected}
+            />
+          ))}
+        </div>
+        {current && <Scorecard model={current} cal={cal} />}
+      </div>
+    </>
+  )
+}
+
+function Head() {
+  return (
+    <header className="view__head">
+      <h1 className="view__title">Models</h1>
+      <p className="view__sub">What this machine can route to, grouped by the quota each one spends.</p>
+    </header>
+  )
+}
+
+function PoolGroup({
+  pool,
+  selected,
+  onSelect,
+}: {
+  pool: Pool
+  selected: string
+  onSelect: (id: string) => void
+}) {
+  return (
+    <section className="pool-g">
+      <div className="pool-g__head">
+        <span className="pool-g__name">{poolLabel(pool.name)}</span>
+        {pool.shared && pool.models.length > 1 && <span className="pool-g__shared">shared quota</span>}
+        {pool.observedCalls > 0 && (
+          <span
+            className="pool-g__spend"
+            title="What Hydra logged against this quota. Not a reading of the provider's remaining balance."
+          >
+            {pool.observedCalls} requests &middot;{' '}
+            {pool.observedCostUsd > 0 ? `${usdExact(pool.observedCostUsd)} logged` : 'no cost'}
+          </span>
+        )}
+      </div>
+      {pool.models.map((m) => (
+        <button
+          key={m.id}
+          className="mrow"
+          aria-current={m.id === selected ? 'true' : undefined}
+          onClick={() => onSelect(m.id)}
+        >
+          <span className={`mrow__dot ${m.enabled ? 'mrow__dot--on' : 'mrow__dot--off'}`} />
+          <span className="mrow__name">{m.name || m.id}</span>
+          <span className="mrow__tier">T{m.tier}</span>
+          <span className="mrow__band">{complexity(m)}</span>
+          <span className={`mrow__cost mrow__cost--${priceBand(m.tier)}`}>{priceMark(m.tier)}</span>
+        </button>
+      ))}
+    </section>
+  )
+}
+
+/**
+ * One model's record. Capability is what the registry claims; the scorecard
+ * below it is what was measured — and it never shows a score without the
+ * sample count that decides whether the score means anything (#593).
+ */
+function Scorecard({ model, cal }: { model: Model; cal: CalibrationRow[] }) {
+  const rows = cal.filter((r) => matches(r.source, model))
+
+  return (
+    <aside className="scard">
+      <div className="scard__name">{model.name || model.id}</div>
+      <div className="scard__sub">
+        {model.provider} &middot; tier <span className="scard__hl">T{model.tier}</span>
+        {!model.enabled && <span className="scard__off"> &middot; switched off</span>}
+      </div>
+
+      <div className="scard__rule" />
+      <Line k="Handles complexity" v={complexity(model)} />
+      <Line k="Speed" v={model.speed ? model.speed.replace(/_/g, ' ') : '—'} />
+      <Line k="Accuracy claimed" v={model.accuracy ? model.accuracy.replace(/_/g, ' ') : '—'} />
+      <Line k="Context window" v={model.contextWindow > 0 ? `${Math.round(model.contextWindow / 1000)}k` : '—'} />
+
+      <div className="scard__rule" />
+      <div className="scard__lbl">Measured record</div>
+      {rows.length === 0 ? (
+        <p className="scard__none">
+          Nothing measured yet. This is absence of evidence, not a low score — record outcomes
+          and it fills in.
+        </p>
+      ) : (
+        rows.map((r) => (
+          <div className="scard__cal" key={`${r.source} ${r.domain}`}>
+            <div className="scard__calTop">
+              <span className="scard__calDom">{r.domain}</span>
+              <span className={`scard__calD scard__calD--${weight(r)}`}>{r.d.toFixed(2)}</span>
+            </div>
+            <div className="scard__calSub">
+              evidence weight &middot; {r.n} {r.n === 1 ? 'outcome' : 'outcomes'}
+              {r.n < 10 && <span className="scard__thin"> &middot; too few to trust</span>}
+            </div>
+          </div>
+        ))
+      )}
+    </aside>
+  )
+}
+
+function Line({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="scard__line">
+      <span className="scard__k">{k}</span>
+      <span className="scard__v">{v}</span>
+    </div>
+  )
+}
+
+function complexity(m: Model): string {
+  if (m.complexityMax <= 0) return '—'
+  return `${m.complexityMin}–${m.complexityMax}`
+}
+
+/**
+ * A model's calibration is keyed by source ("model:claude-sonnet"), which is
+ * not the registry id. Match on the labelled tail so a renamed registry entry
+ * does not silently drop its own history.
+ */
+function matches(source: string, m: Model): boolean {
+  const tail = sourceLabel(source).toLowerCase()
+  const id = m.id.toLowerCase()
+  const name = (m.name || '').toLowerCase()
+  return tail === id || id.includes(tail) || name.includes(tail)
+}
+
+/** Strong / moderate / weak, by the same thresholds the reference views use. */
+function weight(r: CalibrationRow): 'strong' | 'moderate' | 'weak' | 'thin' {
+  if (r.n < 10) return 'thin'
+  if (r.d >= 1) return 'strong'
+  if (r.d >= 0.5) return 'moderate'
+  return 'weak'
+}
+
+/** Price as a shape, not a number: tiers are ordinal and rates move. */
+function priceMark(tier: number): string {
+  if (tier >= 10) return 'free'
+  if (tier >= 7) return '$'
+  if (tier >= 4) return '$$'
+  return '$$$'
+}
+function priceBand(tier: number): 'free' | 'low' | 'mid' | 'high' {
+  if (tier >= 10) return 'free'
+  if (tier >= 7) return 'low'
+  if (tier >= 4) return 'mid'
+  return 'high'
+}
+
+/** agy_claude → "Claude". The raw keys are config, not labels. */
+export function poolLabel(name: string): string {
+  if (name === 'unpooled') return 'No shared quota'
+  return name
+    .replace(/^agy_/, '')
+    .replace(/^local_/, '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}

--- a/desktop/frontend/src/views/Security.tsx
+++ b/desktop/frontend/src/views/Security.tsx
@@ -82,7 +82,7 @@ export function Security({ data }: { data: SecurityReport }) {
       <header className="view__head">
         <div className="sec-headrow">
           <div>
-            <h1 className="view__title">Security</h1>
+            <h1 className="view__title">Audit</h1>
             <p className="view__sub">
               What the agents on this machine did, and whether you need to act today.
             </p>


### PR DESCRIPTION
Closes #603. First step of the desktop app redesign. The TUI canvas (epic #600) is the
reference for vocabulary and IA; this is the Wails app, not a port.

## Why the released build read as jargon
The rail said **Dashboard / Fleet / Session / Security** — Hydra's internal names. Renamed
to the signed-off vocabulary: **Chat · Models · Activity · Usage · Audit**. Prose swept too:
"Nothing has dispatched" became "No requests yet", "governor pressure and the trust
ensemble's record" became "how much context budget is left, and which models earned their
answers". **Labels and strings only** — component and Go names are untouched, per the
design rule, so this is not a rename sweep.

## Models is new, and it is the biggest gap
`GetModels()` shipped in #553 and has fed nothing but the composer's picker. The app could
route to twelve models and show you none of them. Now: a tree grouped by **shared quota**
(because the quota is what a choice actually spends), with health, tier, complexity band and
a price shape, plus a per-model scorecard.

Two honesty rules baked in and tested:
- **No evidence weight without its outcome count.** A `D` with no `n` beside it is the exact
  defect #593 just fixed on the other panel.
- **Anything under ten outcomes renders muted, not coloured.** A `D` of 2.41 on four samples
  must not read as the best score on the card. Tested.

Pool spend is labelled "logged" with a tooltip saying it is not a reading of the provider's
balance, because Hydra cannot see one. A free pool says "no cost" rather than printing an
em-dash, which is what `usdExact(0)` produced on first render — caught in a screenshot, not
in a test.

## Session left the rail
It is a drill-in from Activity, which is how it was already reached. As a peer it had to
guess which run you meant, which is why `selectNav` carried a most-recent-run fallback. That
fallback is now gone.

## One robustness fix worth calling out
The remaining views are wrapped in the existing `ErrorBoundary`. A single undefined field in
the spend payload used to throw from `Dashboard`'s `.toFixed()` and **unmount the entire
shell** — rail included, with nothing in the console. I found it with a deliberately partial
fixture, then re-broke it on purpose to prove the fix: the shell now survives with all five
rail items and a panel reading "Usage failed to render: Cannot read properties of undefined".

## Deliberately not here
- **Agents.** Its headline group is "waiting on you", which needs #583. An always-empty nav
  item is the hollowness this is meant to remove.
- **`SAVED` / `IF THIS HAD FALLEN BACK`.** These need a counterfactual computed net of every
  fallback attempt; naive savings would overstate, because Hydra retries by design.
- **Workflows.** No plan/step engine exists yet.

## Testing
62 frontend tests pass (14 new for Models), `npm run typecheck` and `npm run build` clean,
`go build ./...` clean in `desktop/`. Verified visually against a realistic registry and
calibration fixture, not just against the CSS.