### PR TITLE
feat(tui): chat executes — modes, route reasoning, verify loop, override

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,12 +594,26 @@ Six views, cycled with `tab` (or jump with `1–6`); `?` opens the shortcut glos
 
 | View | What it shows |
 |---|---|
-| **chat** | Route a task and watch the decision: class → tier → model, cost, change impact (routing preview in this phase) |
+| **chat** | Type a task and it **executes**: a route line first (class → tier → model · strategy · plain-words why, with a `local-only (pii)` badge and change impact when they apply), then the real answer or edit. `esc` cancels mid-run; failures link to their trace; session cost accrues in the header |
 | **agents** | Live runs and today's finished ones — `enter` opens a run's trace |
 | **models** | Every scanned model nested under its provider/server, with per-model detail: tier, capability, p50 latency, requests/cost today, calibration scorecard. A down server grays its models; embedding-only models say `embeddings only — never routed` |
 | **activity** | Today's runs with a full trace per run: routed → policy → request → stream → edits → done, fallbacks included |
 | **usage** | Spend today / this month / saved vs all-frontier, by model/tier/day breakdowns, and the orchestrator's context budget |
 | **audit** | Calibration scorecard, audit-log chain integrity, guardrails (PII local-only, injection markers, MCP server trust), and a needs-a-human queue |
+
+Chat has **modes** — what a task does (`shift+tab` cycles the basics, `m` opens the full picker):
+
+| Mode | What it does |
+|---|---|
+| **Ask** | Answer only — never writes files |
+| **Edit** | Direct change when the prompt names an existing file (validated, rollback-safe, snapshotted); otherwise answers and says so |
+| **Plan** | Drafts numbered steps on a cheap tier and waits — `enter`/`y` runs them, `esc` discards |
+| **Auto** | Plan → edit → **verify**: runs `go test ./...` (or your workspace.yaml validator) through the oracle, feeds failures back for up to 2 fixes, and renders a proof strip: `plan ✓ · edit ✓ file +A/−R · tests ✓/✗` |
+| **Architect** | Auto, but plans on a strong tier and implements on a cheap one |
+| **Careful** | Auto, but every file write needs a `y/n` confirm before it lands |
+| **Unattended** | Auto with no confirms and a hard $0.50 per-task cost cap — it stops visibly at the cap |
+
+Where a task runs is separate: `ctrl+o` overrides the **next** task's routing (auto / force tier / local only / best of 3 / consensus check at 90–99.9%). After an edit: `d` shows the diff, `x` restores the pre-task snapshot exactly, `o` opens the file, and the footer's trace id jumps into the activity view.
 
 Everything shown is measured from the machine's real logs — a figure that cannot be computed renders `—`, never an invented number. Lists scroll (`j/k`, `pgup/pgdn`, mouse wheel); `hyctl tui --snapshot [--view 0..5]` prints static frames for docs and bug reports.
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -259,6 +259,11 @@ func cachedProbe(ctx context.Context) *probe.Result {
 	return probeCacheResult
 }
 
+// PIILocalOnly reports whether cfg's pii policy forces local-only routing —
+// the config-level check for callers with no Dispatcher yet (the TUI's route
+// badge), so the rule is never restated (#597).
+func PIILocalOnly(cfg *config.Config) bool { return piiLocalOnly(cfg) }
+
 // piiLocalOnly reports whether cfg's pii policy forces local-only routing.
 func piiLocalOnly(cfg *config.Config) bool {
 	p, ok := cfg.Policies["pii"]

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -39,6 +39,10 @@ type Request struct {
 	// could tell which run touched which file. Empty derives one, as elsewhere.
 	RunID  string
 	TaskID string
+
+	// LocalOnly forces the inner dispatch onto local heads — how a caller's
+	// "nothing leaves this machine" override reaches an edit (#597).
+	LocalOnly bool
 }
 
 // Result is the JSON output emitted by Edit.
@@ -119,10 +123,11 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 	}
 	tierHint := enumToTier(req.Enum)
 	dispResult, err := d.Dispatch(ctx, editPrompt, dispatch.Options{
-		TierHint: tierHint,
-		RunID:    req.RunID,
-		TaskID:   req.TaskID,
-		Resource: req.File,
+		TierHint:  tierHint,
+		LocalOnly: req.LocalOnly,
+		RunID:     req.RunID,
+		TaskID:    req.TaskID,
+		Resource:  req.File,
 	})
 	if err != nil {
 		cleanupBackup()

--- a/internal/tui/chat_exec.go
+++ b/internal/tui/chat_exec.go
@@ -1,0 +1,531 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// chat_exec.go — the chat's execution pipeline: plan → edit → verify, run as
+// tea.Cmds through internal/dispatch, internal/editor and internal/oracle.
+// Modes (modes.go) set the knobs; the ctrl+o override (override.go) sets where
+// the primary dispatch runs. The stage funcs are seams so tests fake the
+// providers, never the pipeline.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/editor"
+	"github.com/ankit373/hydra/internal/oracle"
+	"github.com/ankit373/hydra/internal/policy"
+	"github.com/ankit373/hydra/internal/rank"
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/swarm"
+	"github.com/ankit373/hydra/internal/trust"
+	"github.com/ankit373/hydra/internal/workspace"
+)
+
+// ckMaxFixes caps Auto's fix-and-reverify loop: a change that is still failing
+// after two model-written fixes needs a human, not a third attempt.
+const ckMaxFixes = 2
+
+// ckTaskTimeout bounds one pipeline phase — same reasoning as the desktop's
+// ChatTimeout, wider because a phase can hold several dispatches plus a test run.
+const ckTaskTimeout = 10 * time.Minute
+
+// ckAnswerCapLines bounds how many answer lines are appended to the chat log.
+const ckAnswerCapLines = 400
+
+// ckCodeMaxLines bounds what the code panel streams after an edit.
+const ckCodeMaxLines = 200
+
+// ── task ──────────────────────────────────────────────────────────────────────
+
+type ckVerifyRound struct {
+	passed bool
+	detail string
+}
+
+// ckTask is one chat task: the routing decision plus everything the pipeline
+// accumulates while running it. It moves by value between the UI and the
+// worker — exactly one owner at a time, so no locking.
+type ckTask struct {
+	prompt      string
+	mode        ckModeDef
+	file        string // absolute path of the named existing file; "" = none
+	runID       string
+	taskID      string
+	answerTier  string
+	planTier    string
+	editEnum    string
+	strategy    byte // 0 single · 'B' best of 3 · 'C' consensus (answer stage only)
+	confidence  float64
+	localOnly   bool
+	pii         bool
+	verifyArgv  []string
+	verifyLabel string
+	startedAt   time.Time
+
+	// accumulated across phases
+	plan           string
+	planSteps      int
+	answer         string
+	note           string
+	edited         bool
+	added, removed int
+	rounds         []ckVerifyRound
+	verifySkipped  bool
+	verifyErr      string
+	headName       string
+	tier           int
+	conf           float64 // achieved consensus confidence, when strategy was 'C'
+	fixRound       int
+	fixDetail      string
+
+	// finalized
+	editRef     string // first edit snapshot: undo target, diff's "before"
+	editRefLast string // last edit snapshot: diff's "after"
+	costUSD     float64
+	elapsed     time.Duration
+	errText     string
+	canceled    bool
+	stopped     bool // ended at a gate (plan discarded, write declined)
+	undone      bool
+}
+
+// ckExecState is the live-task handle the UI and the worker share: the stage
+// line under a mutex, and the cancel esc pulls. Everything else is immutable
+// after creation.
+type ckExecState struct {
+	mu      sync.Mutex
+	stage   string
+	ctx     context.Context
+	cancel  context.CancelFunc
+	started time.Time
+}
+
+func (e *ckExecState) setStage(s string) {
+	e.mu.Lock()
+	e.stage = s
+	e.mu.Unlock()
+}
+
+func (e *ckExecState) Stage() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.stage
+}
+
+// ckWait is a pipeline paused for the user: a plan awaiting approval, or a
+// careful-mode write/fix confirm. Approval resumes the task at phase.
+type ckWait struct {
+	task     ckTask
+	phase    int
+	question string
+}
+
+// worker phases.
+const (
+	ckPhaseFull = iota // the whole pipeline in one worker
+	ckPhaseHead        // plan only, then gate (plan approval / careful confirm)
+	ckPhaseTail        // post-gate: edit → verify (or answer)
+	ckPhaseFix         // careful-mode: one confirmed fix, then re-verify
+)
+
+// messages
+type ckExecDoneMsg struct {
+	exec *ckExecState
+	task ckTask
+}
+
+type ckGateMsg struct {
+	exec *ckExecState
+	task ckTask
+	gate byte // 'p' plan approval · 'w' write confirm · 'f' fix confirm
+}
+
+type ckSpinTickMsg struct{ exec *ckExecState }
+
+func ckSpinTick(ex *ckExecState) tea.Cmd {
+	return tea.Tick(time.Second/5, func(time.Time) tea.Msg { return ckSpinTickMsg{ex} })
+}
+
+// ── stage seams ───────────────────────────────────────────────────────────────
+
+// ckStageOut is one dispatch-shaped stage's outcome.
+type ckStageOut struct {
+	output     string
+	head       string
+	tier       int
+	confidence float64 // consensus runs only
+}
+
+// The three provider seams. Tests substitute these; the pipeline around them
+// is always the real one.
+var (
+	ckDispatchStage = ckRealDispatchStage
+	ckEditStage     = ckRealEditStage
+	ckVerifyStage   = ckRealVerifyStage
+)
+
+// ckRealDispatchStage routes one prompt through the real router, honoring the
+// task's strategy for this stage: plain dispatch, best-of-3 swarm, or the SPRT
+// consensus ensemble — the same code paths cmd/hydra's dispatch uses.
+func ckRealDispatchStage(ctx context.Context, t *ckTask, prompt, tierHint string, strat byte) (ckStageOut, error) {
+	d, err := dispatch.New(ctx)
+	if err != nil {
+		return ckStageOut{}, err
+	}
+	class := policy.Classify(prompt)
+	localOnly := t.localOnly || (d.PIILocalOnly() && class.PII)
+	switch strat {
+	case 'B':
+		sw := swarm.New(d, d.Heads(), d)
+		res, err := sw.Run(ctx, prompt, swarm.Options{
+			Mode: swarm.ModeBest, TierHint: tierHint, MaxHeads: 3,
+			LocalOnly: localOnly, RunID: t.runID, TaskID: t.taskID,
+			Classification: &class,
+		})
+		if err != nil {
+			return ckStageOut{}, err
+		}
+		if res.Winner == nil {
+			return ckStageOut{}, errors.New("best of 3: no head produced an answer")
+		}
+		return ckStageOut{output: res.Winner.Output, head: res.Winner.Head.Name, tier: rank.UITier(res.Winner.Head)}, nil
+	case 'C':
+		sw := swarm.New(d, d.Heads(), d)
+		res, err := sw.RunSPRT(ctx, prompt, swarm.Options{
+			Confidence: t.confidence, TierHint: tierHint,
+			LocalOnly: localOnly, RunID: t.runID, TaskID: t.taskID,
+			Classification: &class,
+		})
+		if err != nil {
+			return ckStageOut{}, err
+		}
+		out := ckStageOut{output: res.Trust.Candidate, confidence: res.Trust.Confidence,
+			head: fmt.Sprintf("consensus · %d samples", res.Trust.Samples)}
+		for _, a := range res.Attempts {
+			if a.Status == swarm.StatusOK && a.Output == res.Trust.Candidate {
+				out.head = a.Head.Name
+				out.tier = rank.UITier(a.Head)
+				break
+			}
+		}
+		return out, nil
+	default:
+		res, err := d.Dispatch(ctx, prompt, dispatch.Options{
+			TierHint: tierHint, LocalOnly: localOnly,
+			MaxCostUSD: t.mode.capUSD, RunID: t.runID, TaskID: t.taskID,
+			Classification: &class,
+		})
+		if err != nil {
+			return ckStageOut{}, err
+		}
+		return ckStageOut{output: res.Output, head: res.Head.Name, tier: rank.UITier(res.Head)}, nil
+	}
+}
+
+// ckRealEditStage runs the editor path: scoped, validated, rollback-safe, with
+// the runlog KindEdit snapshot the d/x keys read back.
+func ckRealEditStage(ctx context.Context, t *ckTask, prompt string) (*editor.Result, error) {
+	return editor.Edit(ctx, editor.Request{
+		File: t.file, Enum: t.editEnum, Prompt: prompt, Validate: true,
+		RunID: t.runID, TaskID: t.taskID, LocalOnly: t.localOnly,
+	})
+}
+
+// ckRealVerifyStage runs the workspace's verify command through the oracle.
+// argv carries no placeholders — the file argument was substituted with the
+// real on-disk path, which is what is being verified.
+func ckRealVerifyStage(ctx context.Context, argv []string) (oracle.Verdict, error) {
+	o := &oracle.CommandOracle{Args: argv, Source: "verifier:tui"}
+	return o.Verify(ctx, "", trust.Task{})
+}
+
+// ── verify command resolution ─────────────────────────────────────────────────
+
+// ckVerifyArgs picks the verify command: `go test ./...` when the CWD repo is
+// Go, else the workspace.yaml validator for the edited file's extension.
+// Empty argv means no verifier is configured — the proof strip says so.
+func ckVerifyArgs(file string) (argv []string, label string) {
+	if ckGoModDir() != "" {
+		return []string{"go", "test", "./..."}, "go test ./..."
+	}
+	if file == "" {
+		return nil, ""
+	}
+	reg, err := workspace.Load(config.ScriptHome())
+	if err != nil {
+		return nil, ""
+	}
+	tmpl := reg.ValidatorFor(strings.TrimPrefix(filepath.Ext(file), "."))
+	if tmpl == "" {
+		return nil, ""
+	}
+	// {file} substitutes the real path as one argv element (paths with spaces
+	// survive) — the verifier must check the file on disk, not a temp copy.
+	if idx := strings.Index(tmpl, "{file}"); idx >= 0 {
+		argv = append(strings.Fields(tmpl[:idx]), file)
+		argv = append(argv, strings.Fields(tmpl[idx+len("{file}"):])...)
+	} else {
+		argv = strings.Fields(tmpl)
+	}
+	if len(argv) == 0 {
+		return nil, ""
+	}
+	return argv, strings.ReplaceAll(tmpl, "{file}", filepath.Base(file))
+}
+
+// ckGoModDir walks up from the CWD to the nearest go.mod, stopping at the
+// first .git boundary so a Go directory above an unrelated repo doesn't claim it.
+func ckGoModDir() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return ""
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// ── the worker ────────────────────────────────────────────────────────────────
+
+// ckWorker runs one pipeline phase off the UI loop. A gate (plan approval,
+// careful confirm) returns a ckGateMsg with the run left open; everything else
+// closes the run and returns a ckExecDoneMsg.
+func ckWorker(ex *ckExecState, t ckTask, phase int) tea.Cmd {
+	return func() tea.Msg {
+		hb := runlog.StartHeartbeat(ex.ctx, t.runID, runlog.HeartbeatInterval)
+		defer hb.Stop()
+		rl := runlog.New(t.runID)
+		if phase == ckPhaseFull || phase == ckPhaseHead {
+			_ = rl.Append(runlog.Event{Kind: runlog.KindRunStarted, TaskID: t.taskID, Detail: truncate(t.prompt, 80)})
+		}
+		gate := ckRunStages(ex.ctx, ex, &t, phase)
+		if gate != 0 && t.errText == "" {
+			return ckGateMsg{exec: ex, task: t, gate: gate}
+		}
+		_ = rl.Append(runlog.Event{Kind: runlog.KindRunFinished, TaskID: t.taskID})
+		ckFinalize(&t, ex.ctx)
+		return ckExecDoneMsg{exec: ex, task: t}
+	}
+}
+
+// ckRunStages advances the pipeline for one phase, mutating t as it goes.
+// A non-zero return is the gate that paused it.
+func ckRunStages(ctx context.Context, ex *ckExecState, t *ckTask, phase int) byte {
+	if phase == ckPhaseFull || phase == ckPhaseHead {
+		if t.mode.plan {
+			ex.setStage("planning")
+			out, err := ckDispatchStage(ctx, t, ckPlanPrompt(t), t.planTier, 0)
+			if err != nil {
+				t.errText = "plan: " + err.Error()
+				return 0
+			}
+			t.plan, t.planSteps = out.output, ckCountSteps(out.output)
+			t.headName, t.tier = out.head, out.tier
+			if err := ckOverCap(t); err != nil {
+				t.errText = err.Error()
+				return 0
+			}
+		}
+		if phase == ckPhaseHead {
+			if t.mode.name == "plan" {
+				return 'p'
+			}
+			return 'w' // careful: confirm before the write lands
+		}
+	}
+	if t.file != "" && t.mode.name != "ask" {
+		return ckEditAndVerify(ctx, ex, t)
+	}
+	ex.setStage("answering")
+	out, err := ckDispatchStage(ctx, t, ckAnswerPrompt(t), t.answerTier, t.strategy)
+	if err != nil {
+		t.errText = err.Error()
+		return 0
+	}
+	t.answer, t.conf = out.output, out.confidence
+	t.headName, t.tier = out.head, out.tier
+	if t.mode.name == "edit" && t.file == "" {
+		t.note = "no file named — answered instead"
+	}
+	return 0
+}
+
+// ckEditAndVerify is the edit → verify → fix loop. In careful mode each fix
+// write pauses at a 'f' gate instead of landing unconfirmed.
+func ckEditAndVerify(ctx context.Context, ex *ckExecState, t *ckTask) byte {
+	base := filepath.Base(t.file)
+	editOnce := func(stage, prompt string) bool {
+		ex.setStage(stage)
+		er, err := ckEditStage(ctx, t, prompt)
+		if err != nil {
+			t.errText = "edit " + base + ": " + err.Error()
+			return false
+		}
+		if er.Status != "ok" {
+			t.errText = "edit " + base + ": " + er.Error
+			return false
+		}
+		t.edited = true
+		t.added += er.LinesAdded
+		t.removed += er.LinesRemoved
+		if t.headName == "" {
+			t.headName = er.Head
+		}
+		return true
+	}
+
+	if t.fixRound == 0 {
+		if !editOnce("editing "+base, ckEditPrompt(t)) {
+			return 0
+		}
+		if !t.mode.verify {
+			return 0
+		}
+		if len(t.verifyArgv) == 0 {
+			t.verifySkipped = true
+			return 0
+		}
+	} else { // resumed at a confirmed fix
+		if !editOnce(fmt.Sprintf("fixing (%d/%d) — %s", t.fixRound, ckMaxFixes, base), ckFixPrompt(t)) {
+			return 0
+		}
+	}
+
+	for {
+		ex.setStage("verifying — " + t.verifyLabel)
+		v, verr := ckVerifyStage(ctx, t.verifyArgv)
+		if verr != nil {
+			t.verifyErr = verr.Error()
+			return 0
+		}
+		t.rounds = append(t.rounds, ckVerifyRound{passed: v.Passed, detail: v.Detail})
+		if v.Passed || t.fixRound >= ckMaxFixes {
+			return 0
+		}
+		if err := ckOverCap(t); err != nil {
+			t.errText = err.Error()
+			return 0
+		}
+		t.fixRound++
+		t.fixDetail = v.Detail
+		if t.mode.confirm {
+			return 'f' // careful: this write needs a y first
+		}
+		if !editOnce(fmt.Sprintf("fixing (%d/%d) — %s", t.fixRound, ckMaxFixes, base), ckFixPrompt(t)) {
+			return 0
+		}
+	}
+}
+
+// ckOverCap enforces unattended's hard per-task cap between stages: the next
+// stage is refused once the run's recorded spend reaches it. In-stage spend is
+// bounded separately by dispatch's own MaxCostUSD preflight.
+func ckOverCap(t *ckTask) error {
+	if t.mode.capUSD <= 0 {
+		return nil
+	}
+	if spent := ckRunSpend(t.runID); spent >= t.mode.capUSD {
+		return fmt.Errorf("cost cap $%.2f reached ($%.4f spent) — stopped before the next stage", t.mode.capUSD, spent)
+	}
+	return nil
+}
+
+// ckRunSpend folds the run's recorded cost the same way the activity list does,
+// so the footer, the cap, and the trace can never disagree.
+func ckRunSpend(runID string) float64 {
+	events, err := runlog.Load(runID)
+	if err != nil {
+		return 0
+	}
+	return ckRunFromEvents(runID, events, false).costUSD
+}
+
+// ckFinalize stamps the outcome fields every renderer reads: elapsed, the
+// folded cost, the last edit snapshot ref, and whether esc ended it.
+func ckFinalize(t *ckTask, ctx context.Context) {
+	t.elapsed = time.Since(t.startedAt)
+	if events, err := runlog.Load(t.runID); err == nil {
+		t.costUSD = ckRunFromEvents(t.runID, events, false).costUSD
+		for _, e := range events {
+			if e.Kind == runlog.KindEdit && e.Ref != "" {
+				if t.editRef == "" {
+					t.editRef = e.Ref // first edit: the pre-task state
+				}
+				t.editRefLast = e.Ref
+			}
+		}
+	}
+	// esc is context.Canceled; a deadline is a timeout and stays an error.
+	if t.errText != "" && (errors.Is(ctx.Err(), context.Canceled) ||
+		strings.Contains(t.errText, context.Canceled.Error())) {
+		t.canceled = true
+	}
+}
+
+// ── prompts ───────────────────────────────────────────────────────────────────
+
+func ckPlanPrompt(t *ckTask) string {
+	p := "Plan this task as a short numbered list of concrete steps (at most 8). Steps only — no code, no preamble.\n\nTask: " + t.prompt
+	if t.file != "" {
+		p += "\nTarget file: " + t.file
+	}
+	return p
+}
+
+func ckAnswerPrompt(t *ckTask) string {
+	if t.plan == "" {
+		return t.prompt
+	}
+	return t.prompt + "\n\nA plan was drafted:\n" + t.plan + "\n\nAnswer the task, following the plan where it helps."
+}
+
+func ckEditPrompt(t *ckTask) string {
+	if t.plan == "" {
+		return t.prompt
+	}
+	return t.prompt + "\n\nFollow this plan:\n" + t.plan
+}
+
+func ckFixPrompt(t *ckTask) string {
+	return fmt.Sprintf("The previous change to this file failed verification.\nCommand: %s\nFirst failure line: %s\n\nFix the file so the verification passes. Original task: %s",
+		t.verifyLabel, t.fixDetail, t.prompt)
+}
+
+var ckStepRe = regexp.MustCompile(`^\s*\d+[.)]\s`)
+
+// ckCountSteps counts numbered lines in a plan; an unnumbered non-empty plan
+// still counts as one step rather than zero.
+func ckCountSteps(plan string) int {
+	n := 0
+	for _, l := range strings.Split(plan, "\n") {
+		if ckStepRe.MatchString(l) {
+			n++
+		}
+	}
+	if n == 0 && strings.TrimSpace(plan) != "" {
+		return 1
+	}
+	return n
+}

--- a/internal/tui/chat_exec.go
+++ b/internal/tui/chat_exec.go
@@ -2,11 +2,9 @@
 
 package tui
 
-// chat_exec.go — the chat's execution pipeline: plan → edit → verify, run as
+// chat_exec.go — the chat's execution pipeline (plan → edit → verify), run as
 // tea.Cmds through internal/dispatch, internal/editor and internal/oracle.
