### PR TITLE
feat(tui): parallel task threads with worktree isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,19 @@ Chat has **modes** — what a task does (`shift+tab` cycles the basics, `m` open
 
 Where a task runs is separate: `ctrl+o` overrides the **next** task's routing (auto / force tier / local only / best of 3 / consensus check at 90–99.9%). After an edit: `d` shows the diff, `x` restores the pre-task snapshot exactly, `o` opens the file, and the footer's trace id jumps into the activity view.
 
+Chat runs **parallel threads** — several tasks at once, safely:
+
+| Key | What it does |
+|---|---|
+| `ctrl+t` | New thread (a chip strip appears under the header: `⠸` running · `●` needs you · `✓` done · `◱` queued) |
+| `alt+1–9` | Jump to that thread; `ctrl+←/→` cycles them; the input bar labels its target (`→ thread 2`) |
+| `ctrl+\` | Split: pin a second thread beside the active one (needs ≥100 cols); `ctrl+←/→` moves focus, each side scrolls on its own |
+| `ctrl+b` | Background the thread into the **agents** view — it keeps running and pings chat (`hydra ▸`) when it finishes or needs you |
+| `ctrl+g` | Jump to the next thread needing input (plan gates, confirms, failures); the status bar counts `⠸ running · ● needs you · ◱ queued` |
+| `a` / `x x` | Apply an isolated thread's worktree back to your tree / discard it (twice — it deletes the thread's edits) |
+
+**Isolation**: read-only work shares your checkout; each edit-capable thread gets its own git worktree (`~/.hydra/worktrees/tN-…`, branch `hydra/task-tN-…`) cut from your repo — the header shows `worktree tN-… · merges on apply`. `a` merges it back with standard git: clean applies stage the diff; a divergence leaves ordinary `<<<<<<<` conflict markers (the branch is kept until you resolve); and **unsaved** edits of your own to a file the thread touched block the merge before it starts — nothing half-lands, and work that exists only in your editor is never merged over. Two threads editing the same (or graph-coupled) files never race: the second queues visibly (`◱ queued behind 1 · both touch <path>`) and auto-starts when the first applies or discards. Outside a git repo the TUI says so and runs edits one at a time, in place. Worktrees left behind by a crash are listed at startup, never auto-deleted. Terminal note: `alt+1–9` needs the option/alt key sending ESC (iTerm2: "Esc+"; Terminal.app: "Use Option as Meta key"), and `ctrl+b` is tmux's default prefix — rebind tmux or press `ctrl+b ctrl+b`.
+
 Everything shown is measured from the machine's real logs — a figure that cannot be computed renders `—`, never an invented number. Lists scroll (`j/k`, `pgup/pgdn`, mouse wheel); `hyctl tui --snapshot [--view 0..5]` prints static frames for docs and bug reports.
 
 ---

--- a/internal/editor/edit_test.go
+++ b/internal/editor/edit_test.go
@@ -280,6 +280,55 @@ func TestEdit_RefusesBeforeDispatching(t *testing.T) {
 	}
 }
 
+// Root scopes an edit to a Hydra-managed worktree that lives outside every
+// registered workspace (#598) — accepted under the root, still refused for
+// denied globs and for paths outside it.
+func TestEdit_RootScopesAHydraWorktree(t *testing.T) {
+	editSandbox(t, marked("package wt"))
+	wt := t.TempDir() // stands in for ~/.hydra/worktrees/t1-xxxx
+
+	file := filepath.Join(wt, "a.go")
+	if err := os.WriteFile(file, []byte("package old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "x", Root: wt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "ok" || res.Workspace != "hydra-worktree" {
+		t.Fatalf("rooted edit: status=%q ws=%q err=%q", res.Status, res.Workspace, res.Error)
+	}
+	if raw, _ := os.ReadFile(file); string(raw) != "package wt\n" {
+		t.Errorf("the rooted edit did not land: %q", raw)
+	}
+
+	env := filepath.Join(wt, ".env")
+	if err := os.WriteFile(env, []byte("SECRET=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	res, err = Edit(context.Background(), Request{File: env, Enum: "MODERATE", Prompt: "x", Root: wt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" || !strings.Contains(res.Error, "scope_rejected") {
+		t.Errorf("a denied glob under Root was not refused: %+v", res)
+	}
+
+	outside := filepath.Join(t.TempDir(), "b.go")
+	if err := os.WriteFile(outside, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = Edit(context.Background(), Request{File: outside, Enum: "MODERATE", Prompt: "x", Root: wt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" || !strings.Contains(res.Error, "scope_rejected") {
+		t.Errorf("a file outside Root was not refused: %+v", res)
+	}
+}
+
 // A validator that rejects the edit rolls the file back. An edit that fails
 // validation and stays on disk is worse than no edit at all.
 func TestEdit_FailedValidationRollsBack(t *testing.T) {

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -43,6 +43,11 @@ type Request struct {
 	// LocalOnly forces the inner dispatch onto local heads — how a caller's
 	// "nothing leaves this machine" override reaches an edit (#597).
 	LocalOnly bool
+
+	// Root, when set, scope-checks File against this directory instead of the
+	// workspace registry — for Hydra-managed git worktrees, which live outside
+	// every registered root by design (#598). The default deny globs still apply.
+	Root string
 }
 
 // Result is the JSON output emitted by Edit.
@@ -76,11 +81,19 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 	if err != nil {
 		return failResult(req, "", "", "workspace registry load failed: "+err.Error()), nil
 	}
-	wsName, err := reg.Check(req.File)
+	var wsName string
+	var resolved workspace.Resolved
+	if req.Root != "" {
+		wsName, err = workspace.CheckRooted(req.Root, req.File)
+		resolved = workspace.Resolved{Workspace: wsName, Root: req.Root, Git: "auto",
+			GitRoot: workspace.GitRoot(req.File)}
+	} else {
+		wsName, err = reg.Check(req.File)
+		resolved, _ = reg.Resolve(req.File)
+	}
 	if err != nil {
 		return failResult(req, "", "", "scope_rejected: "+err.Error()), nil
 	}
-	resolved, _ := reg.Resolve(req.File)
 
 	// ── Snapshot ──────────────────────────────────────────────────────────────
 	origContent, origExisted := readFile(req.File)

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -178,6 +178,42 @@ func (g *Graph) DependentCount(nodeID string) int {
 	return len(g.transitiveDependents([]string{nodeID}))
 }
 
+// Coupled reports whether two files are graph-coupled: a node of one
+// transitively depends on a node of the other, in either direction. Unindexed
+// files read as uncoupled — no graph evidence, no fabricated verdict (#598).
+func (g *Graph) Coupled(fileA, fileB string) bool {
+	if g == nil {
+		return false
+	}
+	sa, sb := g.seedsForFile(fileA), g.seedsForFile(fileB)
+	if len(sa) == 0 || len(sb) == 0 {
+		return false
+	}
+	// Shared seeds mean the same node (package-granularity graphs): coupled.
+	inA := make(map[string]bool, len(sa))
+	for _, s := range sa {
+		inA[s] = true
+	}
+	for _, s := range sb {
+		if inA[s] {
+			return true
+		}
+	}
+	depA := g.transitiveDependents(sa)
+	for _, s := range sb {
+		if depA[s] {
+			return true
+		}
+	}
+	depB := g.transitiveDependents(sb)
+	for _, s := range sa {
+		if depB[s] {
+			return true
+		}
+	}
+	return false
+}
+
 // DependentCountForFile returns the number of nodes that transitively depend
 // on any node declared in file, using the same seed set as BlastRadiusForFile.
 // Callers must use this instead of looping NodesInFile+DependentCount per

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -466,6 +466,36 @@ func TestPercolation_SubcriticalIsNeutral(t *testing.T) {
 	}
 }
 
+// Coupled is the queue-on-overlap gate's indirect-collision check (#598):
+// dependency in either direction couples, shared nodes couple, and an
+// unindexed file reads as uncoupled rather than inventing a verdict.
+func TestCoupled_EitherDirectionSharedNodeAndUnknown(t *testing.T) {
+	g := fromDoc(Doc{
+		Nodes: []Node{
+			{ID: "a", File: "a.go"}, {ID: "b", File: "b.go"},
+			{ID: "c", File: "c.go"}, {ID: "p", File: "pkg"},
+		},
+		Edges: []Edge{{From: "b", To: "a"}}, // b depends on a
+	})
+	if !g.Coupled("a.go", "b.go") || !g.Coupled("b.go", "a.go") {
+		t.Error("dependency coupling must hold in both directions")
+	}
+	if g.Coupled("a.go", "c.go") {
+		t.Error("unrelated files read as coupled")
+	}
+	// Package-granularity graphs seed two files onto the same node: coupled.
+	if !g.Coupled("pkg/x.go", "pkg/y.go") {
+		t.Error("files sharing a node read as uncoupled")
+	}
+	if g.Coupled("a.go", "never-indexed.go") {
+		t.Error("an unindexed file fabricated a coupling verdict")
+	}
+	var nilG *Graph
+	if nilG.Coupled("a.go", "b.go") {
+		t.Error("a nil graph fabricated a coupling verdict")
+	}
+}
+
 func TestLoad_RoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "graph.json")
 	data := `{"nodes":[{"id":"a","file":"a.go"},{"id":"b","file":"b.go"}],"edges":[{"from":"b","to":"a"}]}`

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -88,6 +88,9 @@ type CommandOracle struct {
 	Template string
 	// Source is the calibration key for this oracle, e.g. "verifier:go-test".
 	Source string
+	// Dir is the command's working directory; empty inherits the process CWD.
+	// Set when the verified change lives elsewhere, e.g. a task's git worktree.
+	Dir string
 	// writeTemp allows tests to stub file materialization; nil uses the real one.
 	writeTemp func(content string) (path string, cleanup func(), err error)
 }
@@ -116,6 +119,7 @@ func (o *CommandOracle) Verify(ctx context.Context, candidate string, _ trust.Ta
 		return Verdict{}, err
 	}
 	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	cmd.Dir = o.Dir
 	// Both streams share one bounded Accumulator, matching CombinedOutput's
 	// interleaving — but capped, unlike the bytes.Buffer it replaces.
 	out := util.NewAccumulator(outputCap)

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -26,6 +26,25 @@ func TestCommandOracle_PassFail(t *testing.T) {
 	}
 }
 
+// Dir must run the verifier in that directory — an isolated worktree's tests
+// must check the worktree's copy, not whatever the process CWD holds (#598).
+func TestCommandOracle_DirSetsTheWorkingDirectory(t *testing.T) {
+	ctx := context.Background()
+	mod := t.TempDir()
+	if err := os.WriteFile(filepath.Join(mod, "go.mod"), []byte("module oracledir\n\ngo 1.21\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// `go mod verify` exits 0 only inside a module — a portable dir-sensitive probe.
+	in := &CommandOracle{Template: "go mod verify", Dir: mod}
+	if v, err := in.Verify(ctx, "", trust.Task{}); err != nil || !v.Passed {
+		t.Errorf("inside the module: v=%+v err=%v", v, err)
+	}
+	out := &CommandOracle{Template: "go mod verify", Dir: t.TempDir()}
+	if v, err := out.Verify(ctx, "", trust.Task{}); err != nil || v.Passed {
+		t.Errorf("outside a module should fail, not error: v=%+v err=%v", v, err)
+	}
+}
+
 // {file} must be substituted with a real path holding the candidate content,
 // without fragmenting on spaces.
 func TestCommandOracle_FileSubstitution(t *testing.T) {

--- a/internal/tui/chat_exec.go
+++ b/internal/tui/chat_exec.go
@@ -58,7 +58,11 @@ type ckVerifyRound struct {
 type ckTask struct {
 	prompt      string
 	mode        ckModeDef
-	file        string // absolute path of the named existing file; "" = none
+	file        string // absolute path being edited — inside the worktree when isolated
+	rel         string // repo-relative display path; "" when outside the repo
+	root        string // editor scope-root override: the thread's worktree dir
+	dir         string // verify working directory; "" = the process CWD
+	threadID    int    // the owning thread — tea.Cmd results route back by this
 	runID       string
 	taskID      string
 	answerTier  string
@@ -233,19 +237,21 @@ func ckRealDispatchStage(ctx context.Context, t *ckTask, prompt, tierHint string
 }
 
 // ckRealEditStage runs the editor path: scoped, validated, rollback-safe, with
-// the runlog KindEdit snapshot the d/x keys read back.
+// the runlog KindEdit snapshot the d/x keys read back. Root carries a worktree
+// thread's scope override — its files live outside every registered workspace.
 func ckRealEditStage(ctx context.Context, t *ckTask, prompt string) (*editor.Result, error) {
 	return editor.Edit(ctx, editor.Request{
 		File: t.file, Enum: t.editEnum, Prompt: prompt, Validate: true,
-		RunID: t.runID, TaskID: t.taskID, LocalOnly: t.localOnly,
+		RunID: t.runID, TaskID: t.taskID, LocalOnly: t.localOnly, Root: t.root,
 	})
 }
 
 // ckRealVerifyStage runs the workspace's verify command through the oracle.
 // argv carries no placeholders — the file argument was substituted with the
-// real on-disk path, which is what is being verified.
-func ckRealVerifyStage(ctx context.Context, argv []string) (oracle.Verdict, error) {
-	o := &oracle.CommandOracle{Args: argv, Source: "verifier:tui"}
+// real on-disk path, which is what is being verified. dir is the worktree for
+// isolated threads, so the verifier checks the thread's copy, not the user's.
+func ckRealVerifyStage(ctx context.Context, argv []string, dir string) (oracle.Verdict, error) {
+	o := &oracle.CommandOracle{Args: argv, Source: "verifier:tui", Dir: dir}
 	return o.Verify(ctx, "", trust.Task{})
 }
 
@@ -413,7 +419,7 @@ func ckEditAndVerify(ctx context.Context, ex *ckExecState, t *ckTask) byte {
 
 	for {
 		ex.setStage("verifying — " + t.verifyLabel)
-		v, verr := ckVerifyStage(ctx, t.verifyArgv)
+		v, verr := ckVerifyStage(ctx, t.verifyArgv, t.dir)
 		if verr != nil {
 			t.verifyErr = verr.Error()
 			return 0

--- a/internal/tui/chat_exec_test.go
+++ b/internal/tui/chat_exec_test.go
@@ -38,7 +38,7 @@ func stubExec(t *testing.T) {
 		t.Fatal("ckEditStage used without a stub")
 		return nil, nil
 	}
-	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+	ckVerifyStage = func(context.Context, []string, string) (oracle.Verdict, error) {
 		t.Fatal("ckVerifyStage used without a stub")
 		return oracle.Verdict{}, nil
 	}
@@ -139,10 +139,10 @@ func TestExec_AskAnswersAccruesCostAndLinksTrace(t *testing.T) {
 
 	m := chatFixture("ask")
 	m, cmd := enter(typed(m, "explain the users endpoint"))
-	if m.exec == nil || cmd == nil {
+	if m.th().exec == nil || cmd == nil {
 		t.Fatal("submitting did not start a task")
 	}
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "auto-routed") || !strings.Contains(joined, "single") {
 		t.Errorf("no route line before execution:\n%s", joined)
 	}
@@ -151,10 +151,10 @@ func TestExec_AskAnswersAccruesCostAndLinksTrace(t *testing.T) {
 	}
 
 	m = runCmds(t, m, cmd)
-	if m.exec != nil {
+	if m.th().exec != nil {
 		t.Fatal("exec still set after completion")
 	}
-	joined = stripANSI(strings.Join(m.log, "\n"))
+	joined = stripANSI(strings.Join(m.th().log, "\n"))
 	for _, want := range []string{"goroutines are cheap", "use them", "✓ done", "$0.0100", "trace"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("result is missing %q:\n%s", want, joined)
@@ -163,7 +163,7 @@ func TestExec_AskAnswersAccruesCostAndLinksTrace(t *testing.T) {
 	if m.sessionUSD != 0.01 {
 		t.Errorf("sessionUSD = %v, want 0.01", m.sessionUSD)
 	}
-	if m.lastDone == nil || m.lastDone.answer == "" {
+	if m.th().lastDone == nil || m.th().lastDone.answer == "" {
 		t.Fatal("lastDone not recorded")
 	}
 
@@ -172,8 +172,8 @@ func TestExec_AskAnswersAccruesCostAndLinksTrace(t *testing.T) {
 	if m.view != ckViewActivity || !m.actDrill {
 		t.Fatalf("empty enter did not open the trace (view=%d drill=%v)", m.view, m.actDrill)
 	}
-	if got := m.activityRuns()[m.actSel].id; got != m.lastDone.runID {
-		t.Errorf("trace focused run %s, want %s", got, m.lastDone.runID)
+	if got := m.activityRuns()[m.actSel].id; got != m.th().lastDone.runID {
+		t.Errorf("trace focused run %s, want %s", got, m.th().lastDone.runID)
 	}
 }
 
@@ -187,7 +187,7 @@ func TestExec_FailureRendersErrorAndTrace(t *testing.T) {
 	m := chatFixture("ask")
 	m, cmd := enter(typed(m, "explain this"))
 	m = runCmds(t, m, cmd)
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "✗ failed") || !strings.Contains(joined, "no heads answered") {
 		t.Errorf("failure not rendered:\n%s", joined)
 	}
@@ -207,21 +207,21 @@ func TestExec_EscCancelsRunningTask(t *testing.T) {
 	}
 	m := chatFixture("ask")
 	m, cmd := enter(typed(m, "explain this"))
-	if m.exec == nil {
+	if m.th().exec == nil {
 		t.Fatal("no task started")
 	}
 	m = press(m, tea.KeyEsc) // cancel — exec stays until the worker reports back
-	if m.exec == nil {
+	if m.th().exec == nil {
 		t.Fatal("esc cleared exec before the worker returned")
 	}
-	if got := m.exec.Stage(); !strings.Contains(got, "cancelling") {
+	if got := m.th().exec.Stage(); !strings.Contains(got, "cancelling") {
 		t.Errorf("stage = %q after esc", got)
 	}
 	m = runCmds(t, m, cmd)
-	if m.exec != nil {
+	if m.th().exec != nil {
 		t.Fatal("exec still set after the cancelled worker returned")
 	}
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "✗ cancelled") {
 		t.Errorf("cancellation not rendered:\n%s", joined)
 	}
@@ -240,18 +240,18 @@ func TestExec_SubmitWhileRunningRefusesAndKeepsInput(t *testing.T) {
 	m, _ = enter(typed(m, "first task"))
 	m = typed(m, "second task")
 	m, _ = enter(m)
-	if m.input != "second task" {
-		t.Errorf("the queued text was lost: %q", m.input)
+	if m.th().input != "second task" {
+		t.Errorf("the queued text was lost: %q", m.th().input)
 	}
 	if m.flash == "" {
 		t.Error("no explanation for the refusal")
 	}
 	// esc with text clears the text; the task keeps running.
 	m = press(m, tea.KeyEsc)
-	if m.input != "" {
-		t.Errorf("esc did not clear the input: %q", m.input)
+	if m.th().input != "" {
+		t.Errorf("esc did not clear the input: %q", m.th().input)
 	}
-	if got := m.exec.Stage(); strings.Contains(got, "cancelling") {
+	if got := m.th().exec.Stage(); strings.Contains(got, "cancelling") {
 		t.Error("esc cancelled the task while clearing typed input")
 	}
 }
@@ -269,7 +269,7 @@ func TestExec_PIIForcesLocalBadgeAndOption(t *testing.T) {
 	m := chatFixture("ask")
 	m.piiLocal = true
 	m, cmd := enter(typed(m, "email bob@example.com the users report"))
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "local-only (pii)") {
 		t.Errorf("no local-only badge on a PII prompt:\n%s", joined)
 	}
@@ -283,7 +283,7 @@ func TestExec_PIIForcesLocalBadgeAndOption(t *testing.T) {
 	// Without the config policy, the same prompt routes normally: no badge.
 	m2 := chatFixture("ask")
 	m2, _ = enter(typed(m2, "email bob@example.com the users report"))
-	if strings.Contains(stripANSI(strings.Join(m2.log, "\n")), "local-only (pii)") {
+	if strings.Contains(stripANSI(strings.Join(m2.th().log, "\n")), "local-only (pii)") {
 		t.Error("the badge showed with no local-only pii policy configured")
 	}
 }
@@ -307,7 +307,7 @@ func TestExec_EditModeEditsAndDXOWorkOffSnapshots(t *testing.T) {
 	if edits != 1 {
 		t.Fatalf("edit mode ran %d edits, want 1 (no plan step)", edits)
 	}
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	for _, want := range []string{"edit ✓ main.go +1/−1", "tests — skipped (edit mode)", "d diff · x undo · o open"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("proof strip missing %q:\n%s", want, joined)
@@ -317,21 +317,21 @@ func TestExec_EditModeEditsAndDXOWorkOffSnapshots(t *testing.T) {
 		t.Fatalf("the file was not written: %q", raw)
 	}
 	// The code panel streams the real new content — the fake snippets are gone.
-	if !strings.Contains(strings.Join(m.codeLines, "\n"), "var new = 2") {
-		t.Errorf("the code panel does not hold the edited content: %v", m.codeLines)
+	if !strings.Contains(strings.Join(m.th().codeLines, "\n"), "var new = 2") {
+		t.Errorf("the code panel does not hold the edited content: %v", m.th().codeLines)
 	}
 
 	// d: diff on, from the snapshots; d again: back to the file.
 	m, _ = keyRune(m, 'd')
-	if !m.codeDiff {
+	if !m.th().codeDiff {
 		t.Fatal("d did not open the diff")
 	}
-	diffText := strings.Join(m.codeLines, "\n")
+	diffText := strings.Join(m.th().codeLines, "\n")
 	if !strings.Contains(diffText, "-var old = 1") || !strings.Contains(diffText, "+var new = 2") {
 		t.Errorf("the diff does not show the change:\n%s", diffText)
 	}
 	m, _ = keyRune(m, 'd')
-	if m.codeDiff {
+	if m.th().codeDiff {
 		t.Fatal("d did not toggle the diff off")
 	}
 
@@ -365,15 +365,15 @@ func TestExec_EditModeEditsAndDXOWorkOffSnapshots(t *testing.T) {
 func TestExec_DXOTypeWhenNothingToActOn(t *testing.T) {
 	m := testCockpit()
 	m = typed(m, "d")
-	if m.input != "d" || m.codeDiff {
-		t.Errorf("d with no last edit did not type: input=%q", m.input)
+	if m.th().input != "d" || m.th().codeDiff {
+		t.Errorf("d with no last edit did not type: input=%q", m.th().input)
 	}
-	m.input = ""
+	m.th().input = ""
 	ans := chatFixture("ask")
-	ans.lastDone = &ckTask{answer: "text only"} // finished, but nothing edited
+	ans.th().lastDone = &ckTask{answer: "text only"} // finished, but nothing edited
 	ans = typed(ans, "x")
-	if ans.input != "x" {
-		t.Errorf("x with an answer-only result did not type: %q", ans.input)
+	if ans.th().input != "x" {
+		t.Errorf("x with an answer-only result did not type: %q", ans.th().input)
 	}
 }
 
@@ -384,7 +384,7 @@ func TestExec_EditModeWithoutFileAnswersWithNote(t *testing.T) {
 	m := chatFixture("edit")
 	m, cmd := enter(typed(m, "rename the variable"))
 	m = runCmds(t, m, cmd)
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "no file named — answered instead") {
 		t.Errorf("the no-file note is missing:\n%s", joined)
 	}
@@ -402,7 +402,7 @@ func TestExec_PlanApproveRunsTheRest(t *testing.T) {
 	ckDispatchStage = stubAnswer("1. read the file\n2. change it", 0)
 	ckEditStage = stubEdit("package main\n", "package main // edited\n")
 	verifies := 0
-	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+	ckVerifyStage = func(context.Context, []string, string) (oracle.Verdict, error) {
 		verifies++
 		return oracle.Verdict{Passed: true}, nil
 	}
@@ -410,23 +410,23 @@ func TestExec_PlanApproveRunsTheRest(t *testing.T) {
 	m := chatFixture("plan")
 	m, cmd := enter(typed(m, "add a comment to "+rel))
 	m = runCmds(t, m, cmd)
-	if m.planWait == nil {
+	if m.th().planWait == nil {
 		t.Fatal("no plan approval gate")
 	}
-	if m.exec != nil {
+	if m.th().exec != nil {
 		t.Fatal("exec still set while waiting on approval")
 	}
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "PLAN — 2 steps") || !strings.Contains(joined, "1. read the file") {
 		t.Errorf("the plan is not rendered:\n%s", joined)
 	}
 
 	m, cmd = enter(m) // approve
-	if m.planWait != nil || m.exec == nil {
+	if m.th().planWait != nil || m.th().exec == nil {
 		t.Fatal("approval did not resume the pipeline")
 	}
 	m = runCmds(t, m, cmd)
-	joined = stripANSI(strings.Join(m.log, "\n"))
+	joined = stripANSI(strings.Join(m.th().log, "\n"))
 	for _, want := range []string{"plan ✓ 2 steps", "edit ✓ main.go", "tests ✓ go test ./..."} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("proof strip missing %q:\n%s", want, joined)
@@ -445,15 +445,15 @@ func TestExec_PlanApplyKeyApproves(t *testing.T) {
 	m := chatFixture("plan")
 	m, cmd := enter(typed(m, "outline a users endpoint"))
 	m = runCmds(t, m, cmd)
-	if m.planWait == nil {
+	if m.th().planWait == nil {
 		t.Fatal("no plan gate")
 	}
 	m, cmd = keyRune(m, 'a')
-	if m.planWait != nil || m.exec == nil {
+	if m.th().planWait != nil || m.th().exec == nil {
 		t.Fatal("a did not approve the plan")
 	}
 	m = runCmds(t, m, cmd)
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "✓ done") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "✓ done") {
 		t.Error("the approved plan did not finish")
 	}
 }
@@ -468,21 +468,21 @@ func TestExec_PlanDiscardRunsNothing(t *testing.T) {
 	m := chatFixture("plan")
 	m, cmd := enter(typed(m, "rewrite "+rel))
 	m = runCmds(t, m, cmd)
-	if m.planWait == nil {
+	if m.th().planWait == nil {
 		t.Fatal("no plan gate")
 	}
 	m = press(m, tea.KeyEsc)
-	if m.planWait != nil {
+	if m.th().planWait != nil {
 		t.Fatal("esc did not discard the plan")
 	}
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "plan discarded — nothing ran") || !strings.Contains(joined, "◼ stopped") {
 		t.Errorf("the discard is not disclosed:\n%s", joined)
 	}
 	if raw, _ := os.ReadFile(abs); string(raw) != "package main\n" {
 		t.Error("discarding a plan changed the file")
 	}
-	if m.lastDone == nil || !m.lastDone.stopped {
+	if m.th().lastDone == nil || !m.th().lastDone.stopped {
 		t.Error("the discarded task did not settle as stopped")
 	}
 }
@@ -504,7 +504,7 @@ func TestExec_AutoVerifyLoopFixesThenPasses(t *testing.T) {
 		return stubEdit("package main\n", "package main // v"+fmt.Sprint(edits)+"\n")(ctx, tk, prompt)
 	}
 	verifies := 0
-	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+	ckVerifyStage = func(context.Context, []string, string) (oracle.Verdict, error) {
 		verifies++
 		if verifies == 1 {
 			return oracle.Verdict{Passed: false, Detail: "TestBoom failed"}, nil
@@ -521,13 +521,13 @@ func TestExec_AutoVerifyLoopFixesThenPasses(t *testing.T) {
 	if !strings.Contains(fixPrompt, "TestBoom failed") {
 		t.Errorf("the fix re-dispatch does not carry the failure output:\n%s", fixPrompt)
 	}
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "tests ✓ go test ./... (after 1 fix)") {
 		t.Errorf("the strip does not credit the fix loop:\n%s", joined)
 	}
 	// The task's diff spans first-before → last-after, collapsing the fix hops.
 	m, _ = keyRune(m, 'd')
-	diffText := strings.Join(m.codeLines, "\n")
+	diffText := strings.Join(m.th().codeLines, "\n")
 	if !strings.Contains(diffText, "+package main // v2") {
 		t.Errorf("the diff does not end at the final content:\n%s", diffText)
 	}
@@ -544,7 +544,7 @@ func TestExec_AutoVerifyLoopCapsAtTwoFixes(t *testing.T) {
 		return stubEdit("package main\n", "package main // still wrong\n")(ctx, tk, prompt)
 	}
 	verifies := 0
-	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+	ckVerifyStage = func(context.Context, []string, string) (oracle.Verdict, error) {
 		verifies++
 		return oracle.Verdict{Passed: false, Detail: "still broken"}, nil
 	}
@@ -555,7 +555,7 @@ func TestExec_AutoVerifyLoopCapsAtTwoFixes(t *testing.T) {
 	if edits != 1+ckMaxFixes || verifies != 1+ckMaxFixes {
 		t.Fatalf("loop ran %d edits / %d verifies, want %d/%d", edits, verifies, 1+ckMaxFixes, 1+ckMaxFixes)
 	}
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "tests ✗") || !strings.Contains(joined, "after 2 fixes") {
 		t.Errorf("the capped failure is not disclosed:\n%s", joined)
 	}
@@ -582,7 +582,7 @@ func TestExec_AutoWithoutVerifierSaysSo(t *testing.T) {
 	// plan → answer, with the answer rendered.
 	m, cmd := enter(typed(m, "tidy the notes file"))
 	m = runCmds(t, m, cmd)
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "✓ done") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "✓ done") {
 		t.Error("auto without a file did not settle as an answer")
 	}
 	// And with a named .go file but no verifier anywhere: the strip says so.
@@ -604,7 +604,7 @@ func TestExec_CarefulConfirmsEveryWrite(t *testing.T) {
 		return stubEdit("package main\n", "package main // careful\n")(ctx, tk, prompt)
 	}
 	verifies := 0
-	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+	ckVerifyStage = func(context.Context, []string, string) (oracle.Verdict, error) {
 		verifies++
 		if verifies == 1 {
 			return oracle.Verdict{Passed: false, Detail: "not yet"}, nil
@@ -616,15 +616,15 @@ func TestExec_CarefulConfirmsEveryWrite(t *testing.T) {
 	m := chatFixture("careful")
 	m, cmd := enter(typed(m, "change "+rel))
 	m = runCmds(t, m, cmd)
-	if m.confirm == nil || !strings.Contains(m.confirm.question, "write main.go?") {
-		t.Fatalf("no write confirm: %+v", m.confirm)
+	if m.th().confirm == nil || !strings.Contains(m.th().confirm.question, "write main.go?") {
+		t.Fatalf("no write confirm: %+v", m.th().confirm)
 	}
 	m, cmd = keyRune(m, 'n')
 	m = runCmds(t, m, cmd)
 	if edits != 0 {
 		t.Fatal("n still wrote the file")
 	}
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "stopped before writing") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "stopped before writing") {
 		t.Error("the refusal is not disclosed")
 	}
 
@@ -634,22 +634,22 @@ func TestExec_CarefulConfirmsEveryWrite(t *testing.T) {
 	m = runCmds(t, m, cmd)
 	m, cmd = keyRune(m, 'y')
 	m = runCmds(t, m, cmd)
-	if m.confirm == nil || !strings.Contains(m.confirm.question, "fix 1/2") {
-		t.Fatalf("no fix confirm after a failing verify: %+v", m.confirm)
+	if m.th().confirm == nil || !strings.Contains(m.th().confirm.question, "fix 1/2") {
+		t.Fatalf("no fix confirm after a failing verify: %+v", m.th().confirm)
 	}
 	m, cmd = keyRune(m, 'y')
 	m = runCmds(t, m, cmd)
 	if edits != 2 || verifies != 2 {
 		t.Fatalf("confirmed flow ran %d edits / %d verifies, want 2/2", edits, verifies)
 	}
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "tests ✓") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "tests ✓") {
 		t.Error("the confirmed fix did not pass")
 	}
 
 	// esc at a fix gate: the landed edit stays, disclosed as declined.
 	m = chatFixture("careful")
 	verifies, edits = 0, 0
-	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+	ckVerifyStage = func(context.Context, []string, string) (oracle.Verdict, error) {
 		verifies++
 		return oracle.Verdict{Passed: false, Detail: "always red"}, nil
 	}
@@ -657,11 +657,11 @@ func TestExec_CarefulConfirmsEveryWrite(t *testing.T) {
 	m = runCmds(t, m, cmd)
 	m, cmd = keyRune(m, 'y')
 	m = runCmds(t, m, cmd)
-	if m.confirm == nil {
+	if m.th().confirm == nil {
 		t.Fatal("no fix gate")
 	}
 	m = press(m, tea.KeyEsc)
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "fix declined") || !strings.Contains(joined, "tests ✗") {
 		t.Errorf("the declined fix is not honest:\n%s", joined)
 	}
@@ -682,7 +682,7 @@ func TestExec_UnattendedStopsVisiblyAtTheCostCap(t *testing.T) {
 	m := chatFixture("unattended")
 	m, cmd := enter(typed(m, "refactor "+rel))
 	m = runCmds(t, m, cmd)
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "✗ failed") || !strings.Contains(joined, "cost cap $0.50 reached") {
 		t.Errorf("the cap stop is not visible:\n%s", joined)
 	}
@@ -719,7 +719,7 @@ func TestExec_OverrideWiresIntoTheNextDispatchOnly(t *testing.T) {
 	m = typed(m, "jj")
 	m, _ = enter(m)
 	m, cmd := enter(typed(m, "explain the endpoint"))
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "local only") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "local only") {
 		t.Error("the route line does not show the local-only override")
 	}
 	m = runCmds(t, m, cmd)
@@ -737,7 +737,7 @@ func TestExec_OverrideWiresIntoTheNextDispatchOnly(t *testing.T) {
 	m, _ = enter(m)
 	m = typed(m, "3")
 	m, cmd = enter(typed(m, "explain the endpoint"))
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "forced") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "forced") {
 		t.Error("the route line does not show the forced tier")
 	}
 	m = runCmds(t, m, cmd)
@@ -763,14 +763,14 @@ func TestExec_OverrideWiresIntoTheNextDispatchOnly(t *testing.T) {
 	m, _ = enter(m)
 	m = typed(m, "2") // ≥95%
 	m, cmd = enter(typed(m, "is this migration safe?"))
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "consensus ≥95%") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "consensus ≥95%") {
 		t.Error("the route line does not show the consensus strategy")
 	}
 	m = runCmds(t, m, cmd)
 	if strat != 'C' || seen.confidence != 0.95 {
 		t.Errorf("consensus not wired: strat=%q conf=%v", strat, seen.confidence)
 	}
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "confidence 97%") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "confidence 97%") {
 		t.Error("the achieved confidence is not in the footer")
 	}
 }
@@ -786,7 +786,7 @@ func TestExec_OverrideFanoutFallsBackToSingleForEdits(t *testing.T) {
 		return ckStageOut{output: "1. plan", head: "h", tier: 8}, nil
 	}
 	ckEditStage = stubEdit("package main\n", "package main // x\n")
-	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+	ckVerifyStage = func(context.Context, []string, string) (oracle.Verdict, error) {
 		return oracle.Verdict{Passed: true}, nil
 	}
 
@@ -795,7 +795,7 @@ func TestExec_OverrideFanoutFallsBackToSingleForEdits(t *testing.T) {
 	m = typed(m, "jjj") // best of 3
 	m, _ = enter(m)
 	m, cmd := enter(typed(m, "improve "+rel))
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "edits can't fan out") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "edits can't fan out") {
 		t.Error("the single fallback is not disclosed on the route line")
 	}
 	m = runCmds(t, m, cmd)
@@ -821,7 +821,7 @@ func TestExec_ArchitectSplitsPlanAndImplementTiers(t *testing.T) {
 		editTask = tk
 		return stubEdit("package main\n", "package main // built\n")(ctx, tk, prompt)
 	}
-	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+	ckVerifyStage = func(context.Context, []string, string) (oracle.Verdict, error) {
 		return oracle.Verdict{Passed: true}, nil
 	}
 
@@ -834,7 +834,7 @@ func TestExec_ArchitectSplitsPlanAndImplementTiers(t *testing.T) {
 	if editTask == nil || editTask.editEnum != "SIMPLE" {
 		t.Errorf("the implement half is not on the cheap tier: %+v", editTask)
 	}
-	if !strings.Contains(stripANSI(strings.Join(m.log, "\n")), "tests ✓") {
+	if !strings.Contains(stripANSI(strings.Join(m.th().log, "\n")), "tests ✓") {
 		t.Error("architect did not verify")
 	}
 }
@@ -844,15 +844,15 @@ func TestExec_ArchitectSplitsPlanAndImplementTiers(t *testing.T) {
 func TestExec_StaleWorkerMessagesAreIgnored(t *testing.T) {
 	m := testCockpit()
 	ghost := &ckExecState{}
-	before := len(m.log)
+	before := len(m.th().log)
 	next, _ := m.Update(ckExecDoneMsg{exec: ghost, task: ckTask{answer: "ghost"}})
 	m = next.(Cockpit)
-	if len(m.log) != before || m.lastDone != nil {
+	if len(m.th().log) != before || m.th().lastDone != nil {
 		t.Error("a stale done message landed")
 	}
 	next, _ = m.Update(ckGateMsg{exec: ghost, task: ckTask{}, gate: 'p'})
 	m = next.(Cockpit)
-	if m.planWait != nil {
+	if m.th().planWait != nil {
 		t.Error("a stale gate message landed")
 	}
 	// A stale spin tick schedules nothing.
@@ -1045,33 +1045,33 @@ func TestChatStates_LayoutInvariantsAtEverySize(t *testing.T) {
 
 	states := map[string]func(Cockpit) Cockpit{
 		"running": func(m Cockpit) Cockpit {
-			m.exec = &ckExecState{stage: "verifying — go test ./... with a very long stage line " + long[:200], started: time.Now()}
+			m.th().exec = &ckExecState{stage: "verifying — go test ./... with a very long stage line " + long[:200], started: time.Now()}
 			return m
 		},
 		"plan_pending": func(m Cockpit) Cockpit {
 			t := ckTask{plan: "1. first\n2. second\n3. " + long, planSteps: 3, headName: "stub"}
-			m.log = append(m.log, ckPlanLines(t)...)
-			m.planWait = &ckWait{task: t, phase: ckPhaseTail}
+			m.th().log = append(m.th().log, ckPlanLines(t)...)
+			m.th().planWait = &ckWait{task: t, phase: ckPhaseTail}
 			return m
 		},
 		"confirm": func(m Cockpit) Cockpit {
-			m.confirm = &ckWait{question: "write " + long[:120] + "? y/n"}
+			m.th().confirm = &ckWait{question: "write " + long[:120] + "? y/n"}
 			return m
 		},
 		"proof_strip_long_answer": func(m Cockpit) Cockpit {
-			m.log = append(m.log, ckResultLines(longAnswer)...)
-			m.lastDone = &longAnswer
+			m.th().log = append(m.th().log, ckResultLines(longAnswer)...)
+			m.th().lastDone = &longAnswer
 			return m
 		},
 		"mode_picker":    func(m Cockpit) Cockpit { m.modePick = true; return m },
 		"override_modal": func(m Cockpit) Cockpit { m.ovOpen = true; return m },
-		"long_input":     func(m Cockpit) Cockpit { m.input = long; return m },
+		"long_input":     func(m Cockpit) Cockpit { m.th().input = long; return m },
 		"diff_panel": func(m Cockpit) Cockpit {
-			m.codeDiff, m.codeLang = true, "diff"
+			m.th().codeDiff, m.th().codeLang = true, "diff"
 			for i := 0; i < 80; i++ {
-				m.codeLines = append(m.codeLines, "+"+long[:80])
+				m.th().codeLines = append(m.th().codeLines, "+"+long[:80])
 			}
-			m.codeShown = len(m.codeLines)
+			m.th().codeShown = len(m.th().codeLines)
 			return m
 		},
 	}
@@ -1108,16 +1108,16 @@ func TestChatScrollback_SurvivesLongAnswers(t *testing.T) {
 	m := testCockpit()
 	m.w, m.h, m.ready = 100, 24, true
 	for i := 0; i < 60; i++ {
-		m.log = append(m.log, fmt.Sprintf("history %d", i))
+		m.th().log = append(m.th().log, fmt.Sprintf("history %d", i))
 	}
 	m = press(m, tea.KeyPgUp)
-	anchor := m.chatScroll
+	anchor := m.th().scroll
 	if anchor == 0 {
 		t.Fatal("pgup did not anchor")
 	}
 	big := ckTask{runID: "r", answer: strings.Repeat("new answer line\n", 200), elapsed: time.Second}
-	m.log = append(m.log, ckResultLines(big)...)
-	if m.chatScroll != anchor {
+	m.th().log = append(m.th().log, ckResultLines(big)...)
+	if m.th().scroll != anchor {
 		t.Error("a long answer yanked the anchored reader")
 	}
 	if out := stripANSI(m.View()); strings.Contains(out, "new answer line") {
@@ -1175,15 +1175,15 @@ func TestCkRealEditStage_OutsideWorkspaceIsRejected(t *testing.T) {
 
 // The real verify stage maps exit codes to verdicts and launch failures to errors.
 func TestCkRealVerifyStage_ExitCodesBecomeVerdicts(t *testing.T) {
-	v, err := ckRealVerifyStage(context.Background(), []string{"go", "version"})
+	v, err := ckRealVerifyStage(context.Background(), []string{"go", "version"}, "")
 	if err != nil || !v.Passed {
 		t.Fatalf("`go version` did not pass: v=%+v err=%v", v, err)
 	}
-	v, err = ckRealVerifyStage(context.Background(), []string{"go", "tool", "definitely-not-a-tool"})
+	v, err = ckRealVerifyStage(context.Background(), []string{"go", "tool", "definitely-not-a-tool"}, "")
 	if err != nil || v.Passed {
 		t.Fatalf("a failing command did not fail: v=%+v err=%v", v, err)
 	}
-	if _, err = ckRealVerifyStage(context.Background(), []string{"/nonexistent-hydra-verifier"}); err == nil {
+	if _, err = ckRealVerifyStage(context.Background(), []string{"/nonexistent-hydra-verifier"}, ""); err == nil {
 		t.Fatal("an unlaunchable verifier must be an error, not a verdict")
 	}
 }
@@ -1197,13 +1197,13 @@ func TestExec_VerifierErrorIsHonest(t *testing.T) {
 	rel, _ := namedFile(t, "package main\n")
 	ckDispatchStage = stubAnswer("1. edit", 0)
 	ckEditStage = stubEdit("package main\n", "package main // v\n")
-	ckVerifyStage = func(context.Context, []string) (oracle.Verdict, error) {
+	ckVerifyStage = func(context.Context, []string, string) (oracle.Verdict, error) {
 		return oracle.Verdict{}, errors.New("exec: go not found")
 	}
 	m := chatFixture("auto")
 	m, cmd := enter(typed(m, "touch "+rel))
 	m = runCmds(t, m, cmd)
-	joined := stripANSI(strings.Join(m.log, "\n"))
+	joined := stripANSI(strings.Join(m.th().log, "\n"))
 	if !strings.Contains(joined, "tests ? ") || !strings.Contains(joined, "verifier failed") {
 		t.Errorf("a broken verifier is not disclosed:\n%s", joined)
 	}
@@ -1225,13 +1225,13 @@ func TestExec_EditFailureRendersReason(t *testing.T) {
 	m := chatFixture("edit")
 	m, cmd := enter(typed(m, "break "+rel))
 	m = runCmds(t, m, cmd)
-	if joined := stripANSI(strings.Join(m.log, "\n")); !strings.Contains(joined, "validation_failed") {
+	if joined := stripANSI(strings.Join(m.th().log, "\n")); !strings.Contains(joined, "validation_failed") {
 		t.Errorf("the editor's reason is missing:\n%s", joined)
 	}
 	m2 := chatFixture("edit")
 	m2, cmd = enter(typed(m2, "break "+rel))
 	m2 = runCmds(t, m2, cmd)
-	if joined := stripANSI(strings.Join(m2.log, "\n")); !strings.Contains(joined, "dispatcher exploded") {
+	if joined := stripANSI(strings.Join(m2.th().log, "\n")); !strings.Contains(joined, "dispatcher exploded") {
 		t.Errorf("the edit error is missing:\n%s", joined)
 	}
 }
@@ -1244,10 +1244,10 @@ func TestResultActions_DegradeWithoutSnapshots(t *testing.T) {
 	}
 	m := testCockpit()
 	tk := &ckTask{edited: true, file: "x.go", runID: "never-ran"}
-	m.lastDone = tk
+	m.th().lastDone = tk
 	m, _, ok := m.resultKey('d')
-	if !ok || m.codeDiff {
-		t.Errorf("d with no snapshot: ok=%v diff=%v", ok, m.codeDiff)
+	if !ok || m.th().codeDiff {
+		t.Errorf("d with no snapshot: ok=%v diff=%v", ok, m.th().codeDiff)
 	}
 	if !strings.Contains(m.flash, "no snapshot") {
 		t.Errorf("flash = %q", m.flash)
@@ -1314,24 +1314,24 @@ func TestChatScrollGeom_MirrorsInputBarHeight(t *testing.T) {
 	m := testCockpit()
 	m.w, m.h = 100, 24
 	_, logH := m.chatLogGeom()
-	m.input = strings.Repeat("wrap me ", 40)
+	m.th().input = strings.Repeat("wrap me ", 40)
 	_, logHWrapped := m.chatLogGeom()
 	if logHWrapped >= logH {
 		t.Errorf("a wrapped input did not shrink the log window: %d → %d", logH, logHWrapped)
 	}
 	for i := 0; i < 50; i++ {
-		m.log = append(m.log, "line")
+		m.th().log = append(m.th().log, "line")
 	}
 	m = m.chatScrollBy(-1000)
-	if m.chatScroll != 1 {
-		t.Errorf("scrollback did not clamp at the top: %d", m.chatScroll)
+	if m.th().scroll != 1 {
+		t.Errorf("scrollback did not clamp at the top: %d", m.th().scroll)
 	}
 	m = m.chatScrollBy(1000)
-	if m.chatScroll != 0 {
-		t.Errorf("scrollback did not return to live: %d", m.chatScroll)
+	if m.th().scroll != 0 {
+		t.Errorf("scrollback did not return to live: %d", m.th().scroll)
 	}
-	m.log = []string{"one"}
-	if m = m.chatScrollBy(-3); m.chatScroll != 0 {
+	m.th().log = []string{"one"}
+	if m = m.chatScrollBy(-3); m.th().scroll != 0 {
 		t.Error("a fitting log entered scrollback")
 	}
 }

--- a/internal/tui/chat_frame_test.go
+++ b/internal/tui/chat_frame_test.go
@@ -22,7 +22,7 @@ func TestChatCode_LiveFrame80x24NeverOverflows(t *testing.T) {
 	}
 	m.heads = heads
 	m.mode = "ask"
-	m.log = []string{
+	m.th().log = []string{
 		"init line one",
 		"Type a task and press enter. shift+tab mode · ctrl+o route · ? shortcuts · :q quits.",
 		"mode → ask",
@@ -32,10 +32,10 @@ func TestChatCode_LiveFrame80x24NeverOverflows(t *testing.T) {
 		answer: "A goroutine is a lightweight thread managed by the Go runtime.",
 		mode:   ckModeByName("ask"), elapsed: 26300000000,
 	}
-	m.log = append(m.log, ckYouS.Render("❯ what is a goroutine? answer in one short sentence"))
-	m.log = append(m.log, m.routeLines(done, heads[0], "SIMPLE", ckOverride{}, false)...)
-	m.log = append(m.log, ckResultLines(done)...)
-	m.lastDone = &done
+	m.th().log = append(m.th().log, ckYouS.Render("❯ what is a goroutine? answer in one short sentence"))
+	m.th().log = append(m.th().log, m.routeLines(done, heads[0], "SIMPLE", ckOverride{}, false)...)
+	m.th().log = append(m.th().log, ckResultLines(done)...)
+	m.th().lastDone = &done
 
 	bodyH := m.h - 3
 	if got := lipgloss.Height(m.chatCode(bodyH)); got != bodyH {
@@ -50,7 +50,7 @@ func TestChatCode_LiveFrame80x24NeverOverflows(t *testing.T) {
 		t.Errorf("the status bar is not the final line: %q", last)
 	}
 	// The wrapped-count/rendered-line agreement, at the exact narrow width.
-	for i, e := range m.log {
+	for i, e := range m.th().log {
 		for j, l := range strings.Split(ckClipToLines(e, 28, 6), "\n") {
 			if lipgloss.Width(l) > 28 {
 				t.Errorf("entry %d line %d renders %d cells at width 28", i, j, lipgloss.Width(l))

--- a/internal/tui/chat_task.go
+++ b/internal/tui/chat_task.go
@@ -2,9 +2,10 @@
 
 package tui
 
-// chat_task.go — the UI side of a chat task's life: launch with its route
-// line, the plan/confirm gates, the finished rendering (answer block, proof
-// strip, footer), and the d/x/o result actions over runlog edit snapshots.
+// chat_task.go — the UI side of a chat task's life on its thread: launch with
+// the route line (through the overlap gate and worktree isolation), the
+// plan/confirm gates, the finished rendering (answer block, proof strip,
+// footer), and the a/d/x/o result actions.
 
 import (
 	"context"
@@ -34,13 +35,23 @@ var ckTierEnum = map[int]string{
 
 // ── launch ────────────────────────────────────────────────────────────────────
 
-// startTask classifies the task, prints the route line, and spawns the
-// pipeline worker. The ctrl+o override is consumed here — next task only.
+// startTask echoes the prompt on the active thread and begins it.
 func (m Cockpit) startTask(task string) (Cockpit, tea.Cmd) {
-	m.flash = "" // an override's "next task" note is consumed by this task
-	m.log = append(m.log, ckYouS.Render("❯ "+ckSafe(task)))
+	th := m.th()
+	if th.name == "" {
+		th.name = ckThreadName(task)
+	}
+	th.log = append(th.log, ckYouS.Render("❯ "+ckSafe(task)))
+	return m.beginTask(th, task, m.mode)
+}
 
-	md := ckModeByName(m.mode)
+// beginTask classifies the task, gates it on file overlap, prints the route
+// line, and spawns the pipeline — behind worktree creation when the thread
+// needs isolation. The ctrl+o override is consumed here — next task only.
+// modeName is captured at submit time, so a queued task keeps its mode.
+func (m Cockpit) beginTask(th *ckThread, task, modeName string) (Cockpit, tea.Cmd) {
+	m.flash = "" // an override's "next task" note is consumed by this task
+	md := ckModeByName(modeName)
 	enum, wantTier := classifyTask(task)
 	ov := m.override
 	m.override = ckOverride{}
@@ -60,15 +71,44 @@ func (m Cockpit) startTask(task string) (Cockpit, tea.Cmd) {
 	// A real scan can legitimately find nothing; inventing a route is exactly
 	// what #189 removed, and dispatching would only fail later and worse.
 	if idx < 0 {
-		m.log = append(m.log, ckDimS.Render("  no routable model — run `hyctl probe` to see why"))
+		th.log = append(th.log, ckDimS.Render("  no routable model — run `hyctl probe` to see why"))
 		return m, nil
 	}
 	h := m.heads[idx]
 
 	file := ckNamedFile(task)
+	editCapable := file != "" && md.name != "ask"
+	rel := ckRepoRel(m.repoRoot, file)
+
+	// Overlap gate (#598): the same duplicate-target pre-flight
+	// internal/parallel runs, against every other thread's holds. A thread
+	// re-checked after a release keeps its original place in the queue.
+	if editCapable {
+		key := rel
+		if key == "" {
+			key = file
+		}
+		if blocker, overlap := m.overlapBlocker(th, key); blocker != nil {
+			if th.queued != nil {
+				th.requeueBehind(blocker, overlap)
+				return m, nil
+			}
+			th.queueTask(task, key, blocker, overlap)
+			th.queued.mode, th.queued.seq = modeName, m.queueSeq
+			m.queueSeq++
+			return m, nil
+		}
+		if th.queued != nil {
+			th.queued = nil
+			th.log = append(th.log, ckDimS.Render("  ▶ unblocked — starting"))
+		}
+		th.files = ckAppendUnique(th.files, key)
+	}
+
 	t := ckTask{
-		prompt: task, mode: md, file: file,
-		runID: runid.New(), taskID: runid.New(),
+		prompt: task, mode: md, file: file, rel: rel,
+		threadID: th.id,
+		runID:    runid.New(), taskID: runid.New(),
 		answerTier: strconv.Itoa(wantTier),
 		planTier:   md.planTier,
 		editEnum:   ckEditEnum(enum, md, ov),
@@ -86,18 +126,17 @@ func (m Cockpit) startTask(task string) (Cockpit, tea.Cmd) {
 			t.strategy, t.confidence = ov.kind, ov.conf
 		}
 	}
-	if md.verify {
-		t.verifyArgv, t.verifyLabel = ckVerifyArgs(file)
-	}
+	th.lastRunID = t.runID
+	th.clock = th.clock.Tick(ckThreadAgent(th.id))
 
-	m.log = append(m.log, m.routeLines(t, h, enum, ov, pinned)...)
+	th.log = append(th.log, m.routeLines(t, h, enum, ov, pinned)...)
 	if f := ckFileRe.FindString(task); f != "" {
 		if radius, deps, kappa, ok := m.metrics.ckBlastFor(f); ok {
 			risk := ckCheapS
 			if kappa >= 2 {
 				risk = ckExpS
 			}
-			m.log = append(m.log, ckDimS.Render("  impact ")+
+			th.log = append(th.log, ckDimS.Render("  impact ")+
 				risk.Render(fmt.Sprintf("κ=%.1f", kappa))+
 				ckDimS.Render(fmt.Sprintf("  %d dependent%s · radius %.2f×  → %s",
 					deps, plural(deps), radius, truncate(f, 40))))
@@ -106,15 +145,124 @@ func (m Cockpit) startTask(task string) (Cockpit, tea.Cmd) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), ckTaskTimeout)
 	ex := &ckExecState{ctx: ctx, cancel: cancel, started: t.startedAt, stage: "routing"}
-	m.exec = ex
-	m.lastDone = nil
-	m.chatScroll = 0
+	th.exec = ex
+	th.lastDone = nil
+	th.scroll = 0
 
+	// Isolation (#598): an edit thread inside a repo works in its own worktree.
+	if editCapable && rel != "" {
+		if th.wt == nil {
+			ex.setStage("isolating — creating worktree")
+			th.log = append(th.log, ckDimS.Render("  ⎇ isolating — cutting a worktree of ")+
+				ckDimS.Render(truncate(m.repoRoot, 40)))
+			return m, tea.Batch(ckWtCreate(ex, t, m.repoRoot), ckSpinTick(ex))
+		}
+		th.log = append(th.log, ckDimS.Render("  ⎇ worktree ")+ckVioletS.Render(th.wt.tag)+
+			ckDimS.Render(" · merges on apply"))
+		return m.launchTask(th, t, ex)
+	}
+	if editCapable {
+		// No repo (or the file lives outside it): edits land in place, one at a
+		// time — said out loud, never pretended isolation (#598).
+		th.inEdit = true
+		th.log = append(th.log, ckMidS.Render("  ⚠ no isolation ")+
+			ckDimS.Render("— editing your files directly (no git repo here); edits run one at a time"))
+	}
+	return m.launchTask(th, t, ex)
+}
+
+// launchTask finalizes the task against its working tree (worktree or CWD) and
+// spawns the right pipeline phase.
+func (m Cockpit) launchTask(th *ckThread, t ckTask, ex *ckExecState) (Cockpit, tea.Cmd) {
+	if th.wt != nil && t.rel != "" {
+		t.file = filepath.Join(th.wt.dir, filepath.FromSlash(t.rel))
+		t.root = th.wt.dir
+		t.dir = th.wt.dir
+	}
+	if t.mode.verify {
+		t.verifyArgv, t.verifyLabel = ckVerifyArgs(t.file)
+	}
 	phase := ckPhaseFull
-	if md.name == "plan" || (md.confirm && file != "") {
+	if t.mode.name == "plan" || (t.mode.confirm && t.file != "") {
 		phase = ckPhaseHead
 	}
 	return m, tea.Batch(ckWorker(ex, t, phase), ckSpinTick(ex))
+}
+
+// worktreeReady lands the async `git worktree add`: attach it and launch the
+// pending task, or fail the task honestly — never fall back to editing the
+// user's tree when isolation was promised.
+func (m Cockpit) worktreeReady(msg ckWtReadyMsg) (tea.Model, tea.Cmd) {
+	th := m.threadByID(msg.task.threadID)
+	if th == nil || th.exec != msg.exec {
+		if msg.wt != nil { // superseded — do not litter the worktree dir
+			_ = ckDiscardWorktree(msg.wt)
+		}
+		return m, nil
+	}
+	t := msg.task
+	if err := msg.exec.ctx.Err(); err != nil {
+		if msg.wt != nil {
+			_ = ckDiscardWorktree(msg.wt)
+		}
+		t.errText = "worktree creation cancelled"
+		t.canceled = true
+		return m.failBeforeRun(th, t)
+	}
+	if msg.err != nil {
+		t.errText = "worktree creation failed: " + msg.err.Error()
+		return m.failBeforeRun(th, t)
+	}
+	th.wt = msg.wt
+	th.log = append(th.log, ckDimS.Render("  ⎇ worktree ")+ckVioletS.Render(th.wt.tag)+
+		ckDimS.Render(" · branch "+th.wt.branch+" · merges on apply"))
+	return m.launchTask(th, t, msg.exec)
+}
+
+// failBeforeRun settles a task that never reached the pipeline, releasing the
+// thread's fresh hold so queued threads are not blocked by a task that never ran.
+func (m Cockpit) failBeforeRun(th *ckThread, t ckTask) (Cockpit, tea.Cmd) {
+	th.exec = nil
+	key := t.rel
+	if key == "" {
+		key = t.file
+	}
+	th.files = ckRemove(th.files, key)
+	ckFinalize(&t, context.Background())
+	nm, cmd := m.settleTask(th, t)
+	nm, rcmd := nm.releaseThreads(th)
+	return nm, tea.Batch(cmd, rcmd)
+}
+
+// ckRepoRel is file's repo-relative path, or "" when it is not under root.
+func ckRepoRel(root, file string) string {
+	if root == "" || file == "" {
+		return ""
+	}
+	rel, err := filepath.Rel(root, file)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return ""
+	}
+	return filepath.ToSlash(rel)
+}
+
+func ckAppendUnique(files []string, f string) []string {
+	for _, x := range files {
+		if x == f {
+			return files
+		}
+	}
+	return append(files, f)
+}
+
+func ckRemove(files []string, f string) []string {
+	out := files[:0]
+	for _, x := range files {
+		if x != f {
+			out = append(out, x)
+		}
+	}
+	return out
 }
 
 // ckEditEnum picks the editor path's routing enum: the classification, the
@@ -218,30 +366,57 @@ func ckWhyWords(t ckTask, enum string) string {
 
 // ── gates ─────────────────────────────────────────────────────────────────────
 
-// gateTask handles a pipeline paused for the user: render what is waiting and
-// arm the matching wait state.
+// gateTask handles a pipeline paused for the user: render what is waiting on
+// its own thread, arm the matching wait state, and ping chat when that thread
+// is not the one in front of the user.
 func (m Cockpit) gateTask(msg ckGateMsg) (Cockpit, tea.Cmd) {
-	if msg.exec != m.exec || m.exec == nil {
+	th := m.threadByID(msg.task.threadID)
+	if th == nil || th.exec != msg.exec {
 		return m, nil
 	}
-	m.exec = nil
+	th.exec = nil
 	t := msg.task
 	switch msg.gate {
 	case 'p':
-		m.log = append(m.log, ckPlanLines(t)...)
-		m.log = append(m.log, ckFaintS.Render("  enter/y runs it · esc discards"))
-		m.planWait = &ckWait{task: t, phase: ckPhaseTail}
+		th.log = append(th.log, ckPlanLines(t)...)
+		th.log = append(th.log, ckFaintS.Render("  enter/y runs it · esc discards"))
+		th.planWait = &ckWait{task: t, phase: ckPhaseTail}
 	case 'w':
-		m.log = append(m.log, ckPlanLines(t)...)
-		m.confirm = &ckWait{task: t, phase: ckPhaseTail,
+		th.log = append(th.log, ckPlanLines(t)...)
+		th.confirm = &ckWait{task: t, phase: ckPhaseTail,
 			question: "write " + filepath.Base(t.file) + "? y writes · n stops"}
 	case 'f':
-		m.log = append(m.log, ckExpS.Render("  ✗ verify failed ")+
+		th.log = append(th.log, ckExpS.Render("  ✗ verify failed ")+
 			ckDimS.Render(truncate(ckSafe(t.fixDetail), 70)))
-		m.confirm = &ckWait{task: t, phase: ckPhaseFix,
+		th.confirm = &ckWait{task: t, phase: ckPhaseFix,
 			question: fmt.Sprintf("write fix %d/%d to %s? y/n", t.fixRound, ckMaxFixes, filepath.Base(t.file))}
 	}
+	m.pingIfElsewhere(th, "needs you — "+ckGateWord(msg.gate))
 	return m, nil
+}
+
+func ckGateWord(gate byte) string {
+	switch gate {
+	case 'p':
+		return "a plan waits for approval"
+	case 'f':
+		return "a fix wants a y/n"
+	default:
+		return "a write wants a y/n"
+	}
+}
+
+// pingIfElsewhere drops a hydra ▸ line into the ACTIVE thread when th is
+// backgrounded or simply not the one on screen — the spec's completion ping.
+func (m *Cockpit) pingIfElsewhere(th *ckThread, what string) {
+	active := m.th()
+	if th.id == active.id {
+		return
+	}
+	th.attn = th.planWait != nil || th.confirm != nil || th.attn
+	active.log = append(active.log, ckAquaS.Render("hydra ▸ ")+
+		ckDimS.Render(fmt.Sprintf("thread %d %s · alt+%d opens it · ctrl+g next", th.id, what, th.id)))
+	m.flash = fmt.Sprintf("thread %d %s", th.id, what)
 }
 
 // ckPlanLines renders a drafted plan into the log, capped so a rambling plan
@@ -267,67 +442,157 @@ func ckPlanLines(t ckTask) []string {
 
 // resumeTask restarts a gated pipeline at its stored phase with a fresh
 // context; elapsed time keeps counting from the original start.
-func (m Cockpit) resumeTask(w ckWait) (Cockpit, tea.Cmd) {
+func (m Cockpit) resumeTask(th *ckThread, w ckWait) (Cockpit, tea.Cmd) {
 	ctx, cancel := context.WithTimeout(context.Background(), ckTaskTimeout)
 	ex := &ckExecState{ctx: ctx, cancel: cancel, started: w.task.startedAt, stage: "resuming"}
-	m.exec = ex
-	m.planWait, m.confirm = nil, nil
+	th.exec = ex
+	th.planWait, th.confirm = nil, nil
 	return m, tea.Batch(ckWorker(ex, w.task, w.phase), ckSpinTick(ex))
 }
 
 // stopWait ends a gated task without resuming it: the run closes, and what
 // already happened (plan cost, a landed edit) is settled honestly.
-func (m Cockpit) stopWait(w ckWait, note string) (Cockpit, tea.Cmd) {
-	m.planWait, m.confirm = nil, nil
+func (m Cockpit) stopWait(th *ckThread, w ckWait, note string) (Cockpit, tea.Cmd) {
+	th.planWait, th.confirm = nil, nil
 	t := w.task
 	_ = runlog.New(t.runID).Append(runlog.Event{Kind: runlog.KindRunFinished, TaskID: t.taskID})
 	t.stopped = true
 	t.note = note
 	ckFinalize(&t, context.Background())
-	return m.settleTask(t)
+	return m.settleTask(th, t)
 }
 
 // ── completion ────────────────────────────────────────────────────────────────
 
-// finishTask lands a worker's final message.
+// finishTask lands a worker's final message on its thread — routed by the
+// task's thread id, never by whichever thread is current.
 func (m Cockpit) finishTask(msg ckExecDoneMsg) (Cockpit, tea.Cmd) {
-	if msg.exec != m.exec || m.exec == nil {
+	th := m.threadByID(msg.task.threadID)
+	if th == nil || th.exec != msg.exec {
 		return m, nil
 	}
-	m.exec = nil
-	return m.settleTask(msg.task)
+	th.exec = nil
+	return m.settleTask(th, msg.task)
 }
 
-// settleTask renders a finished task and updates everything that watched it:
-// session cost, the run list, the last-result actions, and the code panel.
-func (m Cockpit) settleTask(t ckTask) (Cockpit, tea.Cmd) {
+// settleTask renders a finished task on its thread and updates everything that
+// watched it: session cost, the run list, the result actions, the code panel,
+// held-file release, and the elsewhere ping.
+func (m Cockpit) settleTask(th *ckThread, t ckTask) (Cockpit, tea.Cmd) {
 	m.sessionUSD += t.costUSD
 	m.runsToday = ckLoadRuns(time.Now().UTC())
-	m.lastDone = &t
-	m.log = append(m.log, ckResultLines(t)...)
-	if t.edited && t.editRefLast != "" {
-		if _, after, err := runlog.LoadEdit(t.runID, t.editRefLast); err == nil {
-			m = m.showCode(t.file, string(after))
-			return m, ckCodeTick(m.codeGen)
+	th.lastDone = &t
+	th.inEdit = false
+	th.log = append(th.log, ckResultLines(t)...)
+	if t.edited && th.wt != nil {
+		th.log = append(th.log, ckFaintS.Render("  a applies it to your tree · x x discards the worktree"))
+	}
+
+	// An untouched worktree from a task that never edited (failed plan, declined
+	// write, cancel) is litter, not work — remove it and say so.
+	if th.wt != nil && !t.edited && len(ckWorktreeChanges(th.wt)) == 0 {
+		if err := ckDiscardWorktree(th.wt); err == nil {
+			th.log = append(th.log, ckDimS.Render("  ⎇ worktree removed — nothing landed in it"))
+			th.wt = nil
+			th.files = nil
+		} else {
+			th.log = append(th.log, ckMidS.Render("  ⚠ empty worktree cleanup failed: "+err.Error()))
 		}
 	}
-	return m, nil
+	if th.wt == nil {
+		th.files = nil // in-place holds end with the task; worktrees hold to apply
+	}
+
+	what := "done"
+	switch {
+	case t.canceled:
+		what = "cancelled"
+	case t.errText != "":
+		what = "failed — " + truncate(ckFirstLine(t.errText), 40)
+	case t.stopped:
+		what = "stopped"
+	}
+	m.pingIfElsewhere(th, what)
+	if th.id != m.th().id && (t.errText != "" && !t.canceled) {
+		th.attn = true // a failure elsewhere needs eyes; ctrl+g finds it
+	}
+
+	nm, rcmd := m.releaseThreads(th)
+	m = nm
+	if t.edited && t.editRefLast != "" {
+		if _, after, err := runlog.LoadEdit(t.runID, t.editRefLast); err == nil {
+			m = m.showCode(th, t.file, string(after))
+			return m, tea.Batch(rcmd, ckCodeTick(th.id, th.codeGen))
+		}
+	}
+	return m, rcmd
 }
 
-// showCode streams content into the code panel (real file content — the fake
-// snippets died with the preview-only chat).
-func (m Cockpit) showCode(file, content string) Cockpit {
-	m.codeLang = strings.TrimPrefix(filepath.Ext(file), ".")
+// ckWorktreeChanges lists what the worktree holds beyond its base: dirty files
+// plus anything already committed on its branch.
+func ckWorktreeChanges(wt *ckWorktree) []string {
+	st, err := ckGit(wt.dir, "", "status", "--porcelain")
+	if err != nil {
+		return []string{"unknown: " + ckFirstLine(st)}
+	}
+	changes := ckSplitLines(st)
+	if names, err := ckGit(wt.repo, "", "diff", "--name-only", wt.base, wt.branch); err == nil {
+		changes = append(changes, ckSplitLines(names)...)
+	}
+	return changes
+}
+
+// showCode streams content into the thread's code panel (real file content —
+// the fake snippets died with the preview-only chat).
+func (m Cockpit) showCode(th *ckThread, file, content string) Cockpit {
+	th.codeLang = strings.TrimPrefix(filepath.Ext(file), ".")
 	lines := strings.Split(strings.TrimRight(content, "\n"), "\n")
 	if len(lines) > ckCodeMaxLines {
 		lines = append(lines[:ckCodeMaxLines], "… (truncated)")
 	}
-	m.codeLines = lines
-	m.codeShown = 0
-	m.codeDiff = false
-	m.codeGen++
+	th.codeLines = lines
+	th.codeShown = 0
+	th.codeDiff = false
+	th.codeGen++
 	return m
 }
+
+// ── background (ctrl+b) ───────────────────────────────────────────────────────
+
+// backgroundThread re-parents the active thread to the agents view. Its
+// pipeline keeps running on its own context; completion pings chat.
+func (m Cockpit) backgroundThread() Cockpit {
+	th := m.th()
+	if len(m.threads) >= ckMaxThreads && len(m.visibleThreads()) == 1 {
+		m.flash = "cannot background the last thread — the thread limit is reached"
+		return m
+	}
+	th.bg = true
+	m.runsToday = ckLoadRuns(time.Now().UTC()) // its live run shows up now
+	if m.split && m.splitID == th.id {
+		m.split = false
+	}
+	// The input needs a foreground owner: the next visible thread, or a new one.
+	if vis := m.visibleThreads(); len(vis) > 0 {
+		m = m.focusThread(vis[0].id)
+	} else {
+		m = m.addThread()
+	}
+	m.flash = fmt.Sprintf("thread %d backgrounded — it lives in agents (2) · alt+%d brings it back", th.id, th.id)
+	return m
+}
+
+// threadForRun maps a run id back to its thread (the agents-view join).
+func (m Cockpit) threadForRun(runID string) *ckThread {
+	for _, t := range m.threads {
+		if t.lastRunID == runID {
+			return t
+		}
+	}
+	return nil
+}
+
+// ── result rendering ──────────────────────────────────────────────────────────
 
 // ckResultLines renders a finished task: answer block, proof strip, footer.
 // A failure always carries its trace link — never a dead end.
@@ -383,8 +648,12 @@ func ckProofStrip(t ckTask) string {
 		parts = append(parts, ckCheapS.Render("plan ✓ ")+
 			ckDimS.Render(fmt.Sprintf("%d step%s", t.planSteps, plural(t.planSteps))))
 	}
+	name := t.rel
+	if name == "" {
+		name = filepath.Base(t.file)
+	}
 	parts = append(parts, ckCheapS.Render("edit ✓ ")+
-		ckDimS.Render(fmt.Sprintf("%s +%d/−%d", filepath.Base(t.file), t.added, t.removed)))
+		ckDimS.Render(fmt.Sprintf("%s +%d/−%d", truncate(name, 30), t.added, t.removed)))
 	parts = append(parts, ckTestsCell(t))
 	return "  " + strings.Join(parts, ckFaintS.Render(" · "))
 }
@@ -435,21 +704,41 @@ func ckFirstLine(s string) string {
 	return s
 }
 
-// ── result actions (d/x/o) ────────────────────────────────────────────────────
+// ── result actions (a/d/x/o) ──────────────────────────────────────────────────
 
-// resultKey acts on the last finished edit from an empty input: d toggles the
-// diff in the code panel, x restores the pre-task snapshot, o opens $EDITOR.
+// resultKey acts on the active thread's last finished edit from an empty
+// input: a applies an isolated thread's worktree, d toggles the diff, x undoes
+// (or, on a worktree thread, discards — pressed twice), o opens $EDITOR.
 // Returns handled=false when there is nothing to act on, so the rune types.
 func (m Cockpit) resultKey(r rune) (Cockpit, tea.Cmd, bool) {
-	t := m.lastDone
+	th := m.th()
+	t := th.lastDone
 	if t == nil || !t.edited {
+		if r == 'a' || r == 'x' {
+			// A held worktree can outlive lastDone (e.g. after a declined fix);
+			// apply/discard must still be reachable.
+			if th.wt != nil && th.exec == nil {
+				if r == 'a' {
+					return m.applyThread(th)
+				}
+				return m.discardKey(th)
+			}
+		}
 		return m, nil, false
 	}
 	switch r {
+	case 'a':
+		if th.wt == nil || th.exec != nil {
+			return m, nil, false
+		}
+		return m.applyThread(th)
 	case 'd':
-		return m.toggleDiff(t), nil, true
+		return m.toggleDiff(th, t), nil, true
 	case 'x':
-		return m.undoEdit(t), nil, true
+		if th.wt != nil {
+			return m.discardKey(th)
+		}
+		return m.undoEdit(th, t), nil, true
 	case 'o':
 		ed := os.Getenv("EDITOR")
 		if ed == "" {
@@ -461,17 +750,18 @@ func (m Cockpit) resultKey(r rune) (Cockpit, tea.Cmd, bool) {
 	return m, nil, false
 }
 
-// toggleDiff swaps the code panel between the task's full diff (first before →
-// last after, so the fix loop's intermediate writes collapse) and the file.
-func (m Cockpit) toggleDiff(t *ckTask) Cockpit {
+// toggleDiff swaps the thread's code panel between the task's full diff (first
+// before → last after, so the fix loop's intermediate writes collapse) and the
+// file.
+func (m Cockpit) toggleDiff(th *ckThread, t *ckTask) Cockpit {
 	if t.editRef == "" || t.editRefLast == "" {
 		m.flash = "no snapshot stored for this edit"
 		return m
 	}
-	if m.codeDiff {
+	if th.codeDiff {
 		if _, after, err := runlog.LoadEdit(t.runID, t.editRefLast); err == nil {
-			m = m.showCode(t.file, string(after))
-			m.codeShown = len(m.codeLines)
+			m = m.showCode(th, t.file, string(after))
+			th.codeShown = len(th.codeLines)
 		}
 		return m
 	}
@@ -490,17 +780,17 @@ func (m Cockpit) toggleDiff(t *ckTask) Cockpit {
 	if len(lines) > ckCodeMaxLines {
 		lines = append(lines[:ckCodeMaxLines], "… (truncated)")
 	}
-	m.codeLang = "diff"
-	m.codeLines = lines
-	m.codeShown = len(lines)
-	m.codeDiff = true
-	m.codeGen++ // cancel any stream in flight
+	th.codeLang = "diff"
+	th.codeLines = lines
+	th.codeShown = len(lines)
+	th.codeDiff = true
+	th.codeGen++ // cancel any stream in flight
 	return m
 }
 
 // undoEdit restores the file to its exact pre-task bytes from the first edit
 // snapshot, preserving the file's permissions. One-shot per task.
-func (m Cockpit) undoEdit(t *ckTask) Cockpit {
+func (m Cockpit) undoEdit(th *ckThread, t *ckTask) Cockpit {
 	if t.undone {
 		m.flash = "already restored"
 		return m
@@ -524,7 +814,7 @@ func (m Cockpit) undoEdit(t *ckTask) Cockpit {
 	}
 	t.undone = true // through the pointer: the second x says "already restored"
 	m.flash = "restored " + filepath.Base(t.file) + " to its pre-task state"
-	m = m.showCode(t.file, string(before))
-	m.codeShown = len(m.codeLines)
+	m = m.showCode(th, t.file, string(before))
+	th.codeShown = len(th.codeLines)
 	return m
 }

--- a/internal/tui/chrome.go
+++ b/internal/tui/chrome.go
@@ -115,6 +115,9 @@ func (m Cockpit) statusFact() string {
 		if m.pinnedTier > 0 {
 			s += fmt.Sprintf(" · pinned T%d", m.pinnedTier)
 		}
+		if att := m.attentionFact(); att != "" {
+			s = att + " · " + s
+		}
 		return s
 	case ckViewAgents:
 		live, done := m.agentCounts()

--- a/internal/tui/cockpit.go
+++ b/internal/tui/cockpit.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
+	"github.com/ankit373/hydra/internal/workspace"
 )
 
 // Cockpit views. The name table is the single source of truth — deriving the
@@ -106,29 +107,27 @@ type Cockpit struct {
 	glossary bool
 	flash    string // transient status-bar note, replaced by the next action
 
-	// chat (view 0) — executes for real (#597): modes, gates, and the override.
-	input      string
-	log        []string
+	// chat (view 0) — executes for real (#597) across parallel threads (#598).
+	// Per-task state (input, log, pipeline, code panel) lives on each thread;
+	// the mode, override, and overlays are session-level.
+	threads    []*ckThread
+	cur        int // index into threads — the thread owning the input
+	nextID     int
+	queueSeq   int    // ordering for queued tasks — see overlapBlocker
+	prevCur    int    // previously active thread id — the split's default pin
+	split      bool   // ctrl+\ split: pinned thread beside the active one
+	splitID    int    // the pinned (watch-only) side's thread id
+	repoRoot   string // CWD repo root; "" = no repo, edit isolation degrades
 	mode       string // chat mode name: ask/edit/plan/auto + advanced (modes.go)
 	pinnedTier int    // session default tier for chat, set from the models view
-	chatScroll int    // 0 = follow the live tail; L+1 = scrollback anchored at line L
 	piiLocal   bool   // config's pii policy forces local-only routing
 	override   ckOverride
-	exec       *ckExecState // the running task; nil when idle
-	planWait   *ckWait      // plan awaiting approval
-	confirm    *ckWait      // careful-mode write/fix confirm
-	lastDone   *ckTask      // last finished task, for d/x/o and the trace jump
-	modePick   bool         // `m` mode-picker overlay
+	modePick   bool // `m` mode-picker overlay
 	modeSel    int
 	ovOpen     bool // ctrl+o override modal
 	ovSel      int
 	ovStage    byte // 0 list · 'T' tier digit · 'C' confidence pick
 	ovConfSel  int
-	codeLang   string
-	codeLines  []string
-	codeShown  int
-	codeGen    int  // generation guard so a new run cancels stale tick loops
-	codeDiff   bool // the panel currently shows the last edit's diff
 
 	claudePct  int
 	pctKnown   bool // false when state.json has no claude_pct to read
@@ -205,19 +204,31 @@ func NewCockpit() Cockpit {
 	if cfg, err := config.Load(); err == nil {
 		m.piiLocal = dispatch.PIILocalOnly(cfg)
 	}
+	if cwd, err := os.Getwd(); err == nil {
+		m.repoRoot = workspace.GitRoot(cwd)
+	}
 
+	m = m.withThreads()
+	t := m.th()
 	switch len(heads) {
 	case 0:
-		m.log = []string{
+		t.log = []string{
 			ckDimS.Render("🐉 Hydra initialised · no models found by the scan."),
 			ckDimS.Render("Run `hyctl probe` to see what was scanned, or `hyctl init` to configure."),
 		}
 	default:
-		m.log = []string{
+		t.log = []string{
 			ckDimS.Render(fmt.Sprintf("🐉 Hydra initialised · %d model%s scanned · routing engine ready.",
 				len(heads), plural(len(heads)))),
-			ckDimS.Render("Type a task and press enter. shift+tab mode · ctrl+o route · ? shortcuts · :q quits."),
+			ckDimS.Render("Type a task and press enter. shift+tab mode · ctrl+t thread · ? shortcuts · :q quits."),
 		}
+	}
+	if stale := ckStaleWorktrees(); len(stale) > 0 {
+		t.log = append(t.log,
+			ckMidS.Render(fmt.Sprintf("⚠ %d stale worktree%s from a previous session under %s:",
+				len(stale), plural(len(stale)), ckWorktreeBase())),
+			ckDimS.Render("  "+truncate(strings.Join(stale, " · "), 90)),
+			ckDimS.Render("  recover with `git diff` there, or remove with `git worktree remove <dir>` — nothing is auto-deleted."))
 	}
 	return m
 }
@@ -246,19 +257,23 @@ func ckClaudePct() (pct int, hist []int, ok bool) {
 func (m Cockpit) Init() tea.Cmd { return nil }
 
 func (m Cockpit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	m = m.withThreads()
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.w, m.h, m.ready = msg.Width, msg.Height, true
+		m = m.dropSplitIfNarrow()
 	case ckCodeTickMsg:
 		// Reveal one more code line; ignore ticks from a superseded run.
-		if msg.gen == m.codeGen && m.codeShown < len(m.codeLines) {
-			m.codeShown++
-			if m.codeShown < len(m.codeLines) {
-				return m, ckCodeTick(m.codeGen)
+		if t := m.threadByID(msg.thread); t != nil && msg.gen == t.codeGen && t.codeShown < len(t.codeLines) {
+			t.codeShown++
+			if t.codeShown < len(t.codeLines) {
+				return m, ckCodeTick(msg.thread, t.codeGen)
 			}
 		}
 	case ckRescanMsg:
 		return m.applyRescan(msg), nil
+	case ckWtReadyMsg:
+		return m.worktreeReady(msg)
 	case ckExecDoneMsg:
 		return m.finishTask(msg)
 	case ckGateMsg:
@@ -266,8 +281,10 @@ func (m Cockpit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ckSpinTickMsg:
 		// Keep repainting elapsed/stage while this exact task runs; a stale
 		// tick from a superseded task schedules nothing.
-		if msg.exec == m.exec && m.exec != nil {
-			return m, ckSpinTick(m.exec)
+		for _, t := range m.threads {
+			if t.exec == msg.exec && t.exec != nil {
+				return m, ckSpinTick(t.exec)
+			}
 		}
 	case tea.MouseMsg:
 		switch tea.MouseEvent(msg).Button {
@@ -300,6 +317,7 @@ func (m Cockpit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // ── frame ─────────────────────────────────────────────────────────────────────
 
 func (m Cockpit) View() string {
+	m = m.withThreads()
 	if !m.ready {
 		return "\n  starting hydra cockpit…\n"
 	}
@@ -337,12 +355,12 @@ func (m Cockpit) View() string {
 
 // ── code-stream ticker ─────────────────────────────────────────────────────────
 
-type ckCodeTickMsg struct{ gen int }
+type ckCodeTickMsg struct{ thread, gen int }
 
-// ckCodeTick schedules the next code line to reveal. gen tags the current run so
-// a fresh preview cancels the previous stream instead of double-speeding it.
-func ckCodeTick(gen int) tea.Cmd {
-	return tea.Tick(time.Second/20, func(time.Time) tea.Msg { return ckCodeTickMsg{gen} })
+// ckCodeTick schedules the next code line to reveal on one thread's panel. gen
+// tags the current run so a fresh stream cancels the previous one.
+func ckCodeTick(thread, gen int) tea.Cmd {
+	return tea.Tick(time.Second/20, func(time.Time) tea.Msg { return ckCodeTickMsg{thread, gen} })
 }
 
 // ── snapshot (static render for docs / non-tty preview) ─────────────────────────
@@ -379,12 +397,14 @@ func ckSnapshotModel() Cockpit {
 		headName:    "qwen2.5-coder", tier: 7,
 		costUSD: 0.0041, elapsed: 3200 * time.Millisecond,
 	}
-	m.log = append(m.log, ckYouS.Render("❯ "+demo.prompt))
-	m.log = append(m.log, m.routeLines(demo, ckHead{name: demo.headName, tier: demo.tier}, "STANDARD", ckOverride{}, false)...)
-	m.log = append(m.log, ckResultLines(demo)...)
+	t := m.th()
+	t.name = ckThreadName(demo.prompt)
+	t.log = append(t.log, ckYouS.Render("❯ "+demo.prompt))
+	t.log = append(t.log, m.routeLines(demo, ckHead{name: demo.headName, tier: demo.tier}, "STANDARD", ckOverride{}, false)...)
+	t.log = append(t.log, ckResultLines(demo)...)
 
-	m.codeLang = "go"
-	m.codeLines = []string{
+	t.codeLang = "go"
+	t.codeLines = []string{
 		"// paginated users endpoint",
 		"func (s *Server) ListUsers(w http.ResponseWriter, r *http.Request) {",
 		"    page := parsePage(r.URL.Query())",
@@ -396,7 +416,7 @@ func ckSnapshotModel() Cockpit {
 		"    json.NewEncoder(w).Encode(users)",
 		"}",
 	}
-	m.codeShown = len(m.codeLines)
+	t.codeShown = len(t.codeLines)
 	return m
 }
 

--- a/internal/tui/cockpit_test.go
+++ b/internal/tui/cockpit_test.go
@@ -81,7 +81,8 @@ func testCockpit() Cockpit {
 		testRun("20260904T100100Z-bbbb", "failed", "rotate signing key"),
 		testRun("20260904T100200Z-cccc", "running", "write tests"),
 	}
-	m.log = []string{"welcome"}
+	m = m.withThreads()
+	m.th().log = []string{"welcome"}
 	return m
 }
 
@@ -157,7 +158,7 @@ func TestEveryView_LayoutInvariantsAtEverySize(t *testing.T) {
 	base = typed(base, "add pagination to the users endpoint")
 	next, _ := enter(base)
 	base = next
-	base.log = append(base.log, long, "tail\nwith\nnewlines")
+	base.th().log = append(base.th().log, long, "tail\nwith\nnewlines")
 
 	sizes := []struct{ w, h int }{{60, 15}, {80, 24}, {100, 30}, {120, 40}}
 	for view := 0; view < ckViewCount(); view++ {
@@ -328,30 +329,34 @@ func TestCkHeadsFrom_MirrorsRoutingAndDoesNotFabricatePrices(t *testing.T) {
 	}
 }
 
-// The code-stream tick carries its generation so a superseded stream cannot
-// double-speed the current one.
+// The code-stream tick carries its thread and generation so a superseded
+// stream — or another thread's — cannot double-speed the current one.
 func TestCodeTick_GenerationGuard(t *testing.T) {
-	cmd := ckCodeTick(7)
+	cmd := ckCodeTick(1, 7)
 	if cmd == nil {
 		t.Fatal("ckCodeTick returned no command")
 	}
-	if tick, ok := cmd().(ckCodeTickMsg); !ok || tick.gen != 7 {
-		t.Fatalf("tick = %#v, want gen 7", cmd())
+	if tick, ok := cmd().(ckCodeTickMsg); !ok || tick.gen != 7 || tick.thread != 1 {
+		t.Fatalf("tick = %#v, want thread 1 gen 7", cmd())
 	}
 
 	m := testCockpit()
-	m.codeLines = []string{"a", "b", "c"}
-	m.codeGen = 3
-	next, cmd2 := m.Update(ckCodeTickMsg{gen: 3})
-	if got := next.(Cockpit).codeShown; got != 1 {
+	m.th().codeLines = []string{"a", "b", "c"}
+	m.th().codeGen = 3
+	next, cmd2 := m.Update(ckCodeTickMsg{thread: m.th().id, gen: 3})
+	if got := next.(Cockpit).th().codeShown; got != 1 {
 		t.Errorf("codeShown = %d after one tick", got)
 	}
 	if cmd2 == nil {
 		t.Error("mid-stream tick scheduled nothing")
 	}
-	stale, _ := next.Update(ckCodeTickMsg{gen: 2})
-	if got := stale.(Cockpit).codeShown; got != 1 {
+	stale, _ := next.Update(ckCodeTickMsg{thread: m.th().id, gen: 2})
+	if got := stale.(Cockpit).th().codeShown; got != 1 {
 		t.Errorf("a stale tick advanced the stream to %d", got)
+	}
+	other, _ := next.Update(ckCodeTickMsg{thread: 99, gen: 3})
+	if got := other.(Cockpit).th().codeShown; got != 1 {
+		t.Errorf("another thread's tick advanced this stream to %d", got)
 	}
 }
 

--- a/internal/tui/glossary.go
+++ b/internal/tui/glossary.go
@@ -12,7 +12,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-var ckGlossaryGroups = []string{"EVERYWHERE", "CHAT", "LISTS"}
+var ckGlossaryGroups = []string{"EVERYWHERE", "THREADS", "CHAT", "LISTS"}
 
 // ckGlossaryLines builds the glossary rows from ckKeymap — the single source
 // of every binding, so the overlay cannot document a key that does not exist.

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -30,6 +30,15 @@ var ckKeymap = []ckBinding{
 	{"home/end", "top / bottom · chat: end returns to live", "EVERYWHERE", nil},
 	{"ctrl+c", "quit", "EVERYWHERE", nil},
 
+	{"ctrl+t", "new thread", "THREADS", nil},
+	{"ctrl+t", "thread", "", []int{ckViewChat}},
+	{"alt+1–9", "jump to that thread (foregrounds a backgrounded one)", "THREADS", nil},
+	{"ctrl+←/→", "cycle threads · in a split: move focus between the sides", "THREADS", nil},
+	{"ctrl+\\", "split: pin a second thread beside this one (≥100 cols) · again closes", "THREADS", nil},
+	{"ctrl+b", "background the thread — it keeps running in agents, pings chat when done", "THREADS", nil},
+	{"ctrl+g", "jump to the next thread needing you (confirms, plan gates, failures)", "THREADS", nil},
+	{"a · x", "after an isolated edit: apply the worktree to your tree · x x discards it", "THREADS", nil},
+
 	{"enter", "send · approve a plan · empty input: open the last trace", "CHAT", nil},
 	{"enter", "send", "", []int{ckViewChat}},
 	{"shift+tab", "cycle the basic modes: ask · edit · plan · auto", "CHAT", nil},
@@ -80,7 +89,8 @@ func ckBarBindings(v int) []ckBinding {
 }
 
 // key routes one keypress. Chat keeps every binding it always had — new shell
-// keys apply only where they collide with nothing (#465's discipline).
+// keys apply only where they collide with nothing (#465's discipline); all
+// thread keys are modifier-based so typing is never broken.
 func (m Cockpit) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyCtrlC:
@@ -102,6 +112,15 @@ func (m Cockpit) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.scrollBy(-ckScrollAll), nil
 	case tea.KeyEnd:
 		return m.scrollBy(ckScrollAll), nil
+	case tea.KeyCtrlT:
+		return m.addThread(), nil
+	case tea.KeyCtrlG:
+		return m.nextAttention(), nil
+	}
+	// alt+1–9 jumps to that thread from anywhere.
+	if msg.Alt && msg.Type == tea.KeyRunes && len(msg.Runes) == 1 &&
+		msg.Runes[0] >= '1' && msg.Runes[0] <= '9' {
+		return m.focusThread(int(msg.Runes[0] - '0')), nil
 	}
 	if m.glossary {
 		// The overlay keeps scrolling (above) and closes on esc or ?; every
@@ -171,8 +190,8 @@ func ckClampOff(off, n int) int {
 }
 
 // jump switches to view v, closing transient overlays (glossary, picker,
-// override) and running the on-entry hook. A pending plan/confirm survives —
-// a question must not be lost by looking at activity.
+// override) and running the on-entry hook. A pending plan/confirm survives on
+// its thread — a question must not be lost by looking at activity.
 func (m Cockpit) jump(v int) Cockpit {
 	if !ckValidView(v) {
 		return m
@@ -190,8 +209,10 @@ func (m Cockpit) jump(v int) Cockpit {
 }
 
 // escape closes the topmost thing first: overlay, then modal stage, then a
-// pending question, then typed input, then the running task itself.
+// pending question, then typed input, then the running task itself — always on
+// the ACTIVE thread; other threads keep running untouched.
 func (m Cockpit) escape() (Cockpit, tea.Cmd) {
+	t := m.th()
 	switch {
 	case m.glossary:
 		m.glossary = false
@@ -204,22 +225,26 @@ func (m Cockpit) escape() (Cockpit, tea.Cmd) {
 		} else {
 			m.ovOpen = false
 		}
-	case m.view == ckViewChat && m.confirm != nil:
-		w := *m.confirm
+	case m.view == ckViewChat && t.confirm != nil:
+		w := *t.confirm
 		note := "stopped before writing — nothing changed"
 		if w.phase == ckPhaseFix {
 			note = "fix declined — the file keeps its last write"
 		}
-		return m.stopWait(w, note)
-	case m.view == ckViewChat && m.planWait != nil:
-		return m.stopWait(*m.planWait, "plan discarded — nothing ran")
-	case m.view == ckViewChat && m.input != "":
-		m.input = ""
-	case m.view == ckViewChat && m.exec != nil:
+		return m.stopWait(t, w, note)
+	case m.view == ckViewChat && t.planWait != nil:
+		return m.stopWait(t, *t.planWait, "plan discarded — nothing ran")
+	case m.view == ckViewChat && t.input != "":
+		t.input = ""
+	case m.view == ckViewChat && t.queued != nil:
+		t.queued = nil
+		t.log = append(t.log, ckDimS.Render("  queued task discarded"))
+		return m.releaseThreads(nil) // anything chained behind it re-checks
+	case m.view == ckViewChat && t.exec != nil:
 		// Context cancellation through dispatch: the worker returns with a
 		// cancelled result; exec clears when that message lands.
-		m.exec.cancel()
-		m.exec.setStage("cancelling…")
+		t.exec.cancel()
+		t.exec.setStage("cancelling…")
 	case m.view == ckViewActivity && m.actDrill:
 		m.actDrill = false
 		m.traceOff = 0
@@ -357,6 +382,11 @@ func (m Cockpit) enterRow() (tea.Model, tea.Cmd) {
 	case ckViewAgents:
 		rows := m.agentRows()
 		if m.agentSel >= 0 && m.agentSel < len(rows) {
+			// A backgrounded thread's run re-foregrounds the thread (#598);
+			// every other run opens its trace.
+			if t := m.threadForRun(rows[m.agentSel].id); t != nil && t.bg {
+				return m.focusThread(t.id), nil
+			}
 			m = m.focusRun(rows[m.agentSel].id)
 		}
 	case ckViewModels:

--- a/internal/tui/keys_test.go
+++ b/internal/tui/keys_test.go
@@ -84,8 +84,8 @@ func TestGlossary_QuestionMarkSemantics(t *testing.T) {
 	if chat.glossary {
 		t.Error("? mid-sentence opened the glossary instead of typing")
 	}
-	if chat.input != "what is 2?" {
-		t.Errorf("input = %q, want the ? appended", chat.input)
+	if chat.th().input != "what is 2?" {
+		t.Errorf("input = %q, want the ? appended", chat.th().input)
 	}
 }
 
@@ -108,8 +108,8 @@ func TestDigits_JumpOutsideChatTypeInsideChat(t *testing.T) {
 	if chat.view != ckViewChat {
 		t.Fatal("typing a digit in chat switched views")
 	}
-	if chat.input != "add 2 retries" {
-		t.Errorf("input = %q", chat.input)
+	if chat.th().input != "add 2 retries" {
+		t.Errorf("input = %q", chat.th().input)
 	}
 }
 
@@ -123,18 +123,18 @@ func TestInput_IsScopedToTheChatView(t *testing.T) {
 	m.view = ckViewUsage
 	m = typed(m, "x")
 	m = press(m, tea.KeyBackspace)
-	if m.input != "half a prompt" {
-		t.Errorf("input on a non-chat view = %q, want untouched", m.input)
+	if m.th().input != "half a prompt" {
+		t.Errorf("input on a non-chat view = %q, want untouched", m.th().input)
 	}
-	before := len(m.log)
+	before := len(m.th().log)
 	m, cmd := enter(m)
-	if len(m.log) != before || cmd != nil {
+	if len(m.th().log) != before || cmd != nil {
 		t.Error("enter on a non-chat view ran a chat submit")
 	}
 
 	m.view = ckViewChat
 	m, cmd = enter(m)
-	if len(m.log) <= before {
+	if len(m.th().log) <= before {
 		t.Error("enter on chat did not submit the preserved input")
 	}
 	if cmd == nil {
@@ -172,8 +172,8 @@ func TestEsc_Semantics(t *testing.T) {
 	chat.view = ckViewChat
 	chat = typed(chat, "abc")
 	chat = press(chat, tea.KeyEsc)
-	if chat.input != "" {
-		t.Errorf("esc did not clear the input: %q", chat.input)
+	if chat.th().input != "" {
+		t.Errorf("esc did not clear the input: %q", chat.th().input)
 	}
 }
 
@@ -277,16 +277,16 @@ func TestChatScrollback_NoYankAndEndReturnsToLive(t *testing.T) {
 	m.view = ckViewChat
 	m.w, m.h, m.ready = 100, 24, true
 	for i := 0; i < 80; i++ {
-		m.log = append(m.log, strings.Repeat("history ", 2)+"line")
+		m.th().log = append(m.th().log, strings.Repeat("history ", 2)+"line")
 	}
 
 	m = press(m, tea.KeyPgUp)
-	if m.chatScroll == 0 {
+	if m.th().scroll == 0 {
 		t.Fatal("pgup did not enter scrollback")
 	}
-	anchored := m.chatScroll
-	m.log = append(m.log, "NEW OUTPUT")
-	if m.chatScroll != anchored {
+	anchored := m.th().scroll
+	m.th().log = append(m.th().log, "NEW OUTPUT")
+	if m.th().scroll != anchored {
 		t.Error("an append moved the scrollback anchor")
 	}
 	if out := stripANSI(m.View()); strings.Contains(out, "NEW OUTPUT") {
@@ -296,7 +296,7 @@ func TestChatScrollback_NoYankAndEndReturnsToLive(t *testing.T) {
 	}
 
 	m = press(m, tea.KeyEnd)
-	if m.chatScroll != 0 {
+	if m.th().scroll != 0 {
 		t.Error("end did not return to live")
 	}
 	if out := stripANSI(m.View()); !strings.Contains(out, "NEW OUTPUT") {
@@ -307,7 +307,7 @@ func TestChatScrollback_NoYankAndEndReturnsToLive(t *testing.T) {
 	m = press(m, tea.KeyPgUp)
 	m = typed(m, "a new task")
 	m, _ = enter(m)
-	if m.chatScroll != 0 {
+	if m.th().scroll != 0 {
 		t.Error("sending a message did not return the view to live")
 	}
 }
@@ -318,13 +318,13 @@ func TestChatWheel_ScrollsLog(t *testing.T) {
 	m.view = ckViewChat
 	m.w, m.h, m.ready = 100, 24, true
 	for i := 0; i < 80; i++ {
-		m.log = append(m.log, "line")
+		m.th().log = append(m.th().log, "line")
 	}
 	next, _ := m.Update(tea.MouseMsg{Button: tea.MouseButtonWheelUp, Action: tea.MouseActionPress})
-	if next.(Cockpit).chatScroll == 0 {
+	if next.(Cockpit).th().scroll == 0 {
 		t.Error("wheel up did not scroll the chat log")
 	}
-	if next.(Cockpit).input != "" {
+	if next.(Cockpit).th().input != "" {
 		t.Error("the wheel touched the input")
 	}
 }

--- a/internal/tui/modes.go
+++ b/internal/tui/modes.go
@@ -107,7 +107,7 @@ func (m Cockpit) modePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeySpace:
 		m.modePick = false
-		m.input = "m "
+		m.th().input = "m "
 		return m, nil
 	case tea.KeyUp:
 		return m.moveModeSel(-1), nil
@@ -132,7 +132,7 @@ func (m Cockpit) modePickerKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		// Anything else — a typed letter or a paste — falls through to input.
 		m.modePick = false
-		m.input = "m" + string(msg.Runes)
+		m.th().input = "m" + string(msg.Runes)
 	}
 	return m, nil
 }

--- a/internal/tui/modes_test.go
+++ b/internal/tui/modes_test.go
@@ -63,8 +63,8 @@ func TestModes_PickerOpensSelectsAndCloses(t *testing.T) {
 	if m.modePick {
 		t.Fatal("m typed mid-sentence opened the picker")
 	}
-	if m.input != "make a helper for m" {
-		t.Errorf("input = %q — typing a word starting with m must pass through the picker intact", m.input)
+	if m.th().input != "make a helper for m" {
+		t.Errorf("input = %q — typing a word starting with m must pass through the picker intact", m.th().input)
 	}
 	if m.mode != "unattended" {
 		t.Errorf("typing through the picker changed the mode to %q", m.mode)
@@ -89,15 +89,15 @@ func TestKeys_CoalescedRunesReplayIndividually(t *testing.T) {
 	// Typing coalesced into the input still types everything.
 	chat := testCockpit()
 	next, _ = chat.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("fix the bug")})
-	if got := next.(Cockpit).input; got != "fix the bug" {
+	if got := next.(Cockpit).th().input; got != "fix the bug" {
 		t.Errorf("coalesced typing lost characters: %q", got)
 	}
 	// A bracketed paste is literal input, never a run of shortcuts — even when
 	// it starts with a command letter on an empty input.
 	next, _ = testCockpit().Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("make it so"), Paste: true})
 	pasted := next.(Cockpit)
-	if pasted.modePick || pasted.input != "make it so" {
-		t.Errorf("paste triggered commands: pick=%v input=%q", pasted.modePick, pasted.input)
+	if pasted.modePick || pasted.th().input != "make it so" {
+		t.Errorf("paste triggered commands: pick=%v input=%q", pasted.modePick, pasted.th().input)
 	}
 }
 
@@ -110,13 +110,13 @@ func TestModes_PickerForgivesTyping(t *testing.T) {
 		t.Fatal("picker did not open")
 	}
 	m = press(m, tea.KeyBackspace)
-	if m.modePick || m.input != "" {
-		t.Fatalf("backspace did not un-type the m: pick=%v input=%q", m.modePick, m.input)
+	if m.modePick || m.th().input != "" {
+		t.Fatalf("backspace did not un-type the m: pick=%v input=%q", m.modePick, m.th().input)
 	}
 	m = typed(m, "m")
 	m = press(m, tea.KeySpace)
-	if m.modePick || m.input != "m " {
-		t.Fatalf("space did not type through: pick=%v input=%q", m.modePick, m.input)
+	if m.modePick || m.th().input != "m " {
+		t.Fatalf("space did not type through: pick=%v input=%q", m.modePick, m.th().input)
 	}
 }
 

--- a/internal/tui/thread_queue.go
+++ b/internal/tui/thread_queue.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// thread_queue.go — queue-on-overlap (#598): before an edit thread starts, its
+// file target is checked against every other thread's holds — the same
+// duplicate-target pre-flight internal/parallel runs, plus graph coupling.
+// internal/a2a vector clocks are the apply-time backstop.
+
+import (
+	"fmt"
+	"sort"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ankit373/hydra/internal/a2a"
+)
+
+// ckQueued is a task waiting for an overlap blocker to apply or discard.
+type ckQueued struct {
+	prompt    string
+	mode      string // the chat mode at submit time — kept across the wait
+	rel       string // the repo-relative target that overlapped
+	seq       int    // queue position — earlier seq goes first, so two queued
+	blockerID int    // threads can never block each other symmetrically
+	reason    string // the visible chip/header line, path included
+}
+
+// heldFiles is what an edit thread currently holds against other threads: its
+// running/gated/un-applied targets, plus a queued task's target (chains queue).
+func (t *ckThread) heldFiles() []string {
+	if t.queued != nil {
+		if t.queued.rel != "" {
+			return append(append([]string(nil), t.files...), t.queued.rel)
+		}
+		return t.files
+	}
+	if t.exec != nil || t.planWait != nil || t.confirm != nil || t.wt != nil || t.inEdit {
+		return t.files
+	}
+	return nil
+}
+
+// overlapBlocker finds the thread that blocks self from editing rel ("" =
+// no blocker). Degraded mode (no repo): edits are serial, whatever the file.
+// A queued thread only blocks those behind it in the queue — never the other
+// way round, so releases can never deadlock on symmetric holds.
+func (m Cockpit) overlapBlocker(self *ckThread, rel string) (*ckThread, string) {
+	selfSeq := int(^uint(0) >> 1) // a fresh submit queues behind everyone
+	if self.queued != nil {
+		selfSeq = self.queued.seq
+	}
+	for _, t := range m.threads {
+		if t.id == self.id {
+			continue
+		}
+		if t.queued != nil && t.queued.seq >= selfSeq {
+			continue
+		}
+		if m.repoRoot == "" {
+			// No isolation exists — one in-place edit at a time, full stop.
+			if t.inEdit || t.queued != nil {
+				return t, ""
+			}
+			continue
+		}
+		for _, f := range t.heldFiles() {
+			if f == rel {
+				return t, f
+			}
+			if m.metrics.graph != nil && m.metrics.graph.Coupled(f, rel) {
+				return t, f
+			}
+		}
+	}
+	return nil, ""
+}
+
+// queueTask parks the prompt on the thread with its visible reason.
+func (t *ckThread) queueTask(prompt, rel string, blocker *ckThread, overlap string) {
+	reason := fmt.Sprintf("queued behind %d", blocker.id)
+	switch {
+	case overlap == rel && rel != "":
+		reason += " · both touch " + rel
+	case overlap != "":
+		reason += fmt.Sprintf(" · %s is coupled to %s", rel, overlap)
+	default:
+		reason += " · no git repo — edits run one at a time"
+	}
+	t.queued = &ckQueued{prompt: prompt, rel: rel, blockerID: blocker.id, reason: reason}
+	t.log = append(t.log, ckDimS.Render("  ◱ "+reason+" — auto-starts when it applies or discards"))
+	if t.name == "" {
+		t.name = ckThreadName(prompt)
+	}
+}
+
+// releaseThreads re-checks every queued thread, oldest first, after releaser
+// freed its holds — beginTask re-runs the gate and either starts or requeues.
+// The releaser's clock merges into each waiter: whatever runs next causally
+// follows what was just applied (#598).
+func (m Cockpit) releaseThreads(releaser *ckThread) (Cockpit, tea.Cmd) {
+	var waiting []*ckThread
+	for _, t := range m.threads {
+		if t.queued != nil {
+			waiting = append(waiting, t)
+		}
+	}
+	sort.Slice(waiting, func(i, j int) bool { return waiting[i].queued.seq < waiting[j].queued.seq })
+	var cmds []tea.Cmd
+	for _, t := range waiting {
+		q := *t.queued
+		if releaser != nil {
+			t.clock = t.clock.Merge(releaser.clock)
+		}
+		var cmd tea.Cmd
+		m, cmd = m.beginTask(t, q.prompt, q.mode)
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if len(cmds) == 0 {
+		return m, nil
+	}
+	return m, tea.Batch(cmds...)
+}
+
+// requeueBehind updates the blocker/reason, echoing only on an actual change.
+func (t *ckThread) requeueBehind(blocker *ckThread, overlap string) {
+	if t.queued.blockerID == blocker.id {
+		return
+	}
+	reason := fmt.Sprintf("queued behind %d", blocker.id)
+	if overlap != "" {
+		reason += " · both touch " + overlap
+	}
+	t.queued.blockerID, t.queued.reason = blocker.id, reason
+	t.log = append(t.log, ckDimS.Render("  ◱ now "+reason))
+}
+
+// concurrentWarnings is the a2a backstop at apply time: any other thread whose
+// handoff is causally concurrent AND overlaps this thread's files gets named
+// before the merge — the queue should make this unreachable; the clocks catch
+// what it missed (targets that only became known late).
+func (m Cockpit) concurrentWarnings(self *ckThread) []string {
+	h := &a2a.Handoff{From: ckThreadAgent(self.id), Files: self.files, Clock: self.clock}
+	var out []string
+	for _, t := range m.threads {
+		if t.id == self.id || len(t.files) == 0 {
+			continue
+		}
+		o := &a2a.Handoff{From: ckThreadAgent(t.id), Files: t.files, Clock: t.clock}
+		if h.ConflictsWith(o) {
+			out = append(out, ckMidS.Render("  ⚠ concurrent edit ")+ckDimS.Render(fmt.Sprintf(
+				"thread %d also touched %s (vector clocks concurrent) — expect conflicts",
+				t.id, ckOverlapPath(self.files, t.files))))
+		}
+	}
+	return out
+}
+
+// ckOverlapPath names one file both sides touch, for the warning line.
+func ckOverlapPath(a, b []string) string {
+	set := make(map[string]bool, len(a))
+	for _, f := range a {
+		set[f] = true
+	}
+	for _, f := range b {
+		if set[f] {
+			return f
+		}
+	}
+	return "the same files"
+}

--- a/internal/tui/thread_queue_test.go
+++ b/internal/tui/thread_queue_test.go
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// Queue-on-overlap (#598): same-file edits never run concurrently; the second
+// queues visibly and auto-starts on apply/discard. Vector clocks are the
+// apply-time backstop. The race test at the bottom runs real workers
+// concurrently — the detector must see the actual parallel paths.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ankit373/hydra/internal/a2a"
+	"github.com/ankit373/hydra/internal/editor"
+	"github.com/ankit373/hydra/internal/graph"
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// stubThreadEdit writes tag-stamped content to whatever file the task targets.
+func stubThreadEdit(delay time.Duration) func(context.Context, *ckTask, string) (*editor.Result, error) {
+	return func(ctx context.Context, tk *ckTask, _ string) (*editor.Result, error) {
+		if delay > 0 {
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		before, _ := os.ReadFile(tk.file)
+		after := fmt.Sprintf("package pkg // edited by thread %d\n", tk.threadID)
+		if err := os.WriteFile(tk.file, []byte(after), 0o644); err != nil {
+			return nil, err
+		}
+		runlog.LogEdit(tk.runID, tk.taskID, tk.file, before, []byte(after), 1, 1)
+		return &editor.Result{Status: "ok", File: tk.file, LinesAdded: 1, LinesRemoved: 1, Head: "stub"}, nil
+	}
+}
+
+func TestQueue_SameFileQueuesThenAutoStartsOnApply(t *testing.T) {
+	repo := threadRepo(t)
+	stubExec(t)
+	ckEditStage = stubThreadEdit(0)
+
+	m := chatFixture("edit")
+	m.repoRoot = repo
+	m2, cmd := m.startTask("edit pkg/main.go first")
+	m = runCmds(t, m2, cmd)
+	if m.th().wt == nil {
+		t.Fatal("thread 1 got no worktree")
+	}
+
+	m = press(m, tea.KeyCtrlT)
+	m2, cmd = m.startTask("edit pkg/main.go second")
+	m = runCmds(t, m2, cmd)
+	th2 := m.th()
+	if th2.queued == nil {
+		t.Fatal("the second edit on the same file did not queue")
+	}
+	if th2.status() != "queued" {
+		t.Errorf("status = %q", th2.status())
+	}
+	reason := stripANSI(th2.queued.reason)
+	if !strings.Contains(reason, "queued behind 1") || !strings.Contains(reason, "both touch pkg/main.go") {
+		t.Errorf("reason = %q", reason)
+	}
+	// The strip shows the queued glyph; the header line carries the reason.
+	if !strings.Contains(stripANSI(m.threadStrip(120)), "◱") {
+		t.Error("the strip does not show the queued chip")
+	}
+	if hdr := stripANSI(th2.threadHeaderLine(120)); !strings.Contains(hdr, "queued behind 1") {
+		t.Errorf("header = %q", hdr)
+	}
+
+	// Blocker applies → the queued thread auto-starts and lands its own edit.
+	m = altDigit(m, '1')
+	m, acmd := keyRune(m, 'a')
+	m = runCmds(t, m, acmd)
+	th2 = m.threadByID(2)
+	if th2.queued != nil {
+		t.Fatal("apply did not release the queued thread")
+	}
+	if th2.lastDone == nil || !th2.lastDone.edited {
+		t.Fatalf("the released thread did not run: %+v", th2.lastDone)
+	}
+	logs := stripANSI(strings.Join(th2.log, "\n"))
+	if !strings.Contains(logs, "unblocked — starting") {
+		t.Errorf("the release is not visible: %q", logs)
+	}
+	// Thread 2 ran AFTER thread 1 applied: its clock must dominate thread 1's,
+	// not read as concurrent — that is the causal-ordering merge.
+	if got := th2.clock.Compare(m.threadByID(1).clock); got != a2a.After {
+		t.Errorf("released thread's clock ordering = %v, want After", got)
+	}
+}
+
+func TestQueue_DiscardAlsoReleases(t *testing.T) {
+	repo := threadRepo(t)
+	stubExec(t)
+	ckEditStage = stubThreadEdit(0)
+
+	m := chatFixture("edit")
+	m.repoRoot = repo
+	m2, cmd := m.startTask("edit pkg/other.go one")
+	m = runCmds(t, m2, cmd)
+	m = press(m, tea.KeyCtrlT)
+	m2, cmd = m.startTask("edit pkg/other.go two")
+	m = runCmds(t, m2, cmd)
+	if m.th().queued == nil {
+		t.Fatal("no queue")
+	}
+
+	m = altDigit(m, '1')
+	m, _ = keyRune(m, 'x') // arm
+	m, dcmd := keyRune(m, 'x')
+	m = runCmds(t, m, dcmd)
+	th2 := m.threadByID(2)
+	if th2.queued != nil || th2.lastDone == nil {
+		t.Fatalf("discard did not release the queue: queued=%v done=%v", th2.queued, th2.lastDone)
+	}
+}
+
+func TestQueue_ChainRequeuesBehindTheNewBlocker(t *testing.T) {
+	repo := threadRepo(t)
+	stubExec(t)
+	ckEditStage = stubThreadEdit(0)
+
+	m := chatFixture("edit")
+	m.repoRoot = repo
+	m2, cmd := m.startTask("edit pkg/third.go a")
+	m = runCmds(t, m2, cmd)
+	m = press(m, tea.KeyCtrlT)
+	m2, cmd = m.startTask("edit pkg/third.go b")
+	m = runCmds(t, m2, cmd)
+	m = press(m, tea.KeyCtrlT)
+	m2, cmd = m.startTask("edit pkg/third.go c")
+	m = runCmds(t, m2, cmd)
+
+	if m.threadByID(2).queued == nil || m.threadByID(3).queued == nil {
+		t.Fatal("the chain did not queue")
+	}
+	// Thread 1 applies: 2 starts, 3 requeues behind 2.
+	m = altDigit(m, '1')
+	m, acmd := keyRune(m, 'a')
+	m = runCmds(t, m, acmd)
+	if m.threadByID(2).queued != nil {
+		t.Fatal("thread 2 did not start")
+	}
+	q3 := m.threadByID(3).queued
+	if q3 == nil {
+		t.Fatal("thread 3 started alongside thread 2 — same file")
+	}
+	if q3.blockerID != 2 {
+		t.Errorf("thread 3 queues behind %d, want 2", q3.blockerID)
+	}
+}
+
+// Degraded mode: no git repo → no isolation exists, so edits are serial even
+// on different files, and the degradation is said out loud.
+func TestQueue_NoRepoSerializesEditsInPlace(t *testing.T) {
+	testutil.NewSandbox(t)
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"a.go", "b.go"} {
+		if err := os.WriteFile(filepath.Join(dir, "pkg", f), []byte("package pkg\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	prev, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	stubExec(t)
+	edits := make(chan int, 4)
+	ckEditStage = func(_ context.Context, tk *ckTask, _ string) (*editor.Result, error) {
+		edits <- tk.threadID
+		runlog.LogEdit(tk.runID, tk.taskID, tk.file, []byte("a"), []byte("b"), 1, 0)
+		return &editor.Result{Status: "ok", File: tk.file, LinesAdded: 1, Head: "stub"}, nil
+	}
+
+	m := chatFixture("edit")
+	m.repoRoot = "" // not a git repo
+	// Hold thread 1's edit open by hand so the second submit sees it running.
+	th1 := m.th()
+	th1.inEdit = true
+	th1.files = []string{filepath.Join(dir, "pkg", "a.go")}
+	th1.exec = &ckExecState{stage: "editing"}
+	logs := stripANSI(strings.Join(th1.log, "\n"))
+	_ = logs
+
+	m = press(m, tea.KeyCtrlT)
+	m2, cmd := m.startTask("edit pkg/b.go too")
+	m = runCmds(t, m2, cmd)
+	if m.th().queued == nil {
+		t.Fatal("a second in-place edit ran concurrently with the first")
+	}
+	if !strings.Contains(stripANSI(m.th().queued.reason), "no git repo") {
+		t.Errorf("the degradation is not named: %q", m.th().queued.reason)
+	}
+
+	// The blocker finishing releases it.
+	ex := th1.exec
+	next, rcmd := m.Update(ckExecDoneMsg{exec: ex, task: ckTask{threadID: 1, runID: "r1", elapsed: time.Second}})
+	m = runCmds(t, next.(Cockpit), rcmd)
+	if m.threadByID(2).queued != nil {
+		t.Fatal("the blocker's completion did not release the queue")
+	}
+	if got := <-edits; got != 2 {
+		t.Errorf("the released edit belonged to thread %d", got)
+	}
+	warn := stripANSI(strings.Join(m.threadByID(2).log, "\n"))
+	if !strings.Contains(warn, "no isolation") {
+		t.Errorf("the in-place warning is missing: %q", warn)
+	}
+}
+
+// Graph coupling queues indirect collisions when a graph is loaded.
+func TestQueue_GraphCoupledTargetsQueue(t *testing.T) {
+	repo := threadRepo(t)
+	stubExec(t)
+	ckEditStage = stubThreadEdit(0)
+
+	gpath := filepath.Join(t.TempDir(), "graph.json")
+	data := `{"nodes":[{"id":"m","file":"pkg/main.go"},{"id":"o","file":"pkg/other.go"}],"edges":[{"from":"o","to":"m"}]}`
+	if err := os.WriteFile(gpath, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	g, err := graph.Load(gpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := chatFixture("edit")
+	m.repoRoot = repo
+	m.metrics.graph = g
+	m2, cmd := m.startTask("edit pkg/main.go base")
+	m = runCmds(t, m2, cmd)
+	m = press(m, tea.KeyCtrlT)
+	m2, cmd = m.startTask("edit pkg/other.go dependent")
+	m = runCmds(t, m2, cmd)
+	q := m.th().queued
+	if q == nil {
+		t.Fatal("graph-coupled targets ran concurrently")
+	}
+	if !strings.Contains(stripANSI(q.reason), "coupled") {
+		t.Errorf("reason = %q", q.reason)
+	}
+}
+
+// The a2a backstop: concurrent clocks + overlapping files warn at apply;
+// causally ordered clocks stay silent.
+func TestConcurrentWarnings_VectorClockBackstop(t *testing.T) {
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlT)
+	t1, t2 := m.threadByID(1), m.threadByID(2)
+	t1.files = []string{"pkg/main.go"}
+	t2.files = []string{"pkg/main.go"}
+	// Independent ticks → concurrent.
+	t1.clock = a2a.Clock{}.Tick(ckThreadAgent(1))
+	t2.clock = a2a.Clock{}.Tick(ckThreadAgent(2))
+	warns := m.concurrentWarnings(t1)
+	if len(warns) != 1 || !strings.Contains(stripANSI(warns[0]), "thread 2 also touched pkg/main.go") {
+		t.Fatalf("warns = %v", warns)
+	}
+	// Merge (the release path) orders them: no warning.
+	t2.clock = t2.clock.Merge(t1.clock).Tick(ckThreadAgent(2))
+	if warns := m.concurrentWarnings(t1); len(warns) != 0 {
+		t.Errorf("ordered clocks still warn: %v", warns)
+	}
+	// Disjoint files: concurrent but no overlap — no warning.
+	t2.clock = a2a.Clock{}.Tick(ckThreadAgent(2))
+	t2.files = []string{"pkg/other.go"}
+	if warns := m.concurrentWarnings(t1); len(warns) != 0 {
+		t.Errorf("disjoint files warned: %v", warns)
+	}
+}
+
+// ── concurrency: real workers, run in parallel ───────────────────────────────
+
+// runRounds executes cmd trees in concurrent rounds: every cmd in a round runs
+// in its own goroutine (the workers genuinely race); the resulting messages
+// then apply to the model sequentially, exactly as Bubble Tea would.
+func runRounds(t *testing.T, m Cockpit, cmds []tea.Cmd) Cockpit {
+	t.Helper()
+	for round := 0; len(cmds) > 0; round++ {
+		if round > 20 {
+			t.Fatal("cmd rounds did not converge")
+		}
+		var mu sync.Mutex
+		var msgs []tea.Msg
+		var wg sync.WaitGroup
+		var run func(c tea.Cmd)
+		run = func(c tea.Cmd) {
+			defer wg.Done()
+			if c == nil {
+				return
+			}
+			switch msg := c().(type) {
+			case tea.BatchMsg:
+				for _, cc := range msg {
+					wg.Add(1)
+					go run(cc)
+				}
+			case ckSpinTickMsg, ckCodeTickMsg:
+			default:
+				mu.Lock()
+				msgs = append(msgs, msg)
+				mu.Unlock()
+			}
+		}
+		for _, c := range cmds {
+			wg.Add(1)
+			go run(c)
+		}
+		wg.Wait()
+		cmds = nil
+		for _, msg := range msgs {
+			next, cmd := m.Update(msg)
+			m = next.(Cockpit)
+			if cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+	}
+	return m
+}
+
+// Three edit threads on three different files run their pipelines
+// CONCURRENTLY — separate worktrees, real runlog heartbeats, stubbed editors
+// with real sleeps — and every result must land on its own thread.
+func TestThreads_ConcurrentWorkersSettleOnTheirOwnThreads(t *testing.T) {
+	repo := threadRepo(t)
+	stubExec(t)
+	ckEditStage = stubThreadEdit(30 * time.Millisecond)
+
+	m := chatFixture("edit")
+	m.repoRoot = repo
+	var cmds []tea.Cmd
+	for i, f := range []string{"pkg/main.go", "pkg/other.go", "pkg/third.go"} {
+		if i > 0 {
+			m = press(m, tea.KeyCtrlT)
+		}
+		m2, cmd := m.startTask("edit " + f + " concurrently")
+		m = m2
+		if cmd == nil {
+			t.Fatalf("thread %d did not launch", i+1)
+		}
+		cmds = append(cmds, cmd)
+	}
+	if _, _, queued := m.threadCounts(); queued != 0 {
+		t.Fatal("disjoint files queued — they must run concurrently")
+	}
+
+	m = runRounds(t, m, cmds)
+
+	for id := 1; id <= 3; id++ {
+		th := m.threadByID(id)
+		if th.lastDone == nil || !th.lastDone.edited {
+			t.Fatalf("thread %d did not settle: %+v", id, th.lastDone)
+		}
+		if th.lastDone.threadID != id {
+			t.Errorf("thread %d holds thread %d's task", id, th.lastDone.threadID)
+		}
+		if th.wt == nil {
+			t.Fatalf("thread %d lost its worktree", id)
+		}
+		raw, err := os.ReadFile(filepath.Join(th.wt.dir, "pkg", []string{"main.go", "other.go", "third.go"}[id-1]))
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := fmt.Sprintf("edited by thread %d", id)
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("thread %d's worktree holds %q, want %q", id, raw, want)
+		}
+	}
+
+	// All three apply cleanly — disjoint files cannot conflict.
+	for id := 1; id <= 3; id++ {
+		m = altDigit(m, rune('0'+id))
+		var acmd tea.Cmd
+		m, acmd = keyRune(m, 'a')
+		m = runCmds(t, m, acmd)
+		if m.threadByID(id).wt != nil {
+			t.Errorf("thread %d's apply left its worktree", id)
+		}
+	}
+	for i, f := range []string{"main.go", "other.go", "third.go"} {
+		raw, _ := os.ReadFile(filepath.Join(repo, "pkg", f))
+		want := fmt.Sprintf("edited by thread %d", i+1)
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("%s = %q, want %q", f, raw, want)
+		}
+	}
+}

--- a/internal/tui/thread_worktree.go
+++ b/internal/tui/thread_worktree.go
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// thread_worktree.go — edit-thread isolation (#598): each edit-capable thread
+// gets its own git worktree of the user's repo, and the a / x x keys merge it
+// back with conflicts surfaced (git apply --3way) or discard it.
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/util"
+)
+
+// ckWorktree is one thread's isolated checkout.
+type ckWorktree struct {
+	tag    string // "t3-9f2c1a" — dir basename, branch suffix, and the UI label
+	dir    string // <hydra home>/worktrees/<tag>
+	branch string // hydra/task-<tag>
+	repo   string // the user's repo root it was cut from
+	base   string // commit the worktree was created at — the diff's left side
+}
+
+// ckWorktreeBase is where thread worktrees live: $HYDRA_HOME/worktrees, i.e.
+// ~/.hydra/worktrees on a default install.
+func ckWorktreeBase() string { return filepath.Join(config.Dir(), "worktrees") }
+
+// ckGitTimeout bounds every worktree git command so a wedged lock cannot hang
+// the UI (apply/discard run synchronously — they are index-local and fast).
+const ckGitTimeout = 30 * time.Second
+
+// ckGit runs one git command and returns its combined output, bounded. The
+// messages below are read back, so the locale is pinned: a translated git
+// would otherwise turn a conflicted apply into an unrecognized failure.
+func ckGit(dir, stdin string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ckGitTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANGUAGE=")
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	out := util.NewAccumulator(1 << 22)
+	cmd.Stdout, cmd.Stderr = out, out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// ckNewWorktreeTag is unique across sessions so a stale worktree from a crash
+// can never collide with a new thread's.
+func ckNewWorktreeTag(threadID int) string {
+	var b [3]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("t%d-%d", threadID, time.Now().UnixNano()%0xffffff)
+	}
+	return fmt.Sprintf("t%d-%s", threadID, hex.EncodeToString(b[:]))
+}
+
+// ckCreateWorktree cuts a worktree of repo at HEAD on its own branch.
+func ckCreateWorktree(repo string, threadID int) (*ckWorktree, error) {
+	if err := os.MkdirAll(ckWorktreeBase(), 0o700); err != nil {
+		return nil, err
+	}
+	tag := ckNewWorktreeTag(threadID)
+	wt := &ckWorktree{
+		tag: tag, dir: filepath.Join(ckWorktreeBase(), tag),
+		branch: "hydra/task-" + tag, repo: repo,
+	}
+	if out, err := ckGit(repo, "", "worktree", "add", wt.dir, "-b", wt.branch); err != nil {
+		return nil, fmt.Errorf("git worktree add: %s", ckFirstLine(out))
+	}
+	base, err := ckGit(wt.dir, "", "rev-parse", "HEAD")
+	if err != nil {
+		_ = ckDiscardWorktree(wt)
+		return nil, fmt.Errorf("git rev-parse: %s", ckFirstLine(base))
+	}
+	wt.base = strings.TrimSpace(base)
+	return wt, nil
+}
+
+// ckApplyOut is one apply attempt's honest outcome.
+type ckApplyOut struct {
+	applied    bool     // the diff landed in the user's tree (staged)
+	conflict   bool     // landed with conflict markers (committed divergence)
+	refused    bool     // something blocked it (usually a dirty overlap); nothing applied
+	empty      bool     // the worktree held no changes
+	files      []string // repo-relative paths the diff touches
+	detail     string   // first git line explaining a refusal or failure
+	branchKept bool     // the branch survives (conflict/refusal recovery)
+	err        error    // git itself failed — not a merge outcome
+}
+
+// ckApplyWorktree commits the worktree and 3-way-applies its diff onto the
+// user's tree. Atomic on refusal (dirty overlap: nothing lands), standard
+// conflict markers on committed divergence — never a silent overwrite.
+func ckApplyWorktree(wt *ckWorktree) ckApplyOut {
+	if out, err := ckGit(wt.dir, "", "add", "-A"); err != nil {
+		return ckApplyOut{err: fmt.Errorf("git add: %s", ckFirstLine(out))}
+	}
+	if st, err := ckGit(wt.dir, "", "status", "--porcelain"); err != nil {
+		return ckApplyOut{err: fmt.Errorf("git status: %s", ckFirstLine(st))}
+	} else if strings.TrimSpace(st) != "" {
+		if out, cerr := ckGit(wt.dir, "", "commit", "-m", "hydra: "+wt.tag); cerr != nil {
+			return ckApplyOut{err: fmt.Errorf("git commit: %s", ckFirstLine(out))}
+		}
+	}
+	names, err := ckGit(wt.repo, "", "diff", "--name-only", wt.base, wt.branch)
+	if err != nil {
+		return ckApplyOut{err: fmt.Errorf("git diff: %s", ckFirstLine(names))}
+	}
+	res := ckApplyOut{files: ckSplitLines(names)}
+	if len(res.files) == 0 {
+		res.empty = true
+		res.err = ckCleanupWorktree(wt, false)
+		return res
+	}
+	// Refuse before touching anything when the user has UNSAVED edits to a path
+	// this patch touches. Whether git itself refuses or 3-way-merges there is
+	// platform- and version-dependent, and merging into work that exists in no
+	// object is not a gamble to take on the user's behalf.
+	if dirty := ckUnsavedOverlap(wt.repo, res.files); len(dirty) > 0 {
+		res.refused, res.branchKept = true, true
+		res.detail = "unsaved changes in " + truncate(strings.Join(dirty, ", "), 60)
+		return res
+	}
+	patch, err := ckGit(wt.repo, "", "diff", "--binary", "--full-index", wt.base, wt.branch)
+	if err != nil {
+		return ckApplyOut{err: fmt.Errorf("git diff: %s", ckFirstLine(patch))}
+	}
+	// A tree already mid-merge has unmerged entries of its own; only paths THIS
+	// apply left unmerged are evidence about THIS apply.
+	before := ckUnmergedPaths(wt.repo)
+	out, aerr := ckGit(wt.repo, patch, "apply", "--3way")
+	switch {
+	case aerr == nil:
+		res.applied = true
+		res.err = ckCleanupWorktree(wt, false)
+	case len(ckNewPaths(before, ckUnmergedPaths(wt.repo))) > 0:
+		// Standard-git conflict state, read off the index rather than trusted
+		// from a message: markers in the files, unmerged entries staged.
+		res.applied, res.conflict, res.branchKept = true, true, true
+		res.err = ckCleanupWorktree(wt, true)
+	default:
+		// --3way is atomic, so with no new unmerged entries nothing landed at
+		// all. Everything is kept for a retry once the blocker is cleared.
+		res.refused, res.branchKept = true, true
+		res.detail = ckFirstLine(out)
+	}
+	return res
+}
+
+// ckUnsavedOverlap lists which of files the tree has unsaved (worktree-vs-index)
+// changes to. A merely staged change is safe to merge over — its content is in
+// the object store — but an unsaved edit exists nowhere else.
+func ckUnsavedOverlap(repo string, files []string) []string {
+	out, err := ckGit(repo, "", append([]string{"status", "--porcelain", "-z", "--"}, files...)...)
+	if err != nil {
+		return nil // status failed: leave the decision to git's own apply
+	}
+	var dirty []string
+	for _, rec := range strings.Split(out, "\x00") {
+		// "XY path": Y is the worktree-vs-index column; ' ' means saved.
+		if len(rec) > 3 && rec[1] != ' ' && rec[1] != '?' {
+			dirty = append(dirty, rec[3:])
+		}
+	}
+	return dirty
+}
+
+// ckUnmergedPaths lists paths git left in a conflicted (unmerged) index state.
+func ckUnmergedPaths(repo string) []string {
+	out, err := ckGit(repo, "", "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return nil
+	}
+	return ckSplitLines(out)
+}
+
+// ckNewPaths returns the entries of after that were not already in before.
+func ckNewPaths(before, after []string) []string {
+	had := make(map[string]bool, len(before))
+	for _, p := range before {
+		had[p] = true
+	}
+	var out []string
+	for _, p := range after {
+		if !had[p] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// ckCleanupWorktree removes the worktree checkout, and its branch too unless
+// keepBranch (a conflicted apply keeps it so nothing is lost while resolving).
+func ckCleanupWorktree(wt *ckWorktree, keepBranch bool) error {
+	if out, err := ckGit(wt.repo, "", "worktree", "remove", "--force", wt.dir); err != nil {
+		return fmt.Errorf("git worktree remove: %s", ckFirstLine(out))
+	}
+	if keepBranch {
+		return nil
+	}
+	if out, err := ckGit(wt.repo, "", "branch", "-D", wt.branch); err != nil {
+		return fmt.Errorf("git branch -D: %s", ckFirstLine(out))
+	}
+	return nil
+}
+
+// ckDiscardWorktree drops the worktree and its branch — the thread's un-applied
+// edits are gone, which is exactly what discard means.
+func ckDiscardWorktree(wt *ckWorktree) error { return ckCleanupWorktree(wt, false) }
+
+// ckStaleWorktrees lists leftover worktree dirs from a previous session.
+// Listed and reported, never auto-deleted: they may hold un-applied work.
+func ckStaleWorktrees() []string {
+	entries, err := os.ReadDir(ckWorktreeBase())
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ckSplitLines splits command output into trimmed non-empty lines.
+func ckSplitLines(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if l = strings.TrimSpace(l); l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// ── apply / discard (the a and x x keys) ─────────────────────────────────────
+
+// discardKey is the two-press discard: destructive, so the first x only arms.
+func (m Cockpit) discardKey(th *ckThread) (Cockpit, tea.Cmd, bool) {
+	if !th.discardArm {
+		th.discardArm = true
+		m.flash = fmt.Sprintf("x again discards worktree %s — its edits are lost", th.wt.tag)
+		return m, nil, true
+	}
+	th.discardArm = false
+	tag := th.wt.tag
+	if err := ckDiscardWorktree(th.wt); err != nil {
+		th.log = append(th.log, ckExpS.Render("  ✗ discard failed ")+ckDimS.Render(err.Error()))
+		return m, nil, true
+	}
+	th.wt = nil
+	th.files = nil
+	th.log = append(th.log, ckDimS.Render(fmt.Sprintf("  ⎇ worktree %s discarded — your tree was never touched", tag)))
+	nm, cmd := m.releaseThreads(th)
+	return nm, cmd, true
+}
+
+// applyThread merges the thread's worktree back into the user's tree with
+// conflicts surfaced (thread_worktree.go has the mechanism), then releases
+// whatever queued behind it.
+func (m Cockpit) applyThread(th *ckThread) (Cockpit, tea.Cmd, bool) {
+	th.log = append(th.log, m.concurrentWarnings(th)...)
+	wt := th.wt
+	out := ckApplyWorktree(wt)
+	switch {
+	case out.err != nil && !out.applied && !out.empty:
+		th.log = append(th.log, ckExpS.Render("  ✗ apply failed ")+ckDimS.Render(ckSafe(out.err.Error())))
+		return m, nil, true
+	case out.refused:
+		// Either this code refused up front (unsaved overlap) or git's atomic
+		// apply declined; both mean nothing in the user's tree changed.
+		th.log = append(th.log,
+			ckExpS.Render("  ✗ apply blocked ")+ckDimS.Render("— nothing in your tree was changed"),
+			ckDimS.Render("    "+truncate(ckSafe(out.detail), 80)),
+			ckFaintS.Render("    save or stash the overlapping change, then press a again · x x discards"))
+		return m, nil, true
+	case out.empty:
+		th.log = append(th.log, ckDimS.Render("  ⎇ nothing to apply — worktree removed"))
+	case out.conflict:
+		th.log = append(th.log,
+			ckMidS.Render("  ⚠ applied with conflicts ")+ckDimS.Render("— markers left in "+truncate(strings.Join(out.files, ", "), 60)),
+			ckDimS.Render("    resolve the <<<<<<< markers, then `git add` · `git diff` shows the conflict"),
+			ckDimS.Render("    branch "+wt.branch+" kept — `git branch -D` it once resolved"))
+	default:
+		th.log = append(th.log, ckCheapS.Render("  ✓ applied ")+
+			ckDimS.Render(fmt.Sprintf("%d file%s staged onto %s · worktree and branch removed",
+				len(out.files), plural(len(out.files)), truncate(wt.repo, 40))))
+	}
+	if out.err != nil { // cleanup hiccup after a landed apply — disclose it
+		th.log = append(th.log, ckMidS.Render("  ⚠ cleanup: ")+ckDimS.Render(ckSafe(out.err.Error())))
+	}
+	th.wt = nil
+	th.files = nil
+	th.clock = th.clock.Tick(ckThreadAgent(th.id))
+	nm, cmd := m.releaseThreads(th)
+	return nm, cmd, true
+}
+
+// ── async creation ────────────────────────────────────────────────────────────
+
+// ckWtReadyMsg lands when a thread's worktree finished being cut; the pending
+// task rides along so Update can launch the pipeline against it.
+type ckWtReadyMsg struct {
+	exec *ckExecState
+	task ckTask
+	wt   *ckWorktree
+	err  error
+}
+
+// ckWtCreate cuts the worktree off the UI loop — `git worktree add` checks out
+// the whole tree, which is slow on big repos.
+func ckWtCreate(ex *ckExecState, t ckTask, repo string) tea.Cmd {
+	return func() tea.Msg {
+		wt, err := ckCreateWorktree(repo, t.threadID)
+		return ckWtReadyMsg{exec: ex, task: t, wt: wt, err: err}
+	}
+}

--- a/internal/tui/thread_worktree_test.go
+++ b/internal/tui/thread_worktree_test.go
@@ -1,0 +1,588 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// Worktree isolation lifecycle (#598) against real git: create, apply (clean /
+// conflict / refusal / empty), discard, stale recovery. No git behavior is
+// mocked — the merge semantics ARE the feature.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/editor"
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// threadRepo installs a sandbox with the host's git allowed, builds a
+// committed repo with pkg/{main,other,third}.go, and chdirs into it —
+// mirroring where a user launches `hyctl tui`.
+func threadRepo(t *testing.T) string {
+	t.Helper()
+	s := testutil.NewSandbox(t)
+	if !s.AllowHostBinary(t, "git") {
+		t.Skip("git is not installed on this machine")
+	}
+	repo := t.TempDir()
+	mustGit := func(args ...string) {
+		t.Helper()
+		if out, err := ckGit(repo, "", args...); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	mustGit("init", "-q")
+	mustGit("config", "user.email", "t@t")
+	mustGit("config", "user.name", "t")
+	if err := os.MkdirAll(filepath.Join(repo, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"main.go", "other.go", "third.go"} {
+		if err := os.WriteFile(filepath.Join(repo, "pkg", f),
+			[]byte("package pkg\n\nvar base = 1\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustGit("add", "-A")
+	mustGit("commit", "-qm", "base")
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cwd // symlink-resolved on macOS, matching what ckNamedFile computes
+}
+
+func TestWorktree_CreateApplyCleanLifecycle(t *testing.T) {
+	repo := threadRepo(t)
+
+	wt, err := ckCreateWorktree(repo, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(filepath.Base(wt.dir), "t3-") || !strings.HasPrefix(wt.branch, "hydra/task-t3-") {
+		t.Errorf("naming: dir=%s branch=%s", wt.dir, wt.branch)
+	}
+	if !strings.HasPrefix(wt.dir, ckWorktreeBase()) {
+		t.Errorf("worktree not under %s: %s", ckWorktreeBase(), wt.dir)
+	}
+	if wt.base == "" {
+		t.Error("no base commit recorded")
+	}
+
+	edited := filepath.Join(wt.dir, "pkg", "main.go")
+	if err := os.WriteFile(edited, []byte("package pkg\n\nvar base = 2 // thread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := ckApplyWorktree(wt)
+	if !out.applied || out.conflict || out.refused || out.err != nil {
+		t.Fatalf("clean apply: %+v", out)
+	}
+	if len(out.files) != 1 || out.files[0] != "pkg/main.go" {
+		t.Errorf("touched files = %v", out.files)
+	}
+	raw, _ := os.ReadFile(filepath.Join(repo, "pkg", "main.go"))
+	if !strings.Contains(string(raw), "var base = 2") {
+		t.Errorf("the user's tree did not receive the edit: %q", raw)
+	}
+	if _, err := os.Stat(wt.dir); !os.IsNotExist(err) {
+		t.Error("the worktree dir survived a clean apply")
+	}
+	if bout, err := ckGit(repo, "", "branch", "--list", wt.branch); err != nil || strings.TrimSpace(bout) != "" {
+		t.Errorf("the branch survived a clean apply: %q err=%v", bout, err)
+	}
+}
+
+// The induced-conflict case: the user commits their own change to a file the
+// thread also edited. Apply must land standard conflict markers, keep the
+// branch, and say all of it — never a silent overwrite.
+func TestWorktree_ApplyConflictSurfacesMarkers(t *testing.T) {
+	repo := threadRepo(t)
+
+	wt, err := ckCreateWorktree(repo, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.dir, "pkg", "main.go"),
+		[]byte("package pkg\n\nvar base = 2 // thread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The user commits a conflicting change on the same line.
+	if err := os.WriteFile(filepath.Join(repo, "pkg", "main.go"),
+		[]byte("package pkg\n\nvar base = 3 // user\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := ckGit(repo, "", "commit", "-aqm", "user change"); err != nil {
+		t.Fatalf("user commit: %v\n%s", err, out)
+	}
+
+	out := ckApplyWorktree(wt)
+	if !out.conflict || !out.branchKept {
+		t.Fatalf("conflict apply: %+v", out)
+	}
+	raw, _ := os.ReadFile(filepath.Join(repo, "pkg", "main.go"))
+	if !strings.Contains(string(raw), "<<<<<<<") || !strings.Contains(string(raw), ">>>>>>>") {
+		t.Errorf("no conflict markers in the user's tree: %q", raw)
+	}
+	if st, _ := ckGit(repo, "", "status", "--porcelain"); !strings.Contains(st, "UU pkg/main.go") {
+		t.Errorf("no unmerged index entry: %q", st)
+	}
+	if bout, _ := ckGit(repo, "", "branch", "--list", wt.branch); strings.TrimSpace(bout) == "" {
+		t.Error("the branch was deleted on a conflicted apply — the thread's exact edit is gone")
+	}
+	if _, err := os.Stat(wt.dir); !os.IsNotExist(err) {
+		t.Error("the worktree dir survived the apply")
+	}
+}
+
+// Uncommitted user changes to an overlapping file. Which way git goes here is
+// platform- and version-dependent — a Linux/macOS git refuses the patch
+// atomically, the Windows runner's git 3-way-merges it into conflict markers —
+// so this pins the invariant that holds either way: the user's uncommitted
+// work is never silently replaced, and the thread's edits stay recoverable.
+func TestWorktree_ApplyNeverDiscardsDirtyUserWork(t *testing.T) {
+	repo := threadRepo(t)
+
+	wt, err := ckCreateWorktree(repo, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.dir, "pkg", "main.go"),
+		[]byte("package pkg\n\nvar base = 2 // thread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.dir, "pkg", "other.go"),
+		[]byte("package pkg\n\nvar base2 = 9 // thread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	const userMark = "var base = 7 // user, uncommitted"
+	userEdit := "package pkg\n\n" + userMark + "\n"
+	if err := os.WriteFile(filepath.Join(repo, "pkg", "main.go"), []byte(userEdit), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ckApplyWorktree(wt)
+	raw, _ := os.ReadFile(filepath.Join(repo, "pkg", "main.go"))
+	got := string(raw)
+	t.Logf("dirty-overlap apply: refused=%v conflict=%v applied=%v", out.refused, out.conflict, out.applied)
+
+	switch {
+	case out.refused:
+		if got != userEdit {
+			t.Errorf("the refusal was not atomic — the user's file changed: %q", got)
+		}
+		other, _ := os.ReadFile(filepath.Join(repo, "pkg", "other.go"))
+		if strings.Contains(string(other), "thread") {
+			t.Error("the refusal was not atomic — the clean half of the patch landed anyway")
+		}
+		if _, err := os.Stat(wt.dir); err != nil {
+			t.Error("a refused apply lost the worktree — nothing is retryable")
+		}
+		// Retry once the user commits: it must now land or conflict, not refuse.
+		if cout, cerr := ckGit(repo, "", "commit", "-aqm", "user keeps their edit"); cerr != nil {
+			t.Fatalf("commit: %v\n%s", cerr, cout)
+		}
+		if again := ckApplyWorktree(wt); again.refused {
+			t.Fatalf("retry still refused: %+v", again)
+		}
+	case out.conflict:
+		// Merged instead of refused: the user's line must survive inside the
+		// markers, and the UI must have been told it is a conflict.
+		if !strings.Contains(got, userMark) {
+			t.Errorf("a conflicted apply dropped the user's uncommitted line: %q", got)
+		}
+		if !strings.Contains(got, "<<<<<<<") {
+			t.Errorf("conflict reported with no markers in the file: %q", got)
+		}
+		if !out.branchKept {
+			t.Error("a conflicted apply deleted the branch holding the thread's edit")
+		}
+	default:
+		t.Fatalf("a dirty overlap applied silently — the user's edit was overwritten: %+v\n%q", out, got)
+	}
+	if !out.branchKept {
+		t.Error("the thread's work was not kept recoverable")
+	}
+}
+
+// A merely STAGED overlap (what a previous thread's own clean apply leaves
+// behind) must still merge into conflict markers, not refuse: that content is
+// in the object store, so the markers are recoverable and more useful than
+// "save your work first" for a change the user never made by hand.
+func TestWorktree_StagedOverlapStillConflicts(t *testing.T) {
+	repo := threadRepo(t)
+
+	wt, err := ckCreateWorktree(repo, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.dir, "pkg", "main.go"),
+		[]byte("package pkg\n\nvar base = 5 // thread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Stand in for an earlier thread's apply: change staged, worktree matches.
+	if err := os.WriteFile(filepath.Join(repo, "pkg", "main.go"),
+		[]byte("package pkg\n\nvar base = 2 // earlier thread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, aerr := ckGit(repo, "", "add", "pkg/main.go"); aerr != nil {
+		t.Fatalf("stage: %v\n%s", aerr, out)
+	}
+	if got := ckUnsavedOverlap(repo, []string{"pkg/main.go"}); len(got) != 0 {
+		t.Fatalf("a staged-and-saved file read as unsaved: %v", got)
+	}
+
+	out := ckApplyWorktree(wt)
+	if out.refused {
+		t.Fatalf("a staged overlap was refused instead of merged: %+v", out)
+	}
+	if !out.conflict {
+		t.Fatalf("a staged overlap should surface as a conflict: %+v", out)
+	}
+	raw, _ := os.ReadFile(filepath.Join(repo, "pkg", "main.go"))
+	if !strings.Contains(string(raw), "<<<<<<<") {
+		t.Errorf("no markers left in the tree: %q", raw)
+	}
+}
+
+// The conflict verdict must come from the index, not from git's prose: under a
+// translated locale the message would not match, and a conflicted apply would
+// then be reported as a failure while the markers were already in the tree.
+func TestWorktree_ApplyConflictSurvivesATranslatedLocale(t *testing.T) {
+	repo := threadRepo(t)
+	// Ask git for French messages; ckGit pins LC_ALL=C, and the verdict is read
+	// off the index either way.
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+	t.Setenv("LANGUAGE", "fr")
+
+	wt, err := ckCreateWorktree(repo, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.dir, "pkg", "main.go"),
+		[]byte("package pkg\n\nvar base = 2 // thread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "pkg", "main.go"),
+		[]byte("package pkg\n\nvar base = 3 // user\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, cerr := ckGit(repo, "", "commit", "-aqm", "user change"); cerr != nil {
+		t.Fatalf("user commit: %v\n%s", cerr, out)
+	}
+
+	out := ckApplyWorktree(wt)
+	if !out.conflict || !out.branchKept {
+		t.Fatalf("conflict verdict lost under a translated locale: %+v", out)
+	}
+	if got := ckUnmergedPaths(repo); len(got) != 1 || got[0] != "pkg/main.go" {
+		t.Errorf("unmerged paths = %v", got)
+	}
+}
+
+// A tree already holding someone else's unmerged entries must not make a
+// blocked apply read as "applied with conflicts" — only paths this apply left
+// unmerged count as evidence about this apply.
+func TestWorktree_PreExistingConflictIsNotClaimedAsOurs(t *testing.T) {
+	repo := threadRepo(t)
+
+	// Leave pkg/other.go unmerged from an unrelated merge, before any thread runs.
+	if out, err := ckGit(repo, "", "checkout", "-q", "-b", "sideline"); err != nil {
+		t.Fatalf("branch: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "pkg", "other.go"), []byte("package pkg\n\nvar side = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := ckGit(repo, "", "commit", "-aqm", "sideline"); err != nil {
+		t.Fatalf("commit: %v\n%s", err, out)
+	}
+	if out, err := ckGit(repo, "", "checkout", "-q", "-"); err != nil {
+		t.Fatalf("back: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "pkg", "other.go"), []byte("package pkg\n\nvar side = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := ckGit(repo, "", "commit", "-aqm", "main-side"); err != nil {
+		t.Fatalf("commit: %v\n%s", err, out)
+	}
+	if out, _ := ckGit(repo, "", "merge", "sideline"); !strings.Contains(out, "CONFLICT") {
+		t.Fatalf("could not induce a pre-existing conflict: %s", out)
+	}
+	if got := ckUnmergedPaths(repo); len(got) == 0 {
+		t.Fatal("no pre-existing unmerged entry to test against")
+	}
+
+	// A thread edits a DIFFERENT file; the tree's own merge conflict is in the
+	// way of nothing, but the dirty index blocks the apply.
+	wt, err := ckCreateWorktree(repo, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.dir, "pkg", "main.go"),
+		[]byte("package pkg\n\nvar base = 2 // thread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := ckApplyWorktree(wt)
+	if out.conflict {
+		t.Errorf("the tree's own unmerged entry was claimed as this apply's conflict: %+v", out)
+	}
+	if !out.refused && !out.applied {
+		t.Errorf("neither applied nor refused: %+v", out)
+	}
+}
+
+func TestWorktree_EmptyApplyCleansUp(t *testing.T) {
+	repo := threadRepo(t)
+	wt, err := ckCreateWorktree(repo, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := ckApplyWorktree(wt)
+	if !out.empty || out.err != nil {
+		t.Fatalf("empty apply: %+v", out)
+	}
+	if _, err := os.Stat(wt.dir); !os.IsNotExist(err) {
+		t.Error("an empty worktree was not removed")
+	}
+}
+
+func TestWorktree_DiscardRemovesDirAndBranch(t *testing.T) {
+	repo := threadRepo(t)
+	wt, err := ckCreateWorktree(repo, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt.dir, "pkg", "main.go"), []byte("package pkg // dirty\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ckDiscardWorktree(wt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(wt.dir); !os.IsNotExist(err) {
+		t.Error("discard left the worktree dir")
+	}
+	if bout, _ := ckGit(repo, "", "branch", "--list", wt.branch); strings.TrimSpace(bout) != "" {
+		t.Errorf("discard left the branch: %q", bout)
+	}
+	raw, _ := os.ReadFile(filepath.Join(repo, "pkg", "main.go"))
+	if strings.Contains(string(raw), "dirty") {
+		t.Error("discard touched the user's tree")
+	}
+}
+
+// Stale worktrees from a crashed session are listed and reported, never
+// auto-deleted — they may hold un-applied work.
+func TestStaleWorktrees_ListedNeverDeleted(t *testing.T) {
+	testutil.NewSandbox(t)
+	stale := filepath.Join(ckWorktreeBase(), "t9-dead99")
+	if err := os.MkdirAll(stale, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	got := ckStaleWorktrees()
+	if len(got) != 1 || got[0] != "t9-dead99" {
+		t.Fatalf("stale scan = %v", got)
+	}
+	if _, err := os.Stat(stale); err != nil {
+		t.Error("the scan deleted a stale worktree")
+	}
+}
+
+// A failed worktree creation fails the task honestly and releases the hold —
+// it must never fall back to editing the user's tree.
+func TestWorktreeReady_ErrorFailsTaskAndReleasesQueue(t *testing.T) {
+	testutil.NewSandbox(t)
+	m := testCockpit()
+	th := m.th()
+	ex := &ckExecState{ctx: context.Background()}
+	th.exec = ex
+	th.files = []string{"pkg/main.go"}
+
+	next, _ := m.Update(ckWtReadyMsg{exec: ex, task: ckTask{threadID: th.id, rel: "pkg/main.go", runID: "r1"},
+		err: os.ErrPermission})
+	m = next.(Cockpit)
+	if m.th().exec != nil {
+		t.Error("the failed creation left the thread running")
+	}
+	if m.th().wt != nil {
+		t.Error("a worktree was attached despite the failure")
+	}
+	if len(m.th().files) != 0 {
+		t.Errorf("the hold was not released: %v", m.th().files)
+	}
+	logs := stripANSI(strings.Join(m.th().log, "\n"))
+	if !strings.Contains(logs, "worktree creation failed") {
+		t.Errorf("the failure is not visible: %q", logs)
+	}
+}
+
+// A superseded or cancelled creation discards the worktree it cut — nothing
+// may litter ~/.hydra/worktrees.
+func TestWorktreeReady_SupersededCreationIsDiscarded(t *testing.T) {
+	repo := threadRepo(t)
+	wt, err := ckCreateWorktree(repo, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := testCockpit()
+	// The thread's exec moved on: the arriving worktree belongs to nobody.
+	m.th().exec = &ckExecState{ctx: context.Background()}
+	next, _ := m.Update(ckWtReadyMsg{exec: &ckExecState{}, task: ckTask{threadID: 1}, wt: wt})
+	m = next.(Cockpit)
+	if m.th().wt != nil {
+		t.Error("a superseded worktree was attached")
+	}
+	if _, err := os.Stat(wt.dir); !os.IsNotExist(err) {
+		t.Error("the superseded worktree was left on disk")
+	}
+}
+
+// The full UI path: an edit task lands in the worktree, the user's tree stays
+// untouched until `a`, and apply stages it. Drives startTask → ckWtCreate →
+// worker → settle → resultKey('a') with real git and a stubbed editor.
+func TestThreadEdit_IsolatesThenAppliesThroughTheUI(t *testing.T) {
+	repo := threadRepo(t)
+	stubExec(t)
+	ckEditStage = func(_ context.Context, tk *ckTask, _ string) (*editor.Result, error) {
+		before, _ := os.ReadFile(tk.file)
+		after := "package pkg\n\nvar base = 42 // thread edit\n"
+		if err := os.WriteFile(tk.file, []byte(after), 0o644); err != nil {
+			return nil, err
+		}
+		runlog.LogEdit(tk.runID, tk.taskID, tk.file, before, []byte(after), 1, 1)
+		return &editor.Result{Status: "ok", File: tk.file, LinesAdded: 1, LinesRemoved: 1, Head: "stub-editor"}, nil
+	}
+
+	m := chatFixture("edit")
+	m.repoRoot = repo
+	m2, cmd := m.startTask("edit pkg/main.go please")
+	m = runCmds(t, m2, cmd)
+
+	th := m.th()
+	if th.wt == nil {
+		t.Fatal("the edit thread got no worktree")
+	}
+	if th.lastDone == nil || !th.lastDone.edited {
+		t.Fatalf("the task did not settle as an edit: %+v", th.lastDone)
+	}
+	if !strings.HasPrefix(th.lastDone.file, th.wt.dir) {
+		t.Errorf("the edit targeted %s, not the worktree", th.lastDone.file)
+	}
+	userCopy, _ := os.ReadFile(filepath.Join(repo, "pkg", "main.go"))
+	if strings.Contains(string(userCopy), "thread edit") {
+		t.Fatal("the user's tree changed before apply")
+	}
+	logs := stripANSI(strings.Join(th.log, "\n"))
+	if !strings.Contains(logs, "worktree") || !strings.Contains(logs, "merges on apply") {
+		t.Errorf("isolation is not disclosed: %q", logs)
+	}
+
+	m, acmd := keyRune(m, 'a')
+	m = runCmds(t, m, acmd)
+	if m.th().wt != nil {
+		t.Error("apply left the worktree attached")
+	}
+	userCopy, _ = os.ReadFile(filepath.Join(repo, "pkg", "main.go"))
+	if !strings.Contains(string(userCopy), "thread edit") {
+		t.Errorf("apply did not land the edit: %q", userCopy)
+	}
+	logs = stripANSI(strings.Join(m.th().log, "\n"))
+	if !strings.Contains(logs, "✓ applied") {
+		t.Errorf("apply is not disclosed: %q", logs)
+	}
+}
+
+// x x discards the worktree after a landed edit: tree untouched, worktree and
+// branch gone, and the first x only arms.
+func TestThreadEdit_DoubleXDiscards(t *testing.T) {
+	repo := threadRepo(t)
+	stubExec(t)
+	ckEditStage = func(_ context.Context, tk *ckTask, _ string) (*editor.Result, error) {
+		if err := os.WriteFile(tk.file, []byte("package pkg // discarded\n"), 0o644); err != nil {
+			return nil, err
+		}
+		runlog.LogEdit(tk.runID, tk.taskID, tk.file, []byte("old"), []byte("new"), 1, 0)
+		return &editor.Result{Status: "ok", File: tk.file, LinesAdded: 1, Head: "stub"}, nil
+	}
+	m := chatFixture("edit")
+	m.repoRoot = repo
+	m2, cmd := m.startTask("edit pkg/other.go now")
+	m = runCmds(t, m2, cmd)
+	wt := m.th().wt
+	if wt == nil {
+		t.Fatal("no worktree")
+	}
+
+	m, _ = keyRune(m, 'x')
+	if m.th().wt == nil {
+		t.Fatal("a single x already discarded — it must only arm")
+	}
+	if !strings.Contains(m.flash, "x again discards") {
+		t.Errorf("the arm is silent: %q", m.flash)
+	}
+	m, dcmd := keyRune(m, 'x')
+	m = runCmds(t, m, dcmd)
+	if m.th().wt != nil {
+		t.Fatal("the second x did not discard")
+	}
+	if _, err := os.Stat(wt.dir); !os.IsNotExist(err) {
+		t.Error("discard left the worktree dir")
+	}
+	raw, _ := os.ReadFile(filepath.Join(repo, "pkg", "other.go"))
+	if strings.Contains(string(raw), "discarded") {
+		t.Error("discard let the edit reach the user's tree")
+	}
+}
+
+// The induced-conflict path through the UI: the user's tree moves after the
+// thread edited the same file; `a` surfaces the conflict, and the log says
+// where the markers and the branch are.
+func TestThreadEdit_ApplyConflictThroughTheUI(t *testing.T) {
+	repo := threadRepo(t)
+	stubExec(t)
+	ckEditStage = func(_ context.Context, tk *ckTask, _ string) (*editor.Result, error) {
+		if err := os.WriteFile(tk.file, []byte("package pkg\n\nvar base = 2 // thread\n"), 0o644); err != nil {
+			return nil, err
+		}
+		runlog.LogEdit(tk.runID, tk.taskID, tk.file, []byte("a"), []byte("b"), 1, 1)
+		return &editor.Result{Status: "ok", File: tk.file, LinesAdded: 1, LinesRemoved: 1, Head: "stub"}, nil
+	}
+	m := chatFixture("edit")
+	m.repoRoot = repo
+	m2, cmd := m.startTask("edit pkg/main.go here")
+	m = runCmds(t, m2, cmd)
+	branch := m.th().wt.branch
+
+	// User commits a divergent change before pressing a.
+	if err := os.WriteFile(filepath.Join(repo, "pkg", "main.go"),
+		[]byte("package pkg\n\nvar base = 3 // user\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := ckGit(repo, "", "commit", "-aqm", "user"); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+
+	m, acmd := keyRune(m, 'a')
+	m = runCmds(t, m, acmd)
+	logs := stripANSI(strings.Join(m.th().log, "\n"))
+	if !strings.Contains(logs, "applied with conflicts") || !strings.Contains(logs, branch) {
+		t.Errorf("the conflict is not fully disclosed: %q", logs)
+	}
+	raw, _ := os.ReadFile(filepath.Join(repo, "pkg", "main.go"))
+	if !strings.Contains(string(raw), "<<<<<<<") {
+		t.Errorf("no markers in the user's tree: %q", raw)
+	}
+	if bout, _ := ckGit(repo, "", "branch", "--list", branch); strings.TrimSpace(bout) == "" {
+		t.Error("the branch was deleted despite the conflict")
+	}
+}

--- a/internal/tui/threads.go
+++ b/internal/tui/threads.go
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+// threads.go — parallel chat threads (#598): per-thread task state, the chip
+// strip, switching/attention keys, and split bookkeeping. Worktree isolation
+// lives in thread_worktree.go, queue-on-overlap in thread_queue.go.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ankit373/hydra/internal/a2a"
+)
+
+// ckMaxThreads bounds the strip and keeps every thread reachable by alt+1–9.
+const ckMaxThreads = 9
+
+// ckThread is one chat thread: its own scrollback, input draft, task pipeline,
+// code panel, and (for edit work) worktree + file holds. Threads are held by
+// pointer so a tea.Cmd result can land on the right one whatever is current.
+type ckThread struct {
+	id   int    // stable 1-based id — the chip number and the alt+N target
+	name string // short chip label, from the first prompt
+
+	input  string
+	log    []string
+	scroll int // 0 = live tail; L+1 = anchored at rendered line L
+
+	exec     *ckExecState
+	planWait *ckWait
+	confirm  *ckWait
+	lastDone *ckTask
+	attn     bool // finished needing eyes (a failure) — cleared on visit
+
+	bg         bool        // re-parented to the agents view
+	queued     *ckQueued   // waiting on an overlap blocker; nil otherwise
+	wt         *ckWorktree // edit isolation; nil = shared tree
+	files      []string    // repo-relative edit targets this thread holds
+	clock      a2a.Clock   // causal backstop across threads
+	inEdit     bool        // an in-place (no-isolation) edit task is running
+	discardArm bool        // first x pressed; the next x discards the worktree
+	lastRunID  string      // latest task's run id — the agents-view join key
+
+	// code panel — per thread, each shows its own last edit
+	codeLang  string
+	codeLines []string
+	codeShown int
+	codeGen   int
+	codeDiff  bool
+}
+
+func newThread(id int) *ckThread {
+	return &ckThread{id: id, clock: a2a.Clock{}.Tick(ckThreadAgent(id))}
+}
+
+func ckThreadAgent(id int) string { return fmt.Sprintf("thread-%d", id) }
+
+// status is the chip state: queued < running < needs < done < idle, evaluated
+// in gate order — a queued thread is queued even though nothing executes yet.
+func (t *ckThread) status() string {
+	switch {
+	case t.queued != nil:
+		return "queued"
+	case t.exec != nil:
+		return "running"
+	case t.planWait != nil || t.confirm != nil || t.attn:
+		return "needs"
+	case t.lastDone != nil:
+		return "done"
+	default:
+		return "idle"
+	}
+}
+
+// ckThreadGlyph renders a status as its strip glyph.
+func ckThreadGlyph(status string) string {
+	switch status {
+	case "running":
+		return ckAquaS.Render("⠸")
+	case "needs":
+		return ckMidS.Render("●")
+	case "queued":
+		return ckDimS.Render("◱")
+	case "done":
+		return ckCheapS.Render("✓")
+	default:
+		return ckFaintS.Render("○")
+	}
+}
+
+// ── registry ──────────────────────────────────────────────────────────────────
+
+// withThreads guarantees thread 1 exists — a bare Cockpit{} must render and
+// route keys without panicking, exactly like the pre-thread model did.
+func (m Cockpit) withThreads() Cockpit {
+	if len(m.threads) == 0 {
+		m.threads = []*ckThread{newThread(1)}
+		m.cur, m.nextID = 0, 2
+	}
+	return m
+}
+
+// th is the active thread. Every entry point runs withThreads first, so the
+// index is always valid.
+func (m Cockpit) th() *ckThread { return m.threads[m.cur] }
+
+func (m Cockpit) threadByID(id int) *ckThread {
+	for _, t := range m.threads {
+		if t.id == id {
+			return t
+		}
+	}
+	return nil
+}
+
+// visibleThreads are the strip's chips — backgrounded threads live in the
+// agents view instead.
+func (m Cockpit) visibleThreads() []*ckThread {
+	var out []*ckThread
+	for _, t := range m.threads {
+		if !t.bg {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// threadCounts is the attention tally over every thread, backgrounded included.
+func (m Cockpit) threadCounts() (running, needs, queued int) {
+	for _, t := range m.threads {
+		switch t.status() {
+		case "running":
+			running++
+		case "needs":
+			needs++
+		case "queued":
+			queued++
+		}
+	}
+	return
+}
+
+// ── switching ─────────────────────────────────────────────────────────────────
+
+// addThread opens a fresh thread and makes it current. Capped so alt+1–9 can
+// always address every thread; the cap refuses visibly, never silently.
+func (m Cockpit) addThread() Cockpit {
+	if len(m.threads) >= ckMaxThreads {
+		m.flash = fmt.Sprintf("thread limit %d — apply or reuse an existing one", ckMaxThreads)
+		return m
+	}
+	t := newThread(m.nextID)
+	t.log = []string{ckDimS.Render(fmt.Sprintf("thread %d — type a task and press enter.", t.id))}
+	m.nextID++
+	m.threads = append(m.threads, t)
+	return m.focusThread(t.id)
+}
+
+// focusThread makes thread id current (foregrounding it if backgrounded),
+// clears its attention mark, and lands on the chat view.
+func (m Cockpit) focusThread(id int) Cockpit {
+	t := m.threadByID(id)
+	if t == nil {
+		m.flash = fmt.Sprintf("no thread %d", id)
+		return m
+	}
+	if t.bg {
+		t.bg = false
+	}
+	t.attn = false
+	t.discardArm = false
+	for i, o := range m.threads {
+		if o.id == id {
+			if m.cur != i {
+				m.prevCur = m.threads[m.cur].id
+			}
+			m.cur = i
+			break
+		}
+	}
+	// jump also closes the transient overlays, wherever the key was pressed.
+	m = m.jump(ckViewChat)
+	// A split showing the same thread twice says nothing — drop the pin.
+	if m.split && m.splitID == t.id {
+		m.split = false
+	}
+	return m
+}
+
+// cycleThread moves to the next/previous visible thread; under a split it
+// moves focus to the other pane instead (the pinned side becomes active).
+func (m Cockpit) cycleThread(dir int) Cockpit {
+	if m.split {
+		other := m.threadByID(m.splitID)
+		if other != nil {
+			curID := m.th().id
+			m = m.focusThread(other.id)
+			// focusThread drops a self-pin; re-pin the previous side.
+			m.split, m.splitID = true, curID
+			return m
+		}
+	}
+	vis := m.visibleThreads()
+	if len(vis) < 2 {
+		m.flash = "one thread — ctrl+t opens another"
+		return m
+	}
+	curID := m.th().id
+	idx := 0
+	for i, t := range vis {
+		if t.id == curID {
+			idx = i
+			break
+		}
+	}
+	next := vis[((idx+dir)%len(vis)+len(vis))%len(vis)]
+	return m.focusThread(next.id)
+}
+
+// nextAttention jumps to the next thread needing input (gates, failures) —
+// backgrounded threads included, since their pings point here.
+func (m Cockpit) nextAttention() Cockpit {
+	n := len(m.threads)
+	for off := 1; off <= n; off++ {
+		t := m.threads[(m.cur+off)%n]
+		if t.status() == "needs" {
+			return m.focusThread(t.id)
+		}
+	}
+	m.flash = "nothing needs you"
+	return m
+}
+
+// ── split ─────────────────────────────────────────────────────────────────────
+
+// ckSplitMinCols is the narrowest terminal a split renders in; below it the
+// toggle refuses with a note instead of drawing two broken panes.
+const ckSplitMinCols = 100
+
+// toggleSplit pins a second thread beside the active one (one split max).
+func (m Cockpit) toggleSplit() Cockpit {
+	if m.split {
+		m.split = false
+		return m
+	}
+	if m.w < ckSplitMinCols {
+		m.flash = fmt.Sprintf("split needs ≥%d cols (terminal is %d)", ckSplitMinCols, m.w)
+		return m
+	}
+	pin := m.pickSplitPin()
+	if pin == 0 {
+		m.flash = "no second thread to pin — ctrl+t opens one"
+		return m
+	}
+	m.split, m.splitID = true, pin
+	return m
+}
+
+// pickSplitPin chooses the pinned side: the previously active thread when it
+// is still visible, else the next visible one. 0 = nothing to pin.
+func (m Cockpit) pickSplitPin() int {
+	cur := m.th().id
+	if t := m.threadByID(m.prevCur); t != nil && !t.bg && t.id != cur {
+		return t.id
+	}
+	for _, t := range m.visibleThreads() {
+		if t.id != cur {
+			return t.id
+		}
+	}
+	return 0
+}
+
+// dropSplitIfNarrow disables an active split when the terminal shrinks below
+// the split minimum — one honest pane instead of two garbled ones.
+func (m Cockpit) dropSplitIfNarrow() Cockpit {
+	if m.split && m.w < ckSplitMinCols {
+		m.split = false
+		m.flash = fmt.Sprintf("split closed — needs ≥%d cols", ckSplitMinCols)
+	}
+	return m
+}
+
+// ── strip ─────────────────────────────────────────────────────────────────────
+
+// showStrip: the strip earns its line only once threads exist to switch between.
+func (m Cockpit) showStrip() bool { return len(m.visibleThreads()) > 1 }
+
+// threadStrip renders the chip row: number · status glyph · short name ·
+// worktree tag. Overflow windows around the active chip with ‹/› cues.
+func (m Cockpit) threadStrip(w int) string {
+	vis := m.visibleThreads()
+	chips := make([]string, len(vis))
+	active := 0
+	for i, t := range vis {
+		if t.id == m.th().id {
+			active = i
+		}
+		chips[i] = m.threadChip(t)
+	}
+	sep := ckFaintS.Render(" │ ")
+	row := " " + strings.Join(chips, sep)
+	if lipgloss.Width(row) <= w {
+		return ckFrame(row, w, 1)
+	}
+	// Window around the active chip, widening while it fits.
+	lo, hi := active, active
+	for {
+		grown := false
+		if hi+1 < len(chips) && ckStripFits(chips, lo, hi+1, sep, lo > 0, true, w) {
+			hi++
+			grown = true
+		}
+		if lo > 0 && ckStripFits(chips, lo-1, hi, sep, true, hi < len(chips)-1, w) {
+			lo--
+			grown = true
+		}
+		if !grown {
+			break
+		}
+	}
+	parts := make([]string, 0, hi-lo+3)
+	if lo > 0 {
+		parts = append(parts, ckFaintS.Render(fmt.Sprintf("‹%d", lo)))
+	}
+	parts = append(parts, chips[lo:hi+1]...)
+	if hi < len(chips)-1 {
+		parts = append(parts, ckFaintS.Render(fmt.Sprintf("%d›", len(chips)-1-hi)))
+	}
+	return ckFrame(" "+strings.Join(parts, sep), w, 1)
+}
+
+// ckStripFits reports whether chips[lo..hi] plus overflow cues fit in w cells.
+func ckStripFits(chips []string, lo, hi int, sep string, cueL, cueR bool, w int) bool {
+	total := 1
+	for i := lo; i <= hi; i++ {
+		if i > lo {
+			total += lipgloss.Width(sep)
+		}
+		total += lipgloss.Width(chips[i])
+	}
+	if cueL {
+		total += lipgloss.Width(sep) + 3
+	}
+	if cueR {
+		total += lipgloss.Width(sep) + 3
+	}
+	return total <= w
+}
+
+// threadChip renders one strip chip.
+func (m Cockpit) threadChip(t *ckThread) string {
+	name := t.name
+	if name == "" {
+		name = "new"
+	}
+	label := fmt.Sprintf("%d", t.id)
+	body := " " + truncate(name, 14)
+	if t.wt != nil {
+		body += ckVioletS.Render(" ·wt")
+	}
+	if t.id == m.th().id {
+		return ckChipS.Render(label) + ckThreadGlyph(t.status()) + ckInkS.Bold(true).Render(body)
+	}
+	return ckDimS.Render(label) + ckThreadGlyph(t.status()) + ckDimS.Render(body)
+}
+
+// splitPanes renders the active thread beside the pinned one: each side owns
+// its own scrollback; the shared input bar under both targets the active side.
+func (m Cockpit) splitPanes(mainW, bodyH int) string {
+	input := m.inputBar(mainW)
+	paneH := max(1, bodyH-lipgloss.Height(input))
+	paneW := max(10, (mainW-1)/2)
+	active := m.threadPane(m.th(), paneW, paneH, true)
+	pinned := m.threadPane(m.threadByID(m.splitID), paneW, paneH, false)
+	return lipgloss.JoinVertical(lipgloss.Left,
+		lipgloss.JoinHorizontal(lipgloss.Top, active, " ", pinned), input)
+}
+
+// threadPane is one split side: a title row, the thread's context header when
+// it has one, and its scrollback window.
+func (m Cockpit) threadPane(t *ckThread, w, h int, active bool) string {
+	name := t.name
+	if name == "" {
+		name = "new"
+	}
+	title := fmt.Sprintf("thread %d · %s", t.id, name)
+	style, mark := ckDimS, "  "
+	if active {
+		style, mark = ckAquaS, "▸ "
+	} else {
+		title += " · watching"
+	}
+	rows := []string{ckFrame(style.Render(mark+title), w, 1)}
+	logH := h - 1
+	if hdr := t.threadHeaderLine(w); hdr != "" {
+		rows = append(rows, hdr)
+		logH--
+	}
+	logH = max(1, logH)
+	rows = append(rows, lipgloss.NewStyle().Width(w).Height(logH).
+		Render(ckVisibleLog(t.log, w, logH, t.scroll-1)))
+	return lipgloss.NewStyle().Width(w).Height(h).Render(strings.Join(rows, "\n"))
+}
+
+// threadHeaderLine is the one-line context header above a thread's log: its
+// isolation state, or why it is queued. Empty when there is nothing to say.
+func (t *ckThread) threadHeaderLine(w int) string {
+	switch {
+	case t.queued != nil:
+		return ckFrame(ckDimS.Render(" ◱ "+t.queued.reason), w, 1)
+	case t.wt != nil:
+		return ckFrame(ckDimS.Render(" ⎇ worktree ")+ckVioletS.Render(t.wt.tag)+
+			ckDimS.Render(" · merges on apply"), w, 1)
+	}
+	return ""
+}
+
+// ckThreadName derives the chip label from the first prompt.
+func ckThreadName(prompt string) string {
+	return truncate(ckSafe(strings.TrimSpace(prompt)), 14)
+}
+
+// attentionFact is the status-bar tally: "⠸ 2 running · ● 1 needs you · ◱ 1 queued".
+func (m Cockpit) attentionFact() string {
+	running, needs, queued := m.threadCounts()
+	var parts []string
+	if running > 0 {
+		parts = append(parts, fmt.Sprintf("⠸ %d running", running))
+	}
+	if needs > 0 {
+		parts = append(parts, fmt.Sprintf("● %d needs you", needs))
+	}
+	if queued > 0 {
+		parts = append(parts, fmt.Sprintf("◱ %d queued", queued))
+	}
+	return strings.Join(parts, " · ")
+}

--- a/internal/tui/threads_test.go
+++ b/internal/tui/threads_test.go
@@ -1,0 +1,549 @@
+// SPDX-License-Identifier: MIT
+
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+func altDigit(m Cockpit, d rune) Cockpit {
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{d}, Alt: true})
+	return next.(Cockpit)
+}
+
+// ── registry & switching ─────────────────────────────────────────────────────
+
+func TestThreads_CtrlTCreatesAndAltDigitJumps(t *testing.T) {
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlT)
+	if got := m.th().id; got != 2 {
+		t.Fatalf("ctrl+t landed on thread %d, want 2", got)
+	}
+	if m.th().input != "" {
+		t.Error("a fresh thread inherited input")
+	}
+	m.th().input = "draft for thread 2"
+
+	m = altDigit(m, '1')
+	if m.th().id != 1 {
+		t.Fatalf("alt+1 landed on thread %d", m.th().id)
+	}
+	m = altDigit(m, '2')
+	if m.th().id != 2 || m.th().input != "draft for thread 2" {
+		t.Errorf("alt+2: id=%d input=%q — the draft must survive the switch", m.th().id, m.th().input)
+	}
+	// alt+9 with no thread 9: refused visibly, not a panic or a silent no-op.
+	m = altDigit(m, '9')
+	if m.th().id != 2 || m.flash == "" {
+		t.Errorf("alt+9 on a missing thread: id=%d flash=%q", m.th().id, m.flash)
+	}
+}
+
+func TestThreads_CapRefusesTheTenth(t *testing.T) {
+	m := testCockpit()
+	for i := 0; i < ckMaxThreads+2; i++ {
+		m = press(m, tea.KeyCtrlT)
+	}
+	if len(m.threads) != ckMaxThreads {
+		t.Fatalf("%d threads exist, cap is %d", len(m.threads), ckMaxThreads)
+	}
+	if !strings.Contains(m.flash, "thread limit") {
+		t.Errorf("the cap was silent: flash=%q", m.flash)
+	}
+}
+
+func TestThreads_CtrlArrowsCycleVisible(t *testing.T) {
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlT)
+	m = press(m, tea.KeyCtrlT) // threads 1,2,3 — current 3
+	m = press(m, tea.KeyCtrlRight)
+	if m.th().id != 1 {
+		t.Fatalf("ctrl+→ from 3 landed on %d, want 1 (wraps)", m.th().id)
+	}
+	m = press(m, tea.KeyCtrlLeft)
+	if m.th().id != 3 {
+		t.Fatalf("ctrl+← wrapped to %d, want 3", m.th().id)
+	}
+}
+
+func TestThreads_TypingIsNeverBrokenByPlainDigitsOrLetters(t *testing.T) {
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlT)
+	m = typed(m, "add 19 tests to x.go")
+	if got := m.th().input; got != "add 19 tests to x.go" {
+		t.Errorf("typing into a thread mangled the input: %q", got)
+	}
+}
+
+// ── status, strip, attention ─────────────────────────────────────────────────
+
+func TestThreadStatus_GlyphsAndCounts(t *testing.T) {
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlT)
+	m = press(m, tea.KeyCtrlT)
+	m = press(m, tea.KeyCtrlT)
+	ts := m.threads
+	ts[0].exec = &ckExecState{stage: "running", started: time.Now()}
+	ts[1].planWait = &ckWait{task: ckTask{}}
+	ts[2].queued = &ckQueued{reason: "queued behind 1 · both touch a.go"}
+	ts[3].lastDone = &ckTask{}
+
+	if got := ts[0].status(); got != "running" {
+		t.Errorf("exec status = %q", got)
+	}
+	if got := ts[1].status(); got != "needs" {
+		t.Errorf("planWait status = %q", got)
+	}
+	if got := ts[2].status(); got != "queued" {
+		t.Errorf("queued status = %q", got)
+	}
+	if got := ts[3].status(); got != "done" {
+		t.Errorf("done status = %q", got)
+	}
+	if got := newThread(9).status(); got != "idle" {
+		t.Errorf("fresh thread status = %q", got)
+	}
+
+	running, needs, queued := m.threadCounts()
+	if running != 1 || needs != 1 || queued != 1 {
+		t.Errorf("counts = %d/%d/%d, want 1/1/1", running, needs, queued)
+	}
+	fact := m.attentionFact()
+	for _, want := range []string{"1 running", "1 needs you", "1 queued"} {
+		if !strings.Contains(fact, want) {
+			t.Errorf("attention fact %q lacks %q", fact, want)
+		}
+	}
+	// The chat status bar carries the tally.
+	bar := stripANSI(m.statusBar())
+	if !strings.Contains(bar, "needs you") {
+		t.Errorf("status bar lacks the attention tally: %q", bar)
+	}
+}
+
+func TestThreadStrip_ShowsChipsAndWorktreeTag(t *testing.T) {
+	m := testCockpit()
+	m.th().name = "first-task"
+	m = press(m, tea.KeyCtrlT)
+	m.th().name = "second"
+	m.th().wt = &ckWorktree{tag: "t2-abc123"}
+
+	strip := stripANSI(m.threadStrip(100))
+	for _, want := range []string{"1", "first-task", "2", "second", "·wt"} {
+		if !strings.Contains(strip, want) {
+			t.Errorf("strip %q lacks %q", strip, want)
+		}
+	}
+	if lipgloss.Width(strip) > 100 {
+		t.Errorf("strip is %d cells wide", lipgloss.Width(strip))
+	}
+	// One thread → no strip line (it earns its row only with something to switch).
+	solo := testCockpit()
+	if solo.showStrip() {
+		t.Error("a single thread grew a strip")
+	}
+}
+
+func TestThreadStrip_OverflowWindowsAroundActive(t *testing.T) {
+	m := testCockpit()
+	for i := 0; i < 8; i++ {
+		m = press(m, tea.KeyCtrlT)
+		m.th().name = fmt.Sprintf("a-very-long-thread-name-%d", i+2)
+	}
+	m = altDigit(m, '5')
+	strip := stripANSI(m.threadStrip(60))
+	if lipgloss.Width(strip) > 60 {
+		t.Fatalf("overflowed strip: %d cells: %q", lipgloss.Width(strip), strip)
+	}
+	if !strings.Contains(strip, "5") {
+		t.Errorf("the active chip fell out of its own window: %q", strip)
+	}
+	if !strings.Contains(strip, "‹") && !strings.Contains(strip, "›") {
+		t.Errorf("an overflowing strip shows no cues: %q", strip)
+	}
+}
+
+func TestCtrlG_JumpsToTheNextThreadNeedingInput(t *testing.T) {
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlT)
+	m = press(m, tea.KeyCtrlT)
+	m = altDigit(m, '1')
+	m.threads[1].confirm = &ckWait{question: "write a.go? y/n"}
+	m.threads[2].attn = true
+
+	m = press(m, tea.KeyCtrlG)
+	if m.th().id != 2 {
+		t.Fatalf("ctrl+g landed on %d, want 2", m.th().id)
+	}
+	m = press(m, tea.KeyCtrlG)
+	if m.th().id != 3 {
+		t.Fatalf("second ctrl+g landed on %d, want 3", m.th().id)
+	}
+	if m.th().attn {
+		t.Error("visiting the thread did not clear its attention mark")
+	}
+	m.threads[1].confirm = nil
+	m = press(m, tea.KeyCtrlG)
+	if !strings.Contains(m.flash, "nothing needs you") {
+		t.Errorf("ctrl+g with nothing pending: flash=%q", m.flash)
+	}
+}
+
+// ── split ────────────────────────────────────────────────────────────────────
+
+func TestSplit_ToggleFocusAndNarrowRefusal(t *testing.T) {
+	m := testCockpit()
+	m.w = 120
+	m = press(m, tea.KeyCtrlBackslash)
+	if m.split {
+		t.Fatal("split opened with only one thread")
+	}
+	m = press(m, tea.KeyCtrlT) // thread 2, current
+	m = press(m, tea.KeyCtrlBackslash)
+	if !m.split || m.splitID != 1 {
+		t.Fatalf("split=%v pin=%d, want pin 1 (previously active)", m.split, m.splitID)
+	}
+	// ctrl+→ moves focus: the pinned side becomes active, the old active pins.
+	m = press(m, tea.KeyCtrlRight)
+	if m.th().id != 1 || !m.split || m.splitID != 2 {
+		t.Fatalf("focus swap: cur=%d split=%v pin=%d", m.th().id, m.split, m.splitID)
+	}
+	m = press(m, tea.KeyCtrlBackslash)
+	if m.split {
+		t.Fatal("ctrl+\\ did not close the split")
+	}
+
+	// Too narrow: refuse with a note, render nothing broken.
+	m.w = 80
+	m = press(m, tea.KeyCtrlBackslash)
+	if m.split || !strings.Contains(m.flash, "split needs") {
+		t.Errorf("narrow split: split=%v flash=%q", m.split, m.flash)
+	}
+
+	// A live split degrades honestly when the terminal shrinks under it.
+	m.w = 120
+	m = press(m, tea.KeyCtrlBackslash)
+	if !m.split {
+		t.Fatal("split did not open at 120 cols")
+	}
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = next.(Cockpit)
+	if m.split || !strings.Contains(m.flash, "split closed") {
+		t.Errorf("shrink under a split: split=%v flash=%q", m.split, m.flash)
+	}
+}
+
+func TestSplit_RendersBothThreadsAndScrollsIndependently(t *testing.T) {
+	testutil.NewSandbox(t)
+	m := testCockpit()
+	m.w, m.h = 120, 40
+	for i := 0; i < 60; i++ {
+		m.th().log = append(m.th().log, fmt.Sprintf("one-line-%d", i))
+	}
+	m = press(m, tea.KeyCtrlT)
+	for i := 0; i < 60; i++ {
+		m.th().log = append(m.th().log, fmt.Sprintf("two-line-%d", i))
+	}
+	m = press(m, tea.KeyCtrlBackslash) // pin thread 1 beside thread 2
+
+	out := stripANSI(m.View())
+	if !strings.Contains(out, "two-line-59") || !strings.Contains(out, "one-line-59") {
+		t.Fatalf("split does not show both live tails:\n%s", out)
+	}
+	if !strings.Contains(out, "watching") {
+		t.Error("the pinned side is not labelled watch-only")
+	}
+	if !strings.Contains(out, "→ thread 2") {
+		t.Error("the input bar does not label its target thread")
+	}
+
+	// Scroll the active side only; the pinned side stays live.
+	m = press(m, tea.KeyPgUp)
+	if m.threads[1].scroll == 0 {
+		t.Fatal("pgup did not anchor the active side")
+	}
+	if m.threads[0].scroll != 0 {
+		t.Fatal("pgup moved the pinned side too")
+	}
+	// Focus over, scroll there, come back: each side keeps its own position.
+	m = press(m, tea.KeyCtrlLeft)
+	m = press(m, tea.KeyPgUp)
+	anchored := m.threads[0].scroll
+	if anchored == 0 {
+		t.Fatal("pgup did not anchor the other side")
+	}
+	m = press(m, tea.KeyCtrlRight)
+	if m.threads[0].scroll != anchored {
+		t.Error("switching focus lost the pinned side's scroll position")
+	}
+}
+
+// Per-thread scrollback: anchored positions survive switching threads, and a
+// result landing on thread B never yanks thread A's anchored reader.
+func TestThreads_ScrollbackPreservedAcrossSwitches(t *testing.T) {
+	testutil.NewSandbox(t)
+	m := testCockpit()
+	m.w, m.h = 100, 24
+	for i := 0; i < 60; i++ {
+		m.th().log = append(m.th().log, fmt.Sprintf("history %d", i))
+	}
+	m = press(m, tea.KeyPgUp)
+	anchor := m.th().scroll
+	if anchor == 0 {
+		t.Fatal("pgup did not anchor")
+	}
+	m = press(m, tea.KeyCtrlT)
+	m = altDigit(m, '1')
+	if m.th().scroll != anchor {
+		t.Fatalf("switching threads lost the scroll anchor: %d != %d", m.th().scroll, anchor)
+	}
+
+	// A worker finishing on thread 2 must not move thread 1's view.
+	ex := &ckExecState{}
+	m.threads[1].exec = ex
+	m.threads[1].lastRunID = "r2"
+	next, _ := m.Update(ckExecDoneMsg{exec: ex, task: ckTask{threadID: 2, runID: "r2", answer: strings.Repeat("thread2 answer\n", 40), elapsed: time.Second}})
+	m = next.(Cockpit)
+	if m.th().id != 1 || m.th().scroll != anchor {
+		t.Errorf("thread 2's result yanked thread 1: id=%d scroll=%d", m.th().id, m.th().scroll)
+	}
+	if out := stripANSI(m.View()); strings.Contains(out, "thread2 answer") {
+		t.Error("thread 2's output leaked into thread 1's pane")
+	}
+}
+
+// ── message routing ──────────────────────────────────────────────────────────
+
+// Concurrent tea.Cmd results must land on the thread that owns them — by id,
+// never on whichever thread is current.
+func TestExecDone_RoutesByThreadIDNotCurrent(t *testing.T) {
+	testutil.NewSandbox(t)
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlT)
+	ex1, ex2 := &ckExecState{}, &ckExecState{}
+	m.threads[0].exec = ex1
+	m.threads[1].exec = ex2
+
+	// Current is thread 2; thread 1's worker finishes first.
+	next, _ := m.Update(ckExecDoneMsg{exec: ex1, task: ckTask{threadID: 1, runID: "r1", answer: "one done", elapsed: time.Second}})
+	m = next.(Cockpit)
+	if m.threads[0].exec != nil || m.threads[0].lastDone == nil {
+		t.Fatal("thread 1's completion did not settle on thread 1")
+	}
+	if m.threads[1].exec == nil || m.threads[1].lastDone != nil {
+		t.Fatal("thread 1's completion bled into thread 2")
+	}
+	if !strings.Contains(stripANSI(strings.Join(m.threads[0].log, "\n")), "one done") {
+		t.Error("the answer landed in the wrong log")
+	}
+	// A completion for a thread finds it even when a stale exec pointer would
+	// not match: superseded messages are dropped, not misrouted.
+	stale, _ := m.Update(ckExecDoneMsg{exec: ex1, task: ckTask{threadID: 2, runID: "rX", answer: "stale"}})
+	m = stale.(Cockpit)
+	if m.threads[1].lastDone != nil {
+		t.Error("a stale exec's completion settled anyway")
+	}
+}
+
+func TestGate_OnAnotherThreadPingsChatAndArmsAttention(t *testing.T) {
+	testutil.NewSandbox(t)
+	m := testCockpit()
+	m = press(m, tea.KeyCtrlT)
+	m = altDigit(m, '1') // current: 1; the gate lands on 2
+	ex := &ckExecState{}
+	m.threads[1].exec = ex
+
+	next, _ := m.Update(ckGateMsg{exec: ex, task: ckTask{threadID: 2, plan: "1. step", planSteps: 1, headName: "stub", mode: ckModeByName("plan")}, gate: 'p'})
+	m = next.(Cockpit)
+	if m.threads[1].planWait == nil {
+		t.Fatal("the plan gate did not arm on its thread")
+	}
+	active := stripANSI(strings.Join(m.threads[0].log, "\n"))
+	if !strings.Contains(active, "hydra ▸") || !strings.Contains(active, "thread 2") {
+		t.Errorf("no ping in the active thread's chat: %q", active)
+	}
+	if m.threads[1].status() != "needs" {
+		t.Errorf("gated thread status = %q", m.threads[1].status())
+	}
+}
+
+// ── background (ctrl+b) ──────────────────────────────────────────────────────
+
+func TestBackground_ReparentsToAgentsAndPingsOnCompletion(t *testing.T) {
+	testutil.NewSandbox(t)
+	m := testCockpit()
+	m.th().name = "bg-task"
+	ex := &ckExecState{stage: "running", started: time.Now()}
+	m.th().exec = ex
+	m.th().lastRunID = "20260904T100200Z-cccc" // the fixture's live run
+
+	m = press(m, tea.KeyCtrlB)
+	bg := m.threadByID(1)
+	if !bg.bg {
+		t.Fatal("ctrl+b did not background the thread")
+	}
+	if m.th().id == 1 {
+		t.Fatal("the input still targets the backgrounded thread")
+	}
+	if m.showStrip() {
+		t.Error("a lone foreground thread still renders a strip")
+	}
+
+	// ctrl+b reloads the run list from the (sandboxed, empty) run log; re-seed
+	// the fixture rows the assertions join against.
+	reseed := func() {
+		m.runsToday = []ckRun{testRun("20260904T100200Z-cccc", "running", "write tests")}
+	}
+	reseed()
+
+	// The agents view names it and enter pulls it back.
+	m = m.jump(ckViewAgents)
+	out := stripANSI(m.viewAgents(100, 24))
+	if !strings.Contains(out, "thread 1") {
+		t.Errorf("agents view does not name the backgrounded thread:\n%s", out)
+	}
+	// Its completion pings the active thread's chat.
+	next, _ := m.Update(ckExecDoneMsg{exec: ex, task: ckTask{threadID: 1, runID: "r1", answer: "done in bg", elapsed: time.Second}})
+	m = next.(Cockpit)
+	ping := stripANSI(strings.Join(m.th().log, "\n"))
+	if !strings.Contains(ping, "hydra ▸") || !strings.Contains(ping, "thread 1 done") {
+		t.Errorf("no completion ping: %q", ping)
+	}
+	reseed() // settling reloads the run list too
+
+	// Enter on its agents row re-foregrounds it.
+	m = m.jump(ckViewAgents)
+	rows := m.agentRows()
+	for i, r := range rows {
+		if r.id == "20260904T100200Z-cccc" {
+			m.agentSel = i
+		}
+	}
+	next2, _ := m.enterRow()
+	m = next2.(Cockpit)
+	if m.view != ckViewChat || m.th().id != 1 || m.th().bg {
+		t.Errorf("enter did not foreground the thread: view=%d id=%d bg=%v", m.view, m.th().id, m.th().bg)
+	}
+}
+
+// ── layout regression matrix (#598 additions) ────────────────────────────────
+
+func TestThreadLayouts_NothingOverflowsAtAnySize(t *testing.T) {
+	testutil.NewSandbox(t)
+	long := strings.Repeat("wide thread content — no pane may leak past its column budget. ", 46) // ~3000 chars
+
+	states := map[string]func(Cockpit) Cockpit{
+		"four_threads_long_names": func(m Cockpit) Cockpit {
+			for i := 0; i < 3; i++ {
+				m = press(m, tea.KeyCtrlT)
+			}
+			for i, t := range m.threads {
+				t.name = fmt.Sprintf("an-extremely-long-thread-name-that-must-truncate-%d", i+1)
+			}
+			return m
+		},
+		"split_both_streaming": func(m Cockpit) Cockpit {
+			m = press(m, tea.KeyCtrlT)
+			m.split, m.splitID = true, 1
+			m.threads[0].exec = &ckExecState{stage: "verifying — go test ./...", started: time.Now()}
+			m.threads[0].log = append(m.threads[0].log, strings.Split(long, ". ")...)
+			m.threads[1].exec = &ckExecState{stage: "editing users.go", started: time.Now()}
+			m.threads[1].log = append(m.threads[1].log, strings.Split(long, ". ")...)
+			return m
+		},
+		"queued_chip_long_path": func(m Cockpit) Cockpit {
+			m = press(m, tea.KeyCtrlT)
+			m.th().queued = &ckQueued{reason: "queued behind 1 · both touch internal/very/deeply/nested/path/that/never/ends/handlers/users_endpoint_pagination.go"}
+			m.th().name = "queued-one"
+			return m
+		},
+		"huge_task_while_other_streams": func(m Cockpit) Cockpit {
+			m = press(m, tea.KeyCtrlT)
+			m.threads[0].exec = &ckExecState{stage: "streaming", started: time.Now()}
+			m.threads[0].log = append(m.threads[0].log, "streamed line")
+			m.th().input = long
+			return m
+		},
+		"worktree_header_and_strip": func(m Cockpit) Cockpit {
+			m = press(m, tea.KeyCtrlT)
+			m.th().wt = &ckWorktree{tag: "t2-abc123", branch: "hydra/task-t2-abc123"}
+			m.th().log = append(m.th().log, "an edit landed")
+			return m
+		},
+	}
+
+	sizes := []struct{ w, h int }{{60, 15}, {80, 24}, {100, 30}, {120, 40}}
+	for name, build := range states {
+		for _, sz := range sizes {
+			t.Run(fmt.Sprintf("%s_%dx%d", name, sz.w, sz.h), func(t *testing.T) {
+				m := build(testCockpit())
+				m.w, m.h, m.ready = sz.w, sz.h, true
+				out := m.View()
+				lines := strings.Split(out, "\n")
+				if len(lines) > sz.h {
+					t.Errorf("%s at %dx%d renders %d lines, want <= %d", name, sz.w, sz.h, len(lines), sz.h)
+				}
+				for i, l := range lines {
+					if got := lipgloss.Width(l); got > sz.w {
+						t.Errorf("%s at %dx%d: line %d is %d cells wide", name, sz.w, sz.h, i, got)
+					}
+				}
+				last := stripANSI(lines[len(lines)-1])
+				if !strings.Contains(last, "shortcuts") {
+					t.Errorf("%s at %dx%d: the status bar is not the final line: %q", name, sz.w, sz.h, last)
+				}
+			})
+		}
+	}
+}
+
+// A streamed REAL file (tab-indented, lines that fill the budget) must occupy
+// exactly one panel row each. Found live: the panel's text budget ignored its
+// own padding, so every full line wrapped in two and half the panel was lost —
+// disclosed by ckFrame as "… N more lines", but still half a pane of content.
+func TestCodePanel_RealFileLinesDoNotWrap(t *testing.T) {
+	var lines []string
+	for i := 0; i < 50; i++ {
+		lines = append(lines, fmt.Sprintf("\tif err := doSomethingUseful(ctx, %d); err != nil {", i))
+	}
+	for _, sz := range []struct{ w, h int }{{60, 15}, {80, 24}, {100, 30}, {120, 40}} {
+		m := testCockpit()
+		m.w, m.h, m.ready = sz.w, sz.h, true
+		m = m.addThread() // a strip exists, as it does in a real parallel session
+		th := m.th()
+		th.codeLang, th.codeLines, th.codeShown = "go", lines, len(lines)
+
+		bodyH := sz.h - 3
+		if m.showStrip() {
+			bodyH--
+		}
+		for _, pw := range []int{22, 29, 40} {
+			panel := m.codePanel(th, pw, bodyH)
+			if got := lipgloss.Height(panel); got > bodyH {
+				t.Errorf("%dx%d panel w=%d: height %d > %d — a line wrapped",
+					sz.w, sz.h, pw, got, bodyH)
+			}
+		}
+		if out := m.View(); strings.Contains(stripANSI(out), "more lines — enlarge") {
+			t.Errorf("%dx%d: the frame had to clamp a streamed file", sz.w, sz.h)
+		}
+	}
+}
+
+// The glossary documents the THREADS group and every new key.
+func TestGlossary_DocumentsThreadKeys(t *testing.T) {
+	lines := stripANSI(strings.Join(ckGlossaryLines(), "\n"))
+	for _, want := range []string{"THREADS", "ctrl+t", "alt+1–9", "ctrl+←/→", "ctrl+\\", "ctrl+b", "ctrl+g"} {
+		if !strings.Contains(lines, want) {
+			t.Errorf("glossary lacks %q", want)
+		}
+	}
+}

--- a/internal/tui/view_agents.go
+++ b/internal/tui/view_agents.go
@@ -55,6 +55,11 @@ func (m Cockpit) viewAgents(w, h int) string {
 		if task == "" {
 			task = "(task not recorded)"
 		}
+		// A run owned by a backgrounded chat thread is that thread, re-parented
+		// here (#598) — name it, and let enter pull it back into chat.
+		if t := m.threadForRun(r.id); t != nil && t.bg {
+			task = fmt.Sprintf("thread %d · %s", t.id, task)
+		}
 		line := marker + ckStatusGlyph(r.status) + " " + section + ckFaintS.Render(ckCell(ckShortID(r.id), 8)) + " " +
 			ckInkS.Bold(i == sel).Render(ckCell(ckSafe(task), ckAgentTaskW)) + " "
 		if r.live {
@@ -65,7 +70,7 @@ func (m Cockpit) viewAgents(w, h int) string {
 		lines[i] = line
 	}
 	b.WriteString(strings.Join(ckSelScroll(lines, sel, avail), "\n"))
-	b.WriteString("\n\n" + ckFaintS.Render(" enter opens the run's trace in activity"))
+	b.WriteString("\n\n" + ckFaintS.Render(" enter opens the run's trace · a backgrounded thread's run returns to chat"))
 	return lipgloss.NewStyle().Width(w).Height(h).Padding(0, 1).Render(b.String())
 }
 

--- a/internal/tui/view_chat.go
+++ b/internal/tui/view_chat.go
@@ -2,9 +2,10 @@
 
 package tui
 
-// view_chat.go — view 0: the chat console (bordered input bar with the mode
-// chip), its sidebar, and the code panel. Kept thin: execution lives in
-// chat_exec.go/chat_task.go, modes in modes.go, the override in override.go.
+// view_chat.go — view 0: the chat console (keys, the bordered input bar with
+// its mode chip), its sidebar, and the code panel. Kept thin: execution lives
+// in chat_exec.go/chat_task.go, the strip and split panes in threads.go, modes
+// in modes.go, the override in override.go.
 
 import (
 	"fmt"
@@ -19,17 +20,18 @@ import (
 var ckFileRe = regexp.MustCompile(`[\w/]+\.(go|ts|js|py|rs|java)`)
 
 // chatKey handles keys while the chat view is active. Typing always wins on a
-// non-empty input; the letter commands (?, m, d/x/o) fire only from an empty
+// non-empty input; the letter commands (?, m, a/d/x/o) fire only from an empty
 // one, the same discipline '?' set in phase 1. Pending states are modal.
 func (m Cockpit) chatKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	t := m.th()
 	switch {
 	case m.modePick:
 		return m.modePickerKey(msg)
 	case m.ovOpen:
 		return m.overrideKey(msg)
-	case m.confirm != nil:
+	case t.confirm != nil:
 		return m.confirmKey(msg)
-	case m.planWait != nil:
+	case t.planWait != nil:
 		return m.planKey(msg)
 	}
 	switch msg.Type {
@@ -40,51 +42,61 @@ func (m Cockpit) chatKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyCtrlO:
 		m.ovOpen, m.ovSel, m.ovStage, m.ovConfSel = true, 0, 0, 0
 		return m, nil
+	case tea.KeyCtrlLeft:
+		return m.cycleThread(-1), nil
+	case tea.KeyCtrlRight:
+		return m.cycleThread(1), nil
+	case tea.KeyCtrlBackslash:
+		return m.toggleSplit(), nil
+	case tea.KeyCtrlB:
+		return m.backgroundThread(), nil
 	case tea.KeyEnter:
 		return m.submit()
 	case tea.KeyBackspace:
-		if n := len(m.input); n > 0 {
-			m.input = m.input[:n-1]
+		if n := len(t.input); n > 0 {
+			t.input = t.input[:n-1]
 		}
 	case tea.KeySpace:
-		m.input += " "
+		t.input += " "
 	case tea.KeyRunes:
-		// Pasted text is literal input: a paste starting with m/d/x/o must
+		// Pasted text is literal input: a paste starting with m/a/d/x/o must
 		// type, not fire the letter commands.
-		if m.input == "" && len(msg.Runes) == 1 && !msg.Paste {
+		if t.input == "" && len(msg.Runes) == 1 && !msg.Paste {
 			switch msg.Runes[0] {
 			case '?':
 				m.glossary = true
 				return m, nil
 			case 'm':
 				return m.openModePicker(), nil
-			case 'd', 'x', 'o':
+			case 'a', 'd', 'x', 'o':
 				if nm, cmd, ok := m.resultKey(msg.Runes[0]); ok {
 					return nm, cmd
 				}
 			}
 		}
-		m.input += string(msg.Runes)
+		t.discardArm = false // any typing disarms the pending discard confirm
+		t.input += string(msg.Runes)
 	}
 	return m, nil
 }
 
 // confirmKey is careful mode's y/n gate; esc (handled globally) also declines.
 func (m Cockpit) confirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	t := m.th()
 	if msg.Type != tea.KeyRunes || len(msg.Runes) != 1 {
 		return m, nil
 	}
-	w := *m.confirm
+	w := *t.confirm
 	switch msg.Runes[0] {
 	case 'y', 'Y':
-		m.log = append(m.log, ckDimS.Render("  confirmed — writing"))
-		return m.resumeTask(w)
+		t.log = append(t.log, ckDimS.Render("  confirmed — writing"))
+		return m.resumeTask(t, w)
 	case 'n', 'N':
 		note := "stopped before writing — nothing changed"
 		if w.phase == ckPhaseFix {
 			note = "fix declined — the file keeps its last write"
 		}
-		return m.stopWait(w, note)
+		return m.stopWait(t, w, note)
 	}
 	return m, nil
 }
@@ -92,16 +104,17 @@ func (m Cockpit) confirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // planKey is plan mode's approval gate: enter/y/a run the plan, esc (global)
 // discards it. Everything else is swallowed while the question stands.
 func (m Cockpit) planKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	t := m.th()
 	switch msg.Type {
 	case tea.KeyEnter:
-		m.log = append(m.log, ckDimS.Render("  plan approved — running"))
-		return m.resumeTask(*m.planWait)
+		t.log = append(t.log, ckDimS.Render("  plan approved — running"))
+		return m.resumeTask(t, *t.planWait)
 	case tea.KeyRunes:
 		if len(msg.Runes) == 1 {
 			switch msg.Runes[0] {
 			case 'y', 'Y', 'a', 'A':
-				m.log = append(m.log, ckDimS.Render("  plan approved — running"))
-				return m.resumeTask(*m.planWait)
+				t.log = append(t.log, ckDimS.Render("  plan approved — running"))
+				return m.resumeTask(t, *t.planWait)
 			}
 		}
 	}
@@ -109,17 +122,18 @@ func (m Cockpit) planKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Cockpit) submit() (tea.Model, tea.Cmd) {
-	t := strings.TrimSpace(m.input)
-	m.input = ""
-	m.chatScroll = 0 // sending your own message returns the view to live
+	th := m.th()
+	t := strings.TrimSpace(th.input)
+	th.input = ""
+	th.scroll = 0 // sending your own message returns the view to live
 	// Commands are matched case-insensitively (#465) — free-text task input
 	// below is not, since a real task's casing is meaningful.
 	lt := strings.ToLower(t)
 	switch {
 	case lt == "":
 		// An empty enter after a finished task opens its trace, as the footer says.
-		if m.lastDone != nil && m.exec == nil {
-			return m.focusRun(m.lastDone.runID), nil
+		if th.lastDone != nil && th.exec == nil {
+			return m.focusRun(th.lastDone.runID), nil
 		}
 		return m, nil
 	case lt == ":q" || lt == ":quit":
@@ -130,20 +144,20 @@ func (m Cockpit) submit() (tea.Model, tea.Cmd) {
 				return m.jump(v), nil
 			}
 		}
-		m.log = append(m.log, ckDimS.Render("unknown command "+t))
+		th.log = append(th.log, ckDimS.Render("unknown command "+t))
 		return m, nil
 	case strings.HasPrefix(lt, "/"):
 		if ckIsMode(lt[1:]) {
 			m.mode = lt[1:]
-			m.log = append(m.log, ckDimS.Render("mode → ")+ckCyanS.Render(m.mode))
+			th.log = append(th.log, ckDimS.Render("mode → ")+ckCyanS.Render(m.mode))
 		} else {
-			m.log = append(m.log, ckDimS.Render("unknown command "+t))
+			th.log = append(th.log, ckDimS.Render("unknown command "+t))
 		}
 		return m, nil
 	}
-	if m.exec != nil {
-		m.input = t // nothing typed is lost — the task queue is phase 3
-		m.flash = "a task is running — esc cancels it"
+	if th.exec != nil || th.queued != nil {
+		th.input = t // nothing typed is lost
+		m.flash = fmt.Sprintf("thread %d is busy — ctrl+t opens a new thread · esc cancels", th.id)
 		return m, nil
 	}
 	return m.startTask(t)
@@ -177,78 +191,112 @@ func (m Cockpit) pickHead(wantTier int, localOnly bool) int {
 
 // ── layout ────────────────────────────────────────────────────────────────────
 
-// chatCode lays out the chat console beside the code panel (view 0).
+// chatCode lays out the chat view: the thread strip (once threads exist),
+// then either the active thread beside the code panel, or the ctrl+\ split.
 // It falls back to chat-only when the terminal is too narrow to split.
 func (m Cockpit) chatCode(bodyH int) string {
+	var rows []string
+	if m.showStrip() {
+		rows = append(rows, m.threadStrip(max(1, m.w)))
+		bodyH--
+		if bodyH < 4 {
+			bodyH = 4
+		}
+	}
 	mainW := m.w - 23 // sidebar (21) + right border + gap
 	if mainW < 20 {
 		mainW = 20
 	}
 	sidebar := m.sidebar(bodyH)
-	chatW, split := ckChatSplit(mainW)
-	if !split {
-		// too tight to split — give the whole main pane to chat.
-		return lipgloss.JoinHorizontal(lipgloss.Top, sidebar, " ", m.chatMain(mainW, bodyH))
+	var main string
+	switch {
+	case m.split && m.threadByID(m.splitID) != nil:
+		main = m.splitPanes(mainW, bodyH)
+	default:
+		chatW, split := ckChatSplit(mainW)
+		if !split {
+			// too tight for the code panel — the whole main pane is chat.
+			main = m.chatMain(m.th(), mainW, bodyH)
+		} else {
+			main = lipgloss.JoinHorizontal(lipgloss.Top,
+				m.chatMain(m.th(), chatW, bodyH), m.codePanel(m.th(), mainW-chatW, bodyH))
+		}
 	}
-	return lipgloss.JoinHorizontal(lipgloss.Top,
-		sidebar, " ", m.chatMain(chatW, bodyH), m.codePanel(mainW-chatW, bodyH))
+	rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, sidebar, " ", main))
+	return strings.Join(rows, "\n")
 }
 
-// ckChatSplit decides the chat/code split for the main column budget.
-func ckChatSplit(mainW int) (chatW int, split bool) {
-	chatW = mainW / 2
-	return chatW, mainW-chatW >= 22
-}
-
-// chatLogGeom mirrors chatCode/chatMain's layout so the scrollback handler
-// clamps against the same window the renderer draws.
+// chatLogGeom mirrors chatCode/chatMain's layout for the ACTIVE thread so the
+// scrollback handler clamps against the same window the renderer draws.
 func (m Cockpit) chatLogGeom() (w, logH int) {
-	mainW := m.w - 23
-	if mainW < 20 {
-		mainW = 20
-	}
-	w = mainW
-	if chatW, split := ckChatSplit(mainW); split {
-		w = chatW
-	}
 	bodyH := m.h - 3
 	if bodyH < 6 {
 		bodyH = 6
 	}
-	logH = bodyH - lipgloss.Height(m.inputBar(w))
+	if m.showStrip() {
+		bodyH--
+		if bodyH < 4 {
+			bodyH = 4
+		}
+	}
+	mainW := m.w - 23
+	if mainW < 20 {
+		mainW = 20
+	}
+	t := m.th()
+	if m.split && m.threadByID(m.splitID) != nil {
+		w = (mainW - 1) / 2
+		if w < 10 {
+			w = 10
+		}
+		logH = bodyH - lipgloss.Height(m.inputBar(mainW)) - 1 // pane title
+		if t.threadHeaderLine(w) != "" {
+			logH--
+		}
+	} else {
+		w = mainW
+		if chatW, split := ckChatSplit(mainW); split {
+			w = chatW
+		}
+		logH = bodyH - lipgloss.Height(m.inputBar(w))
+		if t.threadHeaderLine(w) != "" {
+			logH--
+		}
+	}
 	if logH < 1 {
 		logH = 1
 	}
 	return w, logH
 }
 
-// chatScrollBy moves the chat scrollback: 0 in m.chatScroll means live tail,
-// L+1 means anchored at rendered line L — so an anchored reader is never
+// chatScrollBy moves the active thread's scrollback: 0 in scroll means live
+// tail, L+1 means anchored at rendered line L — so an anchored reader is never
 // yanked when new output appends below.
 func (m Cockpit) chatScrollBy(delta int) Cockpit {
+	t := m.th()
 	w, logH := m.chatLogGeom()
 	entryCap := ckLogEntryCap
 	if logH < entryCap {
 		entryCap = logH
 	}
-	top := len(ckLogLines(m.log, w, entryCap)) - logH
+	top := len(ckLogLines(t.log, w, entryCap)) - logH
 	if top <= 0 {
-		m.chatScroll = 0 // everything fits — only live makes sense
+		t.scroll = 0 // everything fits — only live makes sense
 		return m
 	}
 	cur := top
-	if m.chatScroll > 0 {
-		cur = m.chatScroll - 1
+	if t.scroll > 0 {
+		cur = t.scroll - 1
 	}
 	cur += delta
 	if cur >= top {
-		m.chatScroll = 0 // reached the tail — back to live
+		t.scroll = 0 // reached the tail — back to live
 		return m
 	}
 	if cur < 0 {
 		cur = 0
 	}
-	m.chatScroll = cur + 1
+	t.scroll = cur + 1
 	return m
 }
 
@@ -311,44 +359,59 @@ func (m Cockpit) sidebar(h int) string {
 		Render(strings.Join(lines, "\n"))
 }
 
-func (m Cockpit) chatMain(w, h int) string {
+// chatMain renders one thread's log above the input bar.
+func (m Cockpit) chatMain(t *ckThread, w, h int) string {
 	// The pane is the log box plus the input bar, totalling exactly h lines —
 	// anything more and Bubble Tea crops the overflow off the TOP, deleting
 	// the header on every launch (#445).
 	input := m.inputBar(w)
 	logH := h - lipgloss.Height(input)
+	var rows []string
+	if hdr := t.threadHeaderLine(w); hdr != "" {
+		rows = append(rows, hdr)
+		logH--
+	}
 	if logH < 1 {
 		logH = 1
 	}
-	logBox := lipgloss.NewStyle().Width(w).Height(logH).Render(ckVisibleLog(m.log, w, logH, m.chatScroll-1))
-	return lipgloss.JoinVertical(lipgloss.Left, logBox, input)
+	rows = append(rows, lipgloss.NewStyle().Width(w).Height(logH).
+		Render(ckVisibleLog(t.log, w, logH, t.scroll-1)))
+	rows = append(rows, input)
+	return lipgloss.JoinVertical(lipgloss.Left, rows...)
 }
 
 // ckInputWrapCap bounds how many wrapped lines of a long input stay visible —
 // the newest ones, where the cursor is. The rest is typed, just not shown.
 const ckInputWrapCap = 3
 
-// inputBar renders the bordered input with the mode chip: idle placeholder,
-// wrapped typing, the running spinner, or the pending question. Heights too
-// small for a border degrade to one bare line — the input never disappears.
+// inputBar renders the bordered input with the mode chip and — once threads
+// exist to tell apart — its target thread: idle placeholder, wrapped typing,
+// the running spinner, or the pending question. Heights too small for a border
+// degrade to one bare line — the input never disappears.
 func (m Cockpit) inputBar(w int) string {
+	t := m.th()
 	chip := ckChipS.Render(ckModeByName(m.mode).chip + " ▾")
+	if len(m.threads) > 1 {
+		chip += ckDimS.Render(fmt.Sprintf(" → thread %d", t.id))
+	}
 	var body string
 	switch {
-	case m.exec != nil:
+	case t.exec != nil:
 		frames := []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
-		elapsed := time.Since(m.exec.started)
+		elapsed := time.Since(t.exec.started)
 		f := frames[int(elapsed/(200*time.Millisecond))%len(frames)]
-		body = ckAquaS.Render(string(f)+" ") + ckInkS.Render(m.exec.Stage()) +
+		body = ckAquaS.Render(string(f)+" ") + ckInkS.Render(t.exec.Stage()) +
 			ckDimS.Render(fmt.Sprintf(" · %.1fs · ", elapsed.Seconds())) + ckFaintS.Render("esc cancels")
-	case m.confirm != nil:
-		body = ckMidS.Render(m.confirm.question)
-	case m.planWait != nil:
+	case t.confirm != nil:
+		body = ckMidS.Render(t.confirm.question)
+	case t.planWait != nil:
 		body = ckCyanS.Render("plan ready — enter/y runs it · esc discards")
-	case m.input == "":
+	case t.queued != nil:
+		body = ckDimS.Render("◱ " + t.queued.reason + " · esc discards")
+	case t.input == "":
 		body = ckFaintS.Render("what do you need done? — enter runs it")
 	default:
-		body = ckInkS.Render(m.input) + ckAquaS.Render("▏")
+		body = ckInkS.Render(t.input) + ckAquaS.Render("▏")
 	}
 	line := chip + " " + body
 
@@ -373,6 +436,12 @@ func (m Cockpit) inputBar(w int) string {
 		Render(strings.Join(wrapped, "\n"))
 }
 
+// ckChatSplit decides the chat/code split for the main column budget.
+func ckChatSplit(mainW int) (chatW int, split bool) {
+	chatW = mainW / 2
+	return chatW, mainW-chatW >= 22
+}
+
 // ckTailTruncate keeps the END of a styled line within n cells — the input's
 // newest characters, unlike truncate which keeps the start.
 func ckTailTruncate(s string, n int) string {
@@ -384,58 +453,57 @@ func ckTailTruncate(s string, n int) string {
 	return ckFaintS.Render("…") + rows[len(rows)-1]
 }
 
-// codePanel renders the code panel beside the chat console: the last edit's
-// real content (streamed), or its diff after `d`. w is the full column budget.
-func (m Cockpit) codePanel(w, h int) string {
+// codePanel renders the code panel beside the chat console: the thread's last
+// edit's real content (streamed), or its diff after `d`. w is the full column
+// budget.
+func (m Cockpit) codePanel(t *ckThread, w, h int) string {
 	inner := w - 2 // border-left (1) + padding-left (1)
 	if inner < 10 {
 		inner = 10
 	}
-	var b strings.Builder
-	lang := m.codeLang
+	lang := t.codeLang
 	if lang == "" {
 		lang = "—"
 	}
 	title := "CODE"
-	if m.codeDiff {
+	if t.codeDiff {
 		title = "DIFF"
 	}
-	b.WriteString(ckLabelS.Render(title) + ckDimS.Render(" · "+lang) + "\n")
+	rows := []string{ckLabelS.Render(title) + ckDimS.Render(" · "+lang)}
 
-	if len(m.codeLines) == 0 {
-		b.WriteString("\n" + ckFaintS.Render("no edits yet —") + "\n" +
-			ckFaintS.Render("a task that changes a") + "\n" +
-			ckFaintS.Render("file streams it here."))
+	if len(t.codeLines) == 0 {
+		rows = append(rows, "", ckFaintS.Render("no edits yet —"),
+			ckFaintS.Render("a task that changes a"), ckFaintS.Render("file streams it here."))
 	} else {
-		shown := m.codeShown
-		if shown > len(m.codeLines) {
-			shown = len(m.codeLines)
-		}
-		textW := inner - 4 // "NN " gutter + slack
+		shown := min(t.codeShown, len(t.codeLines))
+		// Width() budgets padding too, so a line may only use inner-1 cells;
+		// the 4-cell gutter comes out of that. Overshooting wrapped every full
+		// line in two and silently halved the panel.
+		textW := inner - 1 - 4
 		if textW < 4 {
 			textW = 4
 		}
 		// The panel is a preview, not a pager: show the newest lines that fit.
-		avail := h - 1
-		if avail < 1 {
-			avail = 1
-		}
+		avail := max(1, h-1)
 		start := 0
 		if shown > avail {
 			start = shown - avail
 		}
 		for i := start; i < shown; i++ {
-			gutter := ckFaintS.Render(fmt.Sprintf("%3d ", i+1))
-			b.WriteString(gutter + ckCodeLine(truncate(ckSafe(m.codeLines[i]), textW), m.codeDiff) + "\n")
+			rows = append(rows, ckFaintS.Render(fmt.Sprintf("%3d ", i+1))+
+				ckCodeLine(truncate(ckSafe(t.codeLines[i]), textW), t.codeDiff))
 		}
-		if shown < len(m.codeLines) { // cursor while streaming
-			b.WriteString(ckFaintS.Render(fmt.Sprintf("%3d ", shown+1)) + ckAquaS.Render("▏"))
+		if shown < len(t.codeLines) && len(rows) <= avail { // cursor while streaming
+			rows = append(rows, ckFaintS.Render(fmt.Sprintf("%3d ", shown+1))+ckAquaS.Render("▏"))
 		}
+	}
+	if len(rows) > h {
+		rows = rows[:h]
 	}
 
 	return lipgloss.NewStyle().Width(inner).Height(h).
 		BorderStyle(lipgloss.NormalBorder()).BorderLeft(true).BorderForeground(ckLineC).
-		PaddingLeft(1).Render(b.String())
+		PaddingLeft(1).Render(strings.Join(rows, "\n"))
 }
 
 // ckCodeLine paints one panel line: diff mode colours by +/-/@@ prefix, code

--- a/internal/tui/view_chat_test.go
+++ b/internal/tui/view_chat_test.go
@@ -18,12 +18,12 @@ func TestChat_ViewCommandsSwitchViews(t *testing.T) {
 		if m.view != want {
 			t.Errorf(":%s left view = %d, want %d", name, m.view, want)
 		}
-		if m.input != "" {
-			t.Errorf("the input still holds %q after submitting", m.input)
+		if m.th().input != "" {
+			t.Errorf("the input still holds %q after submitting", m.th().input)
 		}
 	}
 	m, _ := enter(typed(testCockpit(), ":nonsense"))
-	if !strings.Contains(strings.Join(m.log, "\n"), "unknown") {
+	if !strings.Contains(strings.Join(m.th().log, "\n"), "unknown") {
 		t.Error("an unknown :command was not reported")
 	}
 }
@@ -46,7 +46,7 @@ func TestChat_ModeCommands(t *testing.T) {
 		if m.mode != want {
 			t.Errorf("%s left mode = %q", cmd, m.mode)
 		}
-		if !strings.Contains(strings.Join(m.log, "\n"), want) {
+		if !strings.Contains(strings.Join(m.th().log, "\n"), want) {
 			t.Errorf("%s was not acknowledged in the log", cmd)
 		}
 	}
@@ -55,7 +55,7 @@ func TestChat_ModeCommands(t *testing.T) {
 		if m.mode == strings.ToLower(cmd[1:]) {
 			t.Errorf("%s was accepted as a mode", cmd)
 		}
-		if !strings.Contains(strings.Join(m.log, "\n"), "unknown") {
+		if !strings.Contains(strings.Join(m.th().log, "\n"), "unknown") {
 			t.Errorf("%s was not reported as unknown", cmd)
 		}
 	}
@@ -66,11 +66,11 @@ func TestChat_ModeCommands(t *testing.T) {
 func TestChat_EmptySubmitDoesNothing(t *testing.T) {
 	before := testCockpit()
 	m, cmd := enter(before)
-	if len(m.log) != len(before.log) || cmd != nil {
+	if len(m.th().log) != len(before.th().log) || cmd != nil {
 		t.Error("an empty submit did something")
 	}
 	m, cmd = enter(typed(testCockpit(), "   "))
-	if len(m.log) != len(before.log) || cmd != nil {
+	if len(m.th().log) != len(before.th().log) || cmd != nil {
 		t.Error("a whitespace-only submit was treated as a task")
 	}
 }
@@ -81,14 +81,14 @@ func TestChat_NoModelsSaysSoAndRunsNothing(t *testing.T) {
 	m := testCockpit()
 	m.heads = nil
 	m, cmd := enter(typed(m, "add pagination"))
-	joined := strings.Join(m.log, "\n")
+	joined := strings.Join(m.th().log, "\n")
 	if !strings.Contains(joined, "no routable model") {
 		t.Errorf("the log does not say why nothing was routed:\n%s", joined)
 	}
 	if !strings.Contains(joined, "hyctl probe") {
 		t.Error("the message does not tell the user how to find out why")
 	}
-	if m.exec != nil || cmd != nil {
+	if m.th().exec != nil || cmd != nil {
 		t.Error("a task started with nothing to route to")
 	}
 }
@@ -160,7 +160,7 @@ func TestChatStart_ImpactOnlyForFilesTheGraphKnows(t *testing.T) {
 	testutil.NewSandbox(t)
 	m := testCockpit()
 	m, _ = enter(typed(m, "rotate the key in internal/nowhere/absent.go"))
-	joined := strings.Join(m.log, "\n")
+	joined := strings.Join(m.th().log, "\n")
 	if strings.Contains(joined, "κ=") {
 		t.Errorf("an impact figure was printed with no graph loaded:\n%s", joined)
 	}
@@ -174,16 +174,16 @@ func TestChatStart_ImpactOnlyForFilesTheGraphKnows(t *testing.T) {
 func TestChatMain_GeometryHolds(t *testing.T) {
 	m := testCockpit()
 	for _, h := range []int{10, 24, 30, 60} {
-		out := m.chatMain(60, h)
+		out := m.chatMain(m.th(), 60, h)
 		if got := strings.Count(out, "\n") + 1; got != h {
 			t.Errorf("chatMain(60, %d) produced %d lines", h, got)
 		}
 	}
 
-	m.input = "still typing"
-	m.log = []string{strings.Repeat("x", 3000)}
+	m.th().input = "still typing"
+	m.th().log = []string{strings.Repeat("x", 3000)}
 	for _, h := range []int{10, 24} {
-		out := m.chatMain(60, h)
+		out := m.chatMain(m.th(), 60, h)
 		if got := strings.Count(out, "\n") + 1; got != h {
 			t.Errorf("one huge entry changed the height to %d", got)
 		}
@@ -197,12 +197,12 @@ func TestChatMain_GeometryHolds(t *testing.T) {
 // bar always shows the typed text and the mode chip.
 func TestChatMain_KeepsTheNewestLinesAndTheInput(t *testing.T) {
 	m := testCockpit()
-	m.input = "half-typed prompt"
-	m.log = nil
+	m.th().input = "half-typed prompt"
+	m.th().log = nil
 	for i := 0; i < 200; i++ {
-		m.log = append(m.log, fmt.Sprintf("log line %d", i))
+		m.th().log = append(m.th().log, fmt.Sprintf("log line %d", i))
 	}
-	got := stripANSI(m.chatMain(60, 12))
+	got := stripANSI(m.chatMain(m.th(), 60, 12))
 	if !strings.Contains(got, "log line 199") {
 		t.Errorf("the newest line is not shown:\n%s", got)
 	}
@@ -213,7 +213,7 @@ func TestChatMain_KeepsTheNewestLinesAndTheInput(t *testing.T) {
 		t.Errorf("the input line or mode chip is missing:\n%s", got)
 	}
 	// Even with no room for the border, the input itself survives.
-	tiny := stripANSI(m.chatMain(30, 3))
+	tiny := stripANSI(m.chatMain(m.th(), 30, 3))
 	if !strings.Contains(tiny, "prompt") {
 		t.Errorf("at height 3 the input is gone:\n%s", tiny)
 	}
@@ -223,7 +223,7 @@ func TestChatMain_KeepsTheNewestLinesAndTheInput(t *testing.T) {
 // and never grows past the wrap cap.
 func TestInputBar_WrapsAndKeepsTheTail(t *testing.T) {
 	m := testCockpit()
-	m.input = strings.Repeat("word ", 200) + "FINAL"
+	m.th().input = strings.Repeat("word ", 200) + "FINAL"
 	bar := m.inputBar(60)
 	if got := strings.Count(bar, "\n") + 1; got > ckInputWrapCap+2 {
 		t.Errorf("input bar grew to %d lines", got)
@@ -232,7 +232,7 @@ func TestInputBar_WrapsAndKeepsTheTail(t *testing.T) {
 		t.Errorf("the input's tail (cursor region) is not visible:\n%s", stripANSI(bar))
 	}
 	// Placeholder when idle and empty.
-	m.input = ""
+	m.th().input = ""
 	if got := stripANSI(m.inputBar(60)); !strings.Contains(got, "what do you need done?") {
 		t.Errorf("no placeholder on an empty idle input:\n%s", got)
 	}
@@ -283,36 +283,36 @@ func TestSidebar_UnknownContextSaysNoData(t *testing.T) {
 // width — and in diff mode it colours by prefix instead of syntax.
 func TestCodePanel_RendersAtEverySize(t *testing.T) {
 	m := testCockpit()
-	if got := m.codePanel(40, 20); !strings.Contains(got, "no edits yet") {
+	if got := m.codePanel(m.th(), 40, 20); !strings.Contains(got, "no edits yet") {
 		t.Errorf("the empty state does not say what it is waiting for:\n%s", got)
 	}
-	m.codeLang = "go"
-	m.codeLines = []string{"package main", "func main() {}", "// done"}
-	m.codeShown = len(m.codeLines)
+	m.th().codeLang = "go"
+	m.th().codeLines = []string{"package main", "func main() {}", "// done"}
+	m.th().codeShown = len(m.th().codeLines)
 	for _, w := range []int{0, 1, 5, 40, 200} {
-		if got := m.codePanel(w, 20); strings.TrimSpace(got) == "" {
+		if got := m.codePanel(m.th(), w, 20); strings.TrimSpace(got) == "" {
 			t.Errorf("codePanel(%d) rendered nothing", w)
 		}
 	}
-	m.codeShown = len(m.codeLines) + 50
-	if got := m.codePanel(60, 20); strings.TrimSpace(got) == "" {
+	m.th().codeShown = len(m.th().codeLines) + 50
+	if got := m.codePanel(m.th(), 60, 20); strings.TrimSpace(got) == "" {
 		t.Error("codePanel rendered nothing with codeShown past the end")
 	}
 	// A long file shows its newest lines rather than only the top of the file.
-	m.codeLines = nil
+	m.th().codeLines = nil
 	for i := 0; i < 100; i++ {
-		m.codeLines = append(m.codeLines, fmt.Sprintf("line%d", i))
+		m.th().codeLines = append(m.th().codeLines, fmt.Sprintf("line%d", i))
 	}
-	m.codeShown = 100
-	if got := stripANSI(m.codePanel(60, 12)); !strings.Contains(got, "line99") {
+	m.th().codeShown = 100
+	if got := stripANSI(m.codePanel(m.th(), 60, 12)); !strings.Contains(got, "line99") {
 		t.Errorf("the panel does not show the newest streamed lines:\n%s", got)
 	}
 
-	m.codeDiff = true
-	m.codeLang = "diff"
-	m.codeLines = []string{"@@ -1,2 +1,2 @@", "-old line", "+new line", " ctx"}
-	m.codeShown = len(m.codeLines)
-	if got := stripANSI(m.codePanel(60, 20)); !strings.Contains(got, "DIFF") || !strings.Contains(got, "+new line") {
+	m.th().codeDiff = true
+	m.th().codeLang = "diff"
+	m.th().codeLines = []string{"@@ -1,2 +1,2 @@", "-old line", "+new line", " ctx"}
+	m.th().codeShown = len(m.th().codeLines)
+	if got := stripANSI(m.codePanel(m.th(), 60, 20)); !strings.Contains(got, "DIFF") || !strings.Contains(got, "+new line") {
 		t.Errorf("diff mode did not render the diff:\n%s", got)
 	}
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -205,10 +205,32 @@ func (r *Registry) Check(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return ws.check(path)
+}
 
+// CheckRooted validates path against a synthesized workspace rooted at root —
+// the default workspace's glob rules, just not at the CWD repo. It exists for
+// Hydra-managed git worktrees, which live outside every registered root.
+func CheckRooted(root, path string) (string, error) {
+	if !filepath.IsAbs(root) || !filepath.IsAbs(path) {
+		return "", fmt.Errorf("root and path must be absolute: %s, %s", root, path)
+	}
+	ws := Workspace{
+		Name: "hydra-worktree", Root: filepath.Clean(root), Git: "auto",
+		AllowedGlobs: []string{"**"}, DeniedGlobs: defaultDeniedGlobs,
+	}
+	if !contains(ws.Root, path) {
+		return "", fmt.Errorf("worktree root %s does not contain %s", ws.Root, path)
+	}
+	return ws.check(path)
+}
+
+// check applies the workspace's glob rules to a path already known to be
+// contained under its root.
+func (ws Workspace) check(path string) (string, error) {
 	// filepath.Rel cleans both sides, so rel is already free of "." and ".."
-	// segments — and find has established containment, so it cannot start with
-	// "..". ToSlash because the glob patterns are written with forward slashes
+	// segments — and containment is established, so it cannot start with "..".
+	// ToSlash because the glob patterns are written with forward slashes
 	// and matchGlob splits on "/"; without it no pattern matches on Windows.
 	rel, err := filepath.Rel(ws.Root, path)
 	if err != nil {

--- a/internal/workspace/workspace_scope_test.go
+++ b/internal/workspace/workspace_scope_test.go
@@ -648,3 +648,26 @@ func sameDir(t *testing.T, a, b string) bool {
 	}
 	return filepath.Clean(ra) == filepath.Clean(rb)
 }
+
+// CheckRooted scopes a path against a synthesized root — the escape hatch for
+// Hydra-managed worktrees, which live outside every registered workspace. It
+// must keep the default deny globs and refuse anything outside the root.
+func TestCheckRooted_ContainsAndStillDenies(t *testing.T) {
+	root := t.TempDir()
+
+	if ws, err := CheckRooted(root, filepath.Join(root, "pkg", "main.go")); err != nil || ws == "" {
+		t.Errorf("a file under the root was refused: ws=%q err=%v", ws, err)
+	}
+	if _, err := CheckRooted(root, filepath.Join(root, ".env")); err == nil {
+		t.Error("a denied glob was allowed under a rooted check")
+	}
+	if _, err := CheckRooted(root, filepath.Join(t.TempDir(), "outside.go")); err == nil {
+		t.Error("a file outside the root was allowed")
+	}
+	if _, err := CheckRooted(root, filepath.Join(root, "..", "escape.go")); err == nil {
+		t.Error("a ..-escape from the root was allowed")
+	}
+	if _, err := CheckRooted("relative", filepath.Join(root, "a.go")); err == nil {
+		t.Error("a relative root was accepted")
+	}
+}


### PR DESCRIPTION
## Summary

TUI v2 Phase 3: chat runs several tasks at once, safely. Each submitted task becomes a **thread** owning its own scrollback, input draft, dispatch context (per-thread cancellation), code panel and runlog run. A chip strip under the header shows number · status glyph (`⠸` running / `●` needs you / `✓` done / `◱` queued) · short name · `·wt` when isolated, and the input bar labels its target (`→ thread 2`).

Concurrent `tea.Cmd` results route back **by thread id**, never to whichever thread is current — that is the invariant everything else here depends on.

## Apply mechanism, and why this one

`a` on an isolated thread commits its worktree branch and then `git diff --binary --full-index <base>..<branch> | git apply --3way` onto the user's tree. Chosen over `merge --squash` / `cherry-pick` because the user's tree is *live and usually dirty*, and the three outcomes are each exactly what you want, verified experimentally before writing the code:

| Situation | `git apply --3way` result | What the UI does |
|---|---|---|
| User's tree clean of the thread's files | patch applies, changes staged | `✓ applied N files staged · worktree and branch removed` |
| User **committed** a divergent change | ordinary `<<<<<<< ours / >>>>>>> theirs` markers, `UU` in the index | `⚠ applied with conflicts — markers left in <files>`, keeps the branch, points at `git diff` |
| User has **unsaved** changes to a path the patch touches | this code refuses **before** running apply — nothing lands, not even the clean half | `✗ apply blocked — nothing in your tree was changed`, keeps worktree + branch for a retry |

The unsaved-overlap check is mine, not git's, and Windows CI is why: on the runner's git a dirty overlap **3-way-merged into conflict markers** instead of refusing the way it does on Linux and macOS, so the "atomic refusal" I had asserted was one platform's behavior, not a property. Merging into an edit that exists in no git object is not a gamble to take for the user, so the dangerous case is now decided here — identically everywhere — by reading the worktree-vs-index column of `git status --porcelain -z`. A merely **staged** overlap (what an earlier thread's own clean apply leaves) still merges into markers, since that content is in the object store and markers beat "save your work first" for a change the user never typed. Both halves are pinned by tests.

A `merge` would have needed a clean tree (or a stash — unacceptable), and `checkout`/`restore` would silently clobber. The atomic refusal is the property that makes this safe: a partially-applied patch across two files is unrecoverable by hand, and that is the case `--3way` declines rather than half-does.

The conflict verdict is read off the **index** (`git diff --diff-filter=U`), not out of git's prose, and every git call this code parses runs under a pinned `LC_ALL=C`: on a machine with a translated git, matching "with conflicts" would have reported a hard failure while the markers were already sitting in the user's tree. There is a test that asks git for French and still expects the conflict verdict.

Cleanup is symmetric: clean apply and discard remove worktree **and** branch; a conflicted apply keeps the branch (the thread's exact edit is the only copy left); a task that edited nothing has its empty worktree removed with a note. Worktrees left by a crash are listed at startup and **never** auto-deleted.

## Queue-on-overlap

Before an edit thread starts, its target is checked against every other thread's holds — `internal/parallel`'s duplicate-target pre-flight, widened with `graph.Coupled` for indirect collisions. An overlapping thread renders `◱ queued behind N · both touch <path>` and auto-starts when the blocker applies or discards. Queued threads carry a **queue sequence** so two waiters can never block each other symmetrically (that deadlock was real — a chain test caught it). `internal/a2a` vector clocks are the backstop: the releaser's clock merges into whatever starts next, and any *concurrent* clock with overlapping files warns at apply time.

Outside a git repo there is no isolation to offer, so the TUI says so (`⚠ no isolation — editing your files directly …`) and serialises edit threads. It never pretends.

## Key bindings (all in `ckKeymap`, THREADS group; the `?` glossary renders from it)

`ctrl+t` new · `alt+1–9` jump · `ctrl+←/→` cycle (moves focus between split sides) · `ctrl+\` split · `ctrl+b` background · `ctrl+g` next needs-you · `a` apply · `x x` discard.

Deviations from the design's nominal keys, and why:
- **`alt+1–9`, not `ctrl+1–9`**: terminals cannot encode `ctrl`+digit (no distinct control code exists); `alt+digit` arrives as `ESC digit`, which Bubble Tea reports as `Alt`+rune. Documented in the README: iTerm2 needs "Esc+", Terminal.app "Use Option as Meta key".
- **`ctrl+\`** is `KeyCtrlBackslash` (0x1C) and free; `ctrl+[` was avoided since it *is* `esc`.
- **`ctrl+b`** collides with tmux's default prefix (README says: rebind, or press it twice). No alternative is better — `ctrl+n/p` are line-editing keys users expect in an input.
- Every thread key is modifier-based, so typing in the input is never broken; `a`/`x` act only from an **empty** input and only when there is something to act on, the same discipline `d/x/o` already used. `x` is two-press for discard because it destroys work.

## Also fixed (found by the live run, not by a fixture)

The code panel's text budget ignored its own padding, so a **real** file — tab-indented, lines that fill the width — wrapped every line into two and lost half the panel (`ckFrame` disclosed it as "… N more lines", so it was visible but wrong). Phase-2 fixtures used short space-indented snippets and never hit it. Fixed, with a regression test that streams 50 tab-indented full-width lines at four sizes.

## Supporting changes outside the TUI

- `workspace.CheckRooted` / `editor.Request.Root` — scope an edit to a Hydra-managed worktree, which by construction sits outside every registered workspace root. Default deny globs (`.env`, keys, `.git`) still apply, and paths outside the root are still refused.
- `oracle.CommandOracle.Dir` — run a verifier in the thread's worktree, so it checks the thread's copy rather than the user's.
- `graph.Coupled` — "would editing these two files collide"; an unindexed file reads as uncoupled rather than inventing a verdict.

## Gates

1. **Layout** — strip, split and queued chips are all cell-measured. The per-view regression matrix gains: 4 threads with long names, split at both sizes with both sides streaming, a queued chip with a 100-char path, a 3000-char task in one thread while another streams, and the code-panel case above. Nothing overflows at 60×15 / 80×24 / 100×30 / 120×40, and the status bar is always the final line.
2. **Modularity** — the threads machinery is its own three files: `threads.go` (registry, strip, switching, split panes), `thread_worktree.go` (isolation, apply/discard, stale scan), `thread_queue.go` (overlap, release, clock backstop). `view_chat.go` is 621 lines against 553 before — it did grow, by the strip/split wiring and the per-thread parameters, and the split *rendering* was moved out to sit beside the split state machine. `chat_task.go` is the one file I would still call large (820 vs 530): it holds a task's whole UI life, and the apply/discard half already moved to `thread_worktree.go`. Keys only via `ckKeymap`.
3. **Scrolling** — scroll position is per thread and survives switches; append-no-yank holds per thread (a result landing on thread 2 cannot move thread 1's anchored view, asserted directly); split sides scroll independently.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean; full `go test -race -count=1 ./...` green; `staticcheck ./...` clean; `internal/tui` **90.5%** (floor 86); skip budget unchanged at 38/40. The race detector covers genuinely concurrent paths — one test runs three fake-executor threads whose workers execute in parallel goroutines and asserts each result settles on its own thread.

## Live verification

`expect`-free pty harness (real pty + winsize + pyte render), `TERM=xterm-256color`, isolated `HYDRA_HOME`/`HOME`, minimal `PATH` so only the local Ollama heads are routable, throwaway scratch git repo as CWD, all five scenarios at **80×24 and 120×40**. Edits were done by `ollama/Qwen2.5-Coder:7b` (`$0.0000`).

- **(a) two edit tasks, different files** — strip `1⠸ … ·wt │ 2⠸ … ·wt`, status `⠸ 2 running`, separate worktrees (`t1-…`, `t2-…`); both applied cleanly; `M pkg/a.go`+`M pkg/b.go` staged, `A=2`/`B=3` on disk, worktrees dir empty, no `hydra/*` branches left.
- **(b) two edit tasks, same file** — second queued visibly (`◱ queued behind 1 · both touch pkg/a.go`, status `⠸ 1 running · ◱ 1 queued`), started only after the first applied (`▶ unblocked — starting`), cut its own worktree and edited. Its own apply then hit the first's staged change and **surfaced a conflict** rather than overwriting it — an unplanned second instance of the conflict path.
- **(c) induced conflict** — user's tree committed a divergent `A = 777` while the thread held its worktree; apply reported `⚠ applied with conflicts — markers left in pkg/a.go` plus the resolve hint and the kept branch; on disk `UU pkg/a.go` with real `ours/theirs` markers and a `git diff` conflict diff. Tree left in the standard, disclosed git conflict state.
- **(d) `ctrl+b`** — status `thread 1 backgrounded — it lives in agents (2) · alt+1 brings it back`, input moved to a fresh thread, agents showed `1 live` / `⠸ live … thread 1 · edit pkg/a.go…`, and chat received `hydra ▸ thread 1 done · alt+1 opens it · ctrl+g`. (The 80×24 pass caught the failure variant instead — `hydra ▸ thread 1 failed — edit a.go: empty_replacement` with `● 1 needs you` — which is the same path and equally disclosed.)
- **(e) split** — at 120×40 both sides streamed (`▸ thread 2 · …` active, `thread 1 · … · watching` pinned, each with its own worktree header and scrollback, one input labelled `→ thread 2`, `⠸ 2 running`); `ctrl+←/→` swapped focus and the input followed. At 80×24 it refused honestly: `split needs ≥100 cols (terminal is 80)`, both threads still running.
- **Stale recovery** — relaunching against a home holding two leftover worktrees printed `⚠ 2 stale worktrees from a previous session under …` and deleted neither.

Two pre-existing observations, left alone as out of scope: the chat route line previews the head `pickHead` would choose (a tier-8 agy head) while dispatch re-derives and falls back to the local head, and an agents row folds "dispatch ok, editor refused the output" as `✓ done`.

Closes #598
