### PR TITLE
feat(desktop): say what the Usage panels mean, and make Recent lead somewhere

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -222,7 +222,7 @@ export default function App() {
         )}
         {!error && view === "usage" && (
           <ErrorBoundary label="Usage">
-            <Dashboard data={dashboard} />
+            <Dashboard data={dashboard} onOpenRun={openSession} />
           </ErrorBoundary>
         )}
         {!error && view === "activity" && fleet && (

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1921,3 +1921,15 @@ body {
 .run__id { font-family: var(--hy-font-mono); font-size: 10px; color: var(--hy-faint); flex: 0 0 auto; }
 
 .session__goal { font-size: 20px; font-weight: 600; letter-spacing: -.02em; }
+
+/* ── Section heads and openable rows ──────────────────────────────────── */
+
+.section__head { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+.section__hint { font-size: 11.5px; color: var(--hy-dim); }
+
+/* A row that opens something has to look like it does, or the affordance is a
+   secret. Rows without a run id stay inert and say so in the last cell. */
+.row--open { cursor: pointer; }
+.row--open:hover { background: var(--hy-panel); }
+.row--open:hover td:last-child { color: var(--hy-aqua); }
+.row--open:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: -2px; }

--- a/desktop/frontend/src/format.test.ts
+++ b/desktop/frontend/src/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { calibrationLabel, calibrationStrength, calibrationWidthPct, costBand } from './format'
+import { calibrationLabel, calibrationStrength, calibrationWidthPct, contextHeadroom, contextModeText, costBand } from './format'
 
 describe('costBand does not alarm about sub-cent spend', () => {
   // The real defect (#594): $0.0009 was the largest figure in the table, so
@@ -86,5 +86,37 @@ describe('calibration strength says in words what the nats mean', () => {
   it('reads as plain language', () => {
     expect(calibrationLabel('weak')).toBe('weak evidence')
     expect(calibrationLabel('thin')).toBe('too few samples')
+  })
+})
+
+describe('contextHeadroom', () => {
+  // budget.RiskFromHistory returns zero below two observations, so a zero burn
+  // rate means "never measured". Projecting from it would invent headroom.
+  it('refuses to project without a rate signal', () => {
+    expect(contextHeadroom({ pct: 40, burnRatePct: 0, observations: 1 })).toBeNull()
+    expect(contextHeadroom({ pct: 40, burnRatePct: 8, observations: 1 })).toBeNull()
+    expect(contextHeadroom({ pct: 40, burnRatePct: 0, observations: 9 })).toBeNull()
+  })
+
+  it('counts updates to the 80% ceiling, not to 100%', () => {
+    // 64% climbing 8 points per update: 16 points of room, two updates.
+    expect(contextHeadroom({ pct: 64, burnRatePct: 8, observations: 6 })).toBe(2)
+  })
+
+  it('never reports negative room once past the ceiling', () => {
+    expect(contextHeadroom({ pct: 92, burnRatePct: 5, observations: 6 })).toBe(0)
+  })
+})
+
+describe('contextModeText', () => {
+  it('says what each band means rather than naming it', () => {
+    expect(contextModeText('normal')).toMatch(/room/i)
+    expect(contextModeText('caution')).toMatch(/compact/i)
+    expect(contextModeText('emergency')).toMatch(/local/i)
+  })
+
+  // An unrecognised band must still render something truthful.
+  it('falls back to the raw value it was given', () => {
+    expect(contextModeText('something-new')).toBe('something-new')
   })
 })

--- a/desktop/frontend/src/format.ts
+++ b/desktop/frontend/src/format.ts
@@ -137,3 +137,41 @@ export function clockTime(ts: string): string {
   if (t < 0) return ts
   return ts.slice(t + 1, t + 9) || ts
 }
+
+/**
+ * Updates of headroom before the orchestrator's context hits the 80% ceiling,
+ * or null when there is no rate signal to project from.
+ *
+ * budget.RiskFromHistory returns zero below two observations, so a zero burn
+ * rate means "never measured", not "not burning" — presenting that as headroom
+ * would be a lie. Counts claude_pct *updates*, which are not chat turns and not
+ * wall-clock time.
+ */
+export function contextHeadroom(g: {
+  pct: number
+  burnRatePct: number
+  observations: number
+}): number | null {
+  if (g.observations < 2 || g.burnRatePct <= 0) return null
+  return Math.max(0, Math.ceil((80 - g.pct) / g.burnRatePct))
+}
+
+/** What a context-budget mode means, for a reader who does not know the table. */
+export function contextModeText(mode: string): string {
+  switch (mode) {
+    case 'normal':
+      return 'plenty of room'
+    case 'compact':
+      return 'worth compacting soon'
+    case 'caution':
+      return 'compact now'
+    case 'warning':
+      return 'work is being downgraded a tier'
+    case 'critical':
+      return 'only the cheapest models from here'
+    case 'emergency':
+      return 'local models only'
+    default:
+      return mode
+  }
+}

--- a/desktop/frontend/src/views/Dashboard.test.tsx
+++ b/desktop/frontend/src/views/Dashboard.test.tsx
@@ -1,7 +1,7 @@
-import { afterEach, describe, expect, it } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
-import { CalibrationLeaderboard, calBarWidths } from './Dashboard'
-import type { CalibrationRow } from '../types'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { CalibrationLeaderboard, RecentTable, calBarWidths } from './Dashboard'
+import type { CalibrationRow, RecentCall } from '../types'
 
 afterEach(cleanup)
 
@@ -87,5 +87,32 @@ describe('the leaderboard reads correctly on weak real data', () => {
   it('renders the empty state rather than an empty track', () => {
     render(<CalibrationLeaderboard rows={[]} />)
     expect(screen.getByText('No calibration recorded yet')).toBeTruthy()
+  })
+})
+
+describe('the Recent panel is a way in, not decoration', () => {
+  const recent: RecentCall[] = [
+    { ts: '2026-09-03T16:52:18Z', model: 'Gemini 3.5 Flash', tier: 8, costUsd: 0.0009, wallMs: 31300, runId: 'r-1', taskId: 't1' },
+    // No run id: there is no run to open, so the row must stay inert.
+    { ts: '2026-09-03T16:51:46Z', model: 'Antigravity', tier: 4, costUsd: 0, wallMs: 14300, runId: '', taskId: 't2' },
+  ]
+
+  it('opens the run behind a row', () => {
+    const onOpenRun = vi.fn()
+    render(<RecentTable rows={recent} onOpenRun={onOpenRun} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open r-1' }))
+    expect(onOpenRun).toHaveBeenCalledWith('r-1')
+  })
+
+  it('leaves a row with no run id inert rather than offering a dead control', () => {
+    const onOpenRun = vi.fn()
+    render(<RecentTable rows={recent} onOpenRun={onOpenRun} />)
+    // Exactly one openable row, not two.
+    expect(screen.getAllByRole('button', { name: /^Open / })).toHaveLength(1)
+  })
+
+  it('stays inert entirely when nothing can handle an open', () => {
+    render(<RecentTable rows={recent} />)
+    expect(screen.queryByRole('button', { name: /^Open / })).not.toBeInTheDocument()
   })
 })

--- a/desktop/frontend/src/views/Dashboard.tsx
+++ b/desktop/frontend/src/views/Dashboard.tsx
@@ -1,10 +1,18 @@
 import { useEffect, useRef, useState } from 'react'
-import type { Breakdown, CalibrationRow, Dashboard as DashboardData, TrustPanel } from '../types'
+import type {
+  Breakdown,
+  CalibrationRow,
+  Dashboard as DashboardData,
+  RecentCall,
+  TrustPanel,
+} from '../types'
 import {
   calibrationLabel,
   calibrationStrength,
   calibrationWidthPct,
   clockTime,
+  contextHeadroom,
+  contextModeText,
   costBand,
   govBand,
   ms,
@@ -32,14 +40,17 @@ import { useCountUp, useReveal } from '../reveal'
  */
 export function Dashboard({
   data,
+  onOpenRun,
 }: {
   data: DashboardData | null
+  /** Opens one recent request's run. Absent means the rows stay inert. */
+  onOpenRun?: (runID: string) => void
 }) {
   return (
     <>
       <HudChrome />
       {data ? (
-        <DashboardContent data={data} />
+        <DashboardContent data={data} onOpenRun={onOpenRun} />
       ) : (
         <DashboardSkeleton />
       )}
@@ -102,8 +113,10 @@ function SkeletonCard() {
 
 function DashboardContent({
   data,
+  onOpenRun,
 }: {
   data: DashboardData
+  onOpenRun?: (runID: string) => void
 }) {
   const [drawerRow, setDrawerRow] = useState<Breakdown | null>(null)
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -133,7 +146,7 @@ function DashboardContent({
         <TrustCard data={data} />
       </div>
 
-      {data.hasData ? <Breakdowns data={data} onSelectModel={openDrawer} /> : <EmptyState />}
+      {data.hasData ? <Breakdowns data={data} onSelectModel={openDrawer} onOpenRun={onOpenRun} /> : <EmptyState />}
 
       <CalibrationLeaderboard rows={data.calibration} />
 
@@ -180,29 +193,52 @@ function GovernorCard({ data }: { data: DashboardData }) {
   if (!governor.known) {
     return (
       <div className="card">
-        <div className="card__label">Orchestrator context</div>
+        <div className="card__label">Context budget</div>
         <div className="card__value card__value--unknown">unknown</div>
         {/* Not 0%. Nothing has reported usage, and 0% would read as headroom. */}
-        <div className="card__note">No orchestrator has reported its usage.</div>
+        <div className="card__note">Nothing has reported how much context it is using.</div>
       </div>
     )
   }
   const band = govBand(governor.pct)
+  const headroom = contextHeadroom(governor)
   return (
     <div className={`card gov--${band}`}>
-      <div className="card__label">Orchestrator context</div>
+      <div className="card__label">Context budget</div>
       <div className="arc-wrap">
         <ArcGauge
           fraction={Math.min(governor.pct, 100) / 100}
           color={`var(--hy-gov-${band})`}
           centerValue={`${Math.round(displayPct)}%`}
-          centerLabel={governor.mode}
+          centerLabel={governor.effectiveMode || governor.mode}
           revealed={revealed}
         />
       </div>
-      <div className="card__note">mode: {governor.mode}</div>
+      {/* "mode: warning" names a band from a table the reader has never seen.
+          Say what it means, and add the headroom the rate model has computed
+          since #557 and nothing surfaced. */}
+      <div className="card__note">
+        {contextModeText(governor.effectiveMode || governor.mode)}
+        {headroom !== null && (
+          <>
+            {' \u00B7 about '}
+            {headroom} update{headroom === 1 ? '' : 's'} of room
+          </>
+        )}
+      </div>
     </div>
   )
+}
+
+/**
+ * What the consensus machinery actually bought, in a sentence. The ring beside
+ * it shows the same comparison; this says which direction is good.
+ */
+function consensusNote(t: TrustPanel): string {
+  const runs = `${t.runs} check${t.runs === 1 ? '' : 's'}`
+  if (t.meanSamples <= 0 || t.fixedSwarmN <= 0) return runs
+  const asked = t.meanSamples.toFixed(1)
+  return `${runs} \u00B7 asked ${asked} models on average instead of a fixed ${t.fixedSwarmN}`
 }
 
 function TrustCard({ data }: { data: DashboardData }) {
@@ -212,21 +248,20 @@ function TrustCard({ data }: { data: DashboardData }) {
   if (trust.runs === 0) {
     return (
       <div className="card">
-        <div className="card__label">Trust ensemble</div>
-        <div className="card__value card__value--unknown">no runs</div>
+        <div className="card__label">Consensus checks</div>
+        <div className="card__value card__value--unknown">none yet</div>
         <div className="card__note">
-          Try <code>hyctl dispatch --confidence 0.95</code>
+          Asking several models the same question, and stopping once they agree. Try{' '}
+          <code>hyctl dispatch --confidence 0.95</code>
         </div>
       </div>
     )
   }
   return (
     <div className="card">
-      <div className="card__label">Trust ensemble</div>
+      <div className="card__label">Consensus checks</div>
       <TrustCompare trust={trust} revealed={revealed} />
-      <div className="card__note">
-        {trust.runs} run{trust.runs === 1 ? '' : 's'}
-      </div>
+      <div className="card__note">{consensusNote(trust)}</div>
     </div>
   )
 }
@@ -262,9 +297,11 @@ function TrustCompare({ trust, revealed }: { trust: TrustPanel; revealed: boolea
 function Breakdowns({
   data,
   onSelectModel,
+  onOpenRun,
 }: {
   data: DashboardData
   onSelectModel: (row: Breakdown) => void
+  onOpenRun?: (runID: string) => void
 }) {
   return (
     <>
@@ -278,7 +315,7 @@ function Breakdowns({
         <RankedBars title="By model · click a row for detail" rows={data.byModel} onSelect={onSelectModel} />
         <RankedBars title="By tier" rows={data.byTier} />
       </div>
-      <RecentTable data={data} />
+      <RecentTable rows={data.recent} onOpenRun={onOpenRun} />
     </>
   )
 }
@@ -361,7 +398,7 @@ export function CalibrationLeaderboard({ rows }: { rows: CalibrationRow[] }) {
   if (rows.length === 0) {
     return (
       <section>
-        <h2 className="section__title">Calibration leaderboard</h2>
+        <h2 className="section__title">Which models earned their answers</h2>
         <div className="empty" style={{ marginTop: 0 }}>
           <p className="empty__title">No calibration recorded yet</p>
           <p>
@@ -374,7 +411,7 @@ export function CalibrationLeaderboard({ rows }: { rows: CalibrationRow[] }) {
 
   return (
     <section>
-      <h2 className="section__title">Calibration leaderboard · who to trust</h2>
+      <h2 className="section__title">Which models earned their answers</h2>
       <div className="table__wrap">
         <div className="rank">
           {rows.map((r) => (
@@ -519,13 +556,30 @@ function ModelDetailDrawer({
   )
 }
 
-function RecentTable({ data }: { data: DashboardData }) {
-  const rows = data.recent
+/**
+ * The last few requests, each one a way into the run that produced it.
+ *
+ * These rows used to be inert with a bare run id in the last column, which is
+ * why the panel read as decoration: nothing here could be acted on, and the
+ * one identifier shown led nowhere.
+ */
+export function RecentTable({
+  rows,
+  onOpenRun,
+}: {
+  rows: RecentCall[] | null
+  onOpenRun?: (runID: string) => void
+}) {
   if (!rows || rows.length === 0) return null
   const max = Math.max(...rows.map((r) => r.costUsd))
   return (
     <section>
-      <h2 className="section__title">Recent</h2>
+      <div className="section__head">
+        <h2 className="section__title">Recent requests</h2>
+        {onOpenRun && (
+          <span className="section__hint">Open one to see what it was asked and what it did.</span>
+        )}
+      </div>
       <div className="table__wrap">
         <table className="table">
           <thead>
@@ -535,20 +589,42 @@ function RecentTable({ data }: { data: DashboardData }) {
               <th className="num">Tier</th>
               <th className="num">Wall</th>
               <th className="num">Cost</th>
-              <th>Run</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
-            {rows.map((r, i) => (
-              <tr key={`${r.ts}-${i}`}>
-                <td className="mono">{clockTime(r.ts)}</td>
-                <td>{r.model}</td>
-                <td className="num">{r.tier === 0 ? '—' : r.tier}</td>
-                <td className="num">{ms(r.wallMs)}</td>
-                <td className={`num cost--${costBand(r.costUsd, max)}`}>{usdExact(r.costUsd)}</td>
-                <td className="mono">{r.runId || '—'}</td>
-              </tr>
-            ))}
+            {rows.map((r, i) => {
+              const openable = !!(onOpenRun && r.runId)
+              return (
+                <tr
+                  key={`${r.ts}-${i}`}
+                  className={openable ? 'row--open' : undefined}
+                  tabIndex={openable ? 0 : undefined}
+                  role={openable ? 'button' : undefined}
+                  aria-label={openable ? `Open ${r.runId}` : undefined}
+                  onClick={openable ? () => onOpenRun!(r.runId) : undefined}
+                  onKeyDown={
+                    openable
+                      ? (e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault()
+                            onOpenRun!(r.runId)
+                          }
+                        }
+                      : undefined
+                  }
+                >
+                  <td className="mono">{clockTime(r.ts)}</td>
+                  <td>{r.model}</td>
+                  <td className="num">{r.tier === 0 ? '—' : r.tier}</td>
+                  <td className="num">{ms(r.wallMs)}</td>
+                  <td className={`num cost--${costBand(r.costUsd, max)}`}>{usdExact(r.costUsd)}</td>
+                  {/* A request with no run id has no run to open — say so rather
+                      than rendering a control that does nothing. */}
+                  <td className="mono">{openable ? 'open →' : '—'}</td>
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       </div>

--- a/desktop/frontend/src/views/GovernorNotice.tsx
+++ b/desktop/frontend/src/views/GovernorNotice.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { GovernorPanel } from '../types'
+import { contextHeadroom } from '../format'
 
 /**
  * Fires when the orchestrator's context pressure reaches a band worth
@@ -39,10 +40,9 @@ export function GovernorNotice({
   if (!show || !governor) return null
 
   const g = governor
-  // Only claimed when there is a real rate signal: RiskFromHistory returns zero
-  // below two observations, and presenting that as "no risk" would be a lie.
-  const hasRate = g.observations >= 2 && g.burnRatePct > 0
-  const headroom = hasRate ? Math.max(0, Math.ceil((80 - g.pct) / g.burnRatePct)) : 0
+  const projected = contextHeadroom(g)
+  const hasRate = projected !== null
+  const headroom = projected ?? 0
 
   return (
     <div className="gn" role="dialog" aria-modal="true" aria-labelledby="gnTitle">


### PR DESCRIPTION
Third step of the desktop redesign, after #607 and #610. Closes the remaining review notes:
*"what do you mean by orchestrator context"*, *"what is trust ensemble"*, *"how is the
calibration leaderboard even working"*, and *"recent... some dummy things are just moving
here and there."*

## The labels named subsystems instead of describing anything

| Was | Now |
|---|---|
| Orchestrator context | **Context budget** |
| Trust ensemble | **Consensus checks** |
| Calibration leaderboard · who to trust | **Which models earned their answers** |
| Recent | **Recent requests** |

Each note now says what the number is for. "Consensus checks" reads
*"12 checks · asked 2.1 models on average instead of a fixed 4"*, which is the thing the
ring beside it was already drawing without saying which direction was good.

## The context card was hiding data that shipped weeks ago
It said **"mode: warning"** — a band from a table the reader has never seen. It now says what
that means *and* the headroom the rate model has computed since #557 and nothing surfaced:

> work is being downgraded a tier · about 2 updates of room

The arithmetic already existed in `GovernorNotice`, so it moved to `format.ts` and both call
it. Same duplication I got caught on with the band thresholds in #602, so I looked first
this time. The wording stays "updates", not "turns", because that is what
`budget.RiskHorizon` counts.

**It also contradicted itself.** The gauge centre showed the *level* band while my new note
described the *effective* one, so the card displayed "compact" and "being downgraded a tier"
at once. Both now use `effectiveMode`, which is what the router acts on.

## Recent rows now lead somewhere
They were plain `<tr>` with a bare run id in the last column — nothing could be acted on and
the one identifier shown led nowhere. That is the "dummy things moving" note, and it was
literally accurate. Rows open their run, keyboard included.

This is worth more than it would have been an hour ago: since #610, Session leads with what
was asked, so clicking a row lands somewhere that says what the run was *for* rather than on
another timestamp. A row with **no** run id stays inert and shows `—` rather than offering a
control that does nothing.

`RecentTable` is now exported and takes `rows` instead of the whole dashboard payload, since
that is all it ever read — which also makes it testable the way the other tests in that file
already work.

## Two things I checked rather than assumed
Both looked like unit bugs in a screenshot and neither was. `TokensActualPct` and
`SamplesSavedPct` are both computed as `100 * …` on the Go side, so they are already
percentages and `pct()` correctly does not multiply again. My probe fixtures were passing
fractions. No change made.

## Testing
70 frontend tests (8 new): `contextHeadroom` refuses to project without a rate signal
(zero burn rate means never measured, not idle), counts to the 80% ceiling rather than 100%,
never reports negative room; `contextModeText` falls back to the raw band it was handed; and
Recent opens a run, leaves an id-less row inert, and stays wholly inert with no handler.
Typecheck and build clean.