### PR TITLE
test(desktop): assert enum values match Go, not just field names

### DIFF
--- a/desktop/api/typesparity_test.go
+++ b/desktop/api/typesparity_test.go
@@ -142,3 +142,78 @@ func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
 		})
 	}
 }
+
+// The tests above guard field *names*. They say nothing about the *values* a
+// string enum carries, and a value is just as load-bearing: the Audit view
+// looked two checks up by names internal/security never emitted, and both
+// cards silently never rendered (#634). Those were free strings rather than a
+// declared union, but a union can drift the same way — a TypeScript union is
+// only a compile-time promise about the frontend, never a claim about Go.
+//
+// So: every union in types.ts that mirrors a Go string type must hold exactly
+// that type's values.
+
+var tsUnionRE = func(name string) *regexp.Regexp {
+	return regexp.MustCompile(`export type ` + regexp.QuoteMeta(name) + ` =([^\n]+)`)
+}
+
+// tsUnionValues returns the quoted members of a TypeScript string union.
+func tsUnionValues(t *testing.T, src, name string) map[string]bool {
+	t.Helper()
+	m := tsUnionRE(name).FindStringSubmatch(src)
+	if m == nil {
+		t.Fatalf("types.ts declares no union %q", name)
+	}
+	out := map[string]bool{}
+	for _, q := range regexp.MustCompile(`'([^']+)'`).FindAllStringSubmatch(m[1], -1) {
+		out[q[1]] = true
+	}
+	return out
+}
+
+func TestTypesTS_UnionValuesMatchGo(t *testing.T) {
+	src := readTypesTS(t)
+
+	for _, c := range []struct {
+		union  string
+		goVals []string
+	}{
+		{"Verdict", []string{
+			string(security.VerdictActNow),
+			string(security.VerdictAttention),
+			string(security.VerdictOK),
+		}},
+		{"Severity", []string{
+			string(security.SeverityCritical),
+			string(security.SeverityHigh),
+			string(security.SeverityMedium),
+			string(security.SeverityLow),
+		}},
+		{"CoverageStatus", []string{
+			string(security.Enforced),
+			string(security.Configured),
+			string(security.Gap),
+			string(security.NotApplicable),
+		}},
+		{"ActionPriority", []string{
+			string(security.PriorityNow),
+			string(security.PrioritySoon),
+			string(security.PriorityWatch),
+		}},
+	} {
+		t.Run(c.union, func(t *testing.T) {
+			ts := tsUnionValues(t, src, c.union)
+			for _, v := range c.goVals {
+				if !ts[v] {
+					t.Errorf("Go emits %s %q but types.ts does not list it — "+
+						"a value the view can receive and never match", c.union, v)
+				}
+				delete(ts, v)
+			}
+			for extra := range ts {
+				t.Errorf("types.ts lists %s %q, which Go never emits — "+
+					"any branch on it is unreachable", c.union, extra)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follows #635, which found the bug this generalises.

## The gap

`typesparity_test.go` guards field **names** across the bridge. Nothing guarded
a string enum's **values**.

#634 is the proof that matters: the Audit view looked two checks up by names
`internal/security` never emits, and both hero cards silently never rendered on
any build. Those were free strings rather than a declared union — but a union
drifts identically, because **a TypeScript union is a compile-time promise about
the frontend, never a claim about Go**. This typechecks perfectly:

```ts
export type Verdict = 'act now' | 'attention' | 'fine'
```

…while `'fine'` is unreachable and the real `'ok'` never matches anything.

## What ships

`TestTypesTS_UnionValuesMatchGo` asserts set equality for the four unions that
mirror Go string types — `Verdict`, `Severity`, `CoverageStatus`,
`ActionPriority` — reporting the two drift directions separately, since they
fail differently:

```
Go emits Verdict "ok" but types.ts does not list it — a value the view can
receive and never match
types.ts lists Verdict "fine", which Go never emits — any branch on it is
unreachable
```

Expected values are read from the Go constants (`security.VerdictActNow`, …),
not restated, so the test cannot drift independently of the thing it guards.

**All four match today.** I checked each against its Go constants by hand
first; this converts that into something CI states rather than something
someone re-checks after the next rename.

## Verification

- `gofmt`, `go vet` and `desktop/api` clean
- **Proved load-bearing both ways** by renaming a `Verdict` member: the test
  reports the missing Go value *and* the unreachable TS value, in the two
  distinct messages above

I also swept the rest of the frontend's cross-bridge string comparisons while I
was here — runlog kinds (`run_started`, `task_started`, `error`, `sample`,
`attempt`), tree agent states (`pending`, `running`, `ok`, `failed`), the
budget modes (`critical`, `emergency`) and the `n/a` coverage sentinel. All
correct. `'artifact'` looked suspicious but is frontend-derived in `stateClass`,
not a backend value. #634 was the only dead one.

Closes #637