### PR TITLE
fix(desktop): a confirm armed the instant the review bar appears was discarded

### DIFF
--- a/desktop/frontend/src/views/Code.tsx
+++ b/desktop/frontend/src/views/Code.tsx
@@ -116,7 +116,7 @@ export function Code({
         {diff?.found && <DiffBody diff={diff} />}
         {current && diff?.found && (
           <ReviewBar
-            file={current.file}
+            key={current.file}
             outcome={acted[current.file]}
             busy={busy}
             onApprove={() => void act(current.file, 'approve')}
@@ -209,13 +209,11 @@ export function total(edits: Edit[], key: 'added' | 'removed'): number {
  * happen stays next to the diff it applies to.
  */
 function ReviewBar({
-  file,
   outcome,
   busy,
   onApprove,
   onReject,
 }: {
-  file: string
   outcome?: ReviewOutcome
   busy: boolean
   onApprove: () => void
@@ -223,9 +221,10 @@ function ReviewBar({
 }) {
   const [confirming, setConfirming] = useState<'approve' | 'reject' | null>(null)
 
-  // Reset when the pane moves to a different file, or a confirm started on one
-  // file would still be armed on the next.
-  useEffect(() => setConfirming(null), [file])
+  // No reset effect: the parent keys this component by file, so moving to
+  // another file remounts it and the confirm cannot survive the move. The
+  // effect also ran on mount, where it could wipe a confirm armed in the
+  // window between commit and the effect flush.
 
   if (outcome?.error) {
     return (


### PR DESCRIPTION
## Summary

`ReviewBar` reset its confirm state with `useEffect(() => setConfirming(null), [file])`. That effect
also runs on **mount**. React commits the DOM before it flushes passive effects, so a click that
lands in that window arms a confirm the effect immediately wipes: press Accept the instant the
review bar appears and nothing happens.

Reset-on-identity-change is what a `key` is for. The parent now keys the bar by file, so moving to
another file remounts it and no confirm can survive the move, and nothing writes state on mount at
all. The `file` prop existed only to feed the effect, so it goes with it.

## This is the flaky check

`TypeScript typecheck` has been failing about half the time on PRs that touch no frontend code
(#657). It blocked #638 three times. The mechanism is the same window: testing-library's
`findByRole` resolves on the commit mutation, before passive effects flush, so on a loaded CI runner
the test's first click lands exactly there, the confirm is wiped, and the second click re-arms
instead of acting. The `waitFor` then times out on a mock that was never called.

Evidence it was never the PRs' fault: two runs on #638 with **byte-identical** `desktop/frontend/`
trees, one green and one red. And the failure moved between tests in the same file across runs
(`Code.test.tsx:160`, the Accept case, then `:177`, the Undo case) — the pattern is shared by both,
which is what pointed at the mount effect rather than either test.

## Verified

- `npm run typecheck` clean; full suite 132 passing, 3 consecutive green runs locally
- The existing test "drops a pending confirm when the pane moves to another file" still passes,
  which is exactly the behaviour the deleted effect provided, now guaranteed by the key instead
- No test was changed, so the suite is judging the fix rather than being adjusted to it

Closes #657
