### PR TITLE
fix(funding): funding.json failed the FLOSS/fund validator on version and wellKnown

### DIFF
--- a/docs/funding.json
+++ b/docs/funding.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://fundingjson.org/schema/v1.1.0.json",
-  "version": "1.0.0",
+  "version": "v1.0.0",
   "entity": {
     "type": "individual",
     "role": "owner",
@@ -15,16 +15,27 @@
     {
       "guid": "hydra",
       "name": "Hydra",
-      "description": "Hydra is an open source CLI (hyctl), written in Go, that routes developer tasks across every AI model on your machine to a target confidence of correctness. It cuts LLM API costs 70-85% by using cheap or local models for simple tasks and reserving frontier models for work that needs them, enforces PII/local-only policy, and logs spend.",
+      "description": "Hydra is the Trust Control Plane for AI development: an open source CLI (hyctl), written in Go, that discovers every AI model on your machine — CLI coding agents, API keys, local servers — scores each, and routes work to a target confidence of correctness rather than always to the most expensive model. A sequential probability ratio test samples models adaptively and stops as soon as per-model calibration says the evidence is strong enough, so cheap and local heads handle what they can and frontier models are reserved for work that needs them. That typically cuts LLM API spend 70-85%.\n\nBeyond routing, Hydra is the accountability layer for agentic development. It enforces PII and local-only policy so sensitive data never leaves the machine, and logs every dispatch with token counts and cost. `hyctl security` answers what the agents on this machine actually did and whether the record can be trusted: a hash-chained tamper-evident MCP ledger, correlated incident detection, OWASP LLM Top-10 coverage, and a governed risk register with SLA clocks crosswalked to NIST AI RMF, ISO 42001 and MITRE ATLAS. `hyctl mcp registry` scores the MCP servers you actually have installed against the CSA MCP Selection Scorecard — known-CVE cross-reference, typosquat detection, and a trust automaton that drops a server back to provisional on every version bump, the direct answer to a server that ships clean for months and then turns malicious.\n\nEvery run writes a per-run event trace — head selection, swarm attempts, SPRT samples with running confidence, agent-to-agent handoffs and file edits — which the TUI cockpit and the desktop app replay as a live timeline. Ships as a single static binary for macOS, Linux and Windows.",
       "webpageUrl": {
         "url": "https://hydra.uvansa.com/"
       },
       "repositoryUrl": {
         "url": "https://github.com/ankit373/hydra",
-        "wellKnown": "https://raw.githubusercontent.com/ankit373/hydra/main/.well-known/funding-manifest-urls"
+        "wellKnown": "https://github.com/ankit373/hydra/blob/main/.well-known/funding-manifest-urls"
       },
       "licenses": ["spdx:MIT"],
-      "tags": ["ai", "llm", "cli", "developer-tools", "devops", "orchestration", "go"]
+      "tags": [
+        "artificial-intelligence",
+        "developer-tools",
+        "security",
+        "privacy",
+        "devops",
+        "software-engineering",
+        "llm",
+        "cli",
+        "mcp",
+        "go"
+      ]
     }
   ],
   "funding": {
@@ -32,7 +43,8 @@
       {
         "guid": "github-sponsors",
         "type": "payment-provider",
-        "description": "GitHub Sponsors, via Open Source Collective as fiscal host — being set up. Will cover Hydra and other Uvansa open-source projects (e.g. Mainspring) as separate projects under one collective."
+        "address": "https://github.com/sponsors/ankit373",
+        "description": "GitHub Sponsors — one-time or recurring, covering Hydra and the other Uvansa open-source projects."
       },
       {
         "guid": "open-collective",
@@ -45,11 +57,11 @@
         "guid": "sponsor-hydra",
         "status": "active",
         "name": "Sponsor Hydra development",
-        "description": "Recurring or one-time support for Hydra's development — the routing engine, trust control plane, and desktop app.",
+        "description": "Recurring or one-time support for Hydra's development — the routing engine, trust control plane, security posture and MCP trust registry, and the desktop app.",
         "amount": 0,
         "currency": "USD",
         "frequency": "monthly",
-        "channels": ["github-sponsors", "open-collective"]
+        "channels": ["github-sponsors"]
       }
     ]
   }


### PR DESCRIPTION
## Summary

`docs/funding.json` never validated, so it was not listable in the FLOSS/fund directory.
Two hard failures, found by running the reference validator
(`github.com/floss-fund/go-funding-json` — the library behind https://dir.floss.fund/validate)
against the live manifest.

**1. `version` was missing its `v` prefix**

```
INVALID: major version should be v1 (current version is v1.0.0)
```

`schemas/v1/schema.go` validates with `semver.Major(m.Version) != MajorVersion`, and
`golang.org/x/mod/semver` returns `""` for any string without a leading `v`. `"1.0.0"`
could therefore never match `v1`. → `"v1.0.0"`.

**2. `repositoryUrl.wellKnown` was on the wrong host**

```
INVALID: projects[hydra].repositoryUrl.url and `projects[hydra].repositoryUrl.wellKnown` hostnames do not match
```

It pointed at `raw.githubusercontent.com` while `repositoryUrl` is `github.com`;
`common.WellKnownURL` requires `wellKnown.Host == target.Host`. The crawler already
rewrites `github.com/<user>/<repo>/blob/<branch>/.well-known/funding-manifest-urls`
to raw content itself (`TransformURLOrigin` appends `?raw=true`), so the `/blob/` form
is the supported spelling — and it is what the spec's own example uses.

## Also in this PR

The entry described routing and cost only. Refreshed so it matches what ships:
confidence routing (SPRT + calibration), the `hyctl security` posture report
(hash-chained tamper-evident ledger, correlated incidents, OWASP LLM Top-10, risk
register crosswalked to NIST AI RMF / ISO 42001 / MITRE ATLAS), the `hyctl mcp registry`
CSA-scorecard trust registry, and the per-run event trace the TUI and desktop app replay.

Retagged against floss.fund's own tag list — `ai` → `artificial-intelligence`, and
`security` / `privacy` / `mcp` added — 10 tags, the schema maximum.

GitHub Sponsors is live (`https://github.com/sponsors/ankit373` resolves), so that
channel gets its `address` and loses the "being set up" copy. `opencollective.com/hyctl`
still 404s, so it leaves the active plan — it stays declared as a channel, honestly
marked not-yet-created, but no longer advertises a payment route that fails.

## Verification

```
$ vh docs/funding.json
GET https://github.com/ankit373/hydra/blob/main/.well-known/funding-manifest-urls?raw=true -> 200: OK
VALID

$ python -c "jsonschema.validate(manifest, schema_v1_1_0)"
JSON SCHEMA v1.1.0: VALID
```

Both the reference validator (including the live `.well-known` provenance fetch, which
requires the manifest URL to appear as an exact line in the file) and the published
JSON Schema v1.1.0.

No `.well-known` file needed for the site URLs: the manifest sits at the domain root,
so `isWellKnownRequired` returns false for every `hydra.uvansa.com` URL in the manifest.

Closes #633