### PR TITLE
fix(release): authenticate the Homebrew tap push in CI

### DIFF
--- a/scripts/update-tap-formula.sh
+++ b/scripts/update-tap-formula.sh
@@ -5,7 +5,8 @@
 #   scripts/update-tap-formula.sh v1.0.0
 #
 # Requires: gh (authenticated with push access to the tap repo), curl.
-# No HOMEBREW_TAP_GITHUB_TOKEN needed, uses your gh credentials.
+# Locally that is your own gh credentials. In CI, GH_TOKEN is used for the push,
+# because git on a runner has no credential helper of its own.
 set -euo pipefail
 
 TAG="${1:?usage: update-tap-formula.sh vX.Y.Z}"
@@ -77,6 +78,12 @@ echo "→ Committing & pushing formula…"
 git -C "$work/tap" add Formula/hyctl.rb
 git -C "$work/tap" -c user.name="hydra-release" -c user.email="release@uvansa.com" \
   commit -m "chore: hyctl ${TAG}" >/dev/null
-git -C "$work/tap" push origin HEAD >/dev/null
+# git on a runner has no credential helper, so a plain push prompts for a username
+# and dies. GH_TOKEN is known to gh, not to git, so hand it over explicitly.
+if [ -n "${GH_TOKEN:-}" ]; then
+  git -C "$work/tap" push "https://x-access-token:${GH_TOKEN}@github.com/${TAP}.git" HEAD >/dev/null
+else
+  git -C "$work/tap" push origin HEAD >/dev/null
+fi
 
 echo "✓ Tap updated: brew tap ankit373/hydra && brew install hyctl   (→ ${TAG})"


### PR DESCRIPTION
## Summary

`Publish (all channels)` reached the tap push and died with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

`HOMEBREW_TAP_GITHUB_TOKEN` is now set, and the step ran rather than skipping, so
the secret was never the problem. `scripts/update-tap-formula.sh` assumed `git`
could authenticate to GitHub. That is true locally, where `gh auth setup-git`
installs gh as a git credential helper, and false on a runner: `GH_TOKEN` is
known to `gh`, not to `git`. The clone worked because the tap is public and
needs no auth; the push had nothing to authenticate with.

## Changes

- `scripts/update-tap-formula.sh` pushes to an authenticated URL when `GH_TOKEN`
  is set, and keeps the existing plain push when it is not, so a local run is
  unchanged.
- Corrects the header, which claimed no token was needed. True for a local run,
  misleading directly above code that now reads `GH_TOKEN`.

## Verification

- `bash -n` and `shellcheck` clean.
- Confirmed the credential form actually authenticates against the tap, rather
  than assuming it: `git ls-remote https://x-access-token:<token>@github.com/ankit373/homebrew-hydra.git`
  returns the ref.

## This does not backfill v1.4.0

The tap job checks the repo out at `ref: inputs.tag`, so re-running publish for
v1.4.0 keeps using the script as it was at that tag. This fixes v1.5.0 onward.
Homebrew is still on 1.0.1 and gets current either by running
`./scripts/update-tap-formula.sh v1.4.0` locally, or by a main-side change.

## The other two failures in that run were not this

`npm` and `pip / PyPI` failed because v1.4.0 was already published to both and
neither permits overwriting a version (`E403 cannot publish over the previously
published versions: 1.4.0`, and a 400 from PyPI). Expected on any re-run of an
already-published tag, and unrelated.

Closes #677