### PR TITLE
feat(desktop): surface parked questions in chat and let the user answer them

### DIFF
--- a/desktop/api/chat.go
+++ b/desktop/api/chat.go
@@ -40,6 +40,13 @@ type ChatReply struct {
 
 	Error string `json:"error,omitempty"`
 
+	// Question is set when the task parked waiting on a human decision, and
+	// TaskID is what answers it. A parked task is not a failure: routed through
+	// Error it rendered as a red dispatch error, which reads as "this broke"
+	// rather than "this needs you" (#583).
+	Question string `json:"question,omitempty"`
+	TaskID   string `json:"taskId,omitempty"`
+
 	// NeedsProbe is true when there is nothing to route this chat to — zero
 	// heads discovered at all, or heads discovered but none dispatchable for
 	// this request (dispatch.ErrNoHeads, e.g. the dock's "auto-route" default
@@ -141,10 +148,23 @@ func (a *API) Chat(prompt, enum, runID, tier string) (*ChatReply, error) {
 			r.NeedsProbe = true
 			return r, nil
 		}
+		var parked *dispatch.ParkedError
+		if errors.As(err, &parked) {
+			r.Question, r.TaskID, r.Head = parked.Question, parked.TaskID, parked.Head
+			return r, nil
+		}
 		r.Error = err.Error()
 		return r, nil
 	}
 
+	fill(r, res)
+	return r, nil
+}
+
+// fill copies a dispatch result onto a reply. Shared by Chat and
+// AnswerQuestion so a resumed task reports its head, tier and cost the same
+// way a first-time one does.
+func fill(r *ChatReply, res *dispatch.Result) {
 	r.Output = res.Output
 	r.Head = res.Head.ID
 	r.Model = res.Head.Name
@@ -152,7 +172,6 @@ func (a *API) Chat(prompt, enum, runID, tier string) (*ChatReply, error) {
 	if res.Response != nil {
 		r.DurationMS = res.Response.Duration.Milliseconds()
 	}
-	return r, nil
 }
 
 // preview shortens a prompt for a log Detail. Entries stay small because the

--- a/desktop/api/questions.go
+++ b/desktop/api/questions.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/pending"
+)
+
+// PendingQuestion is one task parked waiting on a human decision.
+//
+// AskedAt is sent as epoch milliseconds rather than a Go time, matching how
+// every other DTO here crosses the bridge: the frontend formats ages itself and
+// a marshalled time.Time forces it to parse a layout string first.
+type PendingQuestion struct {
+	TaskID    string `json:"taskId"`
+	RunID     string `json:"runId"`
+	Question  string `json:"question"`
+	Head      string `json:"head"`
+	Resource  string `json:"resource,omitempty"`
+	Prompt    string `json:"prompt"`
+	AskedAtMS int64  `json:"askedAtMs"`
+}
+
+// QuestionQueue is what is waiting, plus whether the queue could be read.
+//
+// Error is reported alongside the questions rather than instead of them: one
+// unreadable file must not hide the answerable ones, or a parked task is
+// forgotten because an unrelated one is corrupt.
+type QuestionQueue struct {
+	Questions []PendingQuestion `json:"questions"`
+	Error     string            `json:"error,omitempty"`
+}
+
+// GetPendingQuestions returns the parked tasks, oldest first.
+//
+// Poll-friendly like GetFleet and GetSession: a question is durable state on
+// disk, so a UI that missed the moment it was asked still finds it.
+func (a *API) GetPendingQuestions() QuestionQueue {
+	out := QuestionQueue{Questions: []PendingQuestion{}}
+	qs, err := pending.List()
+	if err != nil {
+		out.Error = err.Error()
+	}
+	for _, q := range qs {
+		out.Questions = append(out.Questions, PendingQuestion{
+			TaskID: q.TaskID, RunID: q.RunID, Question: q.Question,
+			Head: q.Head, Resource: q.Resource, Prompt: q.Prompt,
+			AskedAtMS: q.AskedAt.UnixMilli(),
+		})
+	}
+	return out
+}
+
+// AnswerQuestion answers a parked task and runs it.
+//
+// Errors come back on the reply rather than as a second return value, the same
+// way Chat reports them, so the transcript can render a failed answer in place
+// instead of the caller needing a separate error path.
+func (a *API) AnswerQuestion(taskID, answer string) (*ChatReply, error) {
+	r := &ChatReply{TaskID: taskID}
+
+	// Everything that can be decided without a router is decided first. Built
+	// the other way round, a double-clicked question on a machine with no
+	// config reported "no hydra config" — a setup error for something that is
+	// not a setup problem.
+	q, lErr := pending.Load(taskID)
+	switch {
+	// Already answered, by a double click or in another window. Not alarming,
+	// and the consumed file is the proof the work did not run twice.
+	case errors.Is(lErr, pending.ErrNotFound):
+		r.Error = "This question was already answered."
+		return r, nil
+	case lErr != nil:
+		// Corrupt or incomplete: loud, never resumed on a zero value.
+		r.Error = lErr.Error()
+		return r, nil
+	}
+	r.RunID = q.RunID
+
+	// Checked here as well as in Resume, so refusing a non-answer does not
+	// depend on a router being constructible.
+	if strings.TrimSpace(answer) == "" {
+		r.Error = "Answer the question to run this task, or decline it."
+		return r, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ChatTimeout)
+	defer cancel()
+
+	d, err := dispatch.New(ctx)
+	if err != nil {
+		r.Error = err.Error()
+		return r, nil
+	}
+	res, err := d.Resume(ctx, taskID, answer)
+	if err != nil {
+		// Answering can park again when the resumed dispatch lands on a head
+		// the human was never asked about: approval is per head.
+		var parked *dispatch.ParkedError
+		if errors.As(err, &parked) {
+			r.Question, r.TaskID, r.Head = parked.Question, parked.TaskID, parked.Head
+			return r, nil
+		}
+		r.Error = err.Error()
+		return r, nil
+	}
+	fill(r, res)
+	return r, nil
+}
+
+// DeclineQuestion refuses a parked task. Nothing runs.
+//
+// Free text cannot carry a refusal reliably — "no, don't" folded into a prompt
+// still dispatches and leaves it to the head to notice — so declining is its
+// own path, and dispatch.Decline needs no config to take it.
+func (a *API) DeclineQuestion(taskID, reason string) error {
+	return dispatch.Decline(taskID, reason)
+}

