### PR TITLE
fix(ci): fail the back-merge when its PR cannot merge

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -97,11 +97,22 @@ jobs:
           fi
 
       - name: Push branch + open/update PR
+        id: pr
         if: steps.prep.outputs.conflict != 'true' && steps.prep.outputs.nothing != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # BACK_MERGE_TOKEN, when set, is a PAT. It exists because GITHUB_TOKEN
+          # cannot produce a mergeable PR here — see the "can it merge" step.
+          GH_TOKEN: ${{ secrets.BACK_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          HAVE_PAT: ${{ secrets.BACK_MERGE_TOKEN != '' && 'true' || 'false' }}
         run: |
+          if [ "$HAVE_PAT" = "true" ]; then
+            git remote set-url origin \
+              "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          fi
           git push -f origin chore/back-merge-main
+          echo "have_pat=$HAVE_PAT" >> "$GITHUB_OUTPUT"
+          echo "head=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
           # Create the PR if one isn't already open for this branch; otherwise the
           # force-push above already updated the existing PR.
           gh pr create \
@@ -110,6 +121,58 @@ jobs:
             --title "chore: back-merge main → develop" \
             --body "Automated GitFlow back-merge: released commits on \`main\` flowing back into \`develop\` via cherry-pick (#428). **Squash-merge** to keep develop's linear history." \
             2>/dev/null || echo "A back-merge PR is already open; it was updated by the force-push."
+
+      # Opening a PR is not syncing. Both of the reasons this PR cannot merge are
+      # invisible on the PR itself — one shows as "checks expected" that never
+      # arrive, the other as "the base branch policy prohibits the merge" while
+      # every check is green — so the job used to report success over a PR that
+      # would sit open forever (#670). Same principle as the conflict step below:
+      # a sync that silently does not sync is worse than no sync at all.
+      - name: Can this PR actually merge?
+        if: steps.pr.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HAVE_PAT: ${{ steps.pr.outputs.have_pat }}
+          HEAD_SHA: ${{ steps.pr.outputs.head }}
+        run: |
+          blocked=0
+
+          # 1. develop requires signed commits, and git-pushed bot commits are
+          #    unsigned. GitHub reports this as a base-branch-policy refusal,
+          #    naming neither signatures nor the offending commit.
+          unsigned=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}" \
+            --jq 'if .commit.verification.verified then empty else .sha end' || echo "$HEAD_SHA")
+          if [ -n "$unsigned" ]; then
+            echo "::error title=Back-merge commit is unsigned::${unsigned} is not signed, and develop has required_signatures with enforce_admins — there is no bypass."
+            blocked=1
+          fi
+
+          # 2. Events raised by GITHUB_TOKEN start no workflow runs, so the 13
+          #    required checks are "expected" and never report.
+          if [ "$HAVE_PAT" != "true" ]; then
+            echo "::error title=Back-merge checks will not run::This PR was opened with GITHUB_TOKEN, whose events trigger no workflows. Its required checks will never start."
+            blocked=1
+          fi
+
+          if [ "$blocked" -eq 0 ]; then
+            echo "Back-merge PR is mergeable on its own."
+            exit 0
+          fi
+
+          cat <<'EOF'
+          develop is now behind main and the PR above cannot merge itself.
+
+          To land it now:
+            git fetch origin chore/back-merge-main
+            git checkout -B backmerge origin/chore/back-merge-main
+            git commit -S --allow-empty -m "chore: sign and trigger the back-merge"
+            git push origin HEAD:chore/back-merge-main
+
+          To stop this recurring, add a BACK_MERGE_TOKEN secret (a PAT with repo
+          scope) and give its account a signing key, so the push is both signed
+          and able to start workflow runs.
+          EOF
+          exit 1
 
       - name: Nothing to sync
         if: steps.prep.outputs.nothing == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -798,9 +798,29 @@ internal/update/update.go     ← startup update checker (24h cache)
                                        from "Closes #n" in each PR body (#217). Its resolver
                                        is close_shipped_issues.py beside it.
 .github/workflows/sync-develop.yml   ← fires on main push → back-merge PR (main → develop).
-                                       FAILS loudly on conflict; a red run here means develop
+                                       FAILS loudly on conflict, and also when the PR it opened
+                                       cannot merge (#670). Either way a red run means develop
                                        is behind main and a release cut will not merge cleanly.
 ```
+
+**The back-merge PR cannot merge itself, and needs one of your commits.** Two independent
+reasons, both invisible on the PR: it is opened by `github-actions[bot]`, whose events start no
+workflow runs, so its required checks are *expected* and never arrive; and it carries
+release-please's **unsigned** commit, which `develop` rejects — `required_signatures` with
+`enforce_admins: true`, so `--admin` does not help and the refusal reads "the base branch policy
+prohibits the merge" while every check is green.
+
+Until a `BACK_MERGE_TOKEN` secret exists (a PAT whose account also signs), land it by hand:
+
+```bash
+git fetch origin chore/back-merge-main
+git checkout -B backmerge origin/chore/back-merge-main
+git commit -S --allow-empty -m "chore: sign and trigger the back-merge"
+git push origin HEAD:chore/back-merge-main
+```
+
+Skipping it leaves develop without the version bump, and the next release computes off a stale
+manifest — the #215 failure mode.
 
 ---
 


### PR DESCRIPTION
## Summary

`sync-develop.yml` opened a back-merge PR and reported **success** over a PR that could never
merge. That is precisely the failure mode its own conflict step exists to prevent, quoting the
comment already in the file:

> A sync that silently does not sync is worse than no sync at all, because it is trusted.

It hit v1.4.0 and would hit every release.

## The two reasons, both invisible on the PR

1. **Opened by `github-actions[bot]`.** Events raised by `GITHUB_TOKEN` start no workflow runs, so
   the 13 required checks are *expected* and never arrive. `--admin` then fails with
   "13 of 13 required status checks are expected".
2. **It carries release-please's unsigned commit.** `develop` has `required_signatures: true` **and**
   `enforce_admins: true`, so unlike `main` there is no bypass:

```
$ git log --format='%h %G? %an %s' origin/develop..origin/chore/back-merge-main
0440a85 G  Ankit Jha           chore: trigger CI on the back-merge
d3c6dcf N  github-actions[bot] chore(main): release 1.4.0 (#668)
```

The refusal reads **"the base branch policy prohibits the merge" while showing 13/13 green**, which
is a signature failure wearing a checks-failure costume.

## What this changes

Neither cause is fixable from inside a `GITHUB_TOKEN` job, so the new step does not pretend
otherwise. It names whichever reasons apply, prints the four commands that land the back-merge, and
**exits 1** so the run is red while develop is behind main.

`BACK_MERGE_TOKEN` is honoured when present, so adding that secret (a PAT whose account also signs)
makes the whole thing automatic and the gate goes quiet on its own.

The signature check reads **GitHub's own `verification.verified`** rather than inferring it, and
treats an API failure as unsigned — a gate that cannot check must not pass.

## Verified against real commits, all three paths

Extracted the step and ran it against known SHAs rather than assuming:

| case | input | result |
|---|---|---|
| unsigned, no PAT | `d3c6dcf` | exit 1, **both** reasons reported |
| signed, no PAT | `08cf81c` | exit 1, **only** the checks reason |
| signed + PAT | `08cf81c` | exit 0, "mergeable on its own" |

`shellcheck -s bash` clean on the extracted script; the workflow YAML parses.

## Docs

`CLAUDE.md` now says the back-merge needs one of your commits, why, and the exact four commands —
because skipping it leaves develop without the version bump and the next release computes off a
stale manifest, which is the #215 failure mode.

Closes #670