### PR TITLE
fix: pin the picked model, and say when something else answered

### DIFF
--- a/desktop/api/chat.go
+++ b/desktop/api/chat.go
@@ -31,6 +31,11 @@ type ChatReply struct {
 	Model string `json:"model"`
 	Tier  int    `json:"tier"`
 
+	// Attempts is every model that was tried and did not answer, with the
+	// reason. A reply that names only the winner cannot distinguish "routed
+	// here" from "fell back here after your choice failed" (#676).
+	Attempts []ChatAttempt `json:"attempts,omitempty"`
+
 	CostUSD    float64 `json:"costUsd"`
 	DurationMS int64   `json:"durationMs"`
 
@@ -55,6 +60,14 @@ type ChatReply struct {
 	// the dock offers to retry (which re-probes) instead of surfacing a CLI
 	// instruction a GUI user has no terminal for (#434, #452).
 	NeedsProbe bool `json:"needsProbe,omitempty"`
+}
+
+// ChatAttempt is one model that was tried and did not answer.
+type ChatAttempt struct {
+	Head   string `json:"head"`
+	Model  string `json:"model"`
+	Tier   int    `json:"tier"`
+	Reason string `json:"reason"`
 }
 
 // NewRunID mints a run id for the caller to hold before a dispatch starts.
@@ -84,7 +97,7 @@ func (a *API) NewRunID() string { return runid.New() }
 // Errors come back inside the reply rather than as a Go error: a failed
 // dispatch is a normal outcome the view renders as a message, not an exception
 // that should blank the window.
-func (a *API) Chat(prompt, enum, runID, tier string) (*ChatReply, error) {
+func (a *API) Chat(prompt, enum, runID, tier, head string) (*ChatReply, error) {
 	if prompt == "" {
 		return &ChatReply{Error: "empty prompt"}, nil
 	}
@@ -136,9 +149,12 @@ func (a *API) Chat(prompt, enum, runID, tier string) (*ChatReply, error) {
 
 	res, err := d.Dispatch(ctx, prompt, dispatch.Options{
 		TierHint: tierHint,
-		Enum:     enum,
-		RunID:    runID,
-		TaskID:   taskID,
+		// A picked model is pinned, not merely preferred: dispatch refuses
+		// rather than answering from something the user did not choose.
+		Head:   head,
+		Enum:   enum,
+		RunID:  runID,
+		TaskID: taskID,
 	})
 	if err != nil {
 		if errors.Is(err, dispatch.ErrNoHeads) {
@@ -169,6 +185,11 @@ func fill(r *ChatReply, res *dispatch.Result) {
 	r.Head = res.Head.ID
 	r.Model = res.Head.Name
 	r.Tier = rank.UITier(res.Head)
+	for _, at := range res.Attempts {
+		r.Attempts = append(r.Attempts, ChatAttempt{
+			Head: at.Head, Model: at.Model, Tier: at.Tier, Reason: at.Reason,
+		})
+	}
 	if res.Response != nil {
 		r.DurationMS = res.Response.Duration.Milliseconds()
 	}

--- a/desktop/api/chat_test.go
+++ b/desktop/api/chat_test.go
@@ -64,7 +64,7 @@ func atoiTier(t *testing.T, s string) int {
 func TestChat_EmptyPromptIsAReplyNotAnError(t *testing.T) {
 	sandbox(t)
 
-	r, err := New().Chat("", "", "", "")
+	r, err := New().Chat("", "", "", "", "")
 	if err != nil {
 		t.Fatalf("an empty prompt must not error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestChat_EmptyPromptIsAReplyNotAnError(t *testing.T) {
 func TestChat_FailedDispatchReturnsAReply(t *testing.T) {
 	sandbox(t)
 
-	r, err := New().Chat("hello", "SIMPLE", "", "")
+	r, err := New().Chat("hello", "SIMPLE", "", "", "")
 	if err != nil {
 		t.Fatalf("a failed dispatch must come back as a reply, not a Go error: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestChat_HonoursCallerSuppliedRunID(t *testing.T) {
 	sandbox(t)
 
 	want := New().NewRunID()
-	r, err := New().Chat("hello", "SIMPLE", want, "")
+	r, err := New().Chat("hello", "SIMPLE", want, "", "")
 	if err != nil {
 		t.Fatalf("a failed dispatch must come back as a reply, not a Go error: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestNewRunID_NonEmptyAndUnique(t *testing.T) {
 func TestChat_UnknownEnumIsRejected(t *testing.T) {
 	sandbox(t)
 
-	r, err := New().Chat("hello", "NOT_A_REAL_ENUM", "", "")
+	r, err := New().Chat("hello", "NOT_A_REAL_ENUM", "", "", "")
 	if err != nil {
 		t.Fatalf("an unknown enum must not error: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestChat_NoHeadsAtAllSetsNeedsProbe(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := New().Chat("hello", "SIMPLE", "", "")
+	r, err := New().Chat("hello", "SIMPLE", "", "", "")
 	if err != nil {
 		t.Fatalf("zero heads must come back as a reply, not a Go error: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestChat_ExplicitTierOutranksEnum(t *testing.T) {
 	// in the sandbox the dispatch still fails, so this asserts on the reply
 	// shape rather than on routing, the point is that a bad tier is rejected
 	// by dispatch's own validation and a good one is accepted.
-	r, err := New().Chat("hello", "GRUNT", "", "2")
+	r, err := New().Chat("hello", "GRUNT", "", "2", "")
 	if err != nil {
 		t.Fatalf("an explicit tier must not turn a failed dispatch into a Go error: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestChat_ExplicitTierOutranksEnum(t *testing.T) {
 func TestChat_RejectsOutOfRangeTier(t *testing.T) {
 	sandbox(t)
 
-	r, err := New().Chat("hello", "", "", "99")
+	r, err := New().Chat("hello", "", "", "99", "")
 	if err != nil {
 		t.Fatalf("a bad tier must come back as a reply, not a Go error: %v", err)
 	}

--- a/desktop/frontend/src/app.css
+++ b/desktop/frontend/src/app.css
@@ -1560,6 +1560,23 @@ body {
 .turn__out { margin: 0; font-size: 14px; line-height: 1.6; white-space: pre-wrap; }
 .turn__wait { margin: 0; color: var(--hy-dim); font-size: 12px; }
 .turn__err { margin: 0; color: var(--hy-expensive); font-size: 12px; font-family: var(--hy-font-mono); }
+/* A fallback is not an error: the answer arrived. It is amber because the
+   model you picked is not the one that replied. */
+.turn__fellback {
+  align-self: flex-start;
+  margin: 2px 0 0;
+  padding: 6px 10px;
+  border-left: 2px solid var(--hy-mid);
+  background: color-mix(in srgb, var(--hy-mid) 8%, transparent);
+  border-radius: 0 3px 3px 0;
+}
+.turn__fellbackRow {
+  margin: 0;
+  color: var(--hy-dim);
+  font-size: 12px;
+  line-height: 1.55;
+  font-family: var(--hy-font-mono);
+}
 .turn__meta {
   align-self: flex-start;
   background: none;

--- a/desktop/frontend/src/bindings.ts
+++ b/desktop/frontend/src/bindings.ts
@@ -34,7 +34,7 @@ interface WailsGo {
       GetFleet(): Promise<Fleet>
       GetSession(runID: string): Promise<Session>
       GetEdits(runID: string): Promise<Edit[]>
-      Chat(prompt: string, enumKey: string, runID: string, tier: string): Promise<ChatReply>
+      Chat(prompt: string, enumKey: string, runID: string, tier: string, head: string): Promise<ChatReply>
       ApproveEdit(file: string): Promise<ReviewOutcome>
       RejectEdit(file: string): Promise<ReviewOutcome>
       GetMCPServers(): Promise<MCPPanel>
@@ -82,7 +82,8 @@ export const Chat = (
   enumKey: string,
   runID: string,
   tier: string,
-): Promise<ChatReply> => backend().Chat(prompt, enumKey, runID, tier)
+  head: string,
+): Promise<ChatReply> => backend().Chat(prompt, enumKey, runID, tier, head)
 
 export const ApproveEdit = (file: string): Promise<ReviewOutcome> => backend().ApproveEdit(file)
 

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -724,11 +724,21 @@ export interface LedgerEvent {
   flag_reason?: string
 }
 
+/** One model that was tried and did not answer. */
+export interface ChatAttempt {
+  head: string
+  model: string
+  tier: number
+  reason: string
+}
+
 export interface ChatReply {
   output: string
   head: string
   model: string
   tier: number
+  /** Models tried that did not answer, with the reason. Empty on a clean run. */
+  attempts?: ChatAttempt[]
   costUsd: number
   durationMs: number
   /** Links the reply into Session, "why did it say that" is one click. */

--- a/desktop/frontend/src/views/ChatView.test.tsx
+++ b/desktop/frontend/src/views/ChatView.test.tsx
@@ -343,4 +343,38 @@ describe('a task parked waiting on a human (#583)', () => {
 
     await waitFor(() => expect(mockAnswer).toHaveBeenCalledWith('task-1', 'go'))
   })
+  it('names the model that could not answer, and the one that did', async () => {
+    // #676: a T1 pick answered by a T10 local head, with nothing said. The
+    // reply used to carry only the winner, so this read as ordinary routing.
+    mockChat.mockResolvedValue({
+      output: 'sure',
+      head: 'ollama/qwen', model: 'Qwen2.5-Coder:7b (Ollama)', tier: 10,
+      costUsd: 0, durationMs: 1700, runId: 'run-1',
+      attempts: [{ head: 'claude', model: 'Claude Code', tier: 1, reason: 'exit status 1' }],
+    })
+    renderDock(vi.fn())
+
+    const textarea = screen.getByPlaceholderText(/ask anything/i)
+    fireEvent.change(textarea, { target: { value: 'is claude code working' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(await screen.findByText(/could not answer/i)).toHaveTextContent('Claude Code')
+    expect(screen.getByText(/could not answer/i)).toHaveTextContent('exit status 1')
+    expect(screen.getByText(/Answered by/i)).toHaveTextContent('Qwen2.5-Coder:7b (Ollama)')
+  })
+
+  it('says nothing about fallbacks when the first model answered', async () => {
+    mockChat.mockResolvedValue({
+      output: 'sure', head: 'claude', model: 'Claude Code', tier: 1,
+      costUsd: 0, durationMs: 900, runId: 'run-1',
+    })
+    renderDock(vi.fn())
+
+    const textarea = screen.getByPlaceholderText(/ask anything/i)
+    fireEvent.change(textarea, { target: { value: 'hello' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    await screen.findByRole('button', { name: /session →/ })
+    expect(screen.queryByText(/could not answer/i)).not.toBeInTheDocument()
+  })
 })

--- a/desktop/frontend/src/views/ChatView.tsx
+++ b/desktop/frontend/src/views/ChatView.tsx
@@ -53,9 +53,10 @@ export function ChatView({
   focusSignal: number
 }) {
   const [prompt, setPrompt] = useState('')
-  // Empty means auto-route. A tier, not an enum: the picker offers models,
-  // and every registry model declares a tier (#558).
-  const [tier, setTier] = useState('')
+  // Empty means auto-route. The model's own id, not its tier: a tier cannot
+  // say which of two T1 heads was picked, and the router was free to answer
+  // from a different one (#676).
+  const [head, setHead] = useState('')
   const [turns, setTurns] = useState<Turn[]>([])
   const [busy, setBusy] = useState(false)
   // The one turn currently in flight, if any, Chat's own busy flag already
@@ -176,7 +177,7 @@ export function ChatView({
     setTurns((t) => [...t, { prompt: p, runId }])
     watchRun(runId)
     try {
-      const reply = await Chat(p, '', runId, tier)
+      const reply = await Chat(p, '', runId, '', head)
       setTurns((t) => t.map((turn, i) => (i === t.length - 1 ? { ...turn, reply } : turn)))
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
@@ -208,7 +209,7 @@ export function ChatView({
     setTurns((t) => t.map((turn, idx) => (idx === i ? { ...turn, runId } : turn)))
     watchRun(runId)
     try {
-      const reply = await Chat(p, '', runId, tier)
+      const reply = await Chat(p, '', runId, '', head)
       setTurns((t) => t.map((turn, idx) => (idx === i ? { ...turn, reply } : turn)))
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
@@ -352,6 +353,7 @@ export function ChatView({
                 )}
                 {/* Which head, which tier, what it cost, this is a router, so
                     that is the part worth showing, not just the answer. */}
+                <FellBack reply={t.reply} />
                 <SessionLink reply={t.reply} onOpenRun={onOpenRun} />
               </>
             )}
@@ -379,7 +381,7 @@ export function ChatView({
           {/* The model control is part of the send row, not a setting buried in
               a header: choosing depth is part of asking (#520). */}
           <div className="chatv__bar">
-            <ModelPicker tier={tier} onPick={setTier} disabled={busy} />
+            <ModelPicker head={head} onPick={setHead} disabled={busy} />
             <span className="chatv__hint">enter to send</span>
             <button
               className="chatv__send"
@@ -398,6 +400,28 @@ export function ChatView({
         lastReply={lastSettled(turns)}
         runId={turns[turns.length - 1]?.runId}
       />
+    </div>
+  )
+}
+
+/**
+ * Names the models that were asked and could not answer. Without it a reply
+ * from a weak local model looks identical whether the router chose it or fell
+ * back to it after the picked model failed, which is what #676 reported: a
+ * T1 pick answered by a T10 head with nothing said.
+ */
+function FellBack({ reply }: { reply: ChatReply }) {
+  const tried = reply.attempts ?? []
+  if (tried.length === 0) return null
+  return (
+    <div className="turn__fellback">
+      {tried.map((a) => (
+        <p key={a.head} className="turn__fellbackRow">
+          <b>{a.model || a.head}</b>
+          {a.tier > 0 && ` (T${a.tier})`} could not answer: {a.reason}
+        </p>
+      ))}
+      <p className="turn__fellbackRow">Answered by {reply.model || reply.head} instead.</p>
     </div>
   )
 }

--- a/desktop/frontend/src/views/ModelPicker.tsx
+++ b/desktop/frontend/src/views/ModelPicker.tsx
@@ -10,19 +10,19 @@ import type { Model, ModelRegistry } from '../types'
  * choosing one spends what the other will need. That consequence is the thing
  * worth knowing at the moment of choosing, and no other surface says it.
  *
- * A choice is expressed as a tier, since every registry model declares one.
- * It is a starting point, not a guarantee, the governor can still downgrade
- * and fallback can still move off it, so the label says "start with", not
- * "use".
+ * A choice is expressed as the model's own id, not its tier. A tier is not a
+ * model: two heads share T1, so a tier could not say which was picked, and the
+ * router was free to answer from a different one entirely (#676). A pinned id
+ * is honoured or refused with a reason, never substituted.
  */
 export function ModelPicker({
-  tier,
+  head,
   onPick,
   disabled,
 }: {
   /** Empty means auto-route. */
-  tier: string
-  onPick: (tier: string) => void
+  head: string
+  onPick: (head: string) => void
   disabled?: boolean
 }) {
   const [reg, setReg] = useState<ModelRegistry | null>(null)
@@ -54,7 +54,7 @@ export function ModelPicker({
   }, [open])
 
   const all = reg?.pools.flatMap((p) => p.models) ?? []
-  const picked = all.find((m) => String(m.tier) === tier)
+  const picked = all.find((m) => m.id === head)
 
   return (
     <div className="picker" ref={wrapRef}>
@@ -67,7 +67,7 @@ export function ModelPicker({
           <div className="picker__body">
             <button
               className="picker__auto"
-              aria-checked={tier === ''}
+              aria-checked={head === ''}
               role="radio"
               onClick={() => {
                 onPick('')
@@ -80,7 +80,7 @@ export function ModelPicker({
                   Hydra reads the task's complexity and picks the cheapest model that clears it
                 </span>
               </span>
-              {tier === '' && <span className="picker__tick">✓</span>}
+              {head === '' && <span className="picker__tick">✓</span>}
             </button>
 
             {reg.pools.map((p) => (
@@ -99,10 +99,10 @@ export function ModelPicker({
                     key={m.id}
                     className="picker__m"
                     role="radio"
-                    aria-checked={String(m.tier) === tier}
+                    aria-checked={m.id === head}
                     disabled={!m.enabled}
                     onClick={() => {
-                      onPick(String(m.tier))
+                      onPick(m.id)
                       setOpen(false)
                     }}
                   >
@@ -111,7 +111,7 @@ export function ModelPicker({
                       <span className="picker__mTier">T{m.tier}</span>
                       {!m.enabled && <span className="picker__off">off</span>}
                     </span>
-                    {String(m.tier) === tier && <span className="picker__tick">✓</span>}
+                    {m.id === head && <span className="picker__tick">✓</span>}
                     <span className="picker__mSpec">{spec(m, p.shared, p.models.length)}</span>
                   </button>
                 ))}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -76,6 +76,13 @@ type Options struct {
 	// silently re-routes to a head the human was never shown.
 	AnsweredHead string
 
+	// Head pins one head by ID. A person choosing a model is asking for that
+	// model, so it is never substituted: if it cannot run, Dispatch says why
+	// instead of quietly answering from a different one. Before this the
+	// desktop picker could only ask for a tier, so choosing a T1 head let the
+	// chain walk down to the T10 local model with nothing said (#676).
+	Head string
+
 	// Classification is prompt's already-computed PII/injection verdict
 	// (policy.Classify), cmdDispatch computes this once for its own
 	// defect-cost/local-only decisions and passes it here so Dispatch and
@@ -90,7 +97,22 @@ type Result struct {
 	Head      provider.Head
 	Fallbacks []provider.Head // remaining candidates after the selected head
 	Retries   int
+
+	// Attempts is every candidate that was tried and did not answer, in the
+	// order tried. Retries counts them; this says which and why. Without it a
+	// caller can only report who answered, so a fallback to a weaker head
+	// looks identical to routing there in the first place (#676).
+	Attempts []Attempt
+
 	*executor.Response
+}
+
+// Attempt is one candidate that did not answer, and the reason.
+type Attempt struct {
+	Head   string
+	Model  string
+	Tier   int
+	Reason string
 }
 
 // ParkedError reports a task stopped before the executor ran because the
@@ -354,6 +376,17 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 
 	localOnly := action.LocalOnly || opts.LocalOnly
 	candidates := d.selectHeads(tier, localOnly)
+	if opts.Head != "" {
+		// A pinned head is the whole candidate list, so there is nothing to
+		// fall back to and no way to answer from a model the user did not ask
+		// for. Pinned but unroutable is an error with a reason, not a
+		// substitution.
+		pinned, err := d.pinHead(opts.Head, localOnly)
+		if err != nil {
+			return nil, err
+		}
+		candidates = []provider.Head{pinned}
+	}
 	if len(candidates) == 0 {
 		// Report the effective localOnly (policy may have forced it), not just
 		// the caller's flag, or a PII-forced local-only run points the user at
@@ -387,6 +420,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 	taskID := runid.ResolveTask(opts.TaskID)
 
 	var lastErr error
+	var attempts []Attempt
 	for i, h := range candidates {
 		// Computed once per candidate instead of once per use below (event
 		// logging, cost estimation): rank.UITier re-derives the same int for
@@ -411,6 +445,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		decision, lerr := ledger.CheckAndRecordDispatch("hydra-dispatch", h.ID, opts.Resource, prompt, class)
 		refuse := func(detail string) {
 			lastErr = fmt.Errorf("%s: head %s", detail, h.ID)
+			attempts = append(attempts, Attempt{Head: h.ID, Model: h.Name, Tier: tier, Reason: detail})
 			_ = rl.Append(runlog.Event{
 				Kind: runlog.KindError, TaskID: taskID,
 				Head: h.ID, Model: h.Name, Tier: tier,
@@ -467,6 +502,8 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 					Head: h.ID, Model: h.Name, Tier: tier,
 					Status: "denied", Detail: "exceeds cost ceiling",
 				})
+				attempts = append(attempts, Attempt{Head: h.ID, Model: h.Name, Tier: tier,
+					Reason: fmt.Sprintf("estimated $%.4f exceeds the $%.4f ceiling", estCost, opts.MaxCostUSD)})
 				// Shares the ledger's accountability trail with policy denials
 				// (Reason distinguishes them) so `hyctl security` has one place
 				// to find every kind of refused access, cost or policy.
@@ -495,9 +532,11 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 				Status: "failed", DurationMS: time.Since(started).Milliseconds(),
 				Detail: truncate(err.Error(), 200),
 			})
+			attempts = append(attempts, Attempt{Head: h.ID, Model: h.Name, Tier: tier,
+				Reason: truncate(err.Error(), 200)})
 			continue
 		}
-		r := &Result{Output: resp.Output, Head: h, Retries: i, Response: resp}
+		r := &Result{Output: resp.Output, Head: h, Retries: i, Attempts: attempts, Response: resp}
 		_ = rl.Append(runlog.Event{
 			Kind: runlog.KindDispatchFinished, TaskID: taskID,
 			Head: h.ID, Model: resp.Model, Tier: tier, Status: "ok",
@@ -767,6 +806,31 @@ func (d *Dispatcher) blockedHeads(localOnly bool) string {
 		return ""
 	}
 	return "Discovered, but not routable:\n" + b.String()
+}
+
+// pinHead resolves Options.Head to one discovered head, or explains why it
+// cannot be used. Every failure names the head the caller asked for, because
+// the caller is a person who picked it from a list and is owed an answer
+// about that model rather than a different one (#676).
+func (d *Dispatcher) pinHead(id string, localOnly bool) (provider.Head, error) {
+	for _, h := range d.heads {
+		if h.ID != id {
+			continue
+		}
+		if localOnly && !h.LocalOnly {
+			return provider.Head{}, fmt.Errorf(
+				"%w: %s is not a local head, and this run is local-only "+
+					"(policy or --local); choose a local model or lift the restriction",
+				ErrNoHeads, h.Name)
+		}
+		if why := executor.Unroutable(h); why != "" {
+			return provider.Head{}, fmt.Errorf("%w: %s cannot be run: %s", ErrNoHeads, h.Name, why)
+		}
+		return h, nil
+	}
+	return provider.Head{}, fmt.Errorf(
+		"%w: no discovered head with id %q; run `hyctl probe` to see what this machine has",
+		ErrNoHeads, id)
 }
 
 // selectHeads returns heads to try, in order of preference.

--- a/internal/dispatch/pin_test.go
+++ b/internal/dispatch/pin_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/ledger"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// brokenHead exits non-zero, so the executor fails and the chain advances. It
+// is the shape that produced #676: a strong head that cannot answer, with a
+// weaker one behind it ready to answer instead.
+func brokenHead(t *testing.T, s *testutil.Sandbox, id string, capScore int) provider.Head {
+	t.Helper()
+	body := "#!/bin/sh\necho 'boom' >&2\nexit 1\n"
+	if runtime.GOOS == "windows" {
+		body = "@echo off\r\necho boom 1>&2\r\nexit /b 1\r\n"
+	}
+	return provider.Head{
+		ID: id, Name: id, Provider: "openai", Source: "cli",
+		CapScore: capScore, AuthReady: true,
+		Executable: s.FakeBinary(t, "fake-head-"+id, body),
+	}
+}
+
+// The defect: the strong head fails, a weaker one answers, and the result says
+// only who answered. A caller that can see just Head cannot tell this apart
+// from having routed to the weak head deliberately.
+func TestDispatch_ResultNamesEveryFailedAttempt(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res, err := liveDispatcher(
+		brokenHead(t, s, "strong", 95),
+		echoHead(t, s, "weak", 50),
+	).Dispatch(context.Background(), "do the thing", Options{RunID: "run-att", TaskID: "task-att"})
+	if err != nil {
+		t.Fatalf("dispatch failed outright: %v", err)
+	}
+	if res.Head.ID != "weak" {
+		t.Fatalf("answered by %q, want the fallback head", res.Head.ID)
+	}
+	if len(res.Attempts) != 1 {
+		t.Fatalf("Attempts = %+v, want the one head that failed", res.Attempts)
+	}
+	a := res.Attempts[0]
+	if a.Head != "strong" {
+		t.Errorf("Attempts[0].Head = %q, want strong", a.Head)
+	}
+	if a.Reason == "" {
+		t.Error("Attempts[0].Reason is empty; the caller still cannot say why it fell back")
+	}
+	if res.Retries != len(res.Attempts) {
+		t.Errorf("Retries = %d but %d attempts recorded; they must agree", res.Retries, len(res.Attempts))
+	}
+}
+
+// A run that needs no fallback must not report one, or every ordinary reply
+// grows a "we tried something else" line that is not true.
+func TestDispatch_NoAttemptsWhenTheFirstHeadAnswers(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res, err := liveDispatcher(echoHead(t, s, "fine", 95)).
+		Dispatch(context.Background(), "do the thing", Options{RunID: "run-ok", TaskID: "task-ok"})
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if len(res.Attempts) != 0 {
+		t.Errorf("Attempts = %+v on a clean run, want none", res.Attempts)
+	}
+}
+
+// A ledger denial is a reason too. It never reaches an executor, so the error
+// text alone would not explain the fallback.
+func TestDispatch_DeniedHeadIsRecordedAsAnAttempt(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	writeLedgerPolicy(t, ledger.Policy{
+		Rules:   []ledger.Rule{{Tool: "blocked", Decision: ledger.Deny}},
+		Default: ledger.Allow,
+	})
+
+	res, err := liveDispatcher(
+		echoHead(t, s, "blocked", 95),
+		echoHead(t, s, "allowed", 50),
+	).Dispatch(context.Background(), "do the thing", Options{RunID: "run-den", TaskID: "task-den"})
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if res.Head.ID != "allowed" {
+		t.Fatalf("answered by %q, want the allowed head", res.Head.ID)
+	}
+	if len(res.Attempts) != 1 || res.Attempts[0].Head != "blocked" {
+		t.Fatalf("Attempts = %+v, want the denied head recorded", res.Attempts)
+	}
+	if !strings.Contains(res.Attempts[0].Reason, "polic") {
+		t.Errorf("Reason = %q, want it to name the policy", res.Attempts[0].Reason)
+	}
+}
+
+// Picking a model is a request for that model. Pinning must never answer from
+// a different one, which is the whole of #676: the picker offered a choice the
+// router was free to ignore.
+func TestDispatch_PinnedHeadNeverFallsThrough(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	_, err := liveDispatcher(
+		brokenHead(t, s, "chosen", 95),
+		echoHead(t, s, "other", 50),
+	).Dispatch(context.Background(), "do the thing", Options{
+		Head: "chosen", RunID: "run-pin", TaskID: "task-pin",
+	})
+	if err == nil {
+		t.Fatal("a pinned head that cannot answer must fail, not substitute another model")
+	}
+}
+
+func TestDispatch_PinnedHeadRunsWhenItCan(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	res, err := liveDispatcher(
+		echoHead(t, s, "strong", 95),
+		echoHead(t, s, "chosen", 50),
+	).Dispatch(context.Background(), "do the thing", Options{
+		Head: "chosen", RunID: "run-pin2", TaskID: "task-pin2",
+	})
+	if err != nil {
+		t.Fatalf("pinned dispatch failed: %v", err)
+	}
+	if res.Head.ID != "chosen" {
+		t.Errorf("answered by %q, want the pinned head even though a stronger one exists", res.Head.ID)
+	}
+}
+
+// An unknown id must say so by name. "no dispatchable heads" alone reads as
+// "this machine has nothing", which sends the user looking in the wrong place.
+func TestDispatch_PinnedHeadUnknownNamesIt(t *testing.T) {
+	s := testutil.NewSandbox(t)
+
+	_, err := liveDispatcher(echoHead(t, s, "real", 95)).
+		Dispatch(context.Background(), "do the thing", Options{Head: "ghost"})
+	if !errors.Is(err, ErrNoHeads) {
+		t.Fatalf("err = %v, want ErrNoHeads", err)
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("err = %q, want it to name the head that was asked for", err)
+	}
+}

--- a/internal/tui/chat_exec.go
+++ b/internal/tui/chat_exec.go
@@ -168,6 +168,10 @@ type ckStageOut struct {
 	head       string
 	tier       int
 	confidence float64 // consensus runs only
+
+	// attempts is every head that was tried and did not answer. Carried so the
+	// task can say it fell back rather than reporting only who replied (#676).
+	attempts []dispatch.Attempt
 }
 
 // The three provider seams. Tests substitute these; the pipeline around them
@@ -232,7 +236,7 @@ func ckRealDispatchStage(ctx context.Context, t *ckTask, prompt, tierHint string
 		if err != nil {
 			return ckStageOut{}, err
 		}
-		return ckStageOut{output: res.Output, head: res.Head.Name, tier: rank.UITier(res.Head)}, nil
+		return ckStageOut{output: res.Output, head: res.Head.Name, tier: rank.UITier(res.Head), attempts: res.Attempts}, nil
 	}
 }
 
@@ -370,10 +374,32 @@ func ckRunStages(ctx context.Context, ex *ckExecState, t *ckTask, phase int) byt
 	}
 	t.answer, t.conf = out.output, out.confidence
 	t.headName, t.tier = out.head, out.tier
+	if n := ckFellBackNote(out); n != "" {
+		t.note = n
+	}
 	if t.mode.name == "edit" && t.file == "" {
 		t.note = "no file named, answered instead"
 	}
 	return 0
+}
+
+// ckFellBackNote says which head was tried and could not answer. Silence here
+// is what #676 reported: a reply from a weak head reads the same whether the
+// router chose it or fell back to it.
+func ckFellBackNote(out ckStageOut) string {
+	if len(out.attempts) == 0 {
+		return ""
+	}
+	a := out.attempts[0]
+	name := a.Model
+	if name == "" {
+		name = a.Head
+	}
+	more := ""
+	if len(out.attempts) > 1 {
+		more = fmt.Sprintf(" (+%d more)", len(out.attempts)-1)
+	}
+	return fmt.Sprintf("%s could not answer%s: %s", name, more, truncate(a.Reason, 60))
 }
 
 // ckEditAndVerify is the edit → verify → fix loop. In careful mode each fix

--- a/internal/tui/chat_exec_test.go
+++ b/internal/tui/chat_exec_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/editor"
 	"github.com/ankit373/hydra/internal/oracle"
 	"github.com/ankit373/hydra/internal/runlog"
@@ -1333,5 +1334,35 @@ func TestChatScrollGeom_MirrorsInputBarHeight(t *testing.T) {
 	m.th().log = []string{"one"}
 	if m = m.chatScrollBy(-3); m.th().scroll != 0 {
 		t.Error("a fitting log entered scrollback")
+	}
+}
+
+// #676: a reply from a weak head reads the same whether the router chose it or
+// fell back to it after the picked one failed. The note is what distinguishes
+// them, so silence here is the defect.
+func TestCkFellBackNote(t *testing.T) {
+	if got := ckFellBackNote(ckStageOut{}); got != "" {
+		t.Errorf("clean run produced a note %q; every ordinary reply would carry it", got)
+	}
+
+	one := ckStageOut{attempts: []dispatch.Attempt{
+		{Head: "claude", Model: "Claude Code", Tier: 1, Reason: "exit status 1"},
+	}}
+	got := ckFellBackNote(one)
+	for _, want := range []string{"Claude Code", "could not answer", "exit status 1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("note = %q, want it to contain %q", got, want)
+		}
+	}
+	if strings.Contains(got, "more") {
+		t.Errorf("note = %q, must not claim more attempts than there were", got)
+	}
+
+	two := ckStageOut{attempts: []dispatch.Attempt{
+		{Head: "a", Model: "A", Tier: 1, Reason: "boom"},
+		{Head: "b", Model: "B", Tier: 2, Reason: "boom"},
+	}}
+	if got := ckFellBackNote(two); !strings.Contains(got, "+1 more") {
+		t.Errorf("note = %q, want it to count the other attempts", got)
 	}
 }


### PR DESCRIPTION
## The report

Pick **Claude Code (T1)** in the desktop app, ask a question, get an answer from
**Qwen2.5-Coder:7b (Ollama) · T10**. Nothing said the chosen model was not used, or why.

## Two defects, not one

### The picker could not pin a model

`dispatch.Options` had only `TierHint`. Choosing "Claude Code" meant *dispatch at tier 1*, and the
router was then free to walk the whole fallback chain down to the tier-10 local head. The UI offered
a choice it had no mechanism to honour.

`ModelPicker` also matched the selection by tier:

```ts
const picked = all.find((m) => String(m.tier) === tier)
```

Two heads share T1, so it could not tell which was picked and would tick the wrong one.

### The reasons were recorded and then dropped

`dispatch` already writes a runlog event per failed head *with the error text*, but `Result` carried
only a count:

```go
Fallbacks []provider.Head // remaining candidates, not the failed ones
Retries   int
```

so callers could report who answered and never who was asked. Same shape as #634 and #644.

## The fix

- **`Options.Head`** pins one head. Pinned is honoured or refused **with a reason**, never
  substituted. `pinHead` reuses `executor.Unroutable` for the why rather than inventing a second
  explanation, and distinguishes unknown id / not local under local-only / not routable.
- **`Result.Attempts`** carries every candidate that did not answer, populated at all four skip
  points: both ledger paths (via the existing `refuse` helper), the cost ceiling, and the executor
  error.
- **The desktop reply** carries them, and chat renders *"Claude Code (T1) could not answer: exit
  status 1 — Answered by Qwen2.5-Coder:7b (Ollama) instead"*. Amber, not red: the answer did arrive.
- **The picker** now expresses the model's own id.
- **The TUI** sets the same note through its existing `note` surface, no new rendering.

## Claude Code was never broken

`hyctl dispatch --tier 1 "reply with exactly: OK"` answers in 7.4s on this machine, and `probe`
scores it 95. The router fell through and the app stayed quiet.

## Verification

Six new dispatch tests, and each asserts a behaviour that did not exist:

| test | asserts |
|---|---|
| `ResultNamesEveryFailedAttempt` | the failed head and its reason survive to the caller; `Retries` agrees with `len(Attempts)` |
| `NoAttemptsWhenTheFirstHeadAnswers` | a clean run reports none, so ordinary replies grow no false line |
| `DeniedHeadIsRecordedAsAnAttempt` | a ledger denial is a reason too, and never reaches an executor |
| `PinnedHeadNeverFallsThrough` | a pinned head that fails errors instead of substituting |
| `PinnedHeadRunsWhenItCan` | a pinned head runs even with a stronger one present |
| `PinnedHeadUnknownNamesIt` | the error names the head asked for, not just "no heads" |

Plus two frontend tests. I verified they fail without the component rather than trusting a green
run: removing `<FellBack>` gives `Unable to find an element with the text: /could not answer/i`.

The `types.ts` parity test caught the new wire field by itself, which is what it was added for.

```
main:     51 packages race-green
desktop:  build / vet / test green
frontend: typecheck clean, 134 tests (was 132)
```

## Not in this PR

Offering to pull a local model that simply is not installed. The reason now reaches the user, which
is the reported problem; auto-installing is a separate piece of work.

Closes #676