--- a/desktop/api/questions_test.go
+++ b/desktop/api/questions_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/pending"
+)
+
+func park(t *testing.T, taskID, question string, asked time.Time) {
+	t.Helper()
+	if err := pending.Save(pending.Question{
+		TaskID: taskID, RunID: "run-" + taskID, Question: question,
+		Prompt: "do the thing", Head: "gated", AskedAt: asked,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// An empty queue must be an empty list, not null: a consumer doing .length on
+// null fails differently than one reading an empty array.
+func TestGetPendingQuestions_EmptyIsAList(t *testing.T) {
+	sandbox(t)
+
+	got := New().GetPendingQuestions()
+	if got.Questions == nil {
+		t.Error("Questions is nil — the bridge must send [] for an empty queue")
+	}
+	if len(got.Questions) != 0 || got.Error != "" {
+		t.Errorf("expected a clean empty queue, got %+v", got)
+	}
+}
+
+func TestGetPendingQuestions_OldestFirstWithEverythingNeededToAnswer(t *testing.T) {
+	sandbox(t)
+	now := time.Now().UTC()
+	park(t, "newer", "Allow gated for B?", now)
+	park(t, "older", "Allow gated for A?", now.Add(-2*time.Hour))
+
+	got := New().GetPendingQuestions()
+	if len(got.Questions) != 2 {
+		t.Fatalf("want 2 questions, got %d", len(got.Questions))
+	}
+	if got.Questions[0].TaskID != "older" {
+		t.Errorf("oldest question should come first, got %q", got.Questions[0].TaskID)
+	}
+	q := got.Questions[0]
+	if q.Question == "" || q.Head == "" || q.RunID == "" {
+		t.Errorf("a question missing its text, head or run cannot be acted on: %+v", q)
+	}
+	if q.AskedAtMS <= 0 {
+		t.Error("AskedAtMs is unset, so the UI cannot say how long it has waited")
+	}
+}
+
+// One unreadable file must not hide the answerable ones, or a parked task is
+// forgotten because an unrelated one is corrupt.
+func TestGetPendingQuestions_ReportsCorruptWithoutHidingTheRest(t *testing.T) {
+	sandbox(t)
+	park(t, "good", "Allow gated?", time.Now().UTC())
+	if err := os.WriteFile(filepath.Join(pending.Dir(), "bad.json"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := New().GetPendingQuestions()
+	if got.Error == "" {
+		t.Error("an unreadable question must be reported")
+	}
+	if len(got.Questions) != 1 || got.Questions[0].TaskID != "good" {
+		t.Errorf("the readable question must still be returned, got %+v", got.Questions)
+	}
+}
+
+// Answering twice must not run the work twice, and the second answer must not
+// read as a crash — it is an ordinary double click or a second window.
+func TestAnswerQuestion_AlreadyAnsweredIsNotAlarming(t *testing.T) {
+	sandbox(t)
+
+	r, err := New().AnswerQuestion("never-parked", "yes")
+	if err != nil {
+		t.Fatalf("AnswerQuestion must report on the reply, not as a second error: %v", err)
+	}
+	if !strings.Contains(r.Error, "already answered") {
+		t.Errorf("want an already-answered message, got %q", r.Error)
+	}
+}
+
+// Dismissing is not answering. An empty answer leaves the task parked.
+func TestAnswerQuestion_EmptyAnswerLeavesItParked(t *testing.T) {
+	sandbox(t)
+	park(t, "t1", "Allow gated?", time.Now().UTC())
+
+	r, err := New().AnswerQuestion("t1", "   ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(r.Error, "decline it") {
+		t.Errorf("want the refuse-or-decline message, got %q", r.Error)
+	}
+	if _, lErr := pending.Load("t1"); lErr != nil {
+		t.Errorf("the task must stay parked after a non-answer: %v", lErr)
+	}
+}
+
+// The run id is only recorded in the pending file, and Resume consumes it, so
+// the reply has to capture it before resuming or a parked task loses its link
+// into Session the moment it is answered.
+func TestAnswerQuestion_ReplyKeepsTheRunLink(t *testing.T) {
+	sandbox(t)
+	park(t, "t1", "Allow gated?", time.Now().UTC())
+
+	r, err := New().AnswerQuestion("t1", "yes, go ahead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.RunID != "run-t1" {
+		t.Errorf("RunID = %q, want run-t1 — the answered task must stay linked to its run", r.RunID)
+	}
+	if r.TaskID != "t1" {
+		t.Errorf("TaskID = %q, want t1", r.TaskID)
+	}
+}
+
+// Declining needs no config: a machine that parked a task must be able to
+// refuse it even when dispatch.New would fail.
+func TestDeclineQuestion_ConsumesTheQuestion(t *testing.T) {
+	sandbox(t)
+	park(t, "t1", "Allow gated?", time.Now().UTC())
+
+	if err := New().DeclineQuestion("t1", "not on production"); err != nil {
+		t.Fatalf("DeclineQuestion: %v", err)
+	}
+	if _, err := pending.Load("t1"); err == nil {
+		t.Error("decline left the question parked")
+	}
+	if got := New().GetPendingQuestions(); len(got.Questions) != 0 {
+		t.Errorf("the declined question is still queued: %+v", got.Questions)
+	}
+}
+
+func TestDeclineQuestion_UnknownTaskErrors(t *testing.T) {
+	sandbox(t)
+	if err := New().DeclineQuestion("nope", ""); err == nil {
+		t.Error("declining an unknown task should error")
+	}
+}

--- a/desktop/api/typesparity_test.go
+++ b/desktop/api/typesparity_test.go
@@ -82,6 +82,9 @@ func TestTypesTS_MirrorsEveryFieldOnTheWire(t *testing.T) {
 		{"GovernorPanel", GovernorPanel{}},
 		{"Run", Run{}},
 		{"Session", Session{}},
+		{"ChatReply", ChatReply{}},
+		{"PendingQuestion", PendingQuestion{}},
+		{"QuestionQueue", QuestionQueue{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			ts := tsInterface(t, src, c.iface)
@@ -114,6 +117,9 @@ func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
 		{"GovernorPanel", GovernorPanel{}},
 		{"Run", Run{}},
 		{"Session", Session{}},
+		{"ChatReply", ChatReply{}},
+		{"PendingQuestion", PendingQuestion{}},
+		{"QuestionQueue", QuestionQueue{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			g := jsonFields(c.goVal)

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import {
   GetDashboard,
   GetEdits,
   GetFleet,
+  GetPendingQuestions,
   GetSecurity,
   GetSession,
   GetVersion,
@@ -66,6 +67,9 @@ export default function App() {
   const [runID, setRunID] = useState<string>("");
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
   const [fleet, setFleet] = useState<FleetData | null>(null);
+  // Parked tasks are visible from every view, not only the thread that
+  // started one: a question nobody is looking at is the case this exists for.
+  const [waiting, setWaiting] = useState(0);
   const [session, setSession] = useState<SessionData | null>(null);
   const [edits, setEdits] = useState<Edit[] | null>(null);
   const [security, setSecurity] = useState<SecurityReport | null>(null);
@@ -110,6 +114,20 @@ export default function App() {
     const t = setInterval(() => void load(view, runID), every);
     return () => clearInterval(t);
   }, [load, view, runID]);
+
+  // Polled regardless of the visible view, unlike the per-view reads above:
+  // the badge's whole job is to be seen from somewhere else.
+  useEffect(() => {
+    const tick = () =>
+      void GetPendingQuestions()
+        .then((q) => setWaiting(q.questions.length))
+        .catch(() => {
+          /* A failed read must not clear a badge that was correct. */
+        });
+    tick();
+    const t = setInterval(tick, DASHBOARD_MS);
+    return () => clearInterval(t);
+  }, []);
 
   useEffect(() => {
     GetVersion()
@@ -185,6 +203,14 @@ export default function App() {
               <span aria-hidden="true">{n.glyph}</span>
               {n.id === "activity" && (fleet?.liveCount ?? 0) > 0 && (
                 <span className="rail__live">{fleet?.liveCount}</span>
+              )}
+              {n.id === "chat" && waiting > 0 && (
+                <span
+                  className="rail__wait"
+                  title={`${waiting} ${waiting === 1 ? "task" : "tasks"} waiting on you`}
+                >
+                  {waiting}
+                </span>
               )}
             </button>
           ))}

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1023,6 +1023,20 @@ body {
   font-weight: 700;
 }
 
+/* Amber, not aqua: aqua means "running by itself", this means "stopped, and
+   only you can clear it". Different states must not read alike. */
+.rail__wait {
+  margin-left: auto;
+  font-family: var(--hy-font-mono);
+  font-size: 10px;
+  background: var(--hy-mid);
+  color: #1A1204;
+  border-radius: 999px;
+  padding: 1px 6px;
+  font-weight: 700;
+  box-shadow: 0 0 12px color-mix(in srgb, var(--hy-mid) 55%, transparent);
+}
+
 .runs { display: flex; flex-direction: column; gap: 11px; }
 
 .run {
@@ -1724,6 +1738,62 @@ body {
 .shift__ico { color: var(--hy-mid); }
 .shift__txt { color: var(--hy-dim); }
 .shift__txt b { color: var(--hy-ink); font-weight: 600; }
+
+/* ── Waiting on you (a parked task) ────────────────────────────────────── */
+
+/* Louder than .shift on purpose: a tier change is something that happened,
+   this is something only the user can clear. */
+.waiting {
+  margin: 6px 0 8px;
+  padding: 12px 14px 13px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--hy-mid) 11%, transparent), rgba(224, 169, 58, 0)),
+    var(--hy-bg-2);
+  border: 1px solid color-mix(in srgb, var(--hy-mid) 38%, transparent);
+  border-left: 2px solid var(--hy-mid);
+  border-radius: 0 var(--hy-radius-sm) var(--hy-radius-sm) 0;
+  box-shadow: 0 0 22px color-mix(in srgb, var(--hy-mid) 13%, transparent);
+}
+.waiting__head { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
+.waiting__ico { color: var(--hy-mid); font-size: 12px; }
+.waiting__lbl {
+  color: var(--hy-mid);
+  font-size: 10.5px; font-weight: 700;
+  letter-spacing: .09em; text-transform: uppercase;
+  text-shadow: 0 0 14px color-mix(in srgb, var(--hy-mid) 45%, transparent);
+}
+.waiting__who { color: var(--hy-dim); font-size: 11px; font-family: var(--hy-mono, monospace); }
+.waiting__q { color: var(--hy-ink); font-size: 13px; line-height: 1.5; margin: 0 0 10px; }
+.waiting__row { display: flex; gap: 7px; align-items: center; }
+.waiting__in {
+  flex: 1 1 auto; min-width: 0;
+  padding: 7px 10px;
+  background: var(--hy-bg-1, #06070F);
+  border: 1px solid var(--hy-line-2);
+  border-radius: var(--hy-radius-sm);
+  color: var(--hy-ink); font-size: 12.5px;
+}
+.waiting__in:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 1px; }
+.waiting__in:disabled { opacity: .55; }
+.waiting__go, .waiting__no {
+  flex: 0 0 auto;
+  padding: 7px 13px;
+  border-radius: var(--hy-radius-sm);
+  font-size: 12px; font-weight: 600;
+  cursor: pointer;
+}
+.waiting__go {
+  background: var(--hy-aqua); border: 1px solid var(--hy-aqua); color: #04121A;
+  box-shadow: 0 0 18px color-mix(in srgb, var(--hy-aqua) 30%, transparent);
+}
+.waiting__no { background: transparent; border: 1px solid var(--hy-line-2); color: var(--hy-dim); }
+.waiting__no:hover:not(:disabled) { color: var(--hy-expensive); border-color: color-mix(in srgb, var(--hy-expensive) 50%, transparent); }
+.waiting__go:disabled, .waiting__no:disabled { opacity: .45; cursor: default; box-shadow: none; }
+.waiting__go:focus-visible, .waiting__no:focus-visible { outline: 2px solid var(--hy-aqua); outline-offset: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .waiting { box-shadow: none; }
+}
 
 /* ── Governor notice ───────────────────────────────────────────────────── */
 

--- a/desktop/frontend/src/bindings.ts
+++ b/desktop/frontend/src/bindings.ts
@@ -15,6 +15,7 @@ import type {
   HyctlStatus,
   InstallResult,
   ModelRegistry,
+  QuestionQueue,
   SecurityReport,
   Session,
   UpdateStatus,
@@ -30,6 +31,9 @@ interface WailsGo {
       GetSession(runID: string): Promise<Session>
       GetEdits(runID: string): Promise<Edit[]>
       Chat(prompt: string, enumKey: string, runID: string, tier: string): Promise<ChatReply>
+      GetPendingQuestions(): Promise<QuestionQueue>
+      AnswerQuestion(taskID: string, answer: string): Promise<ChatReply>
+      DeclineQuestion(taskID: string, reason: string): Promise<void>
       ChatEnums(): Promise<string[]>
       NewRunID(): Promise<string>
       GetDiff(runID: string, ref: string, file: string): Promise<Diff>
@@ -70,6 +74,14 @@ export const Chat = (
   runID: string,
   tier: string,
 ): Promise<ChatReply> => backend().Chat(prompt, enumKey, runID, tier)
+
+export const GetPendingQuestions = (): Promise<QuestionQueue> => backend().GetPendingQuestions()
+
+export const AnswerQuestion = (taskID: string, answer: string): Promise<ChatReply> =>
+  backend().AnswerQuestion(taskID, answer)
+
+export const DeclineQuestion = (taskID: string, reason: string): Promise<void> =>
+  backend().DeclineQuestion(taskID, reason)
 export const ChatEnums = (): Promise<string[]> => backend().ChatEnums()
 export const NewRunID = (): Promise<string> => backend().NewRunID()
 export const GetVersion = (): Promise<Version> => backend().GetVersion()

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -649,6 +649,29 @@ export interface ChatReply {
   /** No heads discoverable at all — the dock offers to retry instead of
    *  showing a raw dispatch error. */
   needsProbe?: boolean
+  /** Set when the task parked waiting on a human decision. Not an error: it
+   *  needs you, it did not break. `taskId` is what answers it. */
+  question?: string
+  taskId?: string
+}
+
+/** One task parked waiting on a human decision. */
+export interface PendingQuestion {
+  taskId: string
+  runId: string
+  question: string
+  head: string
+  resource?: string
+  prompt: string
+  /** Epoch ms — the frontend formats the age itself. */
+  askedAtMs: number
+}
+
+/** The parked queue, plus whether it could be read in full. */
+export interface QuestionQueue {
+  questions: PendingQuestion[]
+  /** One unreadable file must not hide the answerable ones. */
+  error?: string
 }
 
 /** One routable head as registry/models.yaml declares it. */

--- a/desktop/frontend/src/views/ChatView.test.tsx
+++ b/desktop/frontend/src/views/ChatView.test.tsx
@@ -1,7 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ChatView } from './ChatView'
-import { Chat, GetDashboard, GetEdits, GetModels, GetSession, NewRunID } from '../bindings'
+import {
+  AnswerQuestion,
+  Chat,
+  DeclineQuestion,
+  GetDashboard,
+  GetEdits,
+  GetModels,
+  GetSession,
+  NewRunID,
+} from '../bindings'
 import type { ChatReply, Session as SessionData } from '../types'
 
 // ChatView talks to the Go backend only through these bindings — mocking the
@@ -9,7 +18,9 @@ import type { ChatReply, Session as SessionData } from '../types'
 // one that finished while the view was away, a plain dispatch failure) without
 // a real Wails runtime.
 vi.mock('../bindings', () => ({
+  AnswerQuestion: vi.fn(),
   Chat: vi.fn(),
+  DeclineQuestion: vi.fn(),
   GetDashboard: vi.fn(),
   GetEdits: vi.fn(),
   GetModels: vi.fn(),
@@ -18,6 +29,8 @@ vi.mock('../bindings', () => ({
 }))
 
 const mockChat = vi.mocked(Chat)
+const mockAnswer = vi.mocked(AnswerQuestion)
+const mockDecline = vi.mocked(DeclineQuestion)
 const mockGetModels = vi.mocked(GetModels)
 const mockGetDashboard = vi.mocked(GetDashboard)
 const mockGetEdits = vi.mocked(GetEdits)
@@ -227,5 +240,107 @@ describe('recovery after the view closes (#533)', () => {
     renderDock()
 
     expect(await screen.findByText(/check fleet/i)).toBeInTheDocument()
+  })
+})
+
+// A ledger policy can answer `ask`, which parks the task before anything runs
+// (#582). The transcript is where that has to surface: a modal that vanishes
+// leaves the task silently parked.
+describe('a task parked waiting on a human (#583)', () => {
+  function parked(over: Partial<ChatReply> = {}): ChatReply {
+    return {
+      output: '',
+      head: 'gated',
+      model: '',
+      tier: 0,
+      costUsd: 0,
+      durationMs: 0,
+      runId: 'run-1',
+      question: 'Allow gated to run this task? It would act on internal/auth/token.go.',
+      taskId: 'task-1',
+      ...over,
+    }
+  }
+
+  async function askAndPark(over: Partial<ChatReply> = {}) {
+    mockChat.mockResolvedValue(parked(over))
+    renderDock()
+    const textarea = screen.getByPlaceholderText(/ask anything/i)
+    fireEvent.change(textarea, { target: { value: 'rotate the signing key' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    return screen.findByText(/Allow gated to run this task/)
+  }
+
+  it('shows the question in the transcript rather than as an error', async () => {
+    await askAndPark()
+    expect(screen.getByText(/waiting on you/i)).toBeInTheDocument()
+    // The distinction that matters: this needs you, it did not break.
+    expect(screen.queryByText(/dispatch/i)).not.toBeInTheDocument()
+  })
+
+  it('answers the task and replaces the question with the result', async () => {
+    await askAndPark()
+    mockAnswer.mockResolvedValue({
+      output: 'rotated', head: 'gated', model: 'Gated', tier: 3,
+      costUsd: 0.01, durationMs: 12, runId: 'run-1',
+    })
+
+    fireEvent.change(screen.getByLabelText(/your answer/i), { target: { value: 'yes, go ahead' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Answer' }))
+
+    await waitFor(() => expect(mockAnswer).toHaveBeenCalledWith('task-1', 'yes, go ahead'))
+    expect(await screen.findByText('rotated')).toBeInTheDocument()
+    expect(screen.queryByText(/waiting on you/i)).not.toBeInTheDocument()
+  })
+
+  // No default action, nothing that resolves on dismiss: an unanswered
+  // question is not an approval.
+  it('will not answer with an empty box', async () => {
+    await askAndPark()
+    const go = screen.getByRole('button', { name: 'Answer' })
+    expect(go).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText(/your answer/i), { target: { value: '   ' } })
+    expect(go).toBeDisabled()
+    fireEvent.click(go)
+    expect(mockAnswer).not.toHaveBeenCalled()
+  })
+
+  it('declines without running anything', async () => {
+    await askAndPark()
+    mockDecline.mockResolvedValue(undefined)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Decline' }))
+
+    await waitFor(() => expect(mockDecline).toHaveBeenCalledWith('task-1', ''))
+    expect(await screen.findByText(/declined\. nothing ran\./i)).toBeInTheDocument()
+    expect(mockAnswer).not.toHaveBeenCalled()
+  })
+
+  // Approval is per head, so a resumed dispatch can land on a head the human
+  // was never shown and park again. That has to read as a new question.
+  it('shows a second question when answering parks again', async () => {
+    await askAndPark()
+    mockAnswer.mockResolvedValue(parked({ question: 'Allow other to run this task?', taskId: 'task-2' }))
+
+    fireEvent.change(screen.getByLabelText(/your answer/i), { target: { value: 'yes' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Answer' }))
+
+    expect(await screen.findByText('Allow other to run this task?')).toBeInTheDocument()
+    expect(screen.getByText(/waiting on you/i)).toBeInTheDocument()
+  })
+
+  it('answers on Enter as well as the button', async () => {
+    await askAndPark()
+    mockAnswer.mockResolvedValue({
+      output: 'done', head: 'gated', model: 'Gated', tier: 3,
+      costUsd: 0, durationMs: 1, runId: 'run-1',
+    })
+
+    const box = screen.getByLabelText(/your answer/i)
+    fireEvent.change(box, { target: { value: 'go' } })
+    fireEvent.keyDown(box, { key: 'Enter' })
+
+    await waitFor(() => expect(mockAnswer).toHaveBeenCalledWith('task-1', 'go'))
   })
 })

--- a/desktop/frontend/src/views/ChatView.tsx
+++ b/desktop/frontend/src/views/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Chat, GetDashboard, GetSession, NewRunID } from '../bindings'
+import { AnswerQuestion, Chat, DeclineQuestion, GetDashboard, GetSession, NewRunID } from '../bindings'
 import type { ChatReply, GovernorPanel, Session as SessionData } from '../types'
 import { ms, usdExact } from '../format'
 import { Timeline } from './Session'
@@ -222,6 +222,53 @@ export function ChatView({
     }
   }
 
+  // Answering a parked task is a dispatch like any other: same busy flag, same
+  // live timeline, and the answer replaces the question in place so the
+  // transcript reads as one exchange rather than two unrelated entries.
+  async function answer(i: number, text: string) {
+    const t = turns[i]
+    const taskId = t.reply?.taskId
+    if (!taskId || busy || !text.trim()) return
+    setBusy(true)
+    if (t.runId) watchRun(t.runId)
+    try {
+      const reply = await AnswerQuestion(taskId, text)
+      setTurns((ts) => ts.map((turn, idx) => (idx === i ? { ...turn, reply } : turn)))
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      setTurns((ts) =>
+        ts.map((turn, idx) => (idx === i ? { ...turn, reply: { ...emptyReply(), error: message } } : turn)),
+      )
+    } finally {
+      stopPolling()
+      setLiveSession(null)
+      setBusy(false)
+    }
+  }
+
+  // Refusing is a separate path that never reaches an executor, so it is not
+  // an answer of "no" — nothing runs at all.
+  async function decline(i: number) {
+    const taskId = turns[i].reply?.taskId
+    if (!taskId || busy) return
+    setBusy(true)
+    try {
+      await DeclineQuestion(taskId, '')
+      setTurns((ts) =>
+        ts.map((turn, idx) =>
+          idx === i ? { ...turn, reply: { ...emptyReply(), output: 'Declined. Nothing ran.' } } : turn,
+        ),
+      )
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      setTurns((ts) =>
+        ts.map((turn, idx) => (idx === i ? { ...turn, reply: { ...emptyReply(), error: message } } : turn)),
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
   // Focus on mount, and again whenever something asks for the caret.
   useEffect(() => {
     inputRef.current?.focus()
@@ -268,6 +315,15 @@ export function ChatView({
                   <Timeline entries={liveSession.timeline} />
                 )}
               </>
+            )}
+            {t.reply?.question && (
+              <Waiting
+                question={t.reply.question}
+                head={t.reply.head}
+                busy={busy}
+                onAnswer={(text) => void answer(i, text)}
+                onDecline={() => void decline(i)}
+              />
             )}
             {t.reply?.error && !t.reply.needsProbe && (
               <>
@@ -393,4 +449,64 @@ function tierShift(turns: Turn[], i: number): boolean {
   const prev = turns[i - 1].reply
   const cur = turns[i].reply
   return !!prev && !!cur && prev.tier > 0 && cur.tier > 0 && prev.tier !== cur.tier
+}
+
+/**
+ * A task parked waiting on a human decision, shown inline in the transcript.
+ *
+ * Not a modal: a modal that vanishes leaves the task silently parked, and the
+ * question is part of the conversation's record. The task stays parked until
+ * it is answered or declined — there is deliberately no default action and
+ * nothing that resolves on dismiss or timeout.
+ */
+function Waiting({
+  question,
+  head,
+  busy,
+  onAnswer,
+  onDecline,
+}: {
+  question: string
+  head: string
+  busy: boolean
+  onAnswer: (text: string) => void
+  onDecline: () => void
+}) {
+  const [text, setText] = useState('')
+  return (
+    <div className="waiting">
+      <div className="waiting__head">
+        <span className="waiting__ico" aria-hidden="true">&#10073;&#10073;</span>
+        <span className="waiting__lbl">Waiting on you</span>
+        {head && <span className="waiting__who">{head}</span>}
+      </div>
+      <p className="waiting__q">{question}</p>
+      <div className="waiting__row">
+        <input
+          className="waiting__in"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && text.trim() && !busy) {
+              e.preventDefault()
+              onAnswer(text)
+            }
+          }}
+          placeholder="Answer, and it runs"
+          aria-label="Your answer"
+          disabled={busy}
+        />
+        <button
+          className="waiting__go"
+          onClick={() => onAnswer(text)}
+          disabled={busy || !text.trim()}
+        >
+          Answer
+        </button>
+        <button className="waiting__no" onClick={onDecline} disabled={busy}>
+          Decline
+        </button>
+      </div>
+    </div>
+  )
 }


### PR DESCRIPTION
Part 3 of 3 for #517. Depends on #582 (merged in #615).

## The bug it starts from

#582 parks a task on an `ask` verdict. The desktop had no idea that state
existed, so `Chat` mapped the `ParkedError` into `ChatReply.Error` — a task
waiting on a human rendered as a **red dispatch error**. "This broke", for
something that had not broken and only needed an answer.

## What ships

`ChatReply` carries `question` and `taskId`, and the transcript renders the
parked task in place, beside where the tier-shift marker lives.

**Not a modal.** A modal that vanishes leaves the task silently parked, and the
question is part of the conversation's record. There is deliberately no default
action and nothing that resolves on dismiss or timeout — the task stays parked
until answered or declined.

**The rail badges the count on Chat, in amber, not aqua.** Aqua already means
"running by itself"; this means "stopped, and only you can clear it". Two
different states must not read alike. It polls regardless of the visible view,
unlike the per-view reads, because being visible from somewhere else is the
entire point of #517.

## The ordering bug a test caught

`AnswerQuestion` originally built the dispatcher first, so on a machine with no
config a double-clicked question reported **"no hydra config — run: hyctl
init"** — a setup error for something that is not a setup problem. My own
empty-answer test was passing off that same wrong message.

Everything decidable without a router is now decided first: already answered, a
corrupt file, and a non-answer each report accurately **with no config at all**.
The test asserts the specific message so it cannot pass for the wrong reason
again.

## Answering can park again

Approval is per head (#582), so a resumed dispatch that lands on a head the
human was never shown asks a **second** question rather than proceeding.
Covered by a test. Declining stays its own path that never reaches an executor.

`GetPendingQuestions` reports an unreadable file *alongside* the readable ones
rather than instead of them — one corrupt entry must not hide a task someone is
waiting on.

## Types parity

`ChatReply`, `PendingQuestion` and `QuestionQueue` registered in both
directions. **`ChatReply` had never been guarded at all**, so it was free to
drift the way #435's fields did.

## Verification

- 76 frontend tests (6 new), typecheck, build clean; `desktop/api` green;
  `go test -race -count=1 ./...` clean on the root module
- **Proved the tests load-bearing**: disabling the question branch fails 6 of
  the 12 ChatView tests. Restored, all 12 pass.
- **Looked at it, rather than reasoning about the CSS.** The first pause glyph
  (U+23F8) rendered as a quote mark at 12px, and both hourglass candidates came
  out as **colour emoji** against an amber palette. It ships as solid bars,
  confirmed in a screenshot against the built stylesheet.

One pre-existing failure is unrelated and reproduces on develop:
`TestInstallHyctl_RunsTheFetchedScript` needs outbound network, which this
sandbox blocks. CI passes it.

Closes #583