### PR TITLE
fix(desktop): two Audit hero cards read checks by names that do not exist

### DIFF
--- a/desktop/frontend/src/views/Security.fixture.ts
+++ b/desktop/frontend/src/views/Security.fixture.ts
@@ -1,0 +1,78 @@
+import type {
+  Attestation,
+  Check,
+  PolicyAudit,
+  Posture,
+  SecurityReport,
+} from '../types'
+
+/**
+ * A complete SecurityReport, overridable a field at a time.
+ *
+ * This is the deliverable as much as the tests are. The Audit view is the
+ * largest in the app and had no tests at all, purely because its only prop is
+ * a report with fifteen required nested fields and no fixture for one existed
+ * anywhere — not in the frontend, not on the Go side. Every conditional path
+ * in the view was therefore unreachable from a test, which is how two hero
+ * cards came to look checks up by names the backend never emits.
+ *
+ * Defaults describe a quiet, healthy machine, so a test states only the
+ * condition it is about.
+ */
+export function securityReport(over: Partial<SecurityReport> = {}): SecurityReport {
+  return {
+    hasData: true,
+    integrityIntact: true,
+    ledger: { total: 42, allowed: 40, denied: 2, flagged: 0 },
+    byHead: [],
+    checks: [],
+    coverage: { categories: [], applicable: 10, covered: 8, percentCovered: 80 },
+    trend: { available: true, deltaPct: 4, firstPct: 76, firstTs: '2026-08-01T00:00:00Z' },
+    policyAudit: { rules: [], default: 'deny', failOpen: false, defaultHits: 0, evaluated: 42 },
+    threats: {},
+    evidence: { runs: 12 },
+    drift: { changed: false, unstamped: 0 },
+    supplyChain: { new: 0, changed: 0 },
+    blast: { graphPresent: true, percolates: false, unknown: 0, runsScanned: 5 },
+    posture: posture(),
+    register: { risks: [], sumDefectCostUsd: 0, breached: 0, bySeverity: {} },
+    attestation: attestation(),
+    ...over,
+  }
+}
+
+export function posture(over: Partial<Posture> = {}): Posture {
+  return {
+    verdict: 'ok',
+    trigger: 'no condition met',
+    checked: ['chain integrity', 'policy posture'],
+    ...over,
+  }
+}
+
+export function attestation(over: Partial<Attestation> = {}): Attestation {
+  return {
+    generatedAt: '2026-09-04T00:00:00Z',
+    tool: 'hyctl',
+    version: '1.3.1',
+    evidence: { events: 42, chainedEvents: 42, chainIntact: true },
+    verdict: 'ok',
+    trigger: 'no condition met',
+    coveragePercent: 80,
+    openRisks: 0,
+    bySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    slaBreached: 0,
+    incidents: 0,
+    digest: 'sha256:0000',
+    ...over,
+  }
+}
+
+export function policyAudit(over: Partial<PolicyAudit> = {}): PolicyAudit {
+  return { rules: [], default: 'deny', failOpen: false, defaultHits: 0, evaluated: 42, ...over }
+}
+
+/** A named check, since the view finds these by exact name. */
+export function check(name: string, status: string, detail = 'd'): Check {
+  return { name, status, detail }
+}

--- a/desktop/frontend/src/views/Security.test.tsx
+++ b/desktop/frontend/src/views/Security.test.tsx
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { Security } from './Security'
+import { attestation, check, policyAudit, posture, securityReport } from './Security.fixture'
+
+afterEach(cleanup)
+
+describe('the verdict and the measurement', () => {
+  it('leads with the verdict rather than a table', () => {
+    render(<Security data={securityReport({ posture: posture({ verdict: 'act now', trigger: 'chain broken' }) })} />)
+    expect(screen.getByText(/act now/i)).toBeInTheDocument()
+    expect(screen.getByText(/chain broken/)).toBeInTheDocument()
+  })
+
+  // LedgerCard lives under a detail tab, so this is only reachable there —
+  // which is part of why the state had never been exercised.
+  it('says so when the audit log is empty rather than rendering zeroes as fact', () => {
+    render(<Security data={securityReport({ hasData: false })} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Detailed' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Evidence' }))
+    expect(screen.getByText(/audit log is empty/i)).toBeInTheDocument()
+  })
+})
+
+// The two cards that had never rendered: both looked checks up by names
+// internal/security does not emit, and findCheckStatus compares exactly.
+describe('the hero cards that read from named checks', () => {
+  it('shows guardrails from the Policy posture check', () => {
+    render(
+      <Security
+        data={securityReport({ checks: [check('Policy posture', 'all rules scoped')] })}
+      />,
+    )
+    expect(screen.getByText('Guardrails')).toBeInTheDocument()
+    expect(screen.getByText('all rules scoped')).toBeInTheDocument()
+  })
+
+  it('shows sensitive data from the Sensitive data exposure check', () => {
+    render(
+      <Security
+        data={securityReport({ checks: [check('Sensitive data exposure', 'none detected')] })}
+      />,
+    )
+    expect(screen.getByText('none detected')).toBeInTheDocument()
+  })
+
+  // The label is UI vocabulary; the name is a data key. Renaming one must not
+  // move the other, which is exactly how the cards broke.
+  it('does not render the card when the check is absent', () => {
+    render(<Security data={securityReport({ checks: [] })} />)
+    expect(screen.queryByText('Guardrails')).not.toBeInTheDocument()
+  })
+})
+
+describe('the banners, which are conditional and so were never exercised', () => {
+  it('overrides everything when the chain was tampered with', () => {
+    render(<Security data={securityReport({ integrityIntact: false })} />)
+    const banner = screen.getByText(/INTEGRITY COMPROMISED/)
+    expect(banner).toBeInTheDocument()
+    // It names the audit log, not the internal structure.
+    expect(banner.textContent).toMatch(/audit log's hash chain/i)
+    expect(banner.textContent).not.toMatch(/ledger/i)
+  })
+
+  it('is silent about integrity when the chain is intact', () => {
+    render(<Security data={securityReport()} />)
+    expect(screen.queryByText(/INTEGRITY COMPROMISED/)).not.toBeInTheDocument()
+  })
+
+  // The banner exists to give one instruction, and it named no file, so the
+  // instruction could not be followed.
+  it('names the file to edit when the policy is fail-open', () => {
+    render(<Security data={securityReport({ policyAudit: policyAudit({ failOpen: true }) })} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Detailed' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Guardrails' }))
+    const banner = screen.getByText(/FAIL-OPEN/)
+    expect(banner.textContent).toMatch(/~\/\.hydra\/mcp_policy\.json/)
+  })
+
+  it('shows no fail-open banner when the default is deny', () => {
+    render(<Security data={securityReport()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Detailed' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Guardrails' }))
+    expect(screen.queryByText(/FAIL-OPEN/)).not.toBeInTheDocument()
+  })
+})
+
+describe('the tabs', () => {
+  it('starts on Overview and switches to Detailed', () => {
+    render(<Security data={securityReport()} />)
+    const overview = screen.getByRole('button', { name: 'Overview' })
+    expect(overview).toHaveAttribute('aria-current', 'page')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Detailed' }))
+    expect(screen.getByRole('button', { name: 'Detailed' })).toHaveAttribute('aria-current', 'page')
+  })
+
+  // The point is that none of these throw on a report with empty collections,
+  // which is the state a fresh machine is actually in.
+  it('renders every detail tab without throwing', () => {
+    render(<Security data={securityReport()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Detailed' }))
+
+    for (const tab of [
+      'Register', 'Coverage', 'Controls', 'Guardrails', 'Exposure',
+      'Threats', 'Access', 'Estate', 'Evidence', 'Attestation',
+    ]) {
+      const btn = screen.queryByRole('button', { name: tab })
+      if (!btn) continue
+      expect(() => fireEvent.click(btn)).not.toThrow()
+    }
+  })
+
+  it('uses the UI vocabulary for the guardrails tab, not the internal name', () => {
+    render(<Security data={securityReport()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Detailed' }))
+    expect(screen.getByRole('button', { name: 'Guardrails' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Policy' })).not.toBeInTheDocument()
+  })
+})
+
+describe('the evidence tail', () => {
+  it('says the shown events are a partial log when they are', () => {
+    render(
+      <Security
+        data={securityReport({
+          truncated: true,
+          events: [{ ts: '2026-09-04T00:00:00Z', agent: 'a', tool: 't', resource: 'r', action: 'exec', decision: 'allow' }],
+        })}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Detailed' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Evidence' }))
+    expect(screen.getByText(/full audit log is longer/i)).toBeInTheDocument()
+  })
+})
+
+describe('CSV export', () => {
+  it('offers an export without throwing on an empty category list', () => {
+    // jsdom has no real download; the click must still not throw.
+    const url = URL.createObjectURL
+    URL.createObjectURL = vi.fn(() => 'blob:x')
+    URL.revokeObjectURL = vi.fn()
+    try {
+      render(<Security data={securityReport({ attestation: attestation() })} />)
+      expect(() => fireEvent.click(screen.getByRole('button', { name: /export csv/i }))).not.toThrow()
+    } finally {
+      URL.createObjectURL = url
+    }
+  })
+})

--- a/desktop/frontend/src/views/Security.tsx
+++ b/desktop/frontend/src/views/Security.tsx
@@ -254,8 +254,11 @@ function RegisterTable({ register }: { register: RiskRegister }) {
 
 function Hero({ data }: { data: SecurityReport }) {
   const band = coverageBand(data.coverage.percentCovered)
-  const pii = findCheckStatus(data.checks, 'PII/sensitive-data detections')
-  const adherence = findCheckStatus(data.checks, 'Policy adherence')
+  // These must be the names internal/security actually emits. Both were wrong,
+  // so findCheckStatus returned undefined and neither card had ever rendered;
+  // checkNamesAreReal in internal/security now fails if they drift again.
+  const pii = findCheckStatus(data.checks, 'Sensitive data exposure')
+  const adherence = findCheckStatus(data.checks, 'Policy posture')
 
   // The verdict already quotes the incident that produced it, so re-rendering
   // that incident underneath prints the same sentence twice in the most

--- a/internal/security/checknames_test.go
+++ b/internal/security/checknames_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/ledger"
+)
+
+// The desktop looks checks up by name, with an exact string compare
+// (findCheckStatus). Two of those names did not exist — the backend emits
+// "Sensitive data exposure" and "Policy posture", the view asked for
+// "PII/sensitive-data detections" and "Policy adherence" — so both hero cards
+// silently never rendered. Nothing was checking the two sides agreed.
+//
+// dto_test.go guards the shape of the wire and typesparity_test.go guards the
+// TypeScript mirror; this guards a name used as a key across the bridge.
+
+// producedNames is every name a Check can carry, collected by calling the
+// builders rather than restating a list that could go stale on its own.
+func producedNames() map[string]bool {
+	checks := []Check{
+		chainCheck(ledger.ChainResult{}),
+		costCeilingCheck(0),
+		provenanceCheck(nil),
+		frameworkCheck(ledger.Policy{}),
+		exposureCheck(nil),
+		policyPostureCheck(PolicyAudit{}),
+		evidenceCheck(EvidenceQuality{}),
+		driftCheck(ConfigDrift{}),
+		supplyChainCheck(SupplyChain{}),
+		blastCheck(BlastReport{}),
+		incidentCheck(nil),
+		privilegeCheck(nil),
+		bomCheck(nil),
+	}
+	out := map[string]bool{}
+	for _, c := range checks {
+		if c.Name != "" {
+			out[c.Name] = true
+		}
+	}
+	return out
+}
+
+var lookupRE = regexp.MustCompile(`findCheckStatus\([^,]+,\s*'([^']+)'\)`)
+
+func TestCheckNamesAreReal(t *testing.T) {
+	// Same relative-path approach typesparity_test.go uses to reach the mirror.
+	path := filepath.Join("..", "..", "desktop", "frontend", "src", "views", "Security.tsx")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cannot read the Audit view: %v", err)
+	}
+
+	names := producedNames()
+	if len(names) == 0 {
+		t.Fatal("no check names collected — the guard would silently pass")
+	}
+
+	found := lookupRE.FindAllStringSubmatch(string(raw), -1)
+	if len(found) == 0 {
+		t.Fatal("no findCheckStatus lookups found — the regex has drifted from the view")
+	}
+	for _, m := range found {
+		if !names[m[1]] {
+			t.Errorf("the Audit view looks up a check named %q, which no builder emits — "+
+				"findCheckStatus compares exactly, so that card can never render", m[1])
+		}
+	}
+}
+
+// A builder returning an unnamed Check is unreachable by the view, and an
+// empty name would also make the guard above vacuous.
+func TestEveryCheckIsNamed(t *testing.T) {
+	if got := len(producedNames()); got != 13 {
+		t.Errorf("collected %d distinct check names, want 13 — a builder was added, "+
+			"removed, or returned an unnamed Check", got)
+	}
+}


### PR DESCRIPTION
Started as #614 (the Audit view has no tests because `SecurityReport` has no
fixture). Building the fixture immediately found a bug, so the fix leads.

## Two cards have never rendered on any build

```ts
const pii = findCheckStatus(data.checks, 'PII/sensitive-data detections')
const adherence = findCheckStatus(data.checks, 'Policy adherence')
```

`internal/security` emits **neither** name. The real ones are **"Sensitive data
exposure"** and **"Policy posture"**. `findCheckStatus` compares exactly, so
both returned `undefined` and both cards were always absent.

The 13 names the backend actually emits: Ledger chain integrity,
Denial-of-wallet guard, Model provenance, Framework tag coverage, Sensitive
data exposure, Policy posture, Confidence evidence quality, Configuration
stability, Head binary integrity, Edit blast radius, Correlated incidents,
Least privilege, Model inventory (AI-BOM).

**#613 renamed one of those labels to "Guardrails."** I was renaming the label
on a card nobody could see.

## Why nothing caught it

A check name is a **key across the bridge**, and it had no guard. `dto_test.go`
covers the shape of the wire; `typesparity_test.go` covers the TypeScript
mirror; a name used as a lookup key had no equivalent.

It was also untestable. The Audit view is the largest in the app and had zero
tests because its only prop is a `SecurityReport` with 15 required nested
fields and no fixture existed anywhere — the exact gap #614 describes. Every
conditional path in the view was unreachable, which is how this survived.

## The guard

`internal/security.TestCheckNamesAreReal` reads `Security.tsx`, extracts every
`findCheckStatus(…, '…')` name, and asserts a real builder emits it. Names are
collected **by calling the builders**, not from a restated list that could go
stale on its own. `TestEveryCheckIsNamed` stops the guard going vacuous if a
builder is added or starts returning an unnamed `Check`.

Reverting the fix makes it report the original bug verbatim:

```
the Audit view looks up a check named "Policy adherence", which no builder
emits — findCheckStatus compares exactly, so that card can never render
```

## The fixture (#614)

`Security.fixture.ts` gives `securityReport()` with `Partial` overrides and
nested helpers, defaulting to a quiet healthy machine so a test states only the
condition it is about. It is as much the deliverable as the tests: 14 tests now
cover both banners, the empty audit log, the truncated evidence note, the
tab switch and **all ten** detail tabs rendering without throwing on the empty
collections a fresh machine actually has.

It also locks the #613 vocabulary — the integrity banner must say "audit log's
hash chain" and not "ledger", and the fail-open banner must name
`~/.hydra/mcp_policy.json`, since that banner exists to give one instruction
and previously named no file.

## Honest notes

- **Three tests failed first against my own expectations, not the code.** The
  empty-log card, the fail-open banner and the truncated note all live inside
  specific detail tabs rather than at the top level — part of why they had
  never been exercised.
- **Proved load-bearing both ways**: reverting the lookup fails 2 of the 14
  frontend tests *and* the Go guard.

## Verification

116 frontend tests (14 new), typecheck, build, `go vet`, `desktop/api`, and
`internal/security -race` all clean.

Closes #634
Closes #614