### PR TITLE
feat(desktop): lead Activity with what was asked, not the run id

### DIFF
--- a/desktop/api/fleet.go
+++ b/desktop/api/fleet.go
@@ -59,6 +59,14 @@ type Run struct {
 	// as a complete one.
 	Skipped int `json:"skipped"`
 
+	// Goal is what was asked, in the requester's words — the run-started
+	// event's own detail. It is the only human-readable identifier a run has;
+	// without it a list of runs is a list of timestamps. Empty when the run
+	// recorded no prompt (an external orchestrator can supply the id and
+	// nothing else), and a preview rather than the full text, because the log
+	// stores a preview.
+	Goal string `json:"goal,omitempty"`
+
 	// Error is set when this run's log could not be read. The run still appears
 	// as a row — a bad file must not blank the whole view.
 	Error string `json:"error,omitempty"`
@@ -162,6 +170,11 @@ func buildRun(id string, live bool, now time.Time) Run {
 		return r
 	}
 
+	// tree.Reconstruct drops run-level events by design — they describe the
+	// invocation, not a node in it — so the prompt has to be read here, before
+	// the events are handed over, or it is lost to the view entirely.
+	r.Goal = runGoal(events)
+
 	t, _ := tree.Reconstruct(events)
 	r.Skipped = t.Skipped
 
@@ -212,6 +225,18 @@ func buildRun(id string, live bool, now time.Time) Run {
 }
 
 // eventSpan returns the earliest start and latest finish across a run's nodes.
+// runGoal returns what the run was asked to do, from the first run-started
+// event carrying a detail. Later events are ignored: a run has one goal, and
+// the first statement of it is the one that was actually requested.
+func runGoal(events []runlog.Event) string {
+	for _, e := range events {
+		if e.Kind == runlog.KindRunStarted && e.Detail != "" {
+			return e.Detail
+		}
+	}
+	return ""
+}
+
 func eventSpan(t *tree.Tree) (first, last time.Time) {
 	for _, id := range t.Order {
 		n := t.Nodes[id]

--- a/desktop/api/fleet_test.go
+++ b/desktop/api/fleet_test.go
@@ -380,3 +380,76 @@ func TestGetFleet_ConcurrentCallsAreSafe(t *testing.T) {
 		}
 	}
 }
+
+// A list of runs identified only by timestamp id is a list of timestamps. The
+// prompt is recorded on the run-started event, but tree.Reconstruct drops
+// run-level events, so it never reached the view until this read (#603).
+func TestGetFleet_CarriesWhatTheRunWasAskedToDo(t *testing.T) {
+	sandbox(t)
+	const id = "20260903T120000Z-goaltest"
+	writeRun(t, id,
+		runlog.Event{Kind: runlog.KindRunStarted, TaskID: "t1", Detail: "add pagination to /users"},
+		runlog.Event{Kind: runlog.KindHeadSelected, TaskID: "t1", Head: "h", Tier: 6},
+		runlog.Event{Kind: runlog.KindRunFinished, TaskID: "t1"},
+	)
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findRun(t, f, id).Goal; got != "add pagination to /users" {
+		t.Errorf("Goal = %q, want the run-started detail", got)
+	}
+}
+
+// An external orchestrator can supply a run id and never a prompt. That is an
+// absent goal, not an error, and must not be fabricated from another event.
+func TestGetFleet_NoPromptLeavesTheGoalEmpty(t *testing.T) {
+	sandbox(t)
+	const id = "20260903T120001Z-nogoal"
+	writeRun(t, id,
+		runlog.Event{Kind: runlog.KindRunStarted, TaskID: "t1"},
+		runlog.Event{Kind: runlog.KindHeadSelected, TaskID: "t1", Head: "h", Tier: 6,
+			Detail: "candidate 1 of 2"},
+	)
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findRun(t, f, id).Goal; got != "" {
+		t.Errorf("Goal = %q, want empty — a head_selected detail is not the goal", got)
+	}
+}
+
+// One run, one goal: the first statement of it is what was actually requested.
+func TestGetFleet_FirstGoalWinsOverALaterRunStarted(t *testing.T) {
+	sandbox(t)
+	const id = "20260903T120002Z-twogoals"
+	writeRun(t, id,
+		runlog.Event{Kind: runlog.KindRunStarted, TaskID: "t1", Detail: "the real request"},
+		runlog.Event{Kind: runlog.KindHeadSelected, TaskID: "t1", Head: "h", Tier: 6},
+		// A second writer sharing the run appends its own run_started (runlog's
+		// own docs note several writers share one run).
+		runlog.Event{Kind: runlog.KindRunStarted, TaskID: "t2", Detail: "a second writer's idea"},
+	)
+
+	f, err := New().GetFleet()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := findRun(t, f, id).Goal; got != "the real request" {
+		t.Errorf("Goal = %q, want the first run_started detail", got)
+	}
+}
+
+func findRun(t *testing.T, f *Fleet, id string) Run {
+	t.Helper()
+	for _, r := range f.Runs {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("run %q not in fleet of %d", id, len(f.Runs))
+	return Run{}
+}

--- a/desktop/api/session.go
+++ b/desktop/api/session.go
@@ -19,6 +19,11 @@ type Session struct {
 	Found bool   `json:"found"`
 	Error string `json:"error,omitempty"`
 
+	// Goal is what this run was asked to do, in the requester's words. Same
+	// read as Fleet's: tree.Reconstruct discards run-level events, so a view
+	// titled only by run id has no way to say what the run was for.
+	Goal string `json:"goal,omitempty"`
+
 	Timeline []TimelineEntry `json:"timeline"`
 	Agents   []Agent         `json:"agents"`
 	Edges    []Edge          `json:"edges"`
@@ -91,6 +96,7 @@ func (a *API) GetSession(runID string) (*Session, error) {
 		return s, nil
 	}
 	s.Found = true
+	s.Goal = runGoal(events)
 
 	t, tl := tree.Reconstruct(events)
 	s.Skipped = t.Skipped

--- a/desktop/api/session_test.go
+++ b/desktop/api/session_test.go
@@ -322,3 +322,37 @@ func TestGetSession_ConcurrentCallsAreSafe(t *testing.T) {
 		}
 	}
 }
+
+// Session's header is otherwise titled by run id alone, which says nothing
+// about what the run was for (#603).
+func TestGetSession_CarriesTheGoal(t *testing.T) {
+	sandbox(t)
+	const id = "20260903T130000Z-sessgoal"
+	writeRun(t, id,
+		runlog.Event{Kind: runlog.KindRunStarted, TaskID: "t1", Detail: "rotate the signing key"},
+		runlog.Event{Kind: runlog.KindHeadSelected, TaskID: "t1", Head: "h", Tier: 2},
+	)
+
+	s, err := New().GetSession(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.Found {
+		t.Fatal("Found = false for a run that exists")
+	}
+	if s.Goal != "rotate the signing key" {
+		t.Errorf("Goal = %q, want the run-started detail", s.Goal)
+	}
+}
+
+// A run id that names no log has no goal to report, and must not invent one.
+func TestGetSession_MissingRunHasNoGoal(t *testing.T) {
+	sandbox(t)
+	s, err := New().GetSession("20260903T130001Z-absent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Found || s.Goal != "" {
+		t.Errorf("Found=%v Goal=%q; an absent run has neither", s.Found, s.Goal)
+	}
+}

--- a/desktop/api/typesparity_test.go
+++ b/desktop/api/typesparity_test.go
@@ -80,6 +80,8 @@ func TestTypesTS_MirrorsEveryFieldOnTheWire(t *testing.T) {
 		{"Pool", Pool{}},
 		{"ModelRegistry", ModelRegistry{}},
 		{"GovernorPanel", GovernorPanel{}},
+		{"Run", Run{}},
+		{"Session", Session{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			ts := tsInterface(t, src, c.iface)
@@ -110,6 +112,8 @@ func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
 		{"Pool", Pool{}},
 		{"ModelRegistry", ModelRegistry{}},
 		{"GovernorPanel", GovernorPanel{}},
+		{"Run", Run{}},
+		{"Session", Session{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			g := jsonFields(c.goVal)

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1899,3 +1899,25 @@ body {
 .scard__calD--thin     { color: var(--hy-faint); }
 .scard__calSub { font-family: var(--hy-font-mono); font-size: 9.5px; color: var(--hy-faint); }
 .scard__thin { color: var(--hy-mid); }
+
+/* ── Run identity ──────────────────────────────────────────────────────── */
+/* A run is led by what it was asked to do; its id is the correlation handle,
+   not the headline (#603). */
+
+.run__open {
+  display: flex; align-items: baseline; gap: 9px; min-width: 0; flex: 1;
+  background: none; border: 0; padding: 0; text-align: left;
+  color: var(--hy-ink); font: inherit; cursor: pointer;
+}
+.run__open:hover .run__goal { color: var(--hy-aqua); }
+.run__open:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; border-radius: 3px; }
+.run__goal {
+  font-size: 13.5px; font-weight: 600; letter-spacing: -.01em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* No prompt was recorded, so the id IS the title — set in mono, because that
+   is what it is. */
+.run__goal--id { font-family: var(--hy-font-mono); font-size: 12px; font-weight: 500; color: var(--hy-dim); }
+.run__id { font-family: var(--hy-font-mono); font-size: 10px; color: var(--hy-faint); flex: 0 0 auto; }
+
+.session__goal { font-size: 20px; font-weight: 600; letter-spacing: -.02em; }

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -134,6 +134,9 @@ export interface Run {
   allCount: number
   /** Events the reconstruction could not attribute — surfaced, never hidden. */
   skipped: number
+  /** What was asked, in the requester's words. Empty when the run recorded no
+   *  prompt; a preview, because that is what the log stores. */
+  goal?: string
   /** Set when this run's log could not be read; the row still renders. */
   error?: string
 }
@@ -176,6 +179,8 @@ export interface Session {
   /** False when the run id names no log — different from a run that did nothing. */
   found: boolean
   error?: string
+  /** What this run was asked to do. Empty when it recorded no prompt. */
+  goal?: string
   timeline: TimelineEntry[]
   agents: Agent[]
   edges: Edge[]

--- a/desktop/frontend/src/views/Fleet.tsx
+++ b/desktop/frontend/src/views/Fleet.tsx
@@ -75,8 +75,13 @@ function RunCard({
     <section className={`run ${run.live ? 'run--live' : ''}`}>
       <header className="run__head">
         <span className={`run__dot ${run.live ? 'run__dot--live' : ''}`} />
-        <button className="run__id run__id--link" onClick={() => onOpen(run.id)}>
-          {run.id}
+        <button className="run__open" onClick={() => onOpen(run.id)}>
+          {/* A run with no recorded prompt falls back to its id, which is all
+              it has. Saying "untitled" would hide the one handle that works. */}
+          <span className={run.goal ? 'run__goal' : 'run__goal run__goal--id'}>
+            {run.goal || run.id}
+          </span>
+          {run.goal && <span className="run__id">{run.id}</span>}
         </button>
         <span className="run__meta">
           {ms(run.elapsedMs)} · {usdExact(run.costUsd)}

--- a/desktop/frontend/src/views/Session.tsx
+++ b/desktop/frontend/src/views/Session.tsx
@@ -33,13 +33,16 @@ export function Session({
       <header className="view__head">
         <div className="view__headrow">
           <button className="back" onClick={onBack}>
-            ← Fleet
+            ← Activity
           </button>
           <h1 className="view__title">
-            <span className="session__id">{session.runId}</span>
+            <span className={session.goal ? 'session__goal' : 'session__id'}>
+              {session.goal || session.runId}
+            </span>
             {session.live && <span className="session__live">live</span>}
           </h1>
         </div>
+        {session.goal && <p className="view__sub session__id">{session.runId}</p>}
       </header>
 
       {session.error && <div className="error">unreadable: {session.error}</div>}


### PR DESCRIPTION
Second step of the desktop redesign, after #607. Answers the review note directly: *"what
will I do with run ids, I want context of it."*

## The data was always there
Every run records its prompt on the run-started event. But `tree.Reconstruct` drops
run-level events **by design** — they describe the invocation, not a node inside it — so the
prompt never reached a view. Reading it before the events are handed over costs one loop.

I found this gap early and then built other things for a week; this closes it.

## Behaviour
- `Run.Goal` and `Session.Goal` on the wire, both `omitempty`.
- **First `run_started` with a detail wins.** Several writers share one run (runlog's own
  docs say so), and the first statement of the goal is the one that was actually requested.
- **Never inferred from another event.** A `head_selected` detail like "candidate 1 of 2" is
  not a goal. An external orchestrator can supply a run id and no prompt at all, which is a
  legitimately absent goal, not an error.
- A run with no goal **keeps its id as the title**, set in mono because that is what it is.
  "Untitled" would hide the only handle such a run has.
- The id stays visible next to the goal — it is still what correlates a run with the logs
  and its cost rows.

## Also
The Session back button still said "← Fleet" after #607 renamed the view. Now "← Activity".

## Testing
Five new Go tests: the goal is carried, an absent prompt stays empty, a `head_selected`
detail is not mistaken for one, the first of two `run_started` events wins, and Session
reports neither `Found` nor a goal for a run id that names no log. `Run` and `Session` added
to the **types-parity guard in both directions**, so the new field cannot drift from the TS
mirror.

`go test ./api/ -race -count=1`, `gofmt`, `go vet` clean. 62 frontend tests, typecheck and
build clean.

Verified visually against a fixture mixing goal-bearing runs with one that has none: cards
read "Fix the checkout 500s Grafana is alerting on" instead of
`20260902T204114Z-9165760392bae48c`, and the goal-less run falls back to its id in mono.

## One observation, not fixed here
A run whose log contains **only** run-level events produces no agents and is dropped from
Activity entirely — it does not appear at all. My first test fixture hit this. That is
existing behaviour and arguably wrong (the run was requested, and the code elsewhere is
careful that "silently dropping renders a partial fleet as a complete one"), but changing it
is a separate call from this change.