### PR TITLE
fix(ci): close the issues a release shipped, instead of by hand

### DIFF
--- a/.github/workflows/close-shipped-issues.yml
+++ b/.github/workflows/close-shipped-issues.yml
@@ -1,0 +1,79 @@
+name: Close shipped issues
+
+# GitHub only fires a closing keyword on merges into the default branch, and every
+# feature PR here targets develop — so `Closes #n` links but never closes (#217).
+# This closes them at release time instead.
+#
+# Called by release-please.yml and release.yml; workflow_dispatch backfills a tag.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to sweep (e.g. v1.3.1)"
+        required: true
+        type: string
+      dry_run:
+        description: "List what would be closed without closing anything"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: close-shipped-issues
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Close issues shipped in ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      # Deliberately NOT checked out at the tag: the resolver script must be the
+      # current one, or backfilling a tag from before it existed finds no script.
+      # fetch-depth 0 brings the tag along anyway.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # main carries one squash commit per release, so its own log names only the
+      # release PRs. Their refs/pull/N/head is the develop lineage that shipped —
+      # the individual feature PRs live there, and nowhere on main.
+      - name: Collect the PRs in this release
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          git rev-parse -q --verify "refs/tags/${TAG}^{commit}" >/dev/null \
+            || { echo "::error::Tag ${TAG} does not exist."; exit 1; }
+          subjects_to_prs() { sed -nE 's/.*\(#([0-9]+)\)[[:space:]]*$/\1/p'; }
+
+          git log --format='%s' "refs/tags/${TAG}" | subjects_to_prs | sort -un > release_prs.txt
+          echo "Release PRs on main: $(tr '\n' ' ' < release_prs.txt)"
+
+          cp release_prs.txt shipped_prs.txt
+          while read -r pr; do
+            if git fetch --quiet --no-tags origin "refs/pull/${pr}/head:refs/shipped/${pr}" 2>/dev/null; then
+              git log --format='%s' "refs/shipped/${pr}" | subjects_to_prs >> shipped_prs.txt
+            else
+              echo "::warning::refs/pull/${pr}/head is unavailable — skipping its lineage."
+            fi
+          done < release_prs.txt
+
+          sort -un -o shipped_prs.txt shipped_prs.txt
+          echo "Shipped PRs: $(wc -l < shipped_prs.txt)"
+
+      - name: Close their issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: python3 .github/workflows/close_shipped_issues.py

--- a/.github/workflows/close_shipped_issues.py
+++ b/.github/workflows/close_shipped_issues.py
@@ -1,0 +1,108 @@
+"""Close the issues whose PRs shipped in a release. Driven by close-shipped-issues.yml.
+
+Reads shipped_prs.txt (PR numbers in the release), recovers `Closes #n` from each PR
+body, and closes those issues. GitHub's own link API is empty for develop-targeted
+PRs, so the body is the only surviving record of what a PR closes.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+REPO = os.environ["REPO"]
+TAG = os.environ["TAG"]
+DRY_RUN = os.environ.get("DRY_RUN", "") == "true"
+OWNER, NAME = REPO.split("/")
+
+# The keyword set GitHub itself honours. Anchored on a word boundary so "for #517"
+# stays a plain reference and only an actual closing keyword closes anything.
+CLOSES = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)\b", re.IGNORECASE
+)
+BATCH = 50
+
+
+def graphql(query):
+    """A number that is not a PR errors for that alias alone; gh exits 1 but still
+    prints the rest, which is what we want. Only a wholly empty reply is fatal."""
+    out = subprocess.run(
+        ["gh", "api", "graphql", "-f", "query=" + query],
+        capture_output=True, text=True,
+    ).stdout
+    payload = json.loads(out) if out.strip() else {}
+    repo = (payload.get("data") or {}).get("repository")
+    if repo is None:
+        sys.exit("GraphQL returned no repository data: " + out[:500])
+    return [node for node in repo.values() if node]
+
+
+def batched(numbers, field):
+    for i in range(0, len(numbers), BATCH):
+        chunk = numbers[i:i + BATCH]
+        aliases = " ".join("n%d: %s" % (n, field % n) for n in chunk)
+        yield from graphql('{ repository(owner:"%s", name:"%s") { %s } }' % (OWNER, NAME, aliases))
+
+
+def main():
+    with open("shipped_prs.txt") as fh:
+        shipped = sorted({int(line) for line in fh if line.strip()})
+    print("Shipped PRs: %d" % len(shipped))
+
+    closes = {}
+    for pr in batched(shipped, "pullRequest(number:%d){ number body merged }"):
+        if not pr["merged"]:
+            continue
+        for issue in CLOSES.findall(pr["body"] or ""):
+            closes.setdefault(int(issue), set()).add(pr["number"])
+    print("Referenced issue numbers: %d" % len(closes))
+
+    # A closing keyword can name a PR, or an issue someone already closed. Only an
+    # OPEN Issue is touched, which is also what makes a re-run a no-op.
+    query = ("issueOrPullRequest(number:%d){ __typename "
+             "... on Issue { number title state } }")
+    targets = [n for n in batched(sorted(closes), query)
+               if n.get("__typename") == "Issue" and n["state"] == "OPEN"]
+
+    summary = ["### Close shipped issues — `%s`" % TAG, ""]
+    if not targets:
+        print("Nothing to close: every referenced issue is already closed.")
+        summary.append("Nothing to close — every issue in this release is already closed.")
+    else:
+        summary.append("| Issue | Shipped by | Title |")
+        summary.append("|---|---|---|")
+
+    failures = []
+    for issue in targets:
+        num = issue["number"]
+        via = ", ".join("#%d" % p for p in sorted(closes[num]))
+        if DRY_RUN:
+            print("DRY RUN would close #%d (via %s) — %s" % (num, via, issue["title"]))
+        else:
+            done = subprocess.run(
+                ["gh", "issue", "close", str(num), "--repo", REPO,
+                 "--comment", "Shipped in %s." % TAG],
+                capture_output=True, text=True,
+            )
+            if done.returncode != 0:
+                failures.append("#%d: %s" % (num, done.stderr.strip()))
+                continue
+            print("Closed #%d (via %s)" % (num, via))
+            time.sleep(1)  # stay under GitHub's content-creation secondary rate limit
+        summary.append("| #%d | %s | %s |" % (num, via, issue["title"]))
+
+    summary.append("")
+    summary.append("%d issue(s)%s." % (len(targets), " — dry run, nothing closed" if DRY_RUN else " closed"))
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a") as fh:
+            fh.write("\n".join(summary) + "\n")
+
+    if failures:
+        sys.exit("Failed to close:\n  " + "\n  ".join(failures))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/close_shipped_issues.py
+++ b/.github/workflows/close_shipped_issues.py
@@ -1,8 +1,8 @@
 """Close the issues whose PRs shipped in a release. Driven by close-shipped-issues.yml.
 
-Reads shipped_prs.txt (PR numbers in the release), recovers `Closes #n` from each PR
-body, and closes those issues. GitHub's own link API is empty for develop-targeted
-PRs, so the body is the only surviving record of what a PR closes.
+Reads shipped_prs.txt (the numbers in the release's commit subjects), works out what
+each one closes, and closes those issues. GitHub's own link API is empty for
+develop-targeted PRs, so a PR body is the only surviving record of what it closes.
 """
 
 import json
@@ -26,8 +26,9 @@ BATCH = 50
 
 
 def graphql(query):
-    """A number that is not a PR errors for that alias alone; gh exits 1 but still
-    prints the rest, which is what we want. Only a wholly empty reply is fatal."""
+    """A number that exists as neither issue nor PR errors for that alias alone; gh
+    exits 1 but still prints the rest, which is what we want. A batch where every
+    alias came back null is not that — it means the query shape is wrong, so fail."""
     out = subprocess.run(
         ["gh", "api", "graphql", "-f", "query=" + query],
         capture_output=True, text=True,
@@ -36,7 +37,10 @@ def graphql(query):
     repo = (payload.get("data") or {}).get("repository")
     if repo is None:
         sys.exit("GraphQL returned no repository data: " + out[:500])
-    return [node for node in repo.values() if node]
+    nodes = [node for node in repo.values() if node]
+    if repo and not nodes:
+        sys.exit("GraphQL resolved none of %d aliases: %s" % (len(repo), out[:500]))
+    return nodes
 
 
 def batched(numbers, field):
@@ -49,21 +53,30 @@ def batched(numbers, field):
 def main():
     with open("shipped_prs.txt") as fh:
         shipped = sorted({int(line) for line in fh if line.strip()})
-    print("Shipped PRs: %d" % len(shipped))
+    print("Numbers in the release's commit subjects: %d" % len(shipped))
 
-    closes = {}
-    for pr in batched(shipped, "pullRequest(number:%d){ number body merged }"):
-        if not pr["merged"]:
-            continue
-        for issue in CLOSES.findall(pr["body"] or ""):
-            closes.setdefault(int(issue), set()).add(pr["number"])
-    print("Referenced issue numbers: %d" % len(closes))
+    # A trailing (#n) is not always a PR. GitHub's squash default appends the PR
+    # number, but this repo's own commit convention appends the ISSUE number
+    # (CLAUDE.md: `git commit -m "feat(stats): ... (#${ISSUE})"`), and both are in
+    # the history — so resolve what the number actually is and handle each.
+    query = ("issueOrPullRequest(number:%d){ __typename "
+             "... on Issue { number } "
+             "... on PullRequest { number body merged } }")
+    via = {}
+    for node in batched(shipped, query):
+        if node["__typename"] == "Issue":
+            # The commit names the issue it implements: it shipped, no body to read.
+            via.setdefault(node["number"], set()).add("commit subject")
+        elif node["merged"]:
+            for issue in CLOSES.findall(node["body"] or ""):
+                via.setdefault(int(issue), set()).add("#%d" % node["number"])
+    print("Referenced issue numbers: %d" % len(via))
 
     # A closing keyword can name a PR, or an issue someone already closed. Only an
     # OPEN Issue is touched, which is also what makes a re-run a no-op.
     query = ("issueOrPullRequest(number:%d){ __typename "
              "... on Issue { number title state } }")
-    targets = [n for n in batched(sorted(closes), query)
+    targets = [n for n in batched(sorted(via), query)
                if n.get("__typename") == "Issue" and n["state"] == "OPEN"]
 
     summary = ["### Close shipped issues — `%s`" % TAG, ""]
@@ -77,9 +90,9 @@ def main():
     failures = []
     for issue in targets:
         num = issue["number"]
-        via = ", ".join("#%d" % p for p in sorted(closes[num]))
+        source = ", ".join(sorted(via[num]))
         if DRY_RUN:
-            print("DRY RUN would close #%d (via %s) — %s" % (num, via, issue["title"]))
+            print("DRY RUN would close #%d (via %s) — %s" % (num, source, issue["title"]))
         else:
             done = subprocess.run(
                 ["gh", "issue", "close", str(num), "--repo", REPO,
@@ -89,9 +102,9 @@ def main():
             if done.returncode != 0:
                 failures.append("#%d: %s" % (num, done.stderr.strip()))
                 continue
-            print("Closed #%d (via %s)" % (num, via))
+            print("Closed #%d (via %s)" % (num, source))
             time.sleep(1)  # stay under GitHub's content-creation secondary rate limit
-        summary.append("| #%d | %s | %s |" % (num, via, issue["title"]))
+        summary.append("| #%d | %s | %s |" % (num, source, issue["title"]))
 
     summary.append("")
     summary.append("%d issue(s)%s." % (len(targets), " — dry run, nothing closed" if DRY_RUN else " closed"))

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,3 +45,16 @@ jobs:
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
     secrets: inherit
+
+  # The tag release-please creates is made with GITHUB_TOKEN, and events raised by
+  # that token start no workflow — so this has to hang off the job graph, like publish.
+  close-issues:
+    name: Close shipped issues
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/close-shipped-issues.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,14 @@ jobs:
     with:
       tag: ${{ github.ref_name }}
     secrets: inherit
+
+  # Stable tags only — an RC tag points at a release branch that has not shipped.
+  close-issues:
+    name: Close shipped issues
+    if: ${{ !contains(github.ref_name, '-') }}
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/close-shipped-issues.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ Every issue must be:
 2. **Linked to its branch** — GitHub auto-links when branch name contains the issue number (`feature/54-hydra-stats` links to #54)
 3. **Linked to its PR** — PR body must contain `Closes #<issue>` so the PR shows on the issue
 4. **Moving through board states** at every transition (Todo → In Progress → In Review → Done)
-5. **Closed by hand once the release carrying it reaches `main`** — see below; nothing closes it for you
+5. **Closed once the release carrying it reaches `main`** — automated by `close-shipped-issues.yml`, see below
 
 ### Link a branch to an issue (GitHub auto-detection)
 GitHub automatically links a branch to an issue when the branch name contains the issue number.
@@ -308,23 +308,30 @@ gh issue view 54 --json linkedBranches
 ```
 
 ### Link a PR to an issue
-Always include `Closes #<n>` in the PR body. This shows the PR on the issue page and creates the
-link — that is the whole reason to keep writing it.
+Always include `Closes #<n>` in the PR body.
 
-**It does not close the issue.** GitHub only honours the closing keyword when the PR merges into the
-**default branch**, which here is `main`. Every feature/fix PR targets `develop` by design, so the
-keyword links but never fires — and it fails silently: the PR merges green and the issue stays open.
-17 issues accumulated this way before anyone noticed (#217).
+GitHub only honours the closing keyword when the PR merges into the **default branch**, which here
+is `main`. Every feature/fix PR targets `develop` by design, so the keyword links but never fires —
+and it fails silently: the PR merges green and the issue stays open. 17 issues accumulated this way
+before anyone noticed (#217), and 96 more before the sweep below existed.
 
-Close issues explicitly when the release carrying them lands on `main`, which is the board's
-existing `Deploy` → `Done` transition:
+**Write the keyword anyway — it is now the thing that closes the issue.** At release time
+`close-shipped-issues.yml` reads `Closes #n` back out of the body of every PR in the release and
+closes each one with `Shipped in vX.Y.Z.` GitHub's own link API (`closingIssuesReferences`) is
+**empty** for develop-targeted PRs, so the PR body is the only record of the link that survives:
+a PR body without the keyword is an issue that never closes.
+
+If an issue is still open after a release, sweep it by hand:
 
 ```bash
-gh issue close <n> --comment "Shipped in v1.1.0."
+gh workflow run close-shipped-issues.yml -f tag=v1.3.1 -f dry_run=true   # what would close
+gh workflow run close-shipped-issues.yml -f tag=v1.3.1                   # close it
 ```
 
-(This is unrelated to the project-board columns, which need a `read:project` OAuth scope. Closing
-an issue needs no extra scope.)
+Re-running is safe: it only ever closes issues that are open, and never reopens anything.
+
+(Board columns are untouched — they need a `read:project` scope `GITHUB_TOKEN` does not have, so
+`Deploy` → `Done` stays a manual move.)
 
 ---
 
@@ -437,8 +444,8 @@ gh project item-edit --project-id PVT_kwHOAL1qLc4BZbZZ --id "$ITEM_ID" \
 
 **PR rules:**
 - Title must be a valid conventional commit (e.g. `feat(scope): description`)
-- Body must contain `Closes #<issue>` — this links the PR to the issue. It does **not** close it:
-  the keyword only fires on merge into the default branch (`main`). Close it by hand at release.
+- Body must contain `Closes #<issue>`. The keyword does not fire on a develop-targeted PR, but
+  `close-shipped-issues.yml` reads it at release time and closes the issue then. No keyword, no close.
 - All features/fixes target `develop`. Hotfixes target `main` — and there the keyword *does* fire.
 - Never open a PR directly to `main` from a feature branch.
 
@@ -479,9 +486,11 @@ PR: release/v1.2.0 → main  (squash merge — MUST carry a Release-As footer, s
         ↓
 release-please opens Release PR on main (bumps version, updates CHANGELOG)
         ↓
-Merge Release PR → tag v1.2.0 created → release.yml fires
+Merge Release PR → tag v1.2.0 created → release-please.yml fans the release out
         ↓
 GoReleaser builds all platforms, publishes stable release, updates Homebrew tap
+        ↓
+close-shipped-issues.yml closes every issue in the release ("Shipped in v1.2.0.")
         ↓
 Cherry-pick any release-branch fixes back to develop
 ```
@@ -529,6 +538,22 @@ If no Release PR appears, the footer was missing. Fix it by pushing another PR t
 carrying the footer; do **not** create the tag by hand — a manual tag leaves
 `.release-please-manifest.json` behind at the old version, and the next release is then
 computed off the wrong base (#215).
+
+### Closing the issues the release shipped
+
+`close-shipped-issues.yml` does this, hung off release-please.yml's job graph rather than a
+`release` or tag-push trigger: release-please tags with `GITHUB_TOKEN`, and events raised by
+that token start no workflow, so a trigger-based sweep would never fire at all.
+
+`main` carries only one squash commit per release, so its own log names just the release PRs.
+The workflow follows each one's `refs/pull/<n>/head` into the develop lineage that actually
+shipped, recovers `Closes #n` from those PR bodies, and closes what is still open. Verify:
+
+```bash
+gh run list --workflow "Close shipped issues" --limit 1
+```
+
+If it did not fire, re-run it by hand — see **Link a PR to an issue** above.
 
 ### Cutting a release branch
 
@@ -680,9 +705,8 @@ gh project item-edit --project-id PVT_kwHOAL1qLc4BZbZZ --id "$ITEM_ID" \
 gh project item-edit --project-id PVT_kwHOAL1qLc4BZbZZ --id "$ITEM_ID" \
   --field-id PVTSSF_lAHOAL1qLc4BZbZZzhUaGlE --single-select-option-id bcafa7ca
 
-# 6. After the release carrying it lands on main — close the issue, then move to Done.
-#    Nothing does this for you: "Closes #n" does not fire on a develop-targeted PR (#217).
-gh issue close "${ISSUE}" --comment "Shipped in v1.1.0."
+# 6. The release carrying it lands on main → close-shipped-issues.yml closes the issue from
+#    the "Closes #n" in the PR body. Only the board move is left to do by hand.
 gh project item-edit --project-id PVT_kwHOAL1qLc4BZbZZ --id "$ITEM_ID" \
   --field-id PVTSSF_lAHOAL1qLc4BZbZZzhUaGlE --single-select-option-id 98236657
 ```
@@ -720,7 +744,11 @@ internal/update/update.go     ← startup update checker (24h cache)
 .github/workflows/edge.yml    ← fires on develop push → edge build
 .github/workflows/rc.yml      ← fires on release/v* push → RC pre-release
 .github/workflows/publish.yml ← fans a release out to brew/npm/pip
-.github/workflows/release-please.yml ← fires on main push → release PR
+.github/workflows/release-please.yml ← fires on main push → release PR, then fans out to
+                                       publish.yml and close-shipped-issues.yml
+.github/workflows/close-shipped-issues.yml ← closes the issues a release shipped, read back
+                                       from "Closes #n" in each PR body (#217). Its resolver
+                                       is close_shipped_issues.py beside it.
 .github/workflows/sync-develop.yml   ← fires on main push → back-merge PR (main → develop).
                                        FAILS loudly on conflict; a red run here means develop
                                        is behind main and a release cut will not merge cleanly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -547,7 +547,14 @@ that token start no workflow, so a trigger-based sweep would never fire at all.
 
 `main` carries only one squash commit per release, so its own log names just the release PRs.
 The workflow follows each one's `refs/pull/<n>/head` into the develop lineage that actually
-shipped, recovers `Closes #n` from those PR bodies, and closes what is still open. Verify:
+shipped, and reads the trailing `(#n)` off every commit subject there.
+
+**That `(#n)` is not always a PR.** GitHub's squash default appends the PR number, but the
+Quick Start below prescribes `(#${ISSUE})` in the commit subject, and both conventions are in
+the history. So each number is resolved to whichever it is: a PR means read `Closes #m` out of
+its body, an issue means the commit names the issue it shipped. Only issues still open are
+touched. Handling just one convention silently loses most of the release — that is what the
+first cut of this workflow did. Verify:
 
 ```bash
 gh run list --workflow "Close shipped issues" --limit 1


### PR DESCRIPTION
## Summary

`Closes #n` never closes anything here. GitHub only honours a closing keyword when the PR merges
into the **default branch**, and every feature/fix PR targets `develop` by design. The keyword
links and then silently does nothing. 96 issues had to be closed by hand after v1.2.0 / v1.3.1;
documenting the trap (#217) did not hold, so this automates it.

## How "what shipped" is determined, and why

Two facts rule out the obvious methods, both verified against this repo:

1. **Ancestry against `main` is always wrong.** Everything is squash-merged twice
   (feature → `develop`, release → `main`), so a develop commit's SHA is not an ancestor of
   `main` even when its code shipped. `git merge-base --is-ancestor` reports nothing shipped.
2. **`main`'s log names only the release PRs.** It carries exactly one squash commit per
   release. Diffing `v1.2.0..v1.3.1` yields 2 PR refs, and the release-please CHANGELOG entry
   names 1. Neither is the ~190 that actually shipped, so parsing release notes does not work.

A third fact rules out every off-the-shelf action: **GitHub's link API is empty for
develop-targeted PRs.** `PullRequest.closingIssuesReferences` returns `[]` for #584, #585, #586,
#588 and #592, as does the inverse `closedByPullRequestsReferences` on the issues. The PR *body*
is the only surviving record of what a PR closes.

So the workflow does this:

```
tag ──► git log on main ──► the release PRs (#324, #441, #545, …)
            └─► refs/pull/<n>/head ──► the develop lineage that shipped ──► its (#n) subjects
                        ├─► the number is a PR    ──► "Closes #m" in its body
                        └─► the number is an Issue ──► that issue shipped
                                    └─► close the ones still OPEN
```

`refs/pull/<n>/head` is the key: permanent, survives branch deletion, and is the develop lineage
the release was built from. It gives a correct **upper** bound — nothing merged after the cut is
reachable from it. Confirmed against the surviving `release/v1.3.0` branch: its subject set (166)
is a strict subset of PR #441's head lineage (180), so nothing is missed. The lower bound is
deliberately left open, because only OPEN issues are ever touched.

### The trailing `(#n)` is not always a PR

This was a real bug in the first cut of this PR, caught in review. GitHub's squash default
appends the **PR** number, but this repo's Quick Start prescribes
`git commit -m "feat(stats): ... (#${ISSUE})"` — the **issue** number. Both conventions are in
the history, so assuming "PR" returned a partial answer rather than an obviously empty one.

Concretely: issue #118 shipped via PR #361 as `feat(trust): ... (#118)`.
`pullRequest(number:118)` returns null because 118 is an Issue, the null was filtered as
not-a-PR, and #118 never closed. Same shape for #351, #353, #355, #358, #362, #363, #364 and
more. The resolver now uses `issueOrPullRequest` and branches on `__typename`, with a comment
saying why, so it does not get "simplified" back.

## Safety properties

- **Only closes, never reopens.** The sole mutation is `gh issue close`.
- **Evidence required.** Either a *merged* PR in the release's own lineage says it closes the
  issue, or a commit in that lineage names the issue directly. `for #517` is not a closing
  keyword and is not matched.
- **Idempotent.** Only issues in state `OPEN` are selected, so a re-run closes nothing.
- **Fails loudly on a bad query shape.** A batch where every alias resolves to null is no longer
  tolerated as "these were not PRs" — that is exactly what hid the bug above.
- **No extra scope.** `contents: read` + `issues: write` from `GITHUB_TOKEN`. No project-board
  moves — those need `read:project`, which the token does not have, so `Deploy` → `Done` stays
  manual (documented).
- **Backfill.** `workflow_dispatch` takes a `tag` and a `dry_run` flag.

## Why it hangs off the job graph, not a trigger

release-please creates the tag and release with `GITHUB_TOKEN`, and events raised by that token
start no workflow run. A `release: published` or `push: tags` trigger would never fire. So it is
a reusable workflow invoked from `release-please.yml` exactly the way `publish.yml` already is,
plus `release.yml` for the manual-tag path (stable tags only — an RC tag points at a release
branch that has not shipped).

## Validation

`actionlint` (which also shellchecks the `run:` blocks) is clean on all three workflows. The full
pipeline was run locally against the live repo.

**Recall fix, measured against `v1.3.1`:** 192 numbers in the release's commit subjects resolve to
**141** issues, up from 127 before the fix. The +14 come from the direct-issue path, and the two
paths are **disjoint** (overlap 0) — both conventions really are needed. On the eight
ground-truth issues named in review, recall is **8/8**, all via the path that was missing:

```
#118  FOUND  via commit subject     #358  FOUND  via commit subject
#351  FOUND  via commit subject     #362  FOUND  via commit subject
#353  FOUND  via commit subject     #363  FOUND  via commit subject
#355  FOUND  via commit subject     #364  FOUND  via commit subject
```

**Both closing paths, dry run on a synthetic list:**

```
DRY RUN would close #576 (via commit subject) — feat: hyctl mcp registry list …
DRY RUN would close #578 (via commit subject) — feat: local behavioral-drift detection …
DRY RUN would close #580 (via #586) — feat(ledger): add an Ask verdict …
DRY RUN would close #591 (via #592) — docs: index.html never mentioned the MCP registry
DRY RUN would close #595 (via #601) — fix(mcp): scoring engine rewards missing evidence …
```

**The all-null guard** fires on exactly the query shape that hid the bug
(`pullRequest()` over issue numbers) while a healthy mixed batch still resolves.

A nonexistent tag fails loudly rather than sweeping nothing. No Go was touched.

## Changes

- `.github/workflows/close-shipped-issues.yml` — new; reusable + `workflow_dispatch`
- `.github/workflows/close_shipped_issues.py` — the resolver. Kept beside the workflow rather
  than in `.github/scripts/` to stay inside the directory this change was scoped to; GitHub only
  treats `.yml`/`.yaml` there as workflows, so a `.py` is inert
- `.github/workflows/release-please.yml` — invoke it after a release is created
- `.github/workflows/release.yml` — same for the manual-tag path, stable tags only
- `CLAUDE.md` — Issue Hygiene, PR rules, Step 6 and the pipeline file list now describe the
  automation, the two numbering conventions, and how to re-run it by hand

Closes #606