-// Modes (modes.go) set the knobs; the ctrl+o override (override.go) sets where
-// the primary dispatch runs. The stage funcs are seams so tests fake the
-// providers, never the pipeline.
+// The stage funcs are seams: tests fake the providers, never the pipeline.
 
 import (
 	"context"

--- a/internal/tui/chat_exec_test.go
+++ b/internal/tui/chat_exec_test.go
@@ -1,0 +1,1337 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/editor"
+	"github.com/ankit373/hydra/internal/oracle"
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// ── harness ───────────────────────────────────────────────────────────────────
+
+// stubExec snapshots the three provider seams and restores them after t. Every
+// pipeline test starts here so a forgotten assignment cannot leak.
+func stubExec(t *testing.T) {
+	t.Helper()
+	d, e, v := ckDispatchStage, ckEditStage, ckVerifyStage
+	// The pipeline around the seams is real; the providers never are in a test.
+	ckDispatchStage = func(context.Context, *ckTask, string, string, byte) (ckStageOut, error) {
+		t.Fatal("ckDispatchStage used without a stub")
+		return ckStageOut{}, nil
+	}
+	ckEditStage = func(context.Context, *ckTask, string) (*editor.Result, error) {
+		t.Fatal("ckEditStage used without a stub")
+		return nil, nil
+	}
+	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+		t.Fatal("ckVerifyStage used without a stub")
+		return oracle.Verdict{}, nil
+	}
+	t.Cleanup(func() { ckDispatchStage, ckEditStage, ckVerifyStage = d, e, v })
+}
+
+// stubAnswer is a dispatch stage returning out; cost > 0 also records the
+// spend the way real dispatch does, so the cost fold has something to fold.
+func stubAnswer(out string, cost float64) func(context.Context, *ckTask, string, string, byte) (ckStageOut, error) {
+	return func(_ context.Context, tk *ckTask, _ string, _ string, _ byte) (ckStageOut, error) {
+		if cost > 0 {
+			_ = runlog.New(tk.runID).Append(runlog.Event{
+				Kind: runlog.KindDispatchFinished, TaskID: tk.taskID, Status: "ok", CostUSD: cost})
+		}
+		return ckStageOut{output: out, head: "stub-head", tier: 8}, nil
+	}
+}
+
+// stubEdit writes after to the task's file and snapshots before/after via the
+// real runlog.LogEdit — the same record the real editor path leaves.
+func stubEdit(before, after string) func(context.Context, *ckTask, string) (*editor.Result, error) {
+	return func(_ context.Context, tk *ckTask, _ string) (*editor.Result, error) {
+		if err := os.WriteFile(tk.file, []byte(after), 0o644); err != nil {
+			return nil, err
+		}
+		runlog.LogEdit(tk.runID, tk.taskID, tk.file, []byte(before), []byte(after), 1, 1)
+		return &editor.Result{Status: "ok", File: tk.file, LinesAdded: 1, LinesRemoved: 1, Head: "stub-editor"}, nil
+	}
+}
+
+// runCmds executes a command tree synchronously, feeding every message back
+// into Update. Clock ticks are dropped — re-feeding them would loop forever.
+func runCmds(t *testing.T, m Cockpit, cmd tea.Cmd) Cockpit {
+	t.Helper()
+	queue := []tea.Cmd{cmd}
+	for len(queue) > 0 {
+		c := queue[0]
+		queue = queue[1:]
+		if c == nil {
+			continue
+		}
+		switch msg := c().(type) {
+		case tea.BatchMsg:
+			queue = append(queue, msg...)
+		case ckSpinTickMsg, ckCodeTickMsg:
+		default:
+			next, nc := m.Update(msg)
+			m = next.(Cockpit)
+			queue = append(queue, nc)
+		}
+	}
+	return m
+}
+
+func keyRune(m Cockpit, r rune) (Cockpit, tea.Cmd) {
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	return next.(Cockpit), cmd
+}
+
+// chatFixture is a chat-focused cockpit in the given mode.
+func chatFixture(mode string) Cockpit {
+	m := testCockpit()
+	m.mode = mode
+	return m
+}
+
+// namedFile creates dir/pkg/main.go with content and chdirs into dir so the
+// prompt "… pkg/main.go" names a real file (ckFileRe takes word chars and
+// slashes only, which a temp dir's absolute path would not match).
+func namedFile(t *testing.T, content string) (rel, abs string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	abs = filepath.Join(dir, "pkg", "main.go")
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The verify-args probe walks up for go.mod; give the loop a module so
+	// auto-family modes get a real argv (the verify stage itself is stubbed).
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	return "pkg/main.go", abs
+}
+
+// ── ask ───────────────────────────────────────────────────────────────────────
+
+// A typed task actually executes: route line first, then the answer block, the
+// footer with cost and trace, session cost accrual — and an empty enter
+// afterwards opens the trace in activity.
+func TestExec_AskAnswersAccruesCostAndLinksTrace(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	ckDispatchStage = stubAnswer("goroutines are cheap\nuse them", 0.01)
+
+	m := chatFixture("ask")
+	m, cmd := enter(typed(m, "explain the users endpoint"))
+	if m.exec == nil || cmd == nil {
+		t.Fatal("submitting did not start a task")
+	}
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "auto-routed") || !strings.Contains(joined, "single") {
+		t.Errorf("no route line before execution:\n%s", joined)
+	}
+	if !strings.Contains(joined, "why question, standard scope, no PII") {
+		t.Errorf("no plain-words why clause:\n%s", joined)
+	}
+
+	m = runCmds(t, m, cmd)
+	if m.exec != nil {
+		t.Fatal("exec still set after completion")
+	}
+	joined = stripANSI(strings.Join(m.log, "\n"))
+	for _, want := range []string{"goroutines are cheap", "use them", "✓ done", "$0.0100", "trace"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("result is missing %q:\n%s", want, joined)
+		}
+	}
+	if m.sessionUSD != 0.01 {
+		t.Errorf("sessionUSD = %v, want 0.01", m.sessionUSD)
+	}
+	if m.lastDone == nil || m.lastDone.answer == "" {
+		t.Fatal("lastDone not recorded")
+	}
+
+	// The footer's promise: an empty enter opens the trace.
+	m, _ = enter(m)
+	if m.view != ckViewActivity || !m.actDrill {
+		t.Fatalf("empty enter did not open the trace (view=%d drill=%v)", m.view, m.actDrill)
+	}
+	if got := m.activityRuns()[m.actSel].id; got != m.lastDone.runID {
+		t.Errorf("trace focused run %s, want %s", got, m.lastDone.runID)
+	}
+}
+
+// A dispatch failure renders the error and its trace link — never a dead end.
+func TestExec_FailureRendersErrorAndTrace(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	ckDispatchStage = func(context.Context, *ckTask, string, string, byte) (ckStageOut, error) {
+		return ckStageOut{}, errors.New("no heads answered")
+	}
+	m := chatFixture("ask")
+	m, cmd := enter(typed(m, "explain this"))
+	m = runCmds(t, m, cmd)
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "✗ failed") || !strings.Contains(joined, "no heads answered") {
+		t.Errorf("failure not rendered:\n%s", joined)
+	}
+	if !strings.Contains(joined, "trace") {
+		t.Errorf("failure carries no trace link:\n%s", joined)
+	}
+}
+
+// esc cancels the running task through context cancellation, rendered as
+// cancelled — not as a generic failure.
+func TestExec_EscCancelsRunningTask(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	ckDispatchStage = func(ctx context.Context, _ *ckTask, _ string, _ string, _ byte) (ckStageOut, error) {
+		<-ctx.Done()
+		return ckStageOut{}, ctx.Err()
+	}
+	m := chatFixture("ask")
+	m, cmd := enter(typed(m, "explain this"))
+	if m.exec == nil {
+		t.Fatal("no task started")
+	}
+	m = press(m, tea.KeyEsc) // cancel — exec stays until the worker reports back
+	if m.exec == nil {
+		t.Fatal("esc cleared exec before the worker returned")
+	}
+	if got := m.exec.Stage(); !strings.Contains(got, "cancelling") {
+		t.Errorf("stage = %q after esc", got)
+	}
+	m = runCmds(t, m, cmd)
+	if m.exec != nil {
+		t.Fatal("exec still set after the cancelled worker returned")
+	}
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "✗ cancelled") {
+		t.Errorf("cancellation not rendered:\n%s", joined)
+	}
+}
+
+// While a task runs, a second enter refuses without losing the typed text, and
+// esc clears typed input before it cancels anything.
+func TestExec_SubmitWhileRunningRefusesAndKeepsInput(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	ckDispatchStage = func(ctx context.Context, _ *ckTask, _ string, _ string, _ byte) (ckStageOut, error) {
+		<-ctx.Done()
+		return ckStageOut{}, ctx.Err()
+	}
+	m := chatFixture("ask")
+	m, _ = enter(typed(m, "first task"))
+	m = typed(m, "second task")
+	m, _ = enter(m)
+	if m.input != "second task" {
+		t.Errorf("the queued text was lost: %q", m.input)
+	}
+	if m.flash == "" {
+		t.Error("no explanation for the refusal")
+	}
+	// esc with text clears the text; the task keeps running.
+	m = press(m, tea.KeyEsc)
+	if m.input != "" {
+		t.Errorf("esc did not clear the input: %q", m.input)
+	}
+	if got := m.exec.Stage(); strings.Contains(got, "cancelling") {
+		t.Error("esc cancelled the task while clearing typed input")
+	}
+}
+
+// The PII badge shows when the config forces local, and the dispatch options
+// carry LocalOnly — the enforcement is dispatch's, the disclosure is the TUI's.
+func TestExec_PIIForcesLocalBadgeAndOption(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	var got *ckTask
+	ckDispatchStage = func(_ context.Context, tk *ckTask, _ string, _ string, _ byte) (ckStageOut, error) {
+		got = tk
+		return ckStageOut{output: "ok", head: "local-stub", tier: 10}, nil
+	}
+	m := chatFixture("ask")
+	m.piiLocal = true
+	m, cmd := enter(typed(m, "email bob@example.com the users report"))
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "local-only (pii)") {
+		t.Errorf("no local-only badge on a PII prompt:\n%s", joined)
+	}
+	if !strings.Contains(joined, "PII detected") {
+		t.Errorf("the why clause hides the PII:\n%s", joined)
+	}
+	m = runCmds(t, m, cmd)
+	if got == nil || !got.localOnly {
+		t.Error("the dispatch options do not carry LocalOnly")
+	}
+	// Without the config policy, the same prompt routes normally: no badge.
+	m2 := chatFixture("ask")
+	m2, _ = enter(typed(m2, "email bob@example.com the users report"))
+	if strings.Contains(stripANSI(strings.Join(m2.log, "\n")), "local-only (pii)") {
+		t.Error("the badge showed with no local-only pii policy configured")
+	}
+}
+
+// ── edit mode + d/x/o ─────────────────────────────────────────────────────────
+
+func TestExec_EditModeEditsAndDXOWorkOffSnapshots(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	const before, after = "package main\n\nvar old = 1\n", "package main\n\nvar new = 2\n"
+	rel, abs := namedFile(t, before)
+	edits := 0
+	ckEditStage = func(ctx context.Context, tk *ckTask, prompt string) (*editor.Result, error) {
+		edits++
+		return stubEdit(before, after)(ctx, tk, prompt)
+	}
+
+	m := chatFixture("edit")
+	m, cmd := enter(typed(m, "swap old for new in "+rel))
+	m = runCmds(t, m, cmd)
+	if edits != 1 {
+		t.Fatalf("edit mode ran %d edits, want 1 (no plan step)", edits)
+	}
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	for _, want := range []string{"edit ✓ main.go +1/−1", "tests — skipped (edit mode)", "d diff · x undo · o open"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("proof strip missing %q:\n%s", want, joined)
+		}
+	}
+	if raw, _ := os.ReadFile(abs); string(raw) != after {
+		t.Fatalf("the file was not written: %q", raw)
+	}
+	// The code panel streams the real new content — the fake snippets are gone.
+	if !strings.Contains(strings.Join(m.codeLines, "\n"), "var new = 2") {
+		t.Errorf("the code panel does not hold the edited content: %v", m.codeLines)
+	}
+
+	// d: diff on, from the snapshots; d again: back to the file.
+	m, _ = keyRune(m, 'd')
+	if !m.codeDiff {
+		t.Fatal("d did not open the diff")
+	}
+	diffText := strings.Join(m.codeLines, "\n")
+	if !strings.Contains(diffText, "-var old = 1") || !strings.Contains(diffText, "+var new = 2") {
+		t.Errorf("the diff does not show the change:\n%s", diffText)
+	}
+	m, _ = keyRune(m, 'd')
+	if m.codeDiff {
+		t.Fatal("d did not toggle the diff off")
+	}
+
+	// o with no $EDITOR: an explanation, not a dead key.
+	t.Setenv("EDITOR", "")
+	m, cmd = keyRune(m, 'o')
+	if cmd != nil || !strings.Contains(m.flash, "EDITOR") {
+		t.Errorf("o without $EDITOR: cmd=%v flash=%q", cmd, m.flash)
+	}
+	t.Setenv("EDITOR", "true")
+	if _, cmd = keyRune(m, 'o'); cmd == nil {
+		t.Error("o with $EDITOR did not open the file")
+	}
+
+	// x: restore the exact pre-task bytes; a second x refuses.
+	m, _ = keyRune(m, 'x')
+	if raw, _ := os.ReadFile(abs); string(raw) != before {
+		t.Fatalf("undo did not restore exactly:\n got %q\nwant %q", raw, before)
+	}
+	if !strings.Contains(m.flash, "restored") {
+		t.Errorf("undo flash = %q", m.flash)
+	}
+	m, _ = keyRune(m, 'x')
+	if !strings.Contains(m.flash, "already restored") {
+		t.Errorf("second undo flash = %q", m.flash)
+	}
+}
+
+// With no completed edit, d/x/o type like any other letter — the hijack exists
+// only while there is something to act on.
+func TestExec_DXOTypeWhenNothingToActOn(t *testing.T) {
+	m := testCockpit()
+	m = typed(m, "d")
+	if m.input != "d" || m.codeDiff {
+		t.Errorf("d with no last edit did not type: input=%q", m.input)
+	}
+	m.input = ""
+	ans := chatFixture("ask")
+	ans.lastDone = &ckTask{answer: "text only"} // finished, but nothing edited
+	ans = typed(ans, "x")
+	if ans.input != "x" {
+		t.Errorf("x with an answer-only result did not type: %q", ans.input)
+	}
+}
+
+func TestExec_EditModeWithoutFileAnswersWithNote(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	ckDispatchStage = stubAnswer("here is how", 0)
+	m := chatFixture("edit")
+	m, cmd := enter(typed(m, "rename the variable"))
+	m = runCmds(t, m, cmd)
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "no file named — answered instead") {
+		t.Errorf("the no-file note is missing:\n%s", joined)
+	}
+	if !strings.Contains(joined, "here is how") {
+		t.Errorf("the answer is missing:\n%s", joined)
+	}
+}
+
+// ── plan mode ─────────────────────────────────────────────────────────────────
+
+func TestExec_PlanApproveRunsTheRest(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, _ := namedFile(t, "package main\n")
+	ckDispatchStage = stubAnswer("1. read the file\n2. change it", 0)
+	ckEditStage = stubEdit("package main\n", "package main // edited\n")
+	verifies := 0
+	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+		verifies++
+		return oracle.Verdict{Passed: true}, nil
+	}
+
+	m := chatFixture("plan")
+	m, cmd := enter(typed(m, "add a comment to "+rel))
+	m = runCmds(t, m, cmd)
+	if m.planWait == nil {
+		t.Fatal("no plan approval gate")
+	}
+	if m.exec != nil {
+		t.Fatal("exec still set while waiting on approval")
+	}
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "PLAN — 2 steps") || !strings.Contains(joined, "1. read the file") {
+		t.Errorf("the plan is not rendered:\n%s", joined)
+	}
+
+	m, cmd = enter(m) // approve
+	if m.planWait != nil || m.exec == nil {
+		t.Fatal("approval did not resume the pipeline")
+	}
+	m = runCmds(t, m, cmd)
+	joined = stripANSI(strings.Join(m.log, "\n"))
+	for _, want := range []string{"plan ✓ 2 steps", "edit ✓ main.go", "tests ✓ go test ./..."} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("proof strip missing %q:\n%s", want, joined)
+		}
+	}
+	if verifies != 1 {
+		t.Errorf("verify ran %d times, want 1", verifies)
+	}
+}
+
+// 'a' (apply) approves a pending plan exactly like enter/y.
+func TestExec_PlanApplyKeyApproves(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	ckDispatchStage = stubAnswer("1. think\n2. answer", 0)
+	m := chatFixture("plan")
+	m, cmd := enter(typed(m, "outline a users endpoint"))
+	m = runCmds(t, m, cmd)
+	if m.planWait == nil {
+		t.Fatal("no plan gate")
+	}
+	m, cmd = keyRune(m, 'a')
+	if m.planWait != nil || m.exec == nil {
+		t.Fatal("a did not approve the plan")
+	}
+	m = runCmds(t, m, cmd)
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "✓ done") {
+		t.Error("the approved plan did not finish")
+	}
+}
+
+func TestExec_PlanDiscardRunsNothing(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, abs := namedFile(t, "package main\n")
+	ckDispatchStage = stubAnswer("1. do it", 0)
+	// The edit stub stays the harness trap: discarding must never reach it.
+
+	m := chatFixture("plan")
+	m, cmd := enter(typed(m, "rewrite "+rel))
+	m = runCmds(t, m, cmd)
+	if m.planWait == nil {
+		t.Fatal("no plan gate")
+	}
+	m = press(m, tea.KeyEsc)
+	if m.planWait != nil {
+		t.Fatal("esc did not discard the plan")
+	}
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "plan discarded — nothing ran") || !strings.Contains(joined, "◼ stopped") {
+		t.Errorf("the discard is not disclosed:\n%s", joined)
+	}
+	if raw, _ := os.ReadFile(abs); string(raw) != "package main\n" {
+		t.Error("discarding a plan changed the file")
+	}
+	if m.lastDone == nil || !m.lastDone.stopped {
+		t.Error("the discarded task did not settle as stopped")
+	}
+}
+
+// ── auto: the verify loop ─────────────────────────────────────────────────────
+
+func TestExec_AutoVerifyLoopFixesThenPasses(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, _ := namedFile(t, "package main\n")
+	ckDispatchStage = stubAnswer("1. edit\n2. test", 0)
+	var edits int
+	var fixPrompt string
+	ckEditStage = func(ctx context.Context, tk *ckTask, prompt string) (*editor.Result, error) {
+		edits++
+		if edits > 1 {
+			fixPrompt = prompt
+		}
+		return stubEdit("package main\n", "package main // v"+fmt.Sprint(edits)+"\n")(ctx, tk, prompt)
+	}
+	verifies := 0
+	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+		verifies++
+		if verifies == 1 {
+			return oracle.Verdict{Passed: false, Detail: "TestBoom failed"}, nil
+		}
+		return oracle.Verdict{Passed: true}, nil
+	}
+
+	m := chatFixture("auto")
+	m, cmd := enter(typed(m, "make the test pass in "+rel))
+	m = runCmds(t, m, cmd)
+	if edits != 2 || verifies != 2 {
+		t.Fatalf("loop ran %d edits / %d verifies, want 2/2", edits, verifies)
+	}
+	if !strings.Contains(fixPrompt, "TestBoom failed") {
+		t.Errorf("the fix re-dispatch does not carry the failure output:\n%s", fixPrompt)
+	}
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "tests ✓ go test ./... (after 1 fix)") {
+		t.Errorf("the strip does not credit the fix loop:\n%s", joined)
+	}
+	// The task's diff spans first-before → last-after, collapsing the fix hops.
+	m, _ = keyRune(m, 'd')
+	diffText := strings.Join(m.codeLines, "\n")
+	if !strings.Contains(diffText, "+package main // v2") {
+		t.Errorf("the diff does not end at the final content:\n%s", diffText)
+	}
+}
+
+func TestExec_AutoVerifyLoopCapsAtTwoFixes(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, _ := namedFile(t, "package main\n")
+	ckDispatchStage = stubAnswer("1. try", 0)
+	edits := 0
+	ckEditStage = func(ctx context.Context, tk *ckTask, prompt string) (*editor.Result, error) {
+		edits++
+		return stubEdit("package main\n", "package main // still wrong\n")(ctx, tk, prompt)
+	}
+	verifies := 0
+	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+		verifies++
+		return oracle.Verdict{Passed: false, Detail: "still broken"}, nil
+	}
+
+	m := chatFixture("auto")
+	m, cmd := enter(typed(m, "fix "+rel))
+	m = runCmds(t, m, cmd)
+	if edits != 1+ckMaxFixes || verifies != 1+ckMaxFixes {
+		t.Fatalf("loop ran %d edits / %d verifies, want %d/%d", edits, verifies, 1+ckMaxFixes, 1+ckMaxFixes)
+	}
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "tests ✗") || !strings.Contains(joined, "after 2 fixes") {
+		t.Errorf("the capped failure is not disclosed:\n%s", joined)
+	}
+	if !strings.Contains(joined, "still broken") {
+		t.Errorf("the last failure detail is missing:\n%s", joined)
+	}
+}
+
+// Auto with no verifier configured says so instead of pretending it verified.
+func TestExec_AutoWithoutVerifierSaysSo(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	// .txt has no workspace validator and there is no go.mod: argv resolves empty.
+	ckDispatchStage = stubAnswer("1. edit", 0)
+	ckEditStage = stubEdit("x", "y")
+
+	m := chatFixture("auto")
+	// ckFileRe does not match .txt, so no file is named: auto degrades to
+	// plan → answer, with the answer rendered.
+	m, cmd := enter(typed(m, "tidy the notes file"))
+	m = runCmds(t, m, cmd)
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "✓ done") {
+		t.Error("auto without a file did not settle as an answer")
+	}
+	// And with a named .go file but no verifier anywhere: the strip says so.
+	if args, label := ckVerifyArgs(filepath.Join(dir, "main.txt")); args != nil || label != "" {
+		t.Errorf("ckVerifyArgs invented a verifier: %v %q", args, label)
+	}
+}
+
+// ── careful ───────────────────────────────────────────────────────────────────
+
+func TestExec_CarefulConfirmsEveryWrite(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, abs := namedFile(t, "package main\n")
+	ckDispatchStage = stubAnswer("1. edit it", 0)
+	edits := 0
+	ckEditStage = func(ctx context.Context, tk *ckTask, prompt string) (*editor.Result, error) {
+		edits++
+		return stubEdit("package main\n", "package main // careful\n")(ctx, tk, prompt)
+	}
+	verifies := 0
+	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+		verifies++
+		if verifies == 1 {
+			return oracle.Verdict{Passed: false, Detail: "not yet"}, nil
+		}
+		return oracle.Verdict{Passed: true}, nil
+	}
+
+	// n at the write gate: nothing lands.
+	m := chatFixture("careful")
+	m, cmd := enter(typed(m, "change "+rel))
+	m = runCmds(t, m, cmd)
+	if m.confirm == nil || !strings.Contains(m.confirm.question, "write main.go?") {
+		t.Fatalf("no write confirm: %+v", m.confirm)
+	}
+	m, cmd = keyRune(m, 'n')
+	m = runCmds(t, m, cmd)
+	if edits != 0 {
+		t.Fatal("n still wrote the file")
+	}
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "stopped before writing") {
+		t.Error("the refusal is not disclosed")
+	}
+
+	// y at the write gate, then y at the fix gate: both writes were confirmed.
+	m = chatFixture("careful")
+	m, cmd = enter(typed(m, "change "+rel))
+	m = runCmds(t, m, cmd)
+	m, cmd = keyRune(m, 'y')
+	m = runCmds(t, m, cmd)
+	if m.confirm == nil || !strings.Contains(m.confirm.question, "fix 1/2") {
+		t.Fatalf("no fix confirm after a failing verify: %+v", m.confirm)
+	}
+	m, cmd = keyRune(m, 'y')
+	m = runCmds(t, m, cmd)
+	if edits != 2 || verifies != 2 {
+		t.Fatalf("confirmed flow ran %d edits / %d verifies, want 2/2", edits, verifies)
+	}
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "tests ✓") {
+		t.Error("the confirmed fix did not pass")
+	}
+
+	// esc at a fix gate: the landed edit stays, disclosed as declined.
+	m = chatFixture("careful")
+	verifies, edits = 0, 0
+	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+		verifies++
+		return oracle.Verdict{Passed: false, Detail: "always red"}, nil
+	}
+	m, cmd = enter(typed(m, "change "+rel))
+	m = runCmds(t, m, cmd)
+	m, cmd = keyRune(m, 'y')
+	m = runCmds(t, m, cmd)
+	if m.confirm == nil {
+		t.Fatal("no fix gate")
+	}
+	m = press(m, tea.KeyEsc)
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "fix declined") || !strings.Contains(joined, "tests ✗") {
+		t.Errorf("the declined fix is not honest:\n%s", joined)
+	}
+	if raw, _ := os.ReadFile(abs); !strings.Contains(string(raw), "careful") {
+		t.Error("the confirmed first write was rolled back by declining the fix")
+	}
+}
+
+// ── unattended ────────────────────────────────────────────────────────────────
+
+func TestExec_UnattendedStopsVisiblyAtTheCostCap(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, _ := namedFile(t, "package main\n")
+	// The plan alone books more than the cap; the next stage must refuse.
+	ckDispatchStage = stubAnswer("1. spend", 1.00)
+
+	m := chatFixture("unattended")
+	m, cmd := enter(typed(m, "refactor "+rel))
+	m = runCmds(t, m, cmd)
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "✗ failed") || !strings.Contains(joined, "cost cap $0.50 reached") {
+		t.Errorf("the cap stop is not visible:\n%s", joined)
+	}
+	// The stage-level guard also rides along on plain dispatches.
+	var seen *ckTask
+	ckDispatchStage = func(_ context.Context, tk *ckTask, _ string, _ string, _ byte) (ckStageOut, error) {
+		seen = tk
+		return ckStageOut{output: "1. ok", head: "h", tier: 8}, nil
+	}
+	m2 := chatFixture("unattended")
+	m2, cmd = enter(typed(m2, "explain the plan"))
+	_ = runCmds(t, m2, cmd)
+	if seen == nil || seen.mode.capUSD != ckUnattendedCapUSD {
+		t.Error("the per-dispatch MaxCostUSD knob is not threaded")
+	}
+}
+
+// ── ctrl+o override wiring ────────────────────────────────────────────────────
+
+func TestExec_OverrideWiresIntoTheNextDispatchOnly(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	var strat byte
+	var seen *ckTask
+	capture := func(_ context.Context, tk *ckTask, _ string, _ string, s byte) (ckStageOut, error) {
+		seen, strat = tk, s
+		return ckStageOut{output: "ok", head: "h", tier: 8, confidence: 0.97}, nil
+	}
+	ckDispatchStage = capture
+
+	// local only
+	m := chatFixture("ask")
+	m = press(m, tea.KeyCtrlO)
+	m = typed(m, "jj")
+	m, _ = enter(m)
+	m, cmd := enter(typed(m, "explain the endpoint"))
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "local only") {
+		t.Error("the route line does not show the local-only override")
+	}
+	m = runCmds(t, m, cmd)
+	if seen == nil || !seen.localOnly {
+		t.Error("local only did not reach the dispatch options")
+	}
+	if m.override.kind != 0 {
+		t.Error("the override survived the task — it is next-task-only")
+	}
+
+	// force tier 3
+	m = chatFixture("ask")
+	m = press(m, tea.KeyCtrlO)
+	m = typed(m, "j")
+	m, _ = enter(m)
+	m = typed(m, "3")
+	m, cmd = enter(typed(m, "explain the endpoint"))
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "forced") {
+		t.Error("the route line does not show the forced tier")
+	}
+	m = runCmds(t, m, cmd)
+	if seen.answerTier != "3" {
+		t.Errorf("answerTier = %q, want 3", seen.answerTier)
+	}
+
+	// best of 3 reaches the answer stage as its strategy
+	m = chatFixture("ask")
+	m = press(m, tea.KeyCtrlO)
+	m = typed(m, "jjj")
+	m, _ = enter(m)
+	m, cmd = enter(typed(m, "is this migration safe?"))
+	m = runCmds(t, m, cmd)
+	if strat != 'B' {
+		t.Errorf("strategy = %q, want best of 3", strat)
+	}
+
+	// consensus carries its target and renders the achieved confidence
+	m = chatFixture("ask")
+	m = press(m, tea.KeyCtrlO)
+	m = typed(m, "jjjj")
+	m, _ = enter(m)
+	m = typed(m, "2") // ≥95%
+	m, cmd = enter(typed(m, "is this migration safe?"))
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "consensus ≥95%") {
+		t.Error("the route line does not show the consensus strategy")
+	}
+	m = runCmds(t, m, cmd)
+	if strat != 'C' || seen.confidence != 0.95 {
+		t.Errorf("consensus not wired: strat=%q conf=%v", strat, seen.confidence)
+	}
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "confidence 97%") {
+		t.Error("the achieved confidence is not in the footer")
+	}
+}
+
+// A fan-out override on a file edit stays single — visibly.
+func TestExec_OverrideFanoutFallsBackToSingleForEdits(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, _ := namedFile(t, "package main\n")
+	var strat byte = 0xFF
+	ckDispatchStage = func(_ context.Context, _ *ckTask, _ string, _ string, s byte) (ckStageOut, error) {
+		strat = s
+		return ckStageOut{output: "1. plan", head: "h", tier: 8}, nil
+	}
+	ckEditStage = stubEdit("package main\n", "package main // x\n")
+	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+		return oracle.Verdict{Passed: true}, nil
+	}
+
+	m := chatFixture("auto")
+	m = press(m, tea.KeyCtrlO)
+	m = typed(m, "jjj") // best of 3
+	m, _ = enter(m)
+	m, cmd := enter(typed(m, "improve "+rel))
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "edits can't fan out") {
+		t.Error("the single fallback is not disclosed on the route line")
+	}
+	m = runCmds(t, m, cmd)
+	if strat != 0 {
+		t.Errorf("the plan stage ran with strategy %q, want single", strat)
+	}
+	_ = m
+}
+
+// ── architect ─────────────────────────────────────────────────────────────────
+
+func TestExec_ArchitectSplitsPlanAndImplementTiers(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, _ := namedFile(t, "package main\n")
+	var planTier string
+	ckDispatchStage = func(_ context.Context, tk *ckTask, _ string, tier string, _ byte) (ckStageOut, error) {
+		planTier = tier
+		return ckStageOut{output: "1. design\n2. build", head: "opus", tier: 2}, nil
+	}
+	var editTask *ckTask
+	ckEditStage = func(ctx context.Context, tk *ckTask, prompt string) (*editor.Result, error) {
+		editTask = tk
+		return stubEdit("package main\n", "package main // built\n")(ctx, tk, prompt)
+	}
+	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+		return oracle.Verdict{Passed: true}, nil
+	}
+
+	m := chatFixture("architect")
+	m, cmd := enter(typed(m, "restructure "+rel))
+	m = runCmds(t, m, cmd)
+	if planTier != "2" {
+		t.Errorf("the plan ran on tier %q, want the strong tier 2", planTier)
+	}
+	if editTask == nil || editTask.editEnum != "SIMPLE" {
+		t.Errorf("the implement half is not on the cheap tier: %+v", editTask)
+	}
+	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "tests ✓") {
+		t.Error("architect did not verify")
+	}
+}
+
+// ── stale/foreign messages ────────────────────────────────────────────────────
+
+func TestExec_StaleWorkerMessagesAreIgnored(t *testing.T) {
+	m := testCockpit()
+	ghost := &ckExecState{}
+	before := len(m.log)
+	next, _ := m.Update(ckExecDoneMsg{exec: ghost, task: ckTask{answer: "ghost"}})
+	m = next.(Cockpit)
+	if len(m.log) != before || m.lastDone != nil {
+		t.Error("a stale done message landed")
+	}
+	next, _ = m.Update(ckGateMsg{exec: ghost, task: ckTask{}, gate: 'p'})
+	m = next.(Cockpit)
+	if m.planWait != nil {
+		t.Error("a stale gate message landed")
+	}
+	// A stale spin tick schedules nothing.
+	if _, cmd := m.Update(ckSpinTickMsg{exec: ghost}); cmd != nil {
+		t.Error("a stale spin tick rescheduled itself")
+	}
+}
+
+// ── verify command resolution ─────────────────────────────────────────────────
+
+func TestCkVerifyArgs_GoRepoThenWorkspaceValidator(t *testing.T) {
+	testutil.NewSandbox(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	argv, label := ckVerifyArgs("")
+	if len(argv) != 3 || argv[0] != "go" || label != "go test ./..." {
+		t.Errorf("go repo: argv=%v label=%q", argv, label)
+	}
+
+	// Outside a Go repo, the workspace validator for the extension applies,
+	// with {file} substituted by the real path (embedded workspace.yaml has a
+	// py validator and none for go).
+	plain := t.TempDir()
+	t.Chdir(plain)
+	target := filepath.Join(plain, "script.py")
+	argv, label = ckVerifyArgs(target)
+	if len(argv) == 0 || argv[0] != "python3" {
+		t.Fatalf("py validator not resolved: %v", argv)
+	}
+	found := false
+	for _, a := range argv {
+		if a == target {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("{file} was not substituted with the real path: %v", argv)
+	}
+	if !strings.Contains(label, "script.py") || strings.Contains(label, "{file}") {
+		t.Errorf("label = %q", label)
+	}
+
+	// No verifier anywhere: empty, never invented.
+	if argv, label = ckVerifyArgs(filepath.Join(plain, "notes.txt")); argv != nil || label != "" {
+		t.Errorf("invented a verifier: %v %q", argv, label)
+	}
+	if argv, _ = ckVerifyArgs(""); argv != nil {
+		t.Errorf("invented a verifier with no file: %v", argv)
+	}
+}
+
+// A .git boundary stops the go.mod walk: an unrelated repo nested under a Go
+// directory is not "a Go repo".
+func TestCkGoModDir_StopsAtGitBoundary(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module up\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(root, "sub")
+	if err := os.MkdirAll(filepath.Join(nested, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+	if got := ckGoModDir(); got != "" {
+		t.Errorf("the walk crossed a .git boundary to %q", got)
+	}
+	t.Chdir(root)
+	if got := ckGoModDir(); got != root {
+		t.Errorf("go.mod in the cwd not found: %q", got)
+	}
+}
+
+// ── small pieces ──────────────────────────────────────────────────────────────
+
+func TestCkCountSteps(t *testing.T) {
+	if got := ckCountSteps("1. a\n2. b\n3) c\nnot a step"); got != 3 {
+		t.Errorf("counted %d steps", got)
+	}
+	if got := ckCountSteps("just prose"); got != 1 {
+		t.Errorf("unnumbered plan counted %d", got)
+	}
+	if got := ckCountSteps("  \n"); got != 0 {
+		t.Errorf("empty plan counted %d", got)
+	}
+}
+
+func TestCkEditEnum(t *testing.T) {
+	auto := ckModeByName("auto")
+	if got := ckEditEnum("STANDARD", auto, ckOverride{}); got != "STANDARD" {
+		t.Errorf("classified enum not kept: %q", got)
+	}
+	if got := ckEditEnum("CORE", auto, ckOverride{}); got != "EXPERT" {
+		t.Errorf("CORE must cap to EXPERT for edits: %q", got)
+	}
+	if got := ckEditEnum("STANDARD", ckModeByName("architect"), ckOverride{}); got != "SIMPLE" {
+		t.Errorf("architect implements cheap: %q", got)
+	}
+	if got := ckEditEnum("STANDARD", auto, ckOverride{kind: 'T', tier: 5}); got != "COMPLEX" {
+		t.Errorf("forced tier not mapped: %q", got)
+	}
+	if got := ckEditEnum("STANDARD", auto, ckOverride{kind: 'T', tier: 1}); got != "EXPERT" {
+		t.Errorf("forced CORE must cap to EXPERT: %q", got)
+	}
+}
+
+func TestCkNamedFile_OnlyRealFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pkg", "real.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	if got := ckNamedFile("edit pkg/real.go now"); got != filepath.Join(dir, "pkg", "real.go") {
+		t.Errorf("real file not resolved: %q", got)
+	}
+	if got := ckNamedFile("edit pkg/ghost.go now"); got != "" {
+		t.Errorf("a missing file was named: %q", got)
+	}
+	if got := ckNamedFile("no file here"); got != "" {
+		t.Errorf("a file was invented: %q", got)
+	}
+	if got := ckNamedFile("look at pkg"); got != "" {
+		t.Errorf("matched without an extension: %q", got)
+	}
+}
+
+func TestCkTailTruncate_KeepsTheTail(t *testing.T) {
+	long := strings.Repeat("head ", 40) + "TAIL"
+	got := stripANSI(ckTailTruncate(long, 20))
+	if !strings.Contains(got, "TAIL") {
+		t.Errorf("the tail was cut: %q", got)
+	}
+	if lipgloss.Width(got) > 21 { // "…" + up to 20 cells
+		t.Errorf("still %d cells wide", lipgloss.Width(got))
+	}
+	if s := ckTailTruncate("short", 20); s != "short" {
+		t.Errorf("a fitting line was changed: %q", s)
+	}
+}
+
+func TestCkTestsCellAndProofStrip_EveryState(t *testing.T) {
+	base := ckTask{mode: ckModeByName("auto"), file: "a/b.go", added: 3, removed: 1, planSteps: 2, verifyLabel: "go test ./..."}
+	cases := []struct {
+		name string
+		mut  func(*ckTask)
+		want string
+	}{
+		{"skipped mode", func(t *ckTask) { t.mode = ckModeByName("edit") }, "skipped (edit mode)"},
+		{"unconfigured", func(t *ckTask) { t.verifySkipped = true }, "no verifier configured"},
+		{"verifier failed", func(t *ckTask) { t.verifyErr = "exec: not found" }, "verifier failed"},
+		{"not run", func(*ckTask) {}, "tests — not run"},
+		{"passed", func(t *ckTask) { t.rounds = []ckVerifyRound{{passed: true}} }, "tests ✓ go test ./..."},
+		{"passed after fixes", func(t *ckTask) {
+			t.rounds = []ckVerifyRound{{}, {}, {passed: true}}
+		}, "after 2 fixes"},
+		{"failing", func(t *ckTask) {
+			t.rounds = []ckVerifyRound{{detail: "boom"}}
+		}, "still failing: boom"},
+	}
+	for _, tc := range cases {
+		tk := base
+		tc.mut(&tk)
+		if got := stripANSI(ckTestsCell(tk)); !strings.Contains(got, tc.want) {
+			t.Errorf("%s: %q does not contain %q", tc.name, got, tc.want)
+		}
+	}
+	strip := stripANSI(ckProofStrip(base))
+	if !strings.Contains(strip, "plan ✓ 2 steps") || !strings.Contains(strip, "edit ✓ b.go +3/−1") {
+		t.Errorf("strip = %q", strip)
+	}
+}
+
+// ── layout: the new chat states hold the frame ────────────────────────────────
+
+func TestChatStates_LayoutInvariantsAtEverySize(t *testing.T) {
+	testutil.NewSandbox(t)
+	long := strings.Repeat("x", 3000)
+	longAnswer := ckTask{
+		runID: "20260904T111111Z-aaaa1111", mode: ckModeByName("auto"),
+		answer: strings.Repeat("answer line — reasonably long so it wraps at narrow widths\n", 60) + long,
+		edited: true, file: "internal/api/users.go", added: 12, removed: 4, planSteps: 3,
+		rounds: []ckVerifyRound{{passed: true}}, verifyLabel: "go test ./...",
+		costUSD: 0.0123, elapsed: 3 * time.Second,
+	}
+
+	states := map[string]func(Cockpit) Cockpit{
+		"running": func(m Cockpit) Cockpit {
+			m.exec = &ckExecState{stage: "verifying — go test ./... with a very long stage line " + long[:200], started: time.Now()}
+			return m
+		},
+		"plan_pending": func(m Cockpit) Cockpit {
+			t := ckTask{plan: "1. first\n2. second\n3. " + long, planSteps: 3, headName: "stub"}
+			m.log = append(m.log, ckPlanLines(t)...)
+			m.planWait = &ckWait{task: t, phase: ckPhaseTail}
+			return m
+		},
+		"confirm": func(m Cockpit) Cockpit {
+			m.confirm = &ckWait{question: "write " + long[:120] + "? y/n"}
+			return m
+		},
+		"proof_strip_long_answer": func(m Cockpit) Cockpit {
+			m.log = append(m.log, ckResultLines(longAnswer)...)
+			m.lastDone = &longAnswer
+			return m
+		},
+		"mode_picker":    func(m Cockpit) Cockpit { m.modePick = true; return m },
+		"override_modal": func(m Cockpit) Cockpit { m.ovOpen = true; return m },
+		"long_input":     func(m Cockpit) Cockpit { m.input = long; return m },
+		"diff_panel": func(m Cockpit) Cockpit {
+			m.codeDiff, m.codeLang = true, "diff"
+			for i := 0; i < 80; i++ {
+				m.codeLines = append(m.codeLines, "+"+long[:80])
+			}
+			m.codeShown = len(m.codeLines)
+			return m
+		},
+	}
+
+	sizes := []struct{ w, h int }{{60, 15}, {80, 24}, {100, 30}, {120, 40}}
+	for name, build := range states {
+		for _, sz := range sizes {
+			t.Run(fmt.Sprintf("%s_%dx%d", name, sz.w, sz.h), func(t *testing.T) {
+				m := build(testCockpit())
+				m.w, m.h, m.ready = sz.w, sz.h, true
+				out := m.View()
+				lines := strings.Split(out, "\n")
+				if len(lines) > sz.h {
+					t.Errorf("%s at %dx%d renders %d lines, want <= %d", name, sz.w, sz.h, len(lines), sz.h)
+				}
+				for i, l := range lines {
+					if got := lipgloss.Width(l); got > sz.w {
+						t.Errorf("%s at %dx%d: line %d is %d cells wide", name, sz.w, sz.h, i, got)
+					}
+				}
+				last := stripANSI(lines[len(lines)-1])
+				if !strings.Contains(last, "shortcuts") {
+					t.Errorf("%s at %dx%d: the status bar is not the final line: %q", name, sz.w, sz.h, last)
+				}
+			})
+		}
+	}
+}
+
+// Long real outputs keep append-no-yank: a reader anchored in scrollback stays
+// anchored when a 200-line answer lands.
+func TestChatScrollback_SurvivesLongAnswers(t *testing.T) {
+	testutil.NewSandbox(t)
+	m := testCockpit()
+	m.w, m.h, m.ready = 100, 24, true
+	for i := 0; i < 60; i++ {
+		m.log = append(m.log, fmt.Sprintf("history %d", i))
+	}
+	m = press(m, tea.KeyPgUp)
+	anchor := m.chatScroll
+	if anchor == 0 {
+		t.Fatal("pgup did not anchor")
+	}
+	big := ckTask{runID: "r", answer: strings.Repeat("new answer line\n", 200), elapsed: time.Second}
+	m.log = append(m.log, ckResultLines(big)...)
+	if m.chatScroll != anchor {
+		t.Error("a long answer yanked the anchored reader")
+	}
+	if out := stripANSI(m.View()); strings.Contains(out, "new answer line") {
+		t.Error("anchored view was dragged to the new output")
+	}
+	m = press(m, tea.KeyEnd)
+	if out := stripANSI(m.View()); !strings.Contains(out, "✓ done") {
+		t.Error("end did not return to the live tail")
+	}
+}
+
+// ── the real stages (error paths — no provider is ever driven in a unit test) ──
+
+// The real dispatch stage reaches the real router for every strategy; with a
+// config but no heads each strategy fails at its own entry point rather than
+// silently collapsing into one path.
+func TestCkRealDispatchStage_StrategiesReachTheirEntryPoints(t *testing.T) {
+	testutil.NewSandbox(t)
+	tk := &ckTask{runID: "r", taskID: "t", confidence: 0.95}
+
+	// No config at all: dispatch.New itself refuses.
+	if _, err := ckRealDispatchStage(context.Background(), tk, "p", "8", 0); err == nil ||
+		!strings.Contains(err.Error(), "hyctl init") {
+		t.Fatalf("no-config dispatch did not fail loudly: %v", err)
+	}
+
+	if err := config.Save(&config.Config{Cortex: "none"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, strat := range []byte{0, 'B', 'C'} {
+		_, err := ckRealDispatchStage(context.Background(), tk, "p", "", strat)
+		if err == nil {
+			t.Fatalf("strategy %q dispatched with zero heads", strat)
+		}
+		if !strings.Contains(err.Error(), "head") {
+			t.Errorf("strategy %q error does not blame the head pool: %v", strat, err)
+		}
+	}
+}
+
+// The real edit stage is the editor path: outside any workspace it fails as a
+// scope rejection, not a write.
+func TestCkRealEditStage_OutsideWorkspaceIsRejected(t *testing.T) {
+	testutil.NewSandbox(t)
+	dir := t.TempDir()
+	tk := &ckTask{runID: "r", taskID: "t", file: filepath.Join(dir, "x.go"), editEnum: "SIMPLE"}
+	res, err := ckRealEditStage(context.Background(), tk, "change it")
+	if err != nil {
+		t.Fatalf("editor errors travel inside the Result: %v", err)
+	}
+	if res.Status != "fail" || res.Error == "" {
+		t.Fatalf("an out-of-scope edit did not fail: %+v", res)
+	}
+}
+
+// The real verify stage maps exit codes to verdicts and launch failures to errors.
+func TestCkRealVerifyStage_ExitCodesBecomeVerdicts(t *testing.T) {
+	v, err := ckRealVerifyStage(context.Background(), []string{"go", "version"})
+	if err != nil || !v.Passed {
+		t.Fatalf("`go version` did not pass: v=%+v err=%v", v, err)
+	}
+	v, err = ckRealVerifyStage(context.Background(), []string{"go", "tool", "definitely-not-a-tool"})
+	if err != nil || v.Passed {
+		t.Fatalf("a failing command did not fail: v=%+v err=%v", v, err)
+	}
+	if _, err = ckRealVerifyStage(context.Background(), []string{"/nonexistent-hydra-verifier"}); err == nil {
+		t.Fatal("an unlaunchable verifier must be an error, not a verdict")
+	}
+}
+
+// ── pipeline error branches ───────────────────────────────────────────────────
+
+// A verifier that cannot run is disclosed as such — distinct from tests failing.
+func TestExec_VerifierErrorIsHonest(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, _ := namedFile(t, "package main\n")
+	ckDispatchStage = stubAnswer("1. edit", 0)
+	ckEditStage = stubEdit("package main\n", "package main // v\n")
+	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+		return oracle.Verdict{}, errors.New("exec: go not found")
+	}
+	m := chatFixture("auto")
+	m, cmd := enter(typed(m, "touch "+rel))
+	m = runCmds(t, m, cmd)
+	joined := stripANSI(strings.Join(m.log, "\n"))
+	if !strings.Contains(joined, "tests ? ") || !strings.Contains(joined, "verifier failed") {
+		t.Errorf("a broken verifier is not disclosed:\n%s", joined)
+	}
+}
+
+// An editor failure (its Result, not a Go error) fails the task with the reason.
+func TestExec_EditFailureRendersReason(t *testing.T) {
+	testutil.NewSandbox(t)
+	stubExec(t)
+	rel, _ := namedFile(t, "package main\n")
+	calls := 0
+	ckEditStage = func(context.Context, *ckTask, string) (*editor.Result, error) {
+		calls++
+		if calls == 1 {
+			return &editor.Result{Status: "fail", Error: "validation_failed: gofmt"}, nil
+		}
+		return nil, errors.New("dispatcher exploded")
+	}
+	m := chatFixture("edit")
+	m, cmd := enter(typed(m, "break "+rel))
+	m = runCmds(t, m, cmd)
+	if joined := stripANSI(strings.Join(m.log, "\n")); !strings.Contains(joined, "validation_failed") {
+		t.Errorf("the editor's reason is missing:\n%s", joined)
+	}
+	m2 := chatFixture("edit")
+	m2, cmd = enter(typed(m2, "break "+rel))
+	m2 = runCmds(t, m2, cmd)
+	if joined := stripANSI(strings.Join(m2.log, "\n")); !strings.Contains(joined, "dispatcher exploded") {
+		t.Errorf("the edit error is missing:\n%s", joined)
+	}
+}
+
+// ckRunSpend and the result actions degrade cleanly when the runlog has nothing.
+func TestResultActions_DegradeWithoutSnapshots(t *testing.T) {
+	testutil.NewSandbox(t)
+	if got := ckRunSpend("never-ran"); got != 0 {
+		t.Errorf("spend for an unknown run = %v", got)
+	}
+	m := testCockpit()
+	tk := &ckTask{edited: true, file: "x.go", runID: "never-ran"}
+	m.lastDone = tk
+	m, _, ok := m.resultKey('d')
+	if !ok || m.codeDiff {
+		t.Errorf("d with no snapshot: ok=%v diff=%v", ok, m.codeDiff)
+	}
+	if !strings.Contains(m.flash, "no snapshot") {
+		t.Errorf("flash = %q", m.flash)
+	}
+	m, _, _ = m.resultKey('x')
+	if !strings.Contains(m.flash, "no snapshot") {
+		t.Errorf("undo flash = %q", m.flash)
+	}
+	// Refs that point at pruned snapshots surface the loader's reason.
+	tk.editRef, tk.editRefLast = "000001", "000001"
+	m, _, _ = m.resultKey('d')
+	if !strings.Contains(m.flash, "diff unavailable") {
+		t.Errorf("pruned-snapshot diff flash = %q", m.flash)
+	}
+	m, _, _ = m.resultKey('x')
+	if !strings.Contains(m.flash, "undo unavailable") {
+		t.Errorf("pruned-snapshot undo flash = %q", m.flash)
+	}
+}
+
+// ckPlanLines caps a rambling plan and counts what it hid.
+func TestCkPlanLines_CapsLongPlans(t *testing.T) {
+	var steps []string
+	for i := 1; i <= 20; i++ {
+		steps = append(steps, fmt.Sprintf("%d. step", i))
+	}
+	tk := ckTask{plan: strings.Join(steps, "\n"), planSteps: 20, headName: "h"}
+	lines := stripANSI(strings.Join(ckPlanLines(tk), "\n"))
+	if !strings.Contains(lines, "PLAN — 20 steps") || !strings.Contains(lines, "… 8 more lines") {
+		t.Errorf("the cap is not disclosed:\n%s", lines)
+	}
+}
+
+func TestCkClassWordsAndWhy(t *testing.T) {
+	for enum, want := range map[string]string{
+		"CORE": "critical work", "COMPLEX": "complex work", "MODERATE": "moderate work",
+		"STANDARD": "standard work", "SIMPLE": "simple task",
+	} {
+		if got := ckClassWords(enum); got != want {
+			t.Errorf("ckClassWords(%s) = %q", enum, got)
+		}
+	}
+	tk := ckTask{file: "x.go", mode: ckModeByName("auto"), pii: true}
+	if got := ckWhyWords(tk, "COMPLEX"); got != "code edit, complex scope, PII detected" {
+		t.Errorf("why = %q", got)
+	}
+	if got := ckWhyWords(ckTask{mode: ckModeByName("ask"), file: "x.go"}, "SIMPLE"); got != "question, small scope, no PII" {
+		t.Errorf("ask-mode why = %q", got)
+	}
+}
+
+func TestCkFirstLine(t *testing.T) {
+	if got := ckFirstLine("  first\nsecond"); got != "first" {
+		t.Errorf("got %q", got)
+	}
+	if got := ckFirstLine("only"); got != "only" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// The chat scroll geometry mirrors the renderer with the taller input bar, and
+// scrollback still clamps at both ends.
+func TestChatScrollGeom_MirrorsInputBarHeight(t *testing.T) {
+	m := testCockpit()
+	m.w, m.h = 100, 24
+	_, logH := m.chatLogGeom()
+	m.input = strings.Repeat("wrap me ", 40)
+	_, logHWrapped := m.chatLogGeom()
+	if logHWrapped >= logH {
+		t.Errorf("a wrapped input did not shrink the log window: %d → %d", logH, logHWrapped)
+	}
+	for i := 0; i < 50; i++ {
+		m.log = append(m.log, "line")
+	}
+	m = m.chatScrollBy(-1000)
+	if m.chatScroll != 1 {
+		t.Errorf("scrollback did not clamp at the top: %d", m.chatScroll)
+	}
+	m = m.chatScrollBy(1000)
+	if m.chatScroll != 0 {
+		t.Errorf("scrollback did not return to live: %d", m.chatScroll)
+	}
+	m.log = []string{"one"}
+	if m = m.chatScrollBy(-3); m.chatScroll != 0 {
+		t.Error("a fitting log entered scrollback")
+	}
+}

--- a/internal/tui/chat_frame_test.go
+++ b/internal/tui/chat_frame_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Regression for a live 80x24 frame: entries a bit wider than the narrow chat
+// pane (route lines, footers) were counted as one line but rendered as three,
+// pushing the input bar off-frame. The window count and the render must agree
+// for every pane at the split's narrowest widths.
+func TestChatCode_LiveFrame80x24NeverOverflows(t *testing.T) {
+	m := testCockpit()
+	m.w, m.h, m.ready = 80, 24, true
+	var heads []ckHead
+	for i := 0; i < 15; i++ {
+		heads = append(heads, ckHead{id: "h", name: "Gemini 3.5 Flash (Medium)", tier: 8, up: true})
+	}
+	m.heads = heads
+	m.mode = "ask"
+	m.log = []string{
+		"init line one",
+		"Type a task and press enter. shift+tab mode · ctrl+o route · ? shortcuts · :q quits.",
+		"mode → ask",
+	}
+	done := ckTask{
+		runID:  "20260904T120000Z-706a524d",
+		answer: "A goroutine is a lightweight thread managed by the Go runtime.",
+		mode:   ckModeByName("ask"), elapsed: 26300000000,
+	}
+	m.log = append(m.log, ckYouS.Render("❯ what is a goroutine? answer in one short sentence"))
+	m.log = append(m.log, m.routeLines(done, heads[0], "SIMPLE", ckOverride{}, false)...)
+	m.log = append(m.log, ckResultLines(done)...)
+	m.lastDone = &done
+
+	bodyH := m.h - 3
+	if got := lipgloss.Height(m.chatCode(bodyH)); got != bodyH {
+		t.Errorf("chatCode height = %d, want exactly %d", got, bodyH)
+	}
+	out := stripANSI(m.View())
+	if strings.Contains(out, "enlarge the terminal") {
+		t.Errorf("the live frame trips ckFrame's crop disclosure:\n%s", out)
+	}
+	lines := strings.Split(out, "\n")
+	if last := lines[len(lines)-1]; !strings.Contains(last, "shortcuts") {
+		t.Errorf("the status bar is not the final line: %q", last)
+	}
+	// The wrapped-count/rendered-line agreement, at the exact narrow width.
+	for i, e := range m.log {
+		for j, l := range strings.Split(ckClipToLines(e, 28, 6), "\n") {
+			if lipgloss.Width(l) > 28 {
+				t.Errorf("entry %d line %d renders %d cells at width 28", i, j, lipgloss.Width(l))
+			}
+		}
+	}
+}

--- a/internal/tui/chat_task.go
+++ b/internal/tui/chat_task.go
@@ -1,0 +1,531 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// chat_task.go — the UI side of a chat task's life: launch with its route
+// line, the plan/confirm gates, the finished rendering (answer block, proof
+// strip, footer), and the d/x/o result actions over runlog edit snapshots.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ankit373/hydra/internal/diff"
+	"github.com/ankit373/hydra/internal/policy"
+	"github.com/ankit373/hydra/internal/runid"
+	"github.com/ankit373/hydra/internal/runlog"
+)
+
+// ckTierEnum inverts dispatch's enum→tier table for the editor path, which
+// takes an enum, not a tier number.
+var ckTierEnum = map[int]string{
+	1: "CORE", 2: "EXPERT", 3: "VERY_HARD", 4: "HARD", 5: "COMPLEX",
+	6: "MODERATE", 7: "STANDARD", 8: "SIMPLE", 9: "TRIVIAL", 10: "GRUNT",
+}
+
+// ── launch ────────────────────────────────────────────────────────────────────
+
+// startTask classifies the task, prints the route line, and spawns the
+// pipeline worker. The ctrl+o override is consumed here — next task only.
+func (m Cockpit) startTask(task string) (Cockpit, tea.Cmd) {
+	m.flash = "" // an override's "next task" note is consumed by this task
+	m.log = append(m.log, ckYouS.Render("❯ "+ckSafe(task)))
+
+	md := ckModeByName(m.mode)
+	enum, wantTier := classifyTask(task)
+	ov := m.override
+	m.override = ckOverride{}
+
+	pinned := m.pinnedTier > 0 && ov.kind != 'T'
+	switch {
+	case ov.kind == 'T':
+		wantTier = ov.tier
+	case pinned:
+		wantTier = m.pinnedTier
+	}
+
+	class := policy.Classify(task)
+	localOnly := ov.kind == 'L' || (class.PII && m.piiLocal)
+
+	idx := m.pickHead(wantTier, localOnly)
+	// A real scan can legitimately find nothing; inventing a route is exactly
+	// what #189 removed, and dispatching would only fail later and worse.
+	if idx < 0 {
+		m.log = append(m.log, ckDimS.Render("  no routable model — run `hyctl probe` to see why"))
+		return m, nil
+	}
+	h := m.heads[idx]
+
+	file := ckNamedFile(task)
+	t := ckTask{
+		prompt: task, mode: md, file: file,
+		runID: runid.New(), taskID: runid.New(),
+		answerTier: strconv.Itoa(wantTier),
+		planTier:   md.planTier,
+		editEnum:   ckEditEnum(enum, md, ov),
+		localOnly:  localOnly,
+		pii:        class.PII,
+		startedAt:  time.Now(),
+	}
+	if t.planTier == "" {
+		t.planTier = ckPlanTierDefault
+	}
+	// Fan-out strategies produce one answer, not a file write, so an edit task
+	// stays single — visibly, on the route line, not silently.
+	if ov.kind == 'B' || ov.kind == 'C' {
+		if file == "" || md.name == "ask" {
+			t.strategy, t.confidence = ov.kind, ov.conf
+		}
+	}
+	if md.verify {
+		t.verifyArgv, t.verifyLabel = ckVerifyArgs(file)
+	}
+
+	m.log = append(m.log, m.routeLines(t, h, enum, ov, pinned)...)
+	if f := ckFileRe.FindString(task); f != "" {
+		if radius, deps, kappa, ok := m.metrics.ckBlastFor(f); ok {
+			risk := ckCheapS
+			if kappa >= 2 {
+				risk = ckExpS
+			}
+			m.log = append(m.log, ckDimS.Render("  impact ")+
+				risk.Render(fmt.Sprintf("κ=%.1f", kappa))+
+				ckDimS.Render(fmt.Sprintf("  %d dependent%s · radius %.2f×  → %s",
+					deps, plural(deps), radius, truncate(f, 40))))
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), ckTaskTimeout)
+	ex := &ckExecState{ctx: ctx, cancel: cancel, started: t.startedAt, stage: "routing"}
+	m.exec = ex
+	m.lastDone = nil
+	m.chatScroll = 0
+
+	phase := ckPhaseFull
+	if md.name == "plan" || (md.confirm && file != "") {
+		phase = ckPhaseHead
+	}
+	return m, tea.Batch(ckWorker(ex, t, phase), ckSpinTick(ex))
+}
+
+// ckEditEnum picks the editor path's routing enum: the classification, the
+// cheap tier for architect's implement half, or a forced tier's equivalent.
+// CORE maps to EXPERT — the editor refuses CORE by design, and a task that
+// classified there still deserves the strongest tier an edit can use.
+func ckEditEnum(classified string, md ckModeDef, ov ckOverride) string {
+	enum := classified
+	if md.cheapImpl {
+		enum = "SIMPLE"
+	}
+	if ov.kind == 'T' {
+		enum = ckTierEnum[ov.tier]
+	}
+	if enum == "CORE" {
+		enum = "EXPERT"
+	}
+	return enum
+}
+
+// ckNamedFile returns the absolute path of a file the prompt names — only when
+// it exists on disk. Edit runs against real files, never guesses.
+func ckNamedFile(task string) string {
+	f := ckFileRe.FindString(task)
+	if f == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(f)
+	if err != nil {
+		return ""
+	}
+	if st, err := os.Stat(abs); err != nil || st.IsDir() {
+		return ""
+	}
+	return abs
+}
+
+// ── route line ────────────────────────────────────────────────────────────────
+
+// routeLines is the pre-execution routing disclosure: how it was routed, the
+// class in plain words, the tier/model, the strategy, and a why clause.
+func (m Cockpit) routeLines(t ckTask, h ckHead, enum string, ov ckOverride, pinned bool) []string {
+	lead := "auto-routed"
+	switch {
+	case ov.kind == 'T':
+		lead = "forced"
+	case ov.kind == 'L':
+		lead = "local only"
+	case pinned:
+		lead = "pinned"
+	}
+	strategy := ov.strategy()
+	if (ov.kind == 'B' || ov.kind == 'C') && t.strategy == 0 {
+		strategy = "single (edits can't fan out)"
+	}
+	name := lipgloss.NewStyle().Foreground(ckTierColor(h.tier))
+	first := ckDimS.Render("  "+lead+" · ") + ckInkS.Render(ckClassWords(enum)) +
+		ckAquaS.Render(" → ") + ckDimS.Render(fmt.Sprintf("T%d ", h.tier)) + name.Render(h.name) +
+		ckDimS.Render(" · "+strategy)
+	second := ckFaintS.Render("  why ") + ckDimS.Render(ckWhyWords(t, enum))
+	if t.pii && t.localOnly {
+		second += ckMidS.Render(" · local-only (pii)")
+	}
+	return []string{first, second}
+}
+
+// ckClassWords renders a routing enum as plain language.
+func ckClassWords(enum string) string {
+	switch enum {
+	case "CORE":
+		return "critical work"
+	case "COMPLEX":
+		return "complex work"
+	case "MODERATE":
+		return "moderate work"
+	case "STANDARD":
+		return "standard work"
+	default:
+		return "simple task"
+	}
+}
+
+// ckWhyWords is the route line's plain-words reasoning clause.
+func ckWhyWords(t ckTask, enum string) string {
+	kind := "question"
+	if t.file != "" && t.mode.name != "ask" {
+		kind = "code edit"
+	}
+	scope := map[string]string{
+		"CORE": "critical", "COMPLEX": "complex", "MODERATE": "moderate",
+		"STANDARD": "standard",
+	}[enum]
+	if scope == "" {
+		scope = "small"
+	}
+	pii := "no PII"
+	if t.pii {
+		pii = "PII detected"
+	}
+	return kind + ", " + scope + " scope, " + pii
+}
+
+// ── gates ─────────────────────────────────────────────────────────────────────
+
+// gateTask handles a pipeline paused for the user: render what is waiting and
+// arm the matching wait state.
+func (m Cockpit) gateTask(msg ckGateMsg) (Cockpit, tea.Cmd) {
+	if msg.exec != m.exec || m.exec == nil {
+		return m, nil
+	}
+	m.exec = nil
+	t := msg.task
+	switch msg.gate {
+	case 'p':
+		m.log = append(m.log, ckPlanLines(t)...)
+		m.log = append(m.log, ckFaintS.Render("  enter/y runs it · esc discards"))
+		m.planWait = &ckWait{task: t, phase: ckPhaseTail}
+	case 'w':
+		m.log = append(m.log, ckPlanLines(t)...)
+		m.confirm = &ckWait{task: t, phase: ckPhaseTail,
+			question: "write " + filepath.Base(t.file) + "? y writes · n stops"}
+	case 'f':
+		m.log = append(m.log, ckExpS.Render("  ✗ verify failed ")+
+			ckDimS.Render(truncate(ckSafe(t.fixDetail), 70)))
+		m.confirm = &ckWait{task: t, phase: ckPhaseFix,
+			question: fmt.Sprintf("write fix %d/%d to %s? y/n", t.fixRound, ckMaxFixes, filepath.Base(t.file))}
+	}
+	return m, nil
+}
+
+// ckPlanLines renders a drafted plan into the log, capped so a rambling plan
+// cannot flood the pane (scrollback still holds what is shown).
+func ckPlanLines(t ckTask) []string {
+	out := []string{ckLabelS.Render("  PLAN") + ckDimS.Render(
+		fmt.Sprintf(" — %d step%s · drafted by %s", t.planSteps, plural(t.planSteps), t.headName))}
+	lines := strings.Split(strings.TrimRight(t.plan, "\n"), "\n")
+	const keep = 12
+	over := 0
+	if len(lines) > keep {
+		over = len(lines) - keep
+		lines = lines[:keep]
+	}
+	for _, l := range lines {
+		out = append(out, ckDimS.Render("   "+ckSafe(l)))
+	}
+	if over > 0 {
+		out = append(out, ckFaintS.Render(fmt.Sprintf("   … %d more line%s", over, plural(over))))
+	}
+	return out
+}
+
+// resumeTask restarts a gated pipeline at its stored phase with a fresh
+// context; elapsed time keeps counting from the original start.
+func (m Cockpit) resumeTask(w ckWait) (Cockpit, tea.Cmd) {
+	ctx, cancel := context.WithTimeout(context.Background(), ckTaskTimeout)
+	ex := &ckExecState{ctx: ctx, cancel: cancel, started: w.task.startedAt, stage: "resuming"}
+	m.exec = ex
+	m.planWait, m.confirm = nil, nil
+	return m, tea.Batch(ckWorker(ex, w.task, w.phase), ckSpinTick(ex))
+}
+
+// stopWait ends a gated task without resuming it: the run closes, and what
+// already happened (plan cost, a landed edit) is settled honestly.
+func (m Cockpit) stopWait(w ckWait, note string) (Cockpit, tea.Cmd) {
+	m.planWait, m.confirm = nil, nil
+	t := w.task
+	_ = runlog.New(t.runID).Append(runlog.Event{Kind: runlog.KindRunFinished, TaskID: t.taskID})
+	t.stopped = true
+	t.note = note
+	ckFinalize(&t, context.Background())
+	return m.settleTask(t)
+}
+
+// ── completion ────────────────────────────────────────────────────────────────
+
+// finishTask lands a worker's final message.
+func (m Cockpit) finishTask(msg ckExecDoneMsg) (Cockpit, tea.Cmd) {
+	if msg.exec != m.exec || m.exec == nil {
+		return m, nil
+	}
+	m.exec = nil
+	return m.settleTask(msg.task)
+}
+
+// settleTask renders a finished task and updates everything that watched it:
+// session cost, the run list, the last-result actions, and the code panel.
+func (m Cockpit) settleTask(t ckTask) (Cockpit, tea.Cmd) {
+	m.sessionUSD += t.costUSD
+	m.runsToday = ckLoadRuns(time.Now().UTC())
+	m.lastDone = &t
+	m.log = append(m.log, ckResultLines(t)...)
+	if t.edited && t.editRefLast != "" {
+		if _, after, err := runlog.LoadEdit(t.runID, t.editRefLast); err == nil {
+			m = m.showCode(t.file, string(after))
+			return m, ckCodeTick(m.codeGen)
+		}
+	}
+	return m, nil
+}
+
+// showCode streams content into the code panel (real file content — the fake
+// snippets died with the preview-only chat).
+func (m Cockpit) showCode(file, content string) Cockpit {
+	m.codeLang = strings.TrimPrefix(filepath.Ext(file), ".")
+	lines := strings.Split(strings.TrimRight(content, "\n"), "\n")
+	if len(lines) > ckCodeMaxLines {
+		lines = append(lines[:ckCodeMaxLines], "… (truncated)")
+	}
+	m.codeLines = lines
+	m.codeShown = 0
+	m.codeDiff = false
+	m.codeGen++
+	return m
+}
+
+// ckResultLines renders a finished task: answer block, proof strip, footer.
+// A failure always carries its trace link — never a dead end.
+func ckResultLines(t ckTask) []string {
+	var out []string
+	trace := ckDimS.Render(" · trace "+ckShortID(t.runID)) + ckFaintS.Render(" — enter opens the trace")
+	secs := fmt.Sprintf("%.1fs", t.elapsed.Seconds())
+	switch {
+	case t.canceled:
+		return append(out, ckMidS.Render("  ✗ cancelled ")+ckDimS.Render(secs)+trace)
+	case t.errText != "":
+		out = append(out, ckExpS.Render("  ✗ failed ")+ckDimS.Render(secs+" · ")+
+			ckExpS.Render(truncate(ckSafe(ckFirstLine(t.errText)), 90)))
+		return append(out, ckFaintS.Render("  trace "+ckShortID(t.runID)+" — enter opens the trace"))
+	}
+	if t.answer != "" {
+		lines := strings.Split(strings.TrimRight(t.answer, "\n"), "\n")
+		over := 0
+		if len(lines) > ckAnswerCapLines {
+			over = len(lines) - ckAnswerCapLines
+			lines = lines[:ckAnswerCapLines]
+		}
+		for _, l := range lines {
+			out = append(out, ckAquaS.Render("  ▎ ")+ckInkS.Render(ckSafe(l)))
+		}
+		if over > 0 {
+			out = append(out, ckFaintS.Render(fmt.Sprintf("  ▎ … %d more line%s truncated", over, plural(over))))
+		}
+	}
+	if t.note != "" {
+		out = append(out, ckDimS.Render("  "+t.note))
+	}
+	if t.edited {
+		out = append(out, ckProofStrip(t))
+		out = append(out, ckFaintS.Render("  d diff · x undo · o open — on an empty input"))
+	}
+	glyph, tone := "✓ done ", ckCheapS
+	if t.stopped {
+		glyph, tone = "◼ stopped ", ckMidS
+	}
+	foot := tone.Render("  "+glyph) + ckDimS.Render(fmt.Sprintf("%s · $%.4f est", secs, t.costUSD))
+	if t.conf > 0 {
+		foot += ckVioletS.Render(" · confidence " + ckPct(t.conf))
+	}
+	return append(out, foot+trace)
+}
+
+// ckProofStrip is the design's per-edit proof line: plan ✓ N steps · edit ✓
+// file +A/−R · tests ✓/✗ cmd summary.
+func ckProofStrip(t ckTask) string {
+	var parts []string
+	if t.mode.plan {
+		parts = append(parts, ckCheapS.Render("plan ✓ ")+
+			ckDimS.Render(fmt.Sprintf("%d step%s", t.planSteps, plural(t.planSteps))))
+	}
+	parts = append(parts, ckCheapS.Render("edit ✓ ")+
+		ckDimS.Render(fmt.Sprintf("%s +%d/−%d", filepath.Base(t.file), t.added, t.removed)))
+	parts = append(parts, ckTestsCell(t))
+	return "  " + strings.Join(parts, ckFaintS.Render(" · "))
+}
+
+// ckTestsCell is the strip's verification verdict, honest about every state:
+// passed (and after how many fixes), still failing, skipped, unconfigured, or
+// the verifier itself failing to run.
+func ckTestsCell(t ckTask) string {
+	switch {
+	case !t.mode.verify:
+		return ckFaintS.Render("tests — skipped (" + t.mode.name + " mode)")
+	case t.verifySkipped:
+		return ckFaintS.Render("tests — no verifier configured")
+	case t.verifyErr != "":
+		return ckMidS.Render("tests ? ") + ckDimS.Render(
+			t.verifyLabel+" — verifier failed: "+truncate(ckSafe(t.verifyErr), 40))
+	case len(t.rounds) == 0:
+		return ckFaintS.Render("tests — not run")
+	}
+	last := t.rounds[len(t.rounds)-1]
+	fixes := len(t.rounds) - 1
+	if last.passed {
+		s := ckCheapS.Render("tests ✓ ") + ckDimS.Render(t.verifyLabel)
+		if fixes > 0 {
+			s += ckDimS.Render(fmt.Sprintf(" (after %d %s)", fixes, ckFixWord(fixes)))
+		}
+		return s
+	}
+	summary := fmt.Sprintf("%s — still failing", t.verifyLabel)
+	if fixes > 0 {
+		summary += fmt.Sprintf(" after %d %s", fixes, ckFixWord(fixes))
+	}
+	return ckExpS.Render("tests ✗ ") + ckDimS.Render(summary+": "+truncate(ckSafe(last.detail), 40))
+}
+
+func ckFixWord(n int) string {
+	if n == 1 {
+		return "fix"
+	}
+	return "fixes"
+}
+
+func ckFirstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// ── result actions (d/x/o) ────────────────────────────────────────────────────
+
+// resultKey acts on the last finished edit from an empty input: d toggles the
+// diff in the code panel, x restores the pre-task snapshot, o opens $EDITOR.
+// Returns handled=false when there is nothing to act on, so the rune types.
+func (m Cockpit) resultKey(r rune) (Cockpit, tea.Cmd, bool) {
+	t := m.lastDone
+	if t == nil || !t.edited {
+		return m, nil, false
+	}
+	switch r {
+	case 'd':
+		return m.toggleDiff(t), nil, true
+	case 'x':
+		return m.undoEdit(t), nil, true
+	case 'o':
+		ed := os.Getenv("EDITOR")
+		if ed == "" {
+			m.flash = "set $EDITOR to open " + truncate(t.file, 30)
+			return m, nil, true
+		}
+		return m, tea.ExecProcess(exec.Command(ed, t.file), func(error) tea.Msg { return nil }), true
+	}
+	return m, nil, false
+}
+
+// toggleDiff swaps the code panel between the task's full diff (first before →
+// last after, so the fix loop's intermediate writes collapse) and the file.
+func (m Cockpit) toggleDiff(t *ckTask) Cockpit {
+	if t.editRef == "" || t.editRefLast == "" {
+		m.flash = "no snapshot stored for this edit"
+		return m
+	}
+	if m.codeDiff {
+		if _, after, err := runlog.LoadEdit(t.runID, t.editRefLast); err == nil {
+			m = m.showCode(t.file, string(after))
+			m.codeShown = len(m.codeLines)
+		}
+		return m
+	}
+	before, _, err := runlog.LoadEdit(t.runID, t.editRef)
+	if err != nil {
+		m.flash = "diff unavailable — " + err.Error()
+		return m
+	}
+	_, after, err := runlog.LoadEdit(t.runID, t.editRefLast)
+	if err != nil {
+		m.flash = "diff unavailable — " + err.Error()
+		return m
+	}
+	base := filepath.Base(t.file)
+	lines := strings.Split(strings.TrimRight(diff.Unified("a/"+base, "b/"+base, before, after), "\n"), "\n")
+	if len(lines) > ckCodeMaxLines {
+		lines = append(lines[:ckCodeMaxLines], "… (truncated)")
+	}
+	m.codeLang = "diff"
+	m.codeLines = lines
+	m.codeShown = len(lines)
+	m.codeDiff = true
+	m.codeGen++ // cancel any stream in flight
+	return m
+}
+
+// undoEdit restores the file to its exact pre-task bytes from the first edit
+// snapshot, preserving the file's permissions. One-shot per task.
+func (m Cockpit) undoEdit(t *ckTask) Cockpit {
+	if t.undone {
+		m.flash = "already restored"
+		return m
+	}
+	if t.editRef == "" {
+		m.flash = "no snapshot stored for this edit"
+		return m
+	}
+	before, _, err := runlog.LoadEdit(t.runID, t.editRef)
+	if err != nil {
+		m.flash = "undo unavailable — " + err.Error()
+		return m
+	}
+	mode := os.FileMode(0o644)
+	if st, serr := os.Stat(t.file); serr == nil {
+		mode = st.Mode().Perm()
+	}
+	if werr := os.WriteFile(t.file, before, mode); werr != nil {
+		m.flash = "undo failed — " + werr.Error()
+		return m
+	}
+	t.undone = true // through the pointer: the second x says "already restored"
+	m.flash = "restored " + filepath.Base(t.file) + " to its pre-task state"
+	m = m.showCode(t.file, string(before))
+	m.codeShown = len(m.codeLines)
+	return m
+}

--- a/internal/tui/chat_task.go
+++ b/internal/tui/chat_task.go
@@ -119,8 +119,7 @@ func (m Cockpit) startTask(task string) (Cockpit, tea.Cmd) {
 
 // ckEditEnum picks the editor path's routing enum: the classification, the
 // cheap tier for architect's implement half, or a forced tier's equivalent.
-// CORE maps to EXPERT — the editor refuses CORE by design, and a task that
-// classified there still deserves the strongest tier an edit can use.
+// CORE maps to EXPERT — the editor refuses CORE by design.
 func ckEditEnum(classified string, md ckModeDef, ov ckOverride) string {
 	enum := classified
 	if md.cheapImpl {

--- a/internal/tui/chrome.go
+++ b/internal/tui/chrome.go
@@ -111,7 +111,7 @@ func (m Cockpit) statusBar() string {
 func (m Cockpit) statusFact() string {
 	switch m.view {
 	case ckViewChat:
-		s := "mode " + m.mode
+		s := "mode " + m.mode + " · " + m.override.label()
 		if m.pinnedTier > 0 {
 			s += fmt.Sprintf(" · pinned T%d", m.pinnedTier)
 		}

--- a/internal/tui/chrome_test.go
+++ b/internal/tui/chrome_test.go
@@ -87,9 +87,14 @@ func TestStatusBar_FactsAndFlash(t *testing.T) {
 	m := testCockpit()
 	m.view = ckViewChat
 	got := stripANSI(m.statusBar())
-	if !strings.Contains(got, "mode dispatch") {
+	if !strings.Contains(got, "mode auto") || !strings.Contains(got, "route auto") {
 		t.Errorf("chat facts missing: %q", got)
 	}
+	m.override = ckOverride{kind: 'C', conf: 0.95}
+	if got := stripANSI(m.statusBar()); !strings.Contains(got, "consensus ≥95%") {
+		t.Errorf("the override is not shown: %q", got)
+	}
+	m.override = ckOverride{}
 	m.pinnedTier = 7
 	if got := stripANSI(m.statusBar()); !strings.Contains(got, "pinned T7") {
 		t.Errorf("the pin is not shown: %q", got)

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -17,6 +17,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/executor"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
@@ -105,17 +106,29 @@ type Cockpit struct {
 	glossary bool
 	flash    string // transient status-bar note, replaced by the next action
 
-	// chat (view 0) — routing preview only in this phase; execution is #597.
+	// chat (view 0) — executes for real (#597): modes, gates, and the override.
 	input      string
 	log        []string
-	mode       string
-	runs       int
-	pinnedTier int // session default tier for chat, set from the models view
-	chatScroll int // 0 = follow the live tail; L+1 = scrollback anchored at line L
+	mode       string // chat mode name: ask/edit/plan/auto + advanced (modes.go)
+	pinnedTier int    // session default tier for chat, set from the models view
+	chatScroll int    // 0 = follow the live tail; L+1 = scrollback anchored at line L
+	piiLocal   bool   // config's pii policy forces local-only routing
+	override   ckOverride
+	exec       *ckExecState // the running task; nil when idle
+	planWait   *ckWait      // plan awaiting approval
+	confirm    *ckWait      // careful-mode write/fix confirm
+	lastDone   *ckTask      // last finished task, for d/x/o and the trace jump
+	modePick   bool         // `m` mode-picker overlay
+	modeSel    int
+	ovOpen     bool // ctrl+o override modal
+	ovSel      int
+	ovStage    byte // 0 list · 'T' tier digit · 'C' confidence pick
+	ovConfSel  int
 	codeLang   string
 	codeLines  []string
 	codeShown  int
-	codeGen    int // generation guard so a new run cancels stale tick loops
+	codeGen    int  // generation guard so a new run cancels stale tick loops
+	codeDiff   bool // the panel currently shows the last edit's diff
 
 	claudePct  int
 	pctKnown   bool // false when state.json has no claude_pct to read
@@ -172,7 +185,7 @@ func NewCockpit() Cockpit {
 	metrics := ckLoadMetrics(pr)
 
 	m := Cockpit{
-		mode:         "dispatch",
+		mode:         "auto",
 		claudePct:    pct,
 		pctKnown:     known,
 		pctHist:      hist,
@@ -187,6 +200,11 @@ func NewCockpit() Cockpit {
 		auditIgnored: map[string]bool{},
 	}
 	m.runsToday = ckLoadRuns(time.Now().UTC())
+	// The route badge mirrors what dispatch will enforce; with no config there
+	// is no pii policy to mirror.
+	if cfg, err := config.Load(); err == nil {
+		m.piiLocal = dispatch.PIILocalOnly(cfg)
+	}
 
 	switch len(heads) {
 	case 0:
@@ -198,7 +216,7 @@ func NewCockpit() Cockpit {
 		m.log = []string{
 			ckDimS.Render(fmt.Sprintf("🐉 Hydra initialised · %d model%s scanned · routing engine ready.",
 				len(heads), plural(len(heads)))),
-			ckDimS.Render("Type a task and press enter. tab cycles views · ? shortcuts · :q quits."),
+			ckDimS.Render("Type a task and press enter. shift+tab mode · ctrl+o route · ? shortcuts · :q quits."),
 		}
 	}
 	return m
@@ -241,6 +259,16 @@ func (m Cockpit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case ckRescanMsg:
 		return m.applyRescan(msg), nil
+	case ckExecDoneMsg:
+		return m.finishTask(msg)
+	case ckGateMsg:
+		return m.gateTask(msg)
+	case ckSpinTickMsg:
+		// Keep repainting elapsed/stage while this exact task runs; a stale
+		// tick from a superseded task schedules nothing.
+		if msg.exec == m.exec && m.exec != nil {
+			return m, ckSpinTick(m.exec)
+		}
 	case tea.MouseMsg:
 		switch tea.MouseEvent(msg).Button {
 		case tea.MouseButtonWheelUp:
@@ -249,6 +277,22 @@ func (m Cockpit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.scrollBy(3), nil
 		}
 	case tea.KeyMsg:
+		// Real terminals coalesce fast keystrokes into one multi-rune message;
+		// every handler is written for one key at a time, so replay them
+		// individually. Bracketed paste stays one message — pasted text is
+		// literal input, never a run of shortcuts.
+		if msg.Type == tea.KeyRunes && len(msg.Runes) > 1 && !msg.Paste {
+			var cur tea.Model = m
+			var cmds []tea.Cmd
+			for _, r := range msg.Runes {
+				var c tea.Cmd
+				cur, c = cur.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+				if c != nil {
+					cmds = append(cmds, c)
+				}
+			}
+			return cur, tea.Batch(cmds...)
+		}
 		return m.key(msg)
 	}
 	return m, nil
@@ -269,6 +313,10 @@ func (m Cockpit) View() string {
 	switch {
 	case m.glossary:
 		body = m.viewGlossary(w, bodyH)
+	case m.modePick:
+		body = m.viewModePicker(w, bodyH)
+	case m.ovOpen:
+		body = m.viewOverride(w, bodyH)
 	case m.view == ckViewAgents:
 		body = m.viewAgents(w, bodyH)
 	case m.view == ckViewModels:
@@ -318,13 +366,40 @@ func CockpitSnapshotView(view int) string {
 // ckSnapshotModel builds the one demo Cockpit state every snapshot view
 // renders from. Built once instead of once per view — NewCockpit alone does a
 // machine scan and a cost.jsonl read. The audit report stays lazy (#524):
-// jump() builds it only for the frame that shows it.
+// jump() builds it only for the frame that shows it. The transcript is drawn
+// by the real task renderers but never executed: a snapshot must not dispatch.
 func ckSnapshotModel() Cockpit {
 	m := NewCockpit()
-	m = m.run("write a User DTO for profile settings")            // SIMPLE → TS interface
-	m = m.run("rotate the signing key in internal/auth/token.go") // CORE   → Go key-rotation
-	m.codeShown = len(m.codeLines)                                // reveal the whole snippet
 	m.w, m.h, m.ready = 100, 30, true
+
+	demo := ckTask{
+		prompt: "add pagination to the users endpoint",
+		mode:   ckModeByName("auto"), file: "internal/api/users.go",
+		runID:     "20260904T100000Z-demo0000",
+		planSteps: 3, edited: true, added: 24, removed: 6,
+		rounds:      []ckVerifyRound{{passed: true}},
+		verifyLabel: "go test ./...",
+		headName:    "qwen2.5-coder", tier: 7,
+		costUSD: 0.0041, elapsed: 3200 * time.Millisecond,
+	}
+	m.log = append(m.log, ckYouS.Render("❯ "+demo.prompt))
+	m.log = append(m.log, m.routeLines(demo, ckHead{name: demo.headName, tier: demo.tier}, "STANDARD", ckOverride{}, false)...)
+	m.log = append(m.log, ckResultLines(demo)...)
+
+	m.codeLang = "go"
+	m.codeLines = []string{
+		"// paginated users endpoint",
+		"func (s *Server) ListUsers(w http.ResponseWriter, r *http.Request) {",
+		"    page := parsePage(r.URL.Query())",
+		"    users, err := s.repo.Users(r.Context(), page)",
+		"    if err != nil {",
+		"        http.Error(w, err.Error(), 500)",
+		"        return",
+		"    }",
+		"    json.NewEncoder(w).Encode(users)",
+		"}",
+	}
+	m.codeShown = len(m.codeLines)
 	return m
 }
 

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -277,10 +277,9 @@ func (m Cockpit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.scrollBy(3), nil
 		}
 	case tea.KeyMsg:
-		// Real terminals coalesce fast keystrokes into one multi-rune message;
-		// every handler is written for one key at a time, so replay them
-		// individually. Bracketed paste stays one message — pasted text is
-		// literal input, never a run of shortcuts.
+		// Terminals coalesce fast keystrokes into one multi-rune message;
+		// handlers are written for one key at a time, so replay individually.
+		// Bracketed paste stays one message: pasted text is never shortcuts.
 		if msg.Type == tea.KeyRunes && len(msg.Runes) > 1 && !msg.Paste {
 			var cur tea.Model = m
 			var cmds []tea.Cmd
@@ -364,10 +363,8 @@ func CockpitSnapshotView(view int) string {
 }
 
 // ckSnapshotModel builds the one demo Cockpit state every snapshot view
-// renders from. Built once instead of once per view — NewCockpit alone does a
-// machine scan and a cost.jsonl read. The audit report stays lazy (#524):
-// jump() builds it only for the frame that shows it. The transcript is drawn
-// by the real task renderers but never executed: a snapshot must not dispatch.
+// renders from (NewCockpit alone scans the machine; the audit stays lazy,
+// #524). The transcript uses the real renderers — a snapshot never dispatches.
 func ckSnapshotModel() Cockpit {
 	m := NewCockpit()
 	m.w, m.h, m.ready = 100, 30, true

--- a/internal/tui/cockpit_test.go
+++ b/internal/tui/cockpit_test.go
@@ -67,7 +67,7 @@ func testRun(id, status, task string) ckRun {
 // without touching the machine.
 func testCockpit() Cockpit {
 	m := Cockpit{
-		mode:         "dispatch",
+		mode:         "auto",
 		heads:        testHeads(),
 		collapsed:    map[string]bool{},
 		auditIgnored: map[string]bool{},

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -170,10 +170,9 @@ func ckClampOff(off, n int) int {
 	return off
 }
 
-// jump switches to view v, closing any overlay and running the view's
-// on-entry hook (the audit rebuild). A pending plan/confirm survives a view
-// switch — a question must not be lost by looking at activity — but the
-// transient overlays (glossary, picker, override) close.
+// jump switches to view v, closing transient overlays (glossary, picker,
+// override) and running the on-entry hook. A pending plan/confirm survives —
+// a question must not be lost by looking at activity.
 func (m Cockpit) jump(v int) Cockpit {
 	if !ckValidView(v) {
 		return m

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -30,9 +30,17 @@ var ckKeymap = []ckBinding{
 	{"home/end", "top / bottom · chat: end returns to live", "EVERYWHERE", nil},
 	{"ctrl+c", "quit", "EVERYWHERE", nil},
 
-	{"enter", "send", "CHAT", []int{ckViewChat}},
-	{"tab", "views", "", []int{ckViewChat}},
-	{"/dispatch /trust /swarm /local", "set mode", "CHAT", nil},
+	{"enter", "send · approve a plan · empty input: open the last trace", "CHAT", nil},
+	{"enter", "send", "", []int{ckViewChat}},
+	{"shift+tab", "cycle the basic modes: ask · edit · plan · auto", "CHAT", nil},
+	{"shift+tab", "mode", "", []int{ckViewChat}},
+	{"m", "mode picker, advanced modes included (empty input)", "CHAT", nil},
+	{"ctrl+o", "routing override for the next task — where it runs", "CHAT", nil},
+	{"ctrl+o", "route", "", []int{ckViewChat}},
+	{"esc", "cancel the running task · discard a plan · clear the input", "CHAT", nil},
+	{"y/n", "approve / refuse a pending plan or file write", "CHAT", nil},
+	{"d · x · o", "after an edit: diff · undo · open in $EDITOR (empty input)", "CHAT", nil},
+	{"/ask /edit /plan /auto…", "set the mode by name (/architect /careful /unattended too)", "CHAT", nil},
 	{":chat :agents :models :activity :usage :audit", "jump · :q quit", "CHAT", nil},
 
 	{"j/k · ↑/↓", "move (the window follows the selection)", "LISTS", nil},
@@ -80,7 +88,8 @@ func (m Cockpit) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyTab:
 		return m.jump((m.view + 1) % ckViewCount()), nil
 	case tea.KeyEsc:
-		return m.escape(), nil
+		nm, cmd := m.escape()
+		return nm, cmd
 	case tea.KeyPgUp:
 		return m.scrollBy(-m.pageSize()), nil
 	case tea.KeyPgDown:
@@ -162,7 +171,9 @@ func ckClampOff(off, n int) int {
 }
 
 // jump switches to view v, closing any overlay and running the view's
-// on-entry hook (the audit rebuild).
+// on-entry hook (the audit rebuild). A pending plan/confirm survives a view
+// switch — a question must not be lost by looking at activity — but the
+// transient overlays (glossary, picker, override) close.
 func (m Cockpit) jump(v int) Cockpit {
 	if !ckValidView(v) {
 		return m
@@ -170,6 +181,8 @@ func (m Cockpit) jump(v int) Cockpit {
 	m.view = v
 	m.glossary = false
 	m.glossOff = 0
+	m.modePick = false
+	m.ovOpen, m.ovStage = false, 0
 	m.flash = ""
 	if v == ckViewAudit {
 		m = m.loadAudit()
@@ -177,22 +190,44 @@ func (m Cockpit) jump(v int) Cockpit {
 	return m
 }
 
-// escape closes the glossary first; otherwise it means "back" in the active
-// view (clear input, leave drill/detail focus).
-func (m Cockpit) escape() Cockpit {
+// escape closes the topmost thing first: overlay, then modal stage, then a
+// pending question, then typed input, then the running task itself.
+func (m Cockpit) escape() (Cockpit, tea.Cmd) {
 	switch {
 	case m.glossary:
 		m.glossary = false
 		m.glossOff = 0
-	case m.view == ckViewChat:
+	case m.modePick:
+		m.modePick = false
+	case m.ovOpen:
+		if m.ovStage != 0 {
+			m.ovStage = 0 // back to the option list
+		} else {
+			m.ovOpen = false
+		}
+	case m.view == ckViewChat && m.confirm != nil:
+		w := *m.confirm
+		note := "stopped before writing — nothing changed"
+		if w.phase == ckPhaseFix {
+			note = "fix declined — the file keeps its last write"
+		}
+		return m.stopWait(w, note)
+	case m.view == ckViewChat && m.planWait != nil:
+		return m.stopWait(*m.planWait, "plan discarded — nothing ran")
+	case m.view == ckViewChat && m.input != "":
 		m.input = ""
+	case m.view == ckViewChat && m.exec != nil:
+		// Context cancellation through dispatch: the worker returns with a
+		// cancelled result; exec clears when that message lands.
+		m.exec.cancel()
+		m.exec.setStage("cancelling…")
 	case m.view == ckViewActivity && m.actDrill:
 		m.actDrill = false
 		m.traceOff = 0
 	case m.view == ckViewModels && m.modelFocus:
 		m.modelFocus = false
 	}
-	return m
+	return m, nil
 }
 
 // viewKey handles keys on the non-chat views, where no text input exists so

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -303,12 +303,9 @@ func ckVisibleLog(log []string, w, logH, scroll int) string {
 	return strings.Join(out, "\n")
 }
 
-// ckClipToLines wraps one log entry to width w and truncates it to at most
-// maxLines rendered lines, marking the cut — a single overlong entry must
-// never be able to exceed the whole pane on its own. It always returns the
-// WRAPPED text: returning the original when it happened to fit made the
-// scroll window count one line where the renderer would paint three, which
-// pushed the input bar off-frame the moment entries got longer (#597).
+// ckClipToLines wraps one log entry to width w, truncated to maxLines with the
+// cut marked (#506). Always returns the WRAPPED text: returning the original
+// made the window count 1 line where the render painted 3 (#597).
 func ckClipToLines(s string, w, maxLines int) string {
 	if w < 1 {
 		w = 1

--- a/internal/tui/layout.go
+++ b/internal/tui/layout.go
@@ -303,21 +303,23 @@ func ckVisibleLog(log []string, w, logH, scroll int) string {
 	return strings.Join(out, "\n")
 }
 
-// ckClipToLines truncates one log entry to at most maxLines rendered lines,
-// marking the cut — a single overlong entry must never be able to exceed the
-// whole pane on its own.
+// ckClipToLines wraps one log entry to width w and truncates it to at most
+// maxLines rendered lines, marking the cut — a single overlong entry must
+// never be able to exceed the whole pane on its own. It always returns the
+// WRAPPED text: returning the original when it happened to fit made the
+// scroll window count one line where the renderer would paint three, which
+// pushed the input bar off-frame the moment entries got longer (#597).
 func ckClipToLines(s string, w, maxLines int) string {
 	if w < 1 {
 		w = 1
 	}
 	rows := strings.Split(lipgloss.NewStyle().Width(w).Render(s), "\n")
-	if len(rows) <= maxLines {
-		return s
+	if len(rows) > maxLines {
+		if maxLines <= 1 {
+			return ckFaintS.Render("…(truncated)")
+		}
+		rows = append(rows[:maxLines-1], ckFaintS.Render("…(truncated)"))
 	}
-	if maxLines <= 1 {
-		return ckFaintS.Render("…(truncated)")
-	}
-	rows = append(rows[:maxLines-1], ckFaintS.Render("…(truncated)"))
 	return strings.Join(rows, "\n")
 }
 

--- a/internal/tui/layout_test.go
+++ b/internal/tui/layout_test.go
@@ -260,9 +260,25 @@ func TestCkClipToLines_MarksTruncationAndBoundsLength(t *testing.T) {
 	if !strings.Contains(rows[len(rows)-1], "truncated") {
 		t.Errorf("the last row does not disclose the truncation: %q", rows[len(rows)-1])
 	}
+	// A short entry keeps its text and is returned WRAPPED (padded to width):
+	// the window counts these lines and the renderer paints them, so the two
+	// must be the same string — returning the original un-wrapped entry made
+	// the count 1 where the render was 3 (#597's off-frame input bar).
 	short := "a short line"
-	if got := ckClipToLines(short, 60, 4); got != short {
-		t.Errorf("a short entry was altered: %q", got)
+	got = ckClipToLines(short, 60, 4)
+	if stripANSI(strings.TrimRight(got, " ")) != short {
+		t.Errorf("a short entry lost its text: %q", got)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("a fitting entry was split: %q", got)
+	}
+	// A moderately long entry (wider than the pane, within the cap) must come
+	// back as real display lines, none wider than the pane.
+	mid := strings.Repeat("word ", 14) // 70 cells at width 28
+	for i, l := range strings.Split(ckClipToLines(mid, 28, 6), "\n") {
+		if w := lipgloss.Width(l); w > 28 {
+			t.Errorf("line %d is %d cells wide, want <= 28", i, w)
+		}
 	}
 }
 

--- a/internal/tui/modes.go
+++ b/internal/tui/modes.go
@@ -94,10 +94,9 @@ func ckIsMode(name string) bool {
 
 // ── picker overlay ────────────────────────────────────────────────────────────
 
-// modePickerKey handles keys while the `m` picker is open. It is forgiving,
-// not modal: the picker opened on a bare 'm', so a user typing a word that
-// starts with m ("make a helper…") closes it and keeps typing — the m
-// included. Only j/k/arrows/enter/esc/m are picker keys.
+// modePickerKey is forgiving, not modal: the picker opened on a bare 'm', so
+// typing a word that starts with m ("make a helper…") closes it and keeps
+// typing, the m included. Only j/k/arrows/enter/esc/m are picker keys.
 func (m Cockpit) modePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyEsc:

--- a/internal/tui/modes.go
+++ b/internal/tui/modes.go
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// modes.go — the chat modes (what a task DOES: ask/edit/plan/auto + advanced)
+// and the `m` picker overlay. Where a task RUNS is the ctrl+o override
+// (override.go); the two are deliberately separate axes.
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ckUnattendedCapUSD is unattended mode's hard per-task cost cap. Refusal to
+// continue past it is the mode's whole safety story, so it is a visible
+// constant, not a config knob buried somewhere.
+const ckUnattendedCapUSD = 0.50
+
+// ckModeDef is one chat mode: its pipeline knobs plus the picker copy.
+type ckModeDef struct {
+	name      string // key: "auto"
+	chip      string // input-bar chip: "Auto"
+	desc      string
+	basic     bool    // shift+tab cycles basics only
+	plan      bool    // run a plan stage first
+	verify    bool    // run the oracle verify loop after an edit
+	confirm   bool    // pause y/n before a file write lands
+	planTier  string  // "" = cheap default (ckPlanTierDefault)
+	cheapImpl bool    // implement on the cheap tier regardless of classification
+	capUSD    float64 // hard per-task cost cap; 0 = none
+}
+
+// ckPlanTierDefault is where plan drafts route: cheap, per the design — a plan
+// is a numbered list, not the implementation.
+const ckPlanTierDefault = "8"
+
+var ckModes = []ckModeDef{
+	{name: "ask", chip: "Ask", basic: true,
+		desc: "answer only — never writes files"},
+	{name: "edit", chip: "Edit", basic: true,
+		desc: "direct change when the prompt names an existing file — no plan step"},
+	// plan carries verify: an approved plan proceeds as auto (edit → verify).
+	{name: "plan", chip: "Plan", basic: true, plan: true, verify: true,
+		desc: "draft numbered steps and wait — enter/y runs them, esc discards"},
+	{name: "auto", chip: "Auto", basic: true, plan: true, verify: true,
+		desc: "plan → edit → verify with the workspace tests, fixing failures (max 2 tries)"},
+	{name: "architect", chip: "Architect", plan: true, verify: true, planTier: "2", cheapImpl: true,
+		desc: "plan on a strong tier, implement on a cheap one"},
+	{name: "careful", chip: "Careful", plan: true, verify: true, confirm: true,
+		desc: "auto, but every file write needs a y/n confirm first"},
+	{name: "unattended", chip: "Unattended", plan: true, verify: true, capUSD: ckUnattendedCapUSD,
+		desc: "auto with no confirms — hard $0.50 cost cap per task, stops visibly at it"},
+}
+
+// ckModeDef looks a mode up by name; an unknown name reads as auto so a stale
+// saved mode can never wedge the chat.
+func ckModeByName(name string) ckModeDef {
+	for _, d := range ckModes {
+		if d.name == name {
+			return d
+		}
+	}
+	return ckModeByName("auto")
+}
+
+// ckNextBasicMode is the shift+tab cycle: ask → edit → plan → auto → ask.
+// From an advanced mode it returns to the first basic.
+func ckNextBasicMode(cur string) string {
+	var basics []string
+	for _, d := range ckModes {
+		if d.basic {
+			basics = append(basics, d.name)
+		}
+	}
+	for i, n := range basics {
+		if n == cur {
+			return basics[(i+1)%len(basics)]
+		}
+	}
+	return basics[0]
+}
+
+// ckIsMode reports whether name is a defined mode (for the /mode commands).
+func ckIsMode(name string) bool {
+	for _, d := range ckModes {
+		if d.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ── picker overlay ────────────────────────────────────────────────────────────
+
+// modePickerKey handles keys while the `m` picker is open. It is forgiving,
+// not modal: the picker opened on a bare 'm', so a user typing a word that
+// starts with m ("make a helper…") closes it and keeps typing — the m
+// included. Only j/k/arrows/enter/esc/m are picker keys.
+func (m Cockpit) modePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.modePick = false
+		return m, nil
+	case tea.KeyBackspace:
+		m.modePick = false // un-types the m that opened it
+		return m, nil
+	case tea.KeySpace:
+		m.modePick = false
+		m.input = "m "
+		return m, nil
+	case tea.KeyUp:
+		return m.moveModeSel(-1), nil
+	case tea.KeyDown:
+		return m.moveModeSel(1), nil
+	case tea.KeyEnter:
+		m.mode = ckModes[m.modeSel].name
+		m.modePick = false
+		m.flash = "mode → " + m.mode
+		return m, nil
+	case tea.KeyRunes:
+		if len(msg.Runes) == 1 {
+			switch msg.Runes[0] {
+			case 'j':
+				return m.moveModeSel(1), nil
+			case 'k':
+				return m.moveModeSel(-1), nil
+			case 'm':
+				m.modePick = false
+				return m, nil
+			}
+		}
+		// Anything else — a typed letter or a paste — falls through to input.
+		m.modePick = false
+		m.input = "m" + string(msg.Runes)
+	}
+	return m, nil
+}
+
+func (m Cockpit) moveModeSel(delta int) Cockpit {
+	m.modeSel += delta
+	if m.modeSel < 0 {
+		m.modeSel = 0
+	}
+	if m.modeSel >= len(ckModes) {
+		m.modeSel = len(ckModes) - 1
+	}
+	return m
+}
+
+// openModePicker opens the overlay with the current mode selected.
+func (m Cockpit) openModePicker() Cockpit {
+	m.modePick = true
+	m.modeSel = 0
+	for i, d := range ckModes {
+		if d.name == m.mode {
+			m.modeSel = i
+		}
+	}
+	return m
+}
+
+// ckModePickerLines renders the picker rows; sel marks the highlighted mode.
+func ckModePickerLines(sel int) []string {
+	lines := []string{
+		ckLabelS.Render("MODE — what the task does"),
+		ckFaintS.Render("shift+tab cycles the basics · where it runs is ctrl+o"),
+	}
+	lastBasic := true
+	for i, d := range ckModes {
+		if lastBasic && !d.basic {
+			lines = append(lines, "", ckCyanS.Render("ADVANCED"))
+			lastBasic = false
+		}
+		marker := "  "
+		name := ckDimS.Render(ckCell(d.chip, 11))
+		if i == sel {
+			marker = ckAquaS.Render("▸ ")
+			name = ckInkS.Bold(true).Render(ckCell(d.chip, 11))
+		}
+		lines = append(lines, marker+name+ckDimS.Render(d.desc))
+	}
+	return lines
+}
+
+// viewModePicker renders the picker as a centred overlay, degrading to a
+// selection-following scroll list on short terminals (same rule as the
+// glossary).
+func (m Cockpit) viewModePicker(w, h int) string {
+	lines := ckModePickerLines(m.modeSel)
+	box := ckBoxS.BorderForeground(ckAqua).Render(strings.Join(lines, "\n"))
+	if lipgloss.Width(box) <= w && lipgloss.Height(box) <= h {
+		return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, box)
+	}
+	return strings.Join(ckSelScroll(lines, m.modeSel+2, h), "\n")
+}

--- a/internal/tui/modes_test.go
+++ b/internal/tui/modes_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// shift+tab cycles the basic modes in order and never lands on an advanced one.
+func TestModes_ShiftTabCyclesBasicsOnly(t *testing.T) {
+	m := testCockpit()
+	m.mode = "ask"
+	want := []string{"edit", "plan", "auto", "ask"}
+	for _, w := range want {
+		m = press(m, tea.KeyShiftTab)
+		if m.mode != w {
+			t.Fatalf("shift+tab left mode %q, want %q", m.mode, w)
+		}
+	}
+	// From an advanced mode the cycle returns to the first basic.
+	m.mode = "careful"
+	m = press(m, tea.KeyShiftTab)
+	if m.mode != "ask" {
+		t.Errorf("shift+tab from careful = %q, want ask", m.mode)
+	}
+}
+
+// `m` on an empty input opens the picker; with text it types. The picker
+// selects with j/k+enter, closes on esc without changing the mode, and reaches
+// the advanced modes shift+tab never offers.
+func TestModes_PickerOpensSelectsAndCloses(t *testing.T) {
+	m := testCockpit()
+	m = typed(m, "m")
+	if !m.modePick {
+		t.Fatal("m on an empty input did not open the picker")
+	}
+	if ckModes[m.modeSel].name != "auto" {
+		t.Errorf("the picker did not open on the current mode: %s", ckModes[m.modeSel].name)
+	}
+	m = press(m, tea.KeyEsc)
+	if m.modePick || m.mode != "auto" {
+		t.Fatal("esc did not close the picker unchanged")
+	}
+
+	m = typed(m, "m") // reopen
+	for i := 0; i < len(ckModes); i++ {
+		m = typed(m, "j") // clamp at the end
+	}
+	if m.modeSel != len(ckModes)-1 {
+		t.Fatalf("j ran off the end: sel=%d", m.modeSel)
+	}
+	m, _ = enter(m)
+	if m.mode != "unattended" || m.modePick {
+		t.Errorf("enter selected %q, want unattended with the picker closed", m.mode)
+	}
+
+	// With text in the input, m types.
+	m = typed(m, "make a helper for ")
+	m = typed(m, "m")
+	if m.modePick {
+		t.Fatal("m typed mid-sentence opened the picker")
+	}
+	if m.input != "make a helper for m" {
+		t.Errorf("input = %q — typing a word starting with m must pass through the picker intact", m.input)
+	}
+	if m.mode != "unattended" {
+		t.Errorf("typing through the picker changed the mode to %q", m.mode)
+	}
+}
+
+// Real terminals coalesce fast keystrokes into one multi-rune message; the
+// handlers see them replayed one key at a time — found live when "jj" arrived
+// as a single message and every modal dropped it (#597).
+func TestKeys_CoalescedRunesReplayIndividually(t *testing.T) {
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlO)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("jj")})
+	m = next.(Cockpit)
+	if m.ovSel != 2 {
+		t.Fatalf("a coalesced jj moved the selection to %d, want 2", m.ovSel)
+	}
+	m, _ = enter(m)
+	if m.override.kind != 'L' {
+		t.Fatalf("the coalesced navigation did not land on local only: %+v", m.override)
+	}
+	// Typing coalesced into the input still types everything.
+	chat := testCockpit()
+	next, _ = chat.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("fix the bug")})
+	if got := next.(Cockpit).input; got != "fix the bug" {
+		t.Errorf("coalesced typing lost characters: %q", got)
+	}
+	// A bracketed paste is literal input, never a run of shortcuts — even when
+	// it starts with a command letter on an empty input.
+	next, _ = testCockpit().Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("make it so"), Paste: true})
+	pasted := next.(Cockpit)
+	if pasted.modePick || pasted.input != "make it so" {
+		t.Errorf("paste triggered commands: pick=%v input=%q", pasted.modePick, pasted.input)
+	}
+}
+
+// The picker is forgiving, not modal: a non-navigation rune closes it and
+// types on — the opening m included — so "make…" is never eaten. Backspace
+// un-types the m; space keeps it.
+func TestModes_PickerForgivesTyping(t *testing.T) {
+	m := typed(testCockpit(), "m")
+	if !m.modePick {
+		t.Fatal("picker did not open")
+	}
+	m = press(m, tea.KeyBackspace)
+	if m.modePick || m.input != "" {
+		t.Fatalf("backspace did not un-type the m: pick=%v input=%q", m.modePick, m.input)
+	}
+	m = typed(m, "m")
+	m = press(m, tea.KeySpace)
+	if m.modePick || m.input != "m " {
+		t.Fatalf("space did not type through: pick=%v input=%q", m.modePick, m.input)
+	}
+}
+
+// The picker documents every mode; the overlay respects the frame at the
+// mandated sizes.
+func TestModes_PickerRendersEveryMode(t *testing.T) {
+	lines := stripANSI(strings.Join(ckModePickerLines(0), "\n"))
+	for _, d := range ckModes {
+		if !strings.Contains(lines, d.chip) {
+			t.Errorf("the picker does not list %s", d.chip)
+		}
+	}
+	if !strings.Contains(lines, "ADVANCED") {
+		t.Error("the advanced group is not labelled")
+	}
+	// $0.50 cap is unattended's safety story — it must be visible up front.
+	if !strings.Contains(lines, "$0.50") {
+		t.Error("unattended's cost cap is not disclosed in the picker")
+	}
+}
+
+func TestModes_LookupAndCommands(t *testing.T) {
+	if got := ckModeByName("nonsense").name; got != "auto" {
+		t.Errorf("unknown mode resolved to %q, want auto", got)
+	}
+	for _, name := range []string{"ask", "edit", "plan", "auto", "architect", "careful", "unattended"} {
+		if !ckIsMode(name) {
+			t.Errorf("ckIsMode(%q) = false", name)
+		}
+	}
+	if ckIsMode("swarm") {
+		t.Error("the phase-1 strategy names must not be modes")
+	}
+	// The advanced modes carry their distinguishing knobs.
+	if d := ckModeByName("architect"); d.planTier != "2" || !d.cheapImpl {
+		t.Errorf("architect knobs wrong: %+v", d)
+	}
+	if d := ckModeByName("careful"); !d.confirm || !d.verify {
+		t.Errorf("careful knobs wrong: %+v", d)
+	}
+	if d := ckModeByName("unattended"); d.capUSD != ckUnattendedCapUSD || d.confirm {
+		t.Errorf("unattended knobs wrong: %+v", d)
+	}
+	if d := ckModeByName("ask"); d.plan || d.verify || d.confirm {
+		t.Errorf("ask must have no pipeline knobs: %+v", d)
+	}
+}

--- a/internal/tui/override.go
+++ b/internal/tui/override.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// override.go — the ctrl+o routing override modal: where the NEXT task runs
+// (auto / force tier / local only / best of 3 / consensus check). The mode
+// says what a task does; this says where it runs — one task only, then reset.
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ckOverride is the routing override applied to the next task.
+type ckOverride struct {
+	kind byte    // 0 auto · 'T' force tier · 'L' local only · 'B' best of 3 · 'C' consensus
+	tier int     // for 'T'
+	conf float64 // for 'C', in (0,1)
+}
+
+// strategy is the route line's strategy word for this override.
+func (o ckOverride) strategy() string {
+	switch o.kind {
+	case 'B':
+		return "best of 3"
+	case 'C':
+		return fmt.Sprintf("consensus ≥%s", ckPct(o.conf))
+	default:
+		return "single"
+	}
+}
+
+// label names the override for the status bar; auto reads "route auto".
+func (o ckOverride) label() string {
+	switch o.kind {
+	case 'T':
+		return fmt.Sprintf("route T%d forced", o.tier)
+	case 'L':
+		return "route local only"
+	case 'B':
+		return "route best of 3"
+	case 'C':
+		return fmt.Sprintf("route consensus ≥%s", ckPct(o.conf))
+	default:
+		return "route auto"
+	}
+}
+
+// ckPct renders a confidence target without fabricating precision: 0.999
+// reads "99.9%", 0.95 reads "95%".
+func ckPct(c float64) string {
+	s := fmt.Sprintf("%.1f", c*100)
+	return strings.TrimSuffix(s, ".0") + "%"
+}
+
+// ckOvRow is one modal option.
+type ckOvRow struct {
+	name, desc string
+	kind       byte
+	sub        byte // non-zero: selecting it opens this sub-stage first
+}
+
+var ckOvRows = []ckOvRow{
+	{"auto (recommended)", "the router decides — classification picks the tier", 0, 0},
+	{"force tier…", "pin the next task to a tier (1 strongest … 10 cheapest local)", 'T', 'T'},
+	{"local only", "nothing leaves this machine", 'L', 0},
+	{"best of 3", "three heads answer, a judge picks the best", 'B', 0},
+	{"consensus check…", "sample heads until they agree at a target confidence", 'C', 'C'},
+}
+
+// ckOvConfChoices are the consensus targets on offer (the design's 90–99.9%).
+var ckOvConfChoices = []float64{0.90, 0.95, 0.99, 0.999}
+
+// overrideKey handles keys while the ctrl+o modal is open.
+func (m Cockpit) overrideKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.ovStage {
+	case 'T':
+		return m.overrideTierKey(msg)
+	case 'C':
+		return m.overrideConfKey(msg)
+	}
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.ovOpen = false
+		return m, nil
+	case tea.KeyUp:
+		return m.moveOvSel(-1), nil
+	case tea.KeyDown:
+		return m.moveOvSel(1), nil
+	case tea.KeyEnter:
+		row := ckOvRows[m.ovSel]
+		if row.sub != 0 {
+			m.ovStage = row.sub
+			return m, nil
+		}
+		m.override = ckOverride{kind: row.kind}
+		m.ovOpen = false
+		m.flash = m.override.label() + " — next task"
+		return m, nil
+	case tea.KeyRunes:
+		if len(msg.Runes) != 1 {
+			return m, nil
+		}
+		switch msg.Runes[0] {
+		case 'j':
+			return m.moveOvSel(1), nil
+		case 'k':
+			return m.moveOvSel(-1), nil
+		case 'q':
+			m.ovOpen = false
+		}
+	}
+	return m, nil
+}
+
+// overrideTierKey reads one digit: 1–9 → T1–T9, 0 → T10.
+func (m Cockpit) overrideTierKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.ovStage = 0
+		return m, nil
+	case tea.KeyRunes:
+		if len(msg.Runes) != 1 {
+			return m, nil
+		}
+		r := msg.Runes[0]
+		if r < '0' || r > '9' {
+			return m, nil
+		}
+		tier := int(r - '0')
+		if tier == 0 {
+			tier = 10
+		}
+		m.override = ckOverride{kind: 'T', tier: tier}
+		m.ovOpen, m.ovStage = false, 0
+		m.flash = m.override.label() + " — next task"
+	}
+	return m, nil
+}
+
+// overrideConfKey picks a consensus target: j/k + enter, or digits 1–4.
+func (m Cockpit) overrideConfKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	apply := func(i int) (tea.Model, tea.Cmd) {
+		m.override = ckOverride{kind: 'C', conf: ckOvConfChoices[i]}
+		m.ovOpen, m.ovStage, m.ovConfSel = false, 0, 0
+		m.flash = m.override.label() + " — next task"
+		return m, nil
+	}
+	switch msg.Type {
+	case tea.KeyEsc:
+		m.ovStage, m.ovConfSel = 0, 0
+		return m, nil
+	case tea.KeyUp:
+		m.ovConfSel = ckClampOff(m.ovConfSel-1, len(ckOvConfChoices)-1)
+		return m, nil
+	case tea.KeyDown:
+		m.ovConfSel = ckClampOff(m.ovConfSel+1, len(ckOvConfChoices)-1)
+		return m, nil
+	case tea.KeyEnter:
+		return apply(m.ovConfSel)
+	case tea.KeyRunes:
+		if len(msg.Runes) != 1 {
+			return m, nil
+		}
+		switch r := msg.Runes[0]; {
+		case r == 'j':
+			m.ovConfSel = ckClampOff(m.ovConfSel+1, len(ckOvConfChoices)-1)
+		case r == 'k':
+			m.ovConfSel = ckClampOff(m.ovConfSel-1, len(ckOvConfChoices)-1)
+		case r >= '1' && r <= '4':
+			return apply(int(r - '1'))
+		}
+	}
+	return m, nil
+}
+
+func (m Cockpit) moveOvSel(delta int) Cockpit {
+	m.ovSel += delta
+	if m.ovSel < 0 {
+		m.ovSel = 0
+	}
+	if m.ovSel >= len(ckOvRows) {
+		m.ovSel = len(ckOvRows) - 1
+	}
+	return m
+}
+
+// ckOverrideLines renders the modal rows for the current stage.
+func (m Cockpit) ckOverrideLines() []string {
+	lines := []string{
+		ckLabelS.Render("ROUTING OVERRIDE — next task only"),
+		ckFaintS.Render("the mode says what to do; this says where it runs"),
+	}
+	switch m.ovStage {
+	case 'T':
+		lines = append(lines, "",
+			ckInkS.Render(" force tier"),
+			ckDimS.Render(" press 1–9 for T1–T9, 0 for T10 · esc back"))
+	case 'C':
+		lines = append(lines, "", ckInkS.Render(" consensus target"))
+		for i, c := range ckOvConfChoices {
+			marker := "  "
+			style := ckDimS
+			if i == m.ovConfSel {
+				marker = ckAquaS.Render("▸ ")
+				style = ckInkS
+			}
+			lines = append(lines, marker+style.Render(fmt.Sprintf("%d. ≥%s", i+1, ckPct(c))))
+		}
+		lines = append(lines, ckFaintS.Render(" enter picks · esc back"))
+	default:
+		lines = append(lines, "")
+		for i, row := range ckOvRows {
+			marker := "  "
+			name := ckDimS.Render(ckCell(row.name, 20))
+			if i == m.ovSel {
+				marker = ckAquaS.Render("▸ ")
+				name = ckInkS.Bold(true).Render(ckCell(row.name, 20))
+			}
+			lines = append(lines, marker+name+ckFaintS.Render(row.desc))
+		}
+	}
+	return lines
+}
+
+// viewOverride renders the modal centred, or as a scroll list on short
+// terminals — the same degradation rule as every other overlay.
+func (m Cockpit) viewOverride(w, h int) string {
+	lines := m.ckOverrideLines()
+	box := ckBoxS.BorderForeground(ckViolet).Render(strings.Join(lines, "\n"))
+	if lipgloss.Width(box) <= w && lipgloss.Height(box) <= h {
+		return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, box)
+	}
+	sel := m.ovSel + 3
+	if m.ovStage != 0 {
+		sel = 0
+	}
+	return strings.Join(ckSelScroll(lines, sel, h), "\n")
+}

--- a/internal/tui/override_test.go
+++ b/internal/tui/override_test.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func openOverride(t *testing.T) Cockpit {
+	t.Helper()
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlO)
+	if !m.ovOpen {
+		t.Fatal("ctrl+o did not open the override modal")
+	}
+	return m
+}
+
+// The simple options apply directly: local only and best of 3.
+func TestOverride_PicksDirectOptions(t *testing.T) {
+	m := openOverride(t)
+	m = typed(m, "jj") // → local only
+	m, _ = enter(m)
+	if m.ovOpen || m.override.kind != 'L' {
+		t.Fatalf("local only not applied: %+v", m.override)
+	}
+	if got := m.override.label(); got != "route local only" {
+		t.Errorf("label = %q", got)
+	}
+
+	m = press(m, tea.KeyCtrlO)
+	m = typed(m, "jjj") // → best of 3
+	m, _ = enter(m)
+	if m.override.kind != 'B' || m.override.strategy() != "best of 3" {
+		t.Fatalf("best of 3 not applied: %+v", m.override)
+	}
+
+	// auto (row 0) resets to no override.
+	m = press(m, tea.KeyCtrlO)
+	m, _ = enter(m)
+	if m.override.kind != 0 || m.override.label() != "route auto" {
+		t.Errorf("auto did not reset the override: %+v", m.override)
+	}
+}
+
+// Force tier is a two-step pick: the row, then one digit (0 = T10).
+func TestOverride_ForceTierDigits(t *testing.T) {
+	m := openOverride(t)
+	m = typed(m, "j")
+	m, _ = enter(m)
+	if m.ovStage != 'T' || !m.ovOpen {
+		t.Fatal("force tier… did not open the tier sub-stage")
+	}
+	// A non-digit is ignored while the stage waits.
+	m = typed(m, "z")
+	if m.ovStage != 'T' {
+		t.Fatal("a non-digit was accepted as a tier")
+	}
+	m = typed(m, "3")
+	if m.ovOpen || m.override.kind != 'T' || m.override.tier != 3 {
+		t.Fatalf("tier 3 not applied: %+v", m.override)
+	}
+
+	m = press(m, tea.KeyCtrlO)
+	m = typed(m, "j")
+	m, _ = enter(m)
+	m = typed(m, "0")
+	if m.override.tier != 10 {
+		t.Errorf("0 should force T10, got %d", m.override.tier)
+	}
+}
+
+// Consensus is a two-step pick from the design's 90–99.9% targets, by digit or
+// j/k+enter.
+func TestOverride_ConsensusTargets(t *testing.T) {
+	m := openOverride(t)
+	m = typed(m, "jjjj")
+	m, _ = enter(m)
+	if m.ovStage != 'C' {
+		t.Fatal("consensus check… did not open the target sub-stage")
+	}
+	m = typed(m, "2")
+	if m.override.kind != 'C' || m.override.conf != 0.95 {
+		t.Fatalf("target 95%% not applied: %+v", m.override)
+	}
+	if got := m.override.strategy(); got != "consensus ≥95%" {
+		t.Errorf("strategy = %q", got)
+	}
+
+	// j/k + enter picks too — 99.9% renders without a fabricated ".0".
+	m = press(m, tea.KeyCtrlO)
+	m = typed(m, "jjjj")
+	m, _ = enter(m)
+	m = typed(m, "jjjjjj") // clamps at the last target
+	m, _ = enter(m)
+	if m.override.conf != 0.999 {
+		t.Fatalf("conf = %v, want 0.999", m.override.conf)
+	}
+	if got := m.override.strategy(); got != "consensus ≥99.9%" {
+		t.Errorf("strategy = %q", got)
+	}
+}
+
+// esc backs out one level at a time: sub-stage → list → closed. j/k clamp.
+func TestOverride_EscBacksOut(t *testing.T) {
+	m := openOverride(t)
+	for i := 0; i < 10; i++ {
+		m = typed(m, "j")
+	}
+	if m.ovSel != len(ckOvRows)-1 {
+		t.Fatalf("j ran off the end: %d", m.ovSel)
+	}
+	for i := 0; i < 10; i++ {
+		m = typed(m, "k")
+	}
+	if m.ovSel != 0 {
+		t.Fatalf("k ran off the top: %d", m.ovSel)
+	}
+	m = typed(m, "j")
+	m, _ = enter(m) // tier sub-stage
+	m = press(m, tea.KeyEsc)
+	if !m.ovOpen || m.ovStage != 0 {
+		t.Fatal("esc did not return to the option list")
+	}
+	m = press(m, tea.KeyEsc)
+	if m.ovOpen {
+		t.Fatal("esc did not close the modal")
+	}
+	if m.override.kind != 0 {
+		t.Errorf("backing out changed the override: %+v", m.override)
+	}
+}
+
+// The modal renders inside the frame at every mandated size, in all stages.
+func TestOverride_ModalRendersWithinFrame(t *testing.T) {
+	sizes := []struct{ w, h int }{{60, 15}, {80, 24}, {100, 30}, {120, 40}}
+	for _, stage := range []byte{0, 'T', 'C'} {
+		m := openOverride(t)
+		m.ovStage = stage
+		for _, sz := range sizes {
+			m.w, m.h, m.ready = sz.w, sz.h, true
+			out := m.View()
+			lines := strings.Split(out, "\n")
+			if len(lines) > sz.h {
+				t.Errorf("stage %q at %dx%d renders %d lines", stage, sz.w, sz.h, len(lines))
+			}
+			joined := stripANSI(out)
+			if !strings.Contains(joined, "ROUTING OVERRIDE") {
+				t.Errorf("stage %q at %dx%d does not show the modal:\n%s", stage, sz.w, sz.h, joined)
+			}
+		}
+	}
+	// The modal says what it is: mode = what, this = where.
+	m := openOverride(t)
+	m.w, m.h, m.ready = 100, 30, true
+	if got := stripANSI(m.View()); !strings.Contains(got, "where it runs") {
+		t.Error("the modal does not explain the mode/override split")
+	}
+}
+
+func TestOverride_LabelsAndPct(t *testing.T) {
+	cases := map[string]ckOverride{
+		"route auto":           {},
+		"route T3 forced":      {kind: 'T', tier: 3},
+		"route local only":     {kind: 'L'},
+		"route best of 3":      {kind: 'B'},
+		"route consensus ≥90%": {kind: 'C', conf: 0.90},
+	}
+	for want, ov := range cases {
+		if got := ov.label(); got != want {
+			t.Errorf("label(%+v) = %q, want %q", ov, got, want)
+		}
+	}
+	if got := ckPct(0.999); got != "99.9%" {
+		t.Errorf("ckPct(0.999) = %q", got)
+	}
+	if got := ckPct(0.95); got != "95%" {
+		t.Errorf("ckPct(0.95) = %q", got)
+	}
+}

--- a/internal/tui/view_chat.go
+++ b/internal/tui/view_chat.go
@@ -2,14 +2,15 @@
 
 package tui
 
-// view_chat.go — view 0: the chat console, its sidebar, and the live code
-// panel. Routing preview only in this phase: nothing is executed (#597 adds
-// that), and the preview says so. Kept thin: threads/modes land in #597.
+// view_chat.go — view 0: the chat console (bordered input bar with the mode
+// chip), its sidebar, and the code panel. Kept thin: execution lives in
+// chat_exec.go/chat_task.go, modes in modes.go, the override in override.go.
 
 import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -17,12 +18,28 @@ import (
 
 var ckFileRe = regexp.MustCompile(`[\w/]+\.(go|ts|js|py|rs|java)`)
 
-// chatKey handles keys while the chat view is active. Typing always wins:
-// digits and letters go to the input; the one addition is '?' on an EMPTY
-// input, which opens the glossary — a keystroke that never produced a useful
-// task, so no existing binding is overridden.
+// chatKey handles keys while the chat view is active. Typing always wins on a
+// non-empty input; the letter commands (?, m, d/x/o) fire only from an empty
+// one, the same discipline '?' set in phase 1. Pending states are modal.
 func (m Cockpit) chatKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch {
+	case m.modePick:
+		return m.modePickerKey(msg)
+	case m.ovOpen:
+		return m.overrideKey(msg)
+	case m.confirm != nil:
+		return m.confirmKey(msg)
+	case m.planWait != nil:
+		return m.planKey(msg)
+	}
 	switch msg.Type {
+	case tea.KeyShiftTab:
+		m.mode = ckNextBasicMode(m.mode)
+		m.flash = "mode → " + m.mode
+		return m, nil
+	case tea.KeyCtrlO:
+		m.ovOpen, m.ovSel, m.ovStage, m.ovConfSel = true, 0, 0, 0
+		return m, nil
 	case tea.KeyEnter:
 		return m.submit()
 	case tea.KeyBackspace:
@@ -32,11 +49,61 @@ func (m Cockpit) chatKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeySpace:
 		m.input += " "
 	case tea.KeyRunes:
-		if string(msg.Runes) == "?" && m.input == "" {
-			m.glossary = true
-			return m, nil
+		// Pasted text is literal input: a paste starting with m/d/x/o must
+		// type, not fire the letter commands.
+		if m.input == "" && len(msg.Runes) == 1 && !msg.Paste {
+			switch msg.Runes[0] {
+			case '?':
+				m.glossary = true
+				return m, nil
+			case 'm':
+				return m.openModePicker(), nil
+			case 'd', 'x', 'o':
+				if nm, cmd, ok := m.resultKey(msg.Runes[0]); ok {
+					return nm, cmd
+				}
+			}
 		}
 		m.input += string(msg.Runes)
+	}
+	return m, nil
+}
+
+// confirmKey is careful mode's y/n gate; esc (handled globally) also declines.
+func (m Cockpit) confirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.Type != tea.KeyRunes || len(msg.Runes) != 1 {
+		return m, nil
+	}
+	w := *m.confirm
+	switch msg.Runes[0] {
+	case 'y', 'Y':
+		m.log = append(m.log, ckDimS.Render("  confirmed — writing"))
+		return m.resumeTask(w)
+	case 'n', 'N':
+		note := "stopped before writing — nothing changed"
+		if w.phase == ckPhaseFix {
+			note = "fix declined — the file keeps its last write"
+		}
+		return m.stopWait(w, note)
+	}
+	return m, nil
+}
+
+// planKey is plan mode's approval gate: enter/y/a run the plan, esc (global)
+// discards it. Everything else is swallowed while the question stands.
+func (m Cockpit) planKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyEnter:
+		m.log = append(m.log, ckDimS.Render("  plan approved — running"))
+		return m.resumeTask(*m.planWait)
+	case tea.KeyRunes:
+		if len(msg.Runes) == 1 {
+			switch msg.Runes[0] {
+			case 'y', 'Y', 'a', 'A':
+				m.log = append(m.log, ckDimS.Render("  plan approved — running"))
+				return m.resumeTask(*m.planWait)
+			}
+		}
 	}
 	return m, nil
 }
@@ -50,6 +117,10 @@ func (m Cockpit) submit() (tea.Model, tea.Cmd) {
 	lt := strings.ToLower(t)
 	switch {
 	case lt == "":
+		// An empty enter after a finished task opens its trace, as the footer says.
+		if m.lastDone != nil && m.exec == nil {
+			return m.focusRun(m.lastDone.runID), nil
+		}
 		return m, nil
 	case lt == ":q" || lt == ":quit":
 		return m, tea.Quit
@@ -62,99 +133,30 @@ func (m Cockpit) submit() (tea.Model, tea.Cmd) {
 		m.log = append(m.log, ckDimS.Render("unknown command "+t))
 		return m, nil
 	case strings.HasPrefix(lt, "/"):
-		switch lt {
-		case "/dispatch", "/swarm", "/trust", "/local":
+		if ckIsMode(lt[1:]) {
 			m.mode = lt[1:]
 			m.log = append(m.log, ckDimS.Render("mode → ")+ckCyanS.Render(m.mode))
-		default:
+		} else {
 			m.log = append(m.log, ckDimS.Render("unknown command "+t))
 		}
 		return m, nil
 	}
-	nm := m.run(t)
-	return nm, ckCodeTick(nm.codeGen)
-}
-
-// run previews the routing decision for a task and appends it to the log.
-// It does not execute anything — see the note it prints.
-func (m Cockpit) run(task string) Cockpit {
-	m.runs++
-	m.log = append(m.log, ckYouS.Render("❯ "+task))
-
-	enum, wantTier := classifyTask(task, m.mode)
-	pinned := m.pinnedTier > 0 && m.mode != "local"
-	if pinned {
-		wantTier = m.pinnedTier
+	if m.exec != nil {
+		m.input = t // nothing typed is lost — the task queue is phase 3
+		m.flash = "a task is running — esc cancels it"
+		return m, nil
 	}
-	idx := m.pickHead(wantTier)
-	// The roster is a real scan, so it can legitimately be empty on a machine
-	// with nothing installed. There is no route to preview then, and inventing
-	// one is exactly what #189 removed.
-	if idx < 0 {
-		m.log = append(m.log, ckDimS.Render("  no routable model — run `hyctl probe` to see why"))
-		return m
-	}
-	h := m.heads[idx]
-	fell := m.mode != "local" && h.tier > wantTier
-
-	// Load a class-appropriate snippet and (re)start the code stream.
-	m.codeLang, m.codeLines = ckSnippet(enum)
-	m.codeShown = 0
-	m.codeGen++
-
-	tierLabel := fmt.Sprintf("T%d", wantTier)
-	if pinned {
-		tierLabel = fmt.Sprintf("pinned T%d", wantTier)
-	}
-	name := lipgloss.NewStyle().Foreground(ckTierColor(h.tier))
-	flow := ckDimS.Render("  prompt ") + ckAquaS.Render("→ ") + ckInkS.Render(enum) +
-		ckAquaS.Render(" → ") + ckDimS.Render(tierLabel)
-	if fell {
-		flow += ckAquaS.Render(" → ") + ckMidS.Render("no model at that tier") +
-			ckAquaS.Render(" → ") + ckCyanS.Render(fmt.Sprintf("T%d", h.tier))
-	}
-	flow += ckAquaS.Render(" → ") + name.Render(h.name)
-	m.log = append(m.log, flow)
-
-	// Free is a claim only a local model can make; a paid model with no
-	// pricing data reads "cost unknown" rather than implying free. The
-	// "vs all-frontier" comparison lives in the usage view, not per line.
-	costStr := "cost unknown"
-	switch {
-	case h.price > 0:
-		costStr = fmt.Sprintf("~$%.4f", h.price)
-	case h.local:
-		costStr = "free (local)"
-	}
-	m.log = append(m.log, ckDimS.Render("  route  ")+name.Render(h.name)+ckDimS.Render("  "+costStr))
-
-	// Real change impact, walked from graph.json, when the prompt names a file
-	// that is actually in the graph — never a fixed number (#193).
-	if f := ckFileRe.FindString(task); f != "" {
-		if radius, deps, kappa, ok := m.metrics.ckBlastFor(f); ok {
-			risk := ckCheapS
-			if kappa >= 2 {
-				risk = ckExpS
-			}
-			m.log = append(m.log, ckDimS.Render("  impact ")+
-				risk.Render(fmt.Sprintf("κ=%.1f", kappa))+
-				ckDimS.Render(fmt.Sprintf("  %d dependent%s · radius %.2f×  → %s",
-					deps, plural(deps), radius, truncate(f, 40))))
-		}
-	}
-
-	m.log = append(m.log, ckDimS.Render("  plan   ")+
-		ckDimS.Render("routing preview only — chat does not send requests yet"))
-
-	return m
+	return m.startTask(t)
 }
 
 // pickHead finds the cheapest available head at or below the wanted strength,
-// falling back down the ladder to a local model when heads are down.
-func (m Cockpit) pickHead(wantTier int) int {
+// falling back down the ladder to a local model when heads are down. localOnly
+// restricts the whole search to local heads.
+func (m Cockpit) pickHead(wantTier int, localOnly bool) int {
+	eligible := func(h ckHead) bool { return h.up && (!localOnly || h.local) }
 	best := -1
 	for i, h := range m.heads {
-		if h.tier >= wantTier && h.up {
+		if h.tier >= wantTier && eligible(h) {
 			if best == -1 || h.tier < m.heads[best].tier {
 				best = i
 			}
@@ -162,12 +164,12 @@ func (m Cockpit) pickHead(wantTier int) int {
 	}
 	if best == -1 {
 		for i, h := range m.heads {
-			if h.tier >= 10 && h.up {
+			if h.tier >= 10 && eligible(h) {
 				return i
 			}
 		}
 		// Nothing is routable — a machine with only the ollama binary and no
-		// server behind it must not get a preview naming an unusable model (#248).
+		// server behind it must not get a route naming an unusable model (#248).
 		return -1
 	}
 	return best
@@ -175,7 +177,7 @@ func (m Cockpit) pickHead(wantTier int) int {
 
 // ── layout ────────────────────────────────────────────────────────────────────
 
-// chatCode lays out the chat console beside the live code panel (view 0).
+// chatCode lays out the chat console beside the code panel (view 0).
 // It falls back to chat-only when the terminal is too narrow to split.
 func (m Cockpit) chatCode(bodyH int) string {
 	mainW := m.w - 23 // sidebar (21) + right border + gap
@@ -213,7 +215,7 @@ func (m Cockpit) chatLogGeom() (w, logH int) {
 	if bodyH < 6 {
 		bodyH = 6
 	}
-	logH = bodyH - 2
+	logH = bodyH - lipgloss.Height(m.inputBar(w))
 	if logH < 1 {
 		logH = 1
 	}
@@ -310,20 +312,81 @@ func (m Cockpit) sidebar(h int) string {
 }
 
 func (m Cockpit) chatMain(w, h int) string {
-	// h covers the log box, the ╌ divider below it, and the input line — not
-	// just the log box, or the total comes out to h+1 and Bubble Tea crops the
-	// overflow off the TOP, deleting the header on every launch (#445).
-	logH := h - 2
+	// The pane is the log box plus the input bar, totalling exactly h lines —
+	// anything more and Bubble Tea crops the overflow off the TOP, deleting
+	// the header on every launch (#445).
+	input := m.inputBar(w)
+	logH := h - lipgloss.Height(input)
 	if logH < 1 {
 		logH = 1
 	}
 	logBox := lipgloss.NewStyle().Width(w).Height(logH).Render(ckVisibleLog(m.log, w, logH, m.chatScroll-1))
-	input := ckCyanS.Render(m.mode+" ❯ ") + ckInkS.Render(m.input) + ckAquaS.Render("▏")
-	return lipgloss.JoinVertical(lipgloss.Left, logBox, ckFaintS.Render(strings.Repeat("╌", max(1, w))), input)
+	return lipgloss.JoinVertical(lipgloss.Left, logBox, input)
 }
 
-// codePanel renders the streaming code snippet beside the chat console. w is the
-// full column budget (content + left border + left padding).
+// ckInputWrapCap bounds how many wrapped lines of a long input stay visible —
+// the newest ones, where the cursor is. The rest is typed, just not shown.
+const ckInputWrapCap = 3
+
+// inputBar renders the bordered input with the mode chip: idle placeholder,
+// wrapped typing, the running spinner, or the pending question. At heights too
+// small for a border it degrades to one bare line, so the input can never
+// disappear (#506's discipline).
+func (m Cockpit) inputBar(w int) string {
+	chip := ckChipS.Render(ckModeByName(m.mode).chip + " ▾")
+	var body string
+	switch {
+	case m.exec != nil:
+		frames := []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+		elapsed := time.Since(m.exec.started)
+		f := frames[int(elapsed/(200*time.Millisecond))%len(frames)]
+		body = ckAquaS.Render(string(f)+" ") + ckInkS.Render(m.exec.Stage()) +
+			ckDimS.Render(fmt.Sprintf(" · %.1fs · ", elapsed.Seconds())) + ckFaintS.Render("esc cancels")
+	case m.confirm != nil:
+		body = ckMidS.Render(m.confirm.question)
+	case m.planWait != nil:
+		body = ckCyanS.Render("plan ready — enter/y runs it · esc discards")
+	case m.input == "":
+		body = ckFaintS.Render("what do you need done? — enter runs it")
+	default:
+		body = ckInkS.Render(m.input) + ckAquaS.Render("▏")
+	}
+	line := chip + " " + body
+
+	bodyH := m.h - 3
+	if bodyH < 6 {
+		bodyH = 6
+	}
+	inner := w - 4 // border (2) + padding (2)
+	if bodyH < 8 || inner < 10 {
+		// Too short for a border: one bare line, tail-truncated so the cursor
+		// region stays visible.
+		return ckTailTruncate(line, max(1, w))
+	}
+	wrapped := strings.Split(lipgloss.NewStyle().Width(inner).Render(line), "\n")
+	if len(wrapped) > ckInputWrapCap {
+		wrapped = wrapped[len(wrapped)-ckInputWrapCap:]
+		wrapped[0] = ckFaintS.Render("… ") + wrapped[0]
+	}
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).BorderForeground(ckAqua).
+		Padding(0, 1).Width(w - 2).
+		Render(strings.Join(wrapped, "\n"))
+}
+
+// ckTailTruncate keeps the END of a styled line within n cells — the input's
+// newest characters, unlike truncate which keeps the start.
+func ckTailTruncate(s string, n int) string {
+	if lipgloss.Width(s) <= n {
+		return s
+	}
+	// Binary-search-free: drop rendered head lines via the wrap trick.
+	rows := strings.Split(lipgloss.NewStyle().Width(max(1, n-1)).Render(s), "\n")
+	return ckFaintS.Render("…") + rows[len(rows)-1]
+}
+
+// codePanel renders the code panel beside the chat console: the last edit's
+// real content (streamed), or its diff after `d`. w is the full column budget.
 func (m Cockpit) codePanel(w, h int) string {
 	inner := w - 2 // border-left (1) + padding-left (1)
 	if inner < 10 {
@@ -334,12 +397,16 @@ func (m Cockpit) codePanel(w, h int) string {
 	if lang == "" {
 		lang = "—"
 	}
-	b.WriteString(ckLabelS.Render("CODE") + ckDimS.Render(" · "+lang) + "\n")
+	title := "CODE"
+	if m.codeDiff {
+		title = "DIFF"
+	}
+	b.WriteString(ckLabelS.Render(title) + ckDimS.Render(" · "+lang) + "\n")
 
 	if len(m.codeLines) == 0 {
-		b.WriteString("\n" + ckFaintS.Render("awaiting a request —") + "\n" +
-			ckFaintS.Render("type a task to preview") + "\n" +
-			ckFaintS.Render("its route here."))
+		b.WriteString("\n" + ckFaintS.Render("no edits yet —") + "\n" +
+			ckFaintS.Render("a task that changes a") + "\n" +
+			ckFaintS.Render("file streams it here."))
 	} else {
 		shown := m.codeShown
 		if shown > len(m.codeLines) {
@@ -349,12 +416,21 @@ func (m Cockpit) codePanel(w, h int) string {
 		if textW < 4 {
 			textW = 4
 		}
-		for i := 0; i < shown; i++ {
-			gutter := ckFaintS.Render(fmt.Sprintf("%2d ", i+1))
-			b.WriteString(gutter + ckHighlight(truncate(m.codeLines[i], textW)) + "\n")
+		// The panel is a preview, not a pager: show the newest lines that fit.
+		avail := h - 1
+		if avail < 1 {
+			avail = 1
 		}
-		if shown < len(m.codeLines) { // blinking-ish cursor while streaming
-			b.WriteString(ckFaintS.Render(fmt.Sprintf("%2d ", shown+1)) + ckAquaS.Render("▏"))
+		start := 0
+		if shown > avail {
+			start = shown - avail
+		}
+		for i := start; i < shown; i++ {
+			gutter := ckFaintS.Render(fmt.Sprintf("%3d ", i+1))
+			b.WriteString(gutter + ckCodeLine(truncate(ckSafe(m.codeLines[i]), textW), m.codeDiff) + "\n")
+		}
+		if shown < len(m.codeLines) { // cursor while streaming
+			b.WriteString(ckFaintS.Render(fmt.Sprintf("%3d ", shown+1)) + ckAquaS.Render("▏"))
 		}
 	}
 
@@ -363,12 +439,29 @@ func (m Cockpit) codePanel(w, h int) string {
 		PaddingLeft(1).Render(b.String())
 }
 
-// ── task classification (preview only) ───────────────────────────────────────
-
-func classifyTask(task, mode string) (string, int) {
-	if mode == "local" {
-		return "LOCAL", 10
+// ckCodeLine paints one panel line: diff mode colours by +/-/@@ prefix, code
+// mode uses the syntax highlighter.
+func ckCodeLine(line string, isDiff bool) string {
+	if !isDiff {
+		return ckHighlight(line)
 	}
+	switch {
+	case strings.HasPrefix(line, "+"):
+		return ckCheapS.Render(line)
+	case strings.HasPrefix(line, "-"):
+		return ckExpS.Render(line)
+	case strings.HasPrefix(line, "@@"):
+		return ckCyanS.Render(line)
+	default:
+		return ckDimS.Render(line)
+	}
+}
+
+// ── task classification ───────────────────────────────────────────────────────
+
+// classifyTask maps a prompt to a routing enum and its tier — the cockpit's
+// route preview; the dispatch layer re-derives its own decision at run time.
+func classifyTask(task string) (string, int) {
 	t := strings.ToLower(task)
 	switch {
 	case containsAny(t, "architect", "design", "multi-tenant", "security", "migration", "rotate", "signing", "distributed"):
@@ -458,49 +551,4 @@ func ckHighlight(line string) string {
 func isWordChar(r rune) bool {
 	return r == '_' ||
 		(r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
-}
-
-// ckSnippet returns a short, class-appropriate code sample to stream into the
-// code panel: a TS interface for SIMPLE, a Go handler for STANDARD, and a Go
-// key-rotation func for CORE-flavoured work.
-func ckSnippet(enum string) (string, []string) {
-	switch enum {
-	case "CORE", "COMPLEX":
-		return "go", []string{
-			"// rotate the active signing key without breaking live tokens",
-			"func RotateSigningKey(ctx context.Context, ks KeyStore) error {",
-			"    next, err := GenerateKey()",
-			"    if err != nil {",
-			"        return fmt.Errorf(\"generate: %w\", err)",
-			"    }",
-			"    ks.Stage(next)         // new key signs from now on",
-			"    ks.Retire(ks.Active()) // old key still verifies",
-			"    return ks.Commit(ctx)",
-			"}",
-		}
-	case "STANDARD", "MODERATE":
-		return "go", []string{
-			"// paginated users endpoint",
-			"func (s *Server) ListUsers(w http.ResponseWriter, r *http.Request) {",
-			"    page := parsePage(r.URL.Query())",
-			"    users, err := s.repo.Users(r.Context(), page)",
-			"    if err != nil {",
-			"        http.Error(w, err.Error(), 500)",
-			"        return",
-			"    }",
-			"    json.NewEncoder(w).Encode(users)",
-			"}",
-		}
-	default: // SIMPLE / LOCAL
-		return "typescript", []string{
-			"// User profile settings DTO",
-			"export interface UserProfile {",
-			"    id: string;",
-			"    displayName: string;",
-			"    email: string;",
-			"    locale: string;",
-			"    createdAt: Date;",
-			"}",
-		}
-	}
 }

--- a/internal/tui/view_chat.go
+++ b/internal/tui/view_chat.go
@@ -329,9 +329,8 @@ func (m Cockpit) chatMain(w, h int) string {
 const ckInputWrapCap = 3
 
 // inputBar renders the bordered input with the mode chip: idle placeholder,
-// wrapped typing, the running spinner, or the pending question. At heights too
-// small for a border it degrades to one bare line, so the input can never
-// disappear (#506's discipline).
+// wrapped typing, the running spinner, or the pending question. Heights too
+// small for a border degrade to one bare line — the input never disappears.
 func (m Cockpit) inputBar(w int) string {
 	chip := ckChipS.Render(ckModeByName(m.mode).chip + " ▾")
 	var body string

--- a/internal/tui/view_chat_test.go
+++ b/internal/tui/view_chat_test.go
@@ -36,10 +36,11 @@ func TestChat_QuitCommands(t *testing.T) {
 	}
 }
 
-// Mode commands change where the next task routes, so the change must be
-// visible in the log; case-insensitive (#465); unknown ones reported.
+// The /mode commands mirror the picker: every defined mode by name,
+// case-insensitive (#465), unknown ones reported. The phase-1 strategy
+// commands (/dispatch /swarm /trust /local) are gone — strategy is ctrl+o now.
 func TestChat_ModeCommands(t *testing.T) {
-	for _, cmd := range []string{"/dispatch", "/swarm", "/trust", "/local", "/Trust"} {
+	for _, cmd := range []string{"/ask", "/edit", "/plan", "/auto", "/architect", "/careful", "/unattended", "/Ask"} {
 		m, _ := enter(typed(testCockpit(), cmd))
 		want := strings.ToLower(cmd[1:])
 		if m.mode != want {
@@ -49,16 +50,19 @@ func TestChat_ModeCommands(t *testing.T) {
 			t.Errorf("%s was not acknowledged in the log", cmd)
 		}
 	}
-	m, _ := enter(typed(testCockpit(), "/nonsense"))
-	if m.mode == "nonsense" {
-		t.Error("an unknown command was accepted as a mode")
-	}
-	if !strings.Contains(strings.Join(m.log, "\n"), "unknown") {
-		t.Error("the unknown command was not reported")
+	for _, cmd := range []string{"/nonsense", "/swarm", "/dispatch"} {
+		m, _ := enter(typed(testCockpit(), cmd))
+		if m.mode == strings.ToLower(cmd[1:]) {
+			t.Errorf("%s was accepted as a mode", cmd)
+		}
+		if !strings.Contains(strings.Join(m.log, "\n"), "unknown") {
+			t.Errorf("%s was not reported as unknown", cmd)
+		}
 	}
 }
 
-// An empty submit is a no-op, not a request of the empty string.
+// An empty submit is a no-op with nothing finished; after a finished task it
+// opens the trace (tested in chat_exec_test.go).
 func TestChat_EmptySubmitDoesNothing(t *testing.T) {
 	before := testCockpit()
 	m, cmd := enter(before)
@@ -71,12 +75,12 @@ func TestChat_EmptySubmitDoesNothing(t *testing.T) {
 	}
 }
 
-// With no models scanned there is no route to preview. Inventing one is
-// exactly what #189 removed.
-func TestChat_NoModelsSaysSoAndStreamsNothing(t *testing.T) {
+// With no models scanned there is no route, so nothing must execute. Inventing
+// one is exactly what #189 removed.
+func TestChat_NoModelsSaysSoAndRunsNothing(t *testing.T) {
 	m := testCockpit()
 	m.heads = nil
-	m, _ = enter(typed(m, "add pagination"))
+	m, cmd := enter(typed(m, "add pagination"))
 	joined := strings.Join(m.log, "\n")
 	if !strings.Contains(joined, "no routable model") {
 		t.Errorf("the log does not say why nothing was routed:\n%s", joined)
@@ -84,107 +88,44 @@ func TestChat_NoModelsSaysSoAndStreamsNothing(t *testing.T) {
 	if !strings.Contains(joined, "hyctl probe") {
 		t.Error("the message does not tell the user how to find out why")
 	}
-	if len(m.codeLines) != 0 {
-		t.Error("a code stream started with nothing to route to")
+	if m.exec != nil || cmd != nil {
+		t.Error("a task started with nothing to route to")
 	}
 }
 
-// Submitting a task previews the route and starts the code stream — and the
-// per-line "vs all-frontier" comparison is gone (it lives in usage now).
-func TestChat_TaskPreviewStreamsAndCarriesNoComparison(t *testing.T) {
-	before := testCockpit()
-	m, cmd := enter(typed(before, "add pagination to the users endpoint"))
-
-	if len(m.log) <= len(before.log) {
-		t.Fatal("submitting a task produced no log output")
-	}
-	if cmd == nil {
-		t.Error("no code-stream tick was scheduled")
-	}
-	if m.codeGen == before.codeGen {
-		t.Error("the stream generation did not advance")
-	}
-	if m.runs != before.runs+1 {
-		t.Errorf("runs = %d, want incremented", m.runs)
-	}
-	joined := stripANSI(strings.Join(m.log, "\n"))
-	if !strings.Contains(joined, "routing preview only") {
-		t.Errorf("the log does not say nothing was sent:\n%s", joined)
-	}
-	if !strings.Contains(joined, "add pagination") {
-		t.Error("the log does not echo what was asked")
-	}
-	if strings.Contains(joined, "vs all-") {
-		t.Errorf("the per-line cost comparison is back — it moved to the usage view:\n%s", joined)
-	}
-}
-
-// The route line's cost claim must be honest: a real price, "free (local)"
-// only for a local model, and "cost unknown" otherwise.
-func TestChat_RouteCostClaims(t *testing.T) {
-	m := testCockpit()
-	m.heads = []ckHead{{id: "q", name: "qwen", tier: 10, up: true, local: true}}
-	m, _ = enter(typed(m, "rename x to y"))
-	if !strings.Contains(strings.Join(m.log, "\n"), "free (local)") {
-		t.Errorf("a local model's preview does not say free:\n%s", strings.Join(m.log, "\n"))
-	}
-
-	m = testCockpit()
-	m.heads = []ckHead{{id: "c", name: "claude", tier: 1, up: true}}
-	m, _ = enter(typed(m, "rotate the signing key")) // CORE → T1, the only head
-	if !strings.Contains(strings.Join(m.log, "\n"), "cost unknown") {
-		t.Errorf("an unpriced remote model's preview does not say unknown:\n%s", strings.Join(m.log, "\n"))
-	}
-}
-
-// A pinned tier (set from the models view) overrides classification and is
-// visible in the preview.
-func TestChat_PinnedTierOverridesClassification(t *testing.T) {
-	m := testCockpit()
-	m.pinnedTier = 3
-	m, _ = enter(typed(m, "rename x to y")) // SIMPLE → T8 normally
-	joined := stripANSI(strings.Join(m.log, "\n"))
-	if !strings.Contains(joined, "pinned T3") {
-		t.Errorf("the preview does not show the pin:\n%s", joined)
-	}
-	if !strings.Contains(joined, "claude-sonnet") {
-		t.Errorf("the pin did not route to the T3 head:\n%s", joined)
-	}
-	// --local mode still wins over the pin: nothing leaves the machine.
-	m = testCockpit()
-	m.pinnedTier = 1
-	m.mode = "local"
-	m, _ = enter(typed(m, "rename x to y"))
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "qwen") {
-		t.Error("local mode did not override the pin")
-	}
-}
-
-// pickHead is the cockpit's own routing: cheapest at or below the wanted
-// strength, never answering "cheapest" with "most expensive" (#165's shape).
+// pickHead is the cockpit's route preview: cheapest at or below the wanted
+// strength, never answering "cheapest" with "most expensive" (#165's shape),
+// and localOnly restricts the whole search to local heads.
 func TestPickHead_NeverAnswersCheapestWithStrongest(t *testing.T) {
 	m := testCockpit()
-	if got := m.pickHead(10); got < 0 || m.heads[got].id != "qwen" {
+	if got := m.pickHead(10, false); got < 0 || m.heads[got].id != "qwen" {
 		t.Errorf("pickHead(10) = %d, want the local head", got)
 	}
-	if got := m.pickHead(3); m.heads[got].tier < 3 {
+	if got := m.pickHead(3, false); m.heads[got].tier < 3 {
 		t.Errorf("pickHead(3) selected tier %d — stronger than requested", m.heads[got].tier)
 	}
-	if got := m.pickHead(1); m.heads[got].id != "opus" {
+	if got := m.pickHead(1, false); m.heads[got].id != "opus" {
 		t.Errorf("pickHead(1) = %s", m.heads[got].id)
 	}
+	// localOnly: the strongest local head wins even when asked for T1.
+	if got := m.pickHead(1, true); got < 0 || m.heads[got].id != "qwen" {
+		t.Errorf("pickHead(1, localOnly) = %d, want the local head", got)
+	}
 	m.heads[2].up = false
-	if got := m.pickHead(10); got >= 0 && m.heads[got].id == "qwen" {
+	if got := m.pickHead(10, false); got >= 0 && m.heads[got].id == "qwen" {
 		t.Error("pickHead selected a head that is down")
+	}
+	if got := m.pickHead(1, true); got >= 0 {
+		t.Errorf("pickHead(localOnly) = %d with the only local head down", got)
 	}
 	for i := range m.heads {
 		m.heads[i].up = false
 	}
-	if got := m.pickHead(1); got >= 0 {
+	if got := m.pickHead(1, false); got >= 0 {
 		t.Errorf("pickHead = %d with every head down (#248's shape)", got)
 	}
 	m.heads = nil
-	if got := m.pickHead(1); got >= 0 {
+	if got := m.pickHead(1, false); got >= 0 {
 		t.Errorf("pickHead on an empty roster = %d", got)
 	}
 }
@@ -192,32 +133,30 @@ func TestPickHead_NeverAnswersCheapestWithStrongest(t *testing.T) {
 func TestClassifyTask_RoutesByWhatTheWorkActuallyIs(t *testing.T) {
 	tests := []struct {
 		task     string
-		mode     string
 		wantEnum string
 		wantTier int
 	}{
-		{"design a multi-tenant security model", "local", "LOCAL", 10},
-		{"rotate the signing key without breaking live tokens", "", "CORE", 1},
-		{"refactor this for a data race", "", "COMPLEX", 3},
-		{"add pagination to the users endpoint", "", "STANDARD", 6},
-		{"rename x to y", "", "SIMPLE", 8},
-		{"", "", "SIMPLE", 8},
+		{"rotate the signing key without breaking live tokens", "CORE", 1},
+		{"refactor this for a data race", "COMPLEX", 3},
+		{"add pagination to the users endpoint", "STANDARD", 6},
+		{"rename x to y", "SIMPLE", 8},
+		{"", "SIMPLE", 8},
 	}
 	for _, tt := range tests {
-		enum, tier := classifyTask(tt.task, tt.mode)
+		enum, tier := classifyTask(tt.task)
 		if enum != tt.wantEnum || tier != tt.wantTier {
-			t.Errorf("classifyTask(%q, %q) = (%s, %d), want (%s, %d)",
-				tt.task, tt.mode, enum, tier, tt.wantEnum, tt.wantTier)
+			t.Errorf("classifyTask(%q) = (%s, %d), want (%s, %d)",
+				tt.task, enum, tier, tt.wantEnum, tt.wantTier)
 		}
 	}
 	long := strings.Repeat("please do the thing carefully ", 5)
-	if _, tier := classifyTask(long, ""); tier >= 8 {
+	if _, tier := classifyTask(long); tier >= 8 {
 		t.Errorf("a long prompt classified at tier %d — length should lift it", tier)
 	}
 }
 
 // The change-impact line renders only for files a graph actually knows (#193).
-func TestChatRun_ImpactOnlyForFilesTheGraphKnows(t *testing.T) {
+func TestChatStart_ImpactOnlyForFilesTheGraphKnows(t *testing.T) {
 	testutil.NewSandbox(t)
 	m := testCockpit()
 	m, _ = enter(typed(m, "rotate the key in internal/nowhere/absent.go"))
@@ -225,13 +164,13 @@ func TestChatRun_ImpactOnlyForFilesTheGraphKnows(t *testing.T) {
 	if strings.Contains(joined, "κ=") {
 		t.Errorf("an impact figure was printed with no graph loaded:\n%s", joined)
 	}
-	if !strings.Contains(joined, "routing preview only") {
-		t.Errorf("the run did not complete:\n%s", joined)
+	if !strings.Contains(stripANSI(joined), "auto-routed") {
+		t.Errorf("the route line is missing:\n%s", joined)
 	}
 }
 
 // chatMain's total output must be exactly h lines (#445), and one overlong
-// entry must not push the input off-frame (#506).
+// entry must not push the input bar off-frame (#506).
 func TestChatMain_GeometryHolds(t *testing.T) {
 	m := testCockpit()
 	for _, h := range []int{10, 24, 30, 60} {
@@ -254,7 +193,8 @@ func TestChatMain_GeometryHolds(t *testing.T) {
 	}
 }
 
-// The chat pane keeps only the newest lines that fit when live.
+// The chat pane keeps only the newest lines that fit when live, and the input
+// bar always shows the typed text and the mode chip.
 func TestChatMain_KeepsTheNewestLinesAndTheInput(t *testing.T) {
 	m := testCockpit()
 	m.input = "half-typed prompt"
@@ -262,19 +202,39 @@ func TestChatMain_KeepsTheNewestLinesAndTheInput(t *testing.T) {
 	for i := 0; i < 200; i++ {
 		m.log = append(m.log, fmt.Sprintf("log line %d", i))
 	}
-	got := stripANSI(m.chatMain(60, 10))
+	got := stripANSI(m.chatMain(60, 12))
 	if !strings.Contains(got, "log line 199") {
 		t.Errorf("the newest line is not shown:\n%s", got)
 	}
 	if strings.Contains(got, "log line 100") {
-		t.Errorf("an old line survived a 10-row window:\n%s", got)
+		t.Errorf("an old line survived a 12-row window:\n%s", got)
 	}
-	if !strings.Contains(got, "half-typed prompt") || !strings.Contains(got, "dispatch") {
-		t.Errorf("the input line or mode prompt is missing:\n%s", got)
+	if !strings.Contains(got, "half-typed prompt") || !strings.Contains(got, "Auto") {
+		t.Errorf("the input line or mode chip is missing:\n%s", got)
 	}
-	tiny := stripANSI(m.chatMain(20, 0))
-	if !strings.Contains(tiny, "half-typed prompt") {
-		t.Errorf("at height 0 the input is gone:\n%s", tiny)
+	// Even with no room for the border, the input itself survives.
+	tiny := stripANSI(m.chatMain(30, 3))
+	if !strings.Contains(tiny, "prompt") {
+		t.Errorf("at height 3 the input is gone:\n%s", tiny)
+	}
+}
+
+// A very long input wraps inside the bar, keeps its newest characters visible,
+// and never grows past the wrap cap.
+func TestInputBar_WrapsAndKeepsTheTail(t *testing.T) {
+	m := testCockpit()
+	m.input = strings.Repeat("word ", 200) + "FINAL"
+	bar := m.inputBar(60)
+	if got := strings.Count(bar, "\n") + 1; got > ckInputWrapCap+2 {
+		t.Errorf("input bar grew to %d lines", got)
+	}
+	if !strings.Contains(stripANSI(bar), "FINAL") {
+		t.Errorf("the input's tail (cursor region) is not visible:\n%s", stripANSI(bar))
+	}
+	// Placeholder when idle and empty.
+	m.input = ""
+	if got := stripANSI(m.inputBar(60)); !strings.Contains(got, "what do you need done?") {
+		t.Errorf("no placeholder on an empty idle input:\n%s", got)
 	}
 }
 
@@ -319,22 +279,52 @@ func TestSidebar_UnknownContextSaysNoData(t *testing.T) {
 	}
 }
 
-// The code panel renders whether or not anything has streamed yet, at any width.
+// The code panel renders whether or not anything has streamed yet, at any
+// width — and in diff mode it colours by prefix instead of syntax.
 func TestCodePanel_RendersAtEverySize(t *testing.T) {
 	m := testCockpit()
-	if got := m.codePanel(40, 20); !strings.Contains(got, "awaiting a request") {
+	if got := m.codePanel(40, 20); !strings.Contains(got, "no edits yet") {
 		t.Errorf("the empty state does not say what it is waiting for:\n%s", got)
 	}
-	after, _ := enter(typed(m, "write a handler"))
-	after.codeShown = len(after.codeLines)
+	m.codeLang = "go"
+	m.codeLines = []string{"package main", "func main() {}", "// done"}
+	m.codeShown = len(m.codeLines)
 	for _, w := range []int{0, 1, 5, 40, 200} {
-		if got := after.codePanel(w, 20); strings.TrimSpace(got) == "" {
+		if got := m.codePanel(w, 20); strings.TrimSpace(got) == "" {
 			t.Errorf("codePanel(%d) rendered nothing", w)
 		}
 	}
-	after.codeShown = len(after.codeLines) + 50
-	if got := after.codePanel(60, 20); strings.TrimSpace(got) == "" {
+	m.codeShown = len(m.codeLines) + 50
+	if got := m.codePanel(60, 20); strings.TrimSpace(got) == "" {
 		t.Error("codePanel rendered nothing with codeShown past the end")
+	}
+	// A long file shows its newest lines rather than only the top of the file.
+	m.codeLines = nil
+	for i := 0; i < 100; i++ {
+		m.codeLines = append(m.codeLines, fmt.Sprintf("line%d", i))
+	}
+	m.codeShown = 100
+	if got := stripANSI(m.codePanel(60, 12)); !strings.Contains(got, "line99") {
+		t.Errorf("the panel does not show the newest streamed lines:\n%s", got)
+	}
+
+	m.codeDiff = true
+	m.codeLang = "diff"
+	m.codeLines = []string{"@@ -1,2 +1,2 @@", "-old line", "+new line", " ctx"}
+	m.codeShown = len(m.codeLines)
+	if got := stripANSI(m.codePanel(60, 20)); !strings.Contains(got, "DIFF") || !strings.Contains(got, "+new line") {
+		t.Errorf("diff mode did not render the diff:\n%s", got)
+	}
+}
+
+func TestCkCodeLine_DiffColoursByPrefix(t *testing.T) {
+	for _, line := range []string{"+added", "-removed", "@@ hunk @@", " context"} {
+		if got := stripANSI(ckCodeLine(line, true)); got != line {
+			t.Errorf("diff colouring changed the text: %q → %q", line, got)
+		}
+	}
+	if got := stripANSI(ckCodeLine("func main() {}", false)); got != "func main() {}" {
+		t.Errorf("code colouring changed the text: %q", got)
 	}
 }
 
@@ -366,22 +356,6 @@ func TestIsWordChar(t *testing.T) {
 	for _, r := range []rune{' ', '(', '.', '"', '·', '日'} {
 		if isWordChar(r) {
 			t.Errorf("isWordChar(%q) = true", r)
-		}
-	}
-}
-
-// ckSnippet must return a language tag and at least one newline-free line for
-// every enum, including one it has never seen.
-func TestCkSnippet_EveryEnumYieldsRenderableCode(t *testing.T) {
-	for _, enum := range []string{"CORE", "COMPLEX", "STANDARD", "SIMPLE", "GRUNT", "", "NOT_AN_ENUM"} {
-		lang, lines := ckSnippet(enum)
-		if lang == "" || len(lines) == 0 {
-			t.Errorf("ckSnippet(%q) = (%q, %d lines)", enum, lang, len(lines))
-		}
-		for i, l := range lines {
-			if strings.Contains(l, "\n") {
-				t.Errorf("ckSnippet(%q) line %d contains a newline", enum, i)
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

TUI v2 Phase 2 (epic #600): the chat stops being a preview and executes for real inside the Phase-1 shell, through the same code paths the CLI uses — `internal/dispatch`, `internal/editor`, `internal/oracle`, `internal/swarm`.

### What a task looks like now
- **Route line before execution**: `auto-routed · standard work → T7 qwen2.5-coder · single` plus a plain-words why (`code edit, moderate scope, no PII`), the `local-only (pii)` badge when the configured policy forces it, and the graph change-impact line when the prompt names a known file. No per-line cost — session/Usage carry cost, per the design.
- **Execution**: spinner + stage + elapsed in the bordered input bar (`Auto ▾` chip, aqua ring); `esc` cancels via context cancellation through dispatch; answers render as a bordered-left block; edits render the proof strip `plan ✓ N steps · edit ✓ file +A/−R · tests ✓/✗ cmd`; the footer is `✓ done Xs · $Y est · trace #id — enter opens the trace`. Failures always carry the error and the trace link.
- **After an edit**: `d` diff (first-before → last-after across the fix loop), `x` undo (exact pre-task restore, one-shot), `o` open in `$EDITOR` — all off runlog `KindEdit` snapshots. The code panel streams the real new file content (the fake snippets are gone, with the "routing preview only" wording).

### Modes (`shift+tab` cycles basics · `m` opens the picker)
- **Ask** — answer only, never writes.
- **Edit** — editor path when the prompt names an existing file (validated, rollback-safe, snapshotted); otherwise answers with "no file named — answered instead".
- **Plan** — cheap-tier plan, numbered steps, waits: `enter`/`y`/`a` run it (as Auto's tail), `esc` discards; what already ran (the plan's cost) settles honestly as `◼ stopped`.
- **Auto** — plan (internal) → edit → verify through `oracle.CommandOracle`: `go test ./...` when the CWD repo is Go, else the workspace.yaml validator for the file's extension; failures feed a fix re-dispatch, capped at 2 fixes.
- **Architect** — plan on tier 2, implement on the cheap tier.
- **Careful** — every file write (the first *and* each fix) pauses on a `y/n` gate; declining settles honestly (a declined fix keeps the landed write and shows `tests ✗`).
- **Unattended** — no confirms, hard $0.50/task cap enforced between stages (plus dispatch's own `MaxCostUSD` preflight); refusal is rendered, never silent.

### Routing override (`ctrl+o`, next task only)
auto / force tier (digit) / local only / best of 3 / consensus check (90/95/99/99.9%) — wired into the next dispatch's options, reusing `swarm.Run`/`RunSPRT` rather than duplicating strategy logic. Fan-out on a file edit degrades to single, visibly, on the route line. Consensus renders the achieved confidence in the footer.

### Two real bugs found by live testing, fixed here
- `ckClipToLines` returned the *unwrapped* entry whenever it fit the line cap, so the scroll window counted 1 line where the renderer painted 3 — the input bar walked off-frame the moment entries got longer than the narrow chat pane (latent since Phase 1). It now always returns the wrapped text so count and render agree; regression test renders the exact live 80×24 frame.
- Real terminals coalesce fast keystrokes into one multi-rune `KeyMsg`; every modal handler dropped those (`jj` in the override modal did nothing live). Multi-rune messages now replay one key at a time, with bracketed paste kept literal so pasted text can never fire shortcut letters.

### Standing gates
- **Layout**: everything cell-measured through the layout.go helpers; the per-view regression suite extends to the new chat states (running spinner, plan pending, careful confirm, proof strip + 260-line answers, mode picker, override modal in all three stages, 3000-char input) at 60×15 / 80×24 / 100×30 / 120×40 — ≤h lines, ≤w cells, status bar always last; the input bar wraps to a 3-line cap keeping the cursor tail and can never be pushed off-frame.
- **Modularity**: one concern per file — `modes.go` (mode table + picker), `override.go` (modal), `chat_exec.go` (pipeline + worker + seams), `chat_task.go` (UI lifecycle + rendering + d/x/o), `view_chat.go` stays the thin view. All new keys live in `ckKeymap`; the glossary and status bars render from it, and the existing drift test covers them automatically.
- **Scrolling**: append-no-yank verified against 200-line real answers; plan steps live in the scrollback; the picker/modal degrade to selection-following scroll lists at short heights.

### Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` clean; full `go test -race -count=1 ./...` green (no `HYDRA_HOME`).
- covergate: all 41 floors met; `internal/tui` **91.1%** (floor 86; Phase 1 left 91.6).
- **Live** (isolated `HYDRA_HOME`, expect at 80×24 and 120×40, frames extracted and eyeballed):
  - Ask on a real local head: `local only · simple task → T10 Qwen2.5-Coder:7b (Ollama) · single` → real answer in 3.9s, footer + trace.
  - Plan approve flow at 120×40: plan gate → approve → answer (24.6s, local), long answer scrollback clean.
  - Auto in a throwaway scratch git repo (failing `go test`): plan → edit `adder/adder.go +2/−1` → **`tests ✓ go test ./...`** — repo went red→green on disk, run log shows the full pipeline, code panel streamed the fixed file.
  - `ctrl+o` dry-run: modal renders centered with the mode-vs-route explanation; force-tier digit stage; status bar carries `route T3 forced` with nothing dispatched.

README's TUI section now documents the modes table and the override.

Closes #597
