### PR TITLE
fix(desktop): say why a version probe failed, and stop losing to load

### DIFF
--- a/desktop/api/setup.go
+++ b/desktop/api/setup.go
@@ -34,9 +34,12 @@ const (
 	// installRunTimeout bounds running it — it downloads a multi-MB archive
 	// of its own, so it gets much longer than the fetch above.
 	installRunTimeout = 2 * time.Minute
-	// versionProbeTimeout bounds `hyctl --version`, a purely local call.
-	versionProbeTimeout = 3 * time.Second
 )
+
+// versionProbeTimeout bounds `hyctl --version`. Local, but 3s was too tight:
+// forking a process on a loaded machine blew it (#667). A var, not a const,
+// so a test can shrink it rather than sleep for ten seconds.
+var versionProbeTimeout = 10 * time.Second
 
 // HyctlStatus is whether hyctl is set up on this machine, for the first-run
 // banner (#383). A machine that already has hyctl working must see nothing —
@@ -46,6 +49,11 @@ type HyctlStatus struct {
 	Found   bool   `json:"found"`
 	Path    string `json:"path,omitempty"`
 	Version string `json:"version,omitempty"`
+
+	// VersionError says why Version is empty when hyctl was found. Without it
+	// a probe that timed out and one that printed nothing are the same blank
+	// field, which is what made #667 hard to read.
+	VersionError string `json:"versionError,omitempty"`
 
 	// Supported is false on platforms InstallHyctl cannot drive (Windows —
 	// see its doc comment). The frontend uses this to decide between offering
@@ -72,7 +80,7 @@ func (a *API) CheckHyctl() HyctlStatus {
 
 	st.Found = true
 	st.Path = path
-	st.Version = hyctlVersion(path)
+	st.Version, st.VersionError = hyctlVersion(path)
 	return st
 }
 
@@ -80,6 +88,10 @@ func (a *API) CheckHyctl() HyctlStatus {
 type InstallResult struct {
 	OK      bool   `json:"ok"`
 	Version string `json:"version,omitempty"`
+
+	// VersionError carries CheckHyctl's reason when the post-install probe
+	// could not read a version — the install still succeeded (#667).
+	VersionError string `json:"versionError,omitempty"`
 
 	// Log is the installer's combined stdout/stderr, capped by
 	// util.Accumulator. Returned on both success and failure — "it eventually
@@ -136,7 +148,12 @@ func (a *API) InstallHyctl() InstallResult {
 	}
 
 	status := a.CheckHyctl()
-	return InstallResult{OK: status.Found, Version: status.Version, Log: out.String()}
+	return InstallResult{
+		OK:           status.Found,
+		Version:      status.Version,
+		VersionError: status.VersionError,
+		Log:          out.String(),
+	}
 }
 
 // fetchInstallScript downloads install.sh's current contents. Capped at 1 MB
@@ -219,16 +236,27 @@ func findHyctlInCommonDirs() (string, error) {
 
 // hyctlVersion runs `hyctl --version` and returns its first line — the
 // "  hydra vX.Y.Z" line versionText() in cmd/hydra/main.go prints — trimmed.
-// Empty on any error: the caller already knows Found=true, so a version that
-// could not be read is decoration lost, not a reason to report hyctl absent.
-func hyctlVersion(path string) string {
+//
+// The reason is returned alongside, because "hyctl printed no version" and
+// "the probe never finished" are different facts and an empty string told the
+// caller neither (#667). Still never fatal: the caller already knows
+// Found=true, so an unread version is decoration lost, not hyctl missing.
+func hyctlVersion(path string) (string, string) {
 	ctx, cancel := context.WithTimeout(context.Background(), versionProbeTimeout)
 	defer cancel()
 
 	out, err := exec.CommandContext(ctx, path, "--version").Output()
 	if err != nil {
-		return ""
+		// ctx, not err: a killed process reports "signal: killed", which says
+		// nothing about who killed it or why.
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Sprintf("%s did not respond within %s", path, versionProbeTimeout)
+		}
+		return "", fmt.Sprintf("could not run %s --version: %v", path, err)
 	}
 	line, _, _ := strings.Cut(strings.TrimSpace(string(out)), "\n")
-	return strings.TrimSpace(line)
+	if line = strings.TrimSpace(line); line == "" {
+		return "", fmt.Sprintf("%s --version printed nothing", path)
+	}
+	return line, ""
 }

--- a/desktop/api/setup_test.go
+++ b/desktop/api/setup_test.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 )
 
 // withPath puts dir as the only entry on $PATH, so exec.LookPath finds
@@ -105,6 +107,90 @@ func TestCheckHyctl_FallsBackToCommonInstallDirs(t *testing.T) {
 	}
 	if st.Version != "hydra v1.2.3" {
 		t.Errorf("Version = %q, want hydra v1.2.3", st.Version)
+	}
+}
+
+// withVersionProbeTimeout shrinks the probe deadline so a timeout test costs
+// milliseconds instead of the real ten seconds.
+func withVersionProbeTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := versionProbeTimeout
+	versionProbeTimeout = d
+	t.Cleanup(func() { versionProbeTimeout = orig })
+}
+
+// slowHyctl writes an executable that sleeps before printing, to outlast the
+// probe deadline. Windows has no /bin/sh, and a .bat cannot sleep portably,
+// so the timeout path is exercised on the platforms InstallHyctl supports.
+func slowHyctl(t *testing.T, dir string) {
+	t.Helper()
+	path := filepath.Join(dir, "hyctl")
+	script := "#!/bin/sh\nsleep 5\necho 'hydra v9.9.9'\n"
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A probe that never finished and one that ran and printed nothing both left
+// Version empty, so a loaded machine looked identical to a broken hyctl and
+// the frontend could say nothing useful about either (#667).
+func TestCheckHyctl_TimeoutIsDistinctFromNoOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake needs /bin/sh to sleep")
+	}
+
+	t.Run("timeout says so", func(t *testing.T) {
+		withVersionProbeTimeout(t, 50*time.Millisecond)
+		dir := t.TempDir()
+		slowHyctl(t, dir)
+		withPath(t, dir+string(os.PathListSeparator)+"/usr/bin"+string(os.PathListSeparator)+"/bin")
+		withHyctlSearchDirs(t)
+
+		st := New().CheckHyctl()
+		if !st.Found {
+			t.Fatal("Found = false; the probe's deadline must not make hyctl look absent")
+		}
+		if st.Version != "" {
+			t.Errorf("Version = %q, want empty on a timeout", st.Version)
+		}
+		if !strings.Contains(st.VersionError, "did not respond") {
+			t.Errorf("VersionError = %q, want it to name the timeout", st.VersionError)
+		}
+	})
+
+	t.Run("silent binary says something else", func(t *testing.T) {
+		dir := t.TempDir()
+		fakeHyctl(t, dir, "")
+		withPath(t, dir)
+		withHyctlSearchDirs(t)
+
+		st := New().CheckHyctl()
+		if !st.Found {
+			t.Fatal("Found = false; a silent hyctl is still present")
+		}
+		if st.VersionError == "" {
+			t.Fatal("VersionError is empty; the caller cannot tell why Version is blank")
+		}
+		if strings.Contains(st.VersionError, "did not respond") {
+			t.Errorf("VersionError = %q, but nothing timed out here", st.VersionError)
+		}
+	})
+}
+
+// A version that reads fine must leave VersionError empty, or the frontend
+// would render a fault on every healthy machine.
+func TestCheckHyctl_NoVersionErrorOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	fakeHyctl(t, dir, "hydra v1.2.3")
+	withPath(t, dir)
+	withHyctlSearchDirs(t)
+
+	st := New().CheckHyctl()
+	if st.Version != "hydra v1.2.3" {
+		t.Fatalf("Version = %q, want hydra v1.2.3", st.Version)
+	}
+	if st.VersionError != "" {
+		t.Errorf("VersionError = %q, want empty when the version read fine", st.VersionError)
 	}
 }
 

--- a/desktop/api/typesparity_test.go
+++ b/desktop/api/typesparity_test.go
@@ -95,6 +95,8 @@ func TestTypesTS_MirrorsEveryFieldOnTheWire(t *testing.T) {
 		{"ChatReply", ChatReply{}},
 		{"PendingQuestion", PendingQuestion{}},
 		{"QuestionQueue", QuestionQueue{}},
+		{"HyctlStatus", HyctlStatus{}},
+		{"InstallResult", InstallResult{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			ts := tsInterface(t, src, c.iface)
@@ -140,6 +142,8 @@ func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
 		{"ChatReply", ChatReply{}},
 		{"PendingQuestion", PendingQuestion{}},
 		{"QuestionQueue", QuestionQueue{}},
+		{"HyctlStatus", HyctlStatus{}},
+		{"InstallResult", InstallResult{}},
 	} {
 		t.Run(c.iface, func(t *testing.T) {
 			g := jsonFields(c.goVal)

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -306,6 +306,8 @@ export interface HyctlStatus {
   found: boolean
   path?: string
   version?: string
+  /** Why version is empty despite hyctl being found — a timeout reads differently from no output. */
+  versionError?: string
   /** False on platforms InstallHyctl cannot drive (Windows) — see its Go doc. */
   supported: boolean
 }
@@ -313,6 +315,8 @@ export interface HyctlStatus {
 export interface InstallResult {
   ok: boolean
   version?: string
+  /** Set when the post-install probe could not read a version; the install still succeeded. */
+  versionError?: string
   /** The installer's combined stdout/stderr, shown on both success and failure. */
   log: string
   error?: string

--- a/desktop/frontend/src/views/SetupBanner.tsx
+++ b/desktop/frontend/src/views/SetupBanner.tsx
@@ -31,7 +31,12 @@ export function SetupBanner({
       const r = await InstallHyctl()
       setResult(r)
       if (r.ok) {
-        onChanged({ found: true, version: r.version, supported: status.supported })
+        onChanged({
+          found: true,
+          version: r.version,
+          versionError: r.versionError,
+          supported: status.supported,
+        })
       }
     } finally {
       setBusy(false)
@@ -70,6 +75,12 @@ export function SetupBanner({
 
       {result && !result.ok && (
         <p className="setup__error">{result.error || 'Install failed for an unknown reason.'}</p>
+      )}
+
+      {/* The install worked; only the version read did not. Saying which beats
+          a button that reads "Installed" with a blank where a version goes. */}
+      {result?.ok && result.versionError && (
+        <p className="setup__body">Installed, but its version could not be read: {result.versionError}</p>
       )}
 
       {result?.log && (


### PR DESCRIPTION
## Summary

`hyctlVersion` had a 3s deadline and returned `""` on every failure, so "the machine was busy" and
"hyctl is broken" produced the identical blank field.

Reproduced deterministically at **exactly 3.02s** (`versionProbeTimeout = 3 * time.Second`) while
`go test -race ./...` saturated every core. Idle, the same call takes **1.165s**.

## Changes

Raising the timeout alone would just pick a new arbitrary number that is also wrong one day, so
both halves:

- **3s → 10s.** Verified against load average **9.84**, higher than the ~6.5 that originally broke
  it: three consecutive passes, each under 0.8s.
- **`hyctlVersion` returns the reason**, surfaced as `VersionError` on `HyctlStatus` and
  `InstallResult`. It reads `ctx.Err()` rather than the exec error, because a killed process only
  reports `signal: killed`, which says nothing about who killed it.

Three outcomes are now distinguishable where there was one blank string: timed out, ran and printed
nothing, could not be run at all.

## The UI actually renders it

`SetupBanner` previously showed `Installed ${result.version ?? ''}` — a blank where a version goes.
It now says "Installed, but its version could not be read: …". A field nothing renders is not a fix.

## Parity gap closed while here

`HyctlStatus` and `InstallResult` were **not** in `typesparity_test.go`, which is precisely the
drift #435 added that test for. Both are now covered in both directions, and I verified the test
fails without the mirrored field rather than trusting that it passes:

```
HyctlStatus.versionError ships on the wire but types.ts does not declare it
```

## Verification

```
desktop: go build / go vet / gofmt      clean
desktop: go test ./...                  ok (both packages)
frontend: npm run typecheck             exit 0
frontend: npm test                      10 files, 132 tests passed
```

Plus the previously failing test run three times under load average 9.84, all green.

Closes #667