### PR TITLE
test(docs): fail the build when a version reference goes stale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -855,7 +855,19 @@ docs/robots.txt    ← AI crawler rules (only change if bot policy changes)
 - `app.html`'s direct download links are **version-pinned by necessity**, desktop asset names embed
   their version, so GitHub's `/releases/latest/download/` shortcut cannot address them. They go stale
   every release and must be bumped by hand; the `install-app.sh` command beside them resolves the
-  newest tag at runtime and never goes stale, which is why it is the primary path on the page
+  newest tag at runtime and never goes stale, which is why it is the primary path on the page.
+  **`cmd/hydra/docs_version_test.go` now fails the build when they drift**, so a missed bump is red
+  rather than a 404 someone finds later. It checks three things: every version reference in
+  `app.html`, `index.html` and `README.md` names one version; that version matches
+  `.release-please-manifest.json`; and each asset URL's tag matches the version inside its filename.
+  Bump them all together:
+
+  ```bash
+  OLD=1.4.0 NEW=1.4.1
+  sed -i '' "s/v${OLD}/v${NEW}/g; s/\"softwareVersion\": \"${OLD}\"/\"softwareVersion\": \"${NEW}\"/" \
+    docs/app.html docs/index.html README.md
+  go test ./cmd/hydra -run TestDocs_Version   # must pass before the release PR
+  ```
 - Do not add features to `llms.txt` that haven't shipped to `main` yet
 
 ---

--- a/cmd/hydra/docs_version_test.go
+++ b/cmd/hydra/docs_version_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+)
+
+// Version strings are hand-maintained in several files and go stale every
+// release. app.html alone carries 23 of them, so a partial update is the
+// normal failure, not a rare one: the ones you miss keep pointing at the
+// previous release's assets, which 404, and nothing says so.
+//
+// CLAUDE.md already documents that these need bumping by hand. That is what
+// keeps failing. This turns "remember to update them" into a red build.
+
+var semverRE = regexp.MustCompile(`\b(\d+\.\d+\.\d+)\b`)
+
+// releasedVersion is what release-please last shipped, and the version the
+// asset names on the releases page actually carry.
+func releasedVersion(t *testing.T) string {
+	t.Helper()
+	var m map[string]string
+	if err := json.Unmarshal([]byte(repoFile(t, ".release-please-manifest.json")), &m); err != nil {
+		t.Fatalf("release-please manifest is not valid JSON: %v", err)
+	}
+	v, ok := m["."]
+	if !ok || v == "" {
+		t.Fatal(`release-please manifest has no "." entry; there is no version to check against`)
+	}
+	return v
+}
+
+// Every version reference in the docs must name one version. A file naming two
+// is mid-update, which is exactly the state that ships broken download links.
+func TestDocs_VersionReferencesAgree(t *testing.T) {
+	files := map[string]string{
+		"docs/app.html":   repoFile(t, "docs", "app.html"),
+		"docs/index.html": repoFile(t, "docs", "index.html"),
+		"README.md":       repoFile(t, "README.md"),
+	}
+
+	// Only lines that are actually about the Hydra release: a page mentions
+	// plenty of other version-shaped numbers (Wails 2.15.0, schema versions).
+	rx := regexp.MustCompile(`(?:HYDRA_VERSION=v|releases/download/v|hydra-desktop_v|"softwareVersion":\s*"|Release&nbsp;: <span class="g">v)(\d+\.\d+\.\d+)`)
+
+	seen := map[string][]string{} // version -> files naming it
+	for name, src := range files {
+		for _, m := range rx.FindAllStringSubmatch(src, -1) {
+			v := m[1]
+			if !contains(seen[v], name) {
+				seen[v] = append(seen[v], name)
+			}
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatal("no Hydra version references found at all; this test has stopped testing anything")
+	}
+	if len(seen) > 1 {
+		t.Errorf("the docs name %d different Hydra versions; a partial bump ships download links that 404:", len(seen))
+		for v, where := range seen {
+			t.Errorf("  %s in %v", v, where)
+		}
+	}
+}
+
+// The docs must not fall behind what was actually released, or every download
+// link points at the previous release's asset names.
+func TestDocs_VersionMatchesTheRelease(t *testing.T) {
+	want := releasedVersion(t)
+	src := repoFile(t, "docs", "app.html")
+
+	rx := regexp.MustCompile(`releases/download/v(\d+\.\d+\.\d+)/`)
+	found := map[string]bool{}
+	for _, m := range rx.FindAllStringSubmatch(src, -1) {
+		found[m[1]] = true
+	}
+	if len(found) == 0 {
+		t.Fatal("app.html has no release download links; this test has stopped testing anything")
+	}
+	for v := range found {
+		if v != want {
+			t.Errorf("app.html links to v%s but the manifest last released %s.\n"+
+				"Desktop asset names embed their version, so /releases/latest/download/ "+
+				"cannot address them and these go stale every release. Bump them, or the "+
+				"downloads 404.", v, want)
+		}
+	}
+}
+
+// An asset URL names the version twice, in the tag and in the filename. They
+// have drifted apart before, and a mismatched pair 404s while looking right.
+func TestDocs_AssetNamesMatchTheirTag(t *testing.T) {
+	src := repoFile(t, "docs", "app.html")
+	rx := regexp.MustCompile(`releases/download/v(\d+\.\d+\.\d+)/hydra-desktop_v(\d+\.\d+\.\d+)_`)
+
+	ms := rx.FindAllStringSubmatch(src, -1)
+	if len(ms) == 0 {
+		t.Fatal("no desktop asset links found; this test has stopped testing anything")
+	}
+	for _, m := range ms {
+		if m[1] != m[2] {
+			t.Errorf("asset link uses tag v%s but filename v%s; one of them 404s", m[1], m[2])
+		}
+	}
+}
+
+func contains(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/hydra/docs_version_test.go
+++ b/cmd/hydra/docs_version_test.go
@@ -16,8 +16,6 @@ import (
 // CLAUDE.md already documents that these need bumping by hand. That is what
 // keeps failing. This turns "remember to update them" into a red build.
 
-var semverRE = regexp.MustCompile(`\b(\d+\.\d+\.\d+)\b`)
-
 // releasedVersion is what release-please last shipped, and the version the
 // asset names on the releases page actually carry.
 func releasedVersion(t *testing.T) string {


### PR DESCRIPTION
## Why

`docs/app.html` carries **23** version references. A partial bump is therefore the normal failure,
not a rare one: the ones you miss keep pointing at the previous release's asset names and 404
silently, while the page looks fine.

CLAUDE.md already documents that these must be bumped by hand. That instruction is exactly what
keeps getting missed, so this turns it into a red build instead.

## Three checks

| check | catches |
|---|---|
| every version reference across `app.html`, `index.html`, `README.md` names **one** version | a partial bump |
| that version matches `.release-please-manifest.json` | docs falling behind what shipped |
| each asset URL's tag matches the version inside its **filename** | a mismatched pair that 404s while looking right |

The last one matters because an asset URL names the version twice:
`releases/download/v1.4.0/hydra-desktop_v1.4.0_darwin_universal.zip`.

## Proven against real drift, not assumed

I simulated each failure rather than trusting a green run:

```
# bump 20 of 23 references
--- FAIL: TestDocs_VersionReferencesAgree
    the docs name 2 different Hydra versions; a partial bump ships download links that 404

# tag bumped, filename not
--- FAIL: TestDocs_AssetNamesMatchTheirTag
    asset link uses tag v1.4.1 but filename v1.4.0; one of them 404s
```

Each test also fails loudly if it stops finding references at all, so it cannot quietly degrade into
testing nothing.

## Scoped deliberately

The regex matches only references that are genuinely about a Hydra release (`HYDRA_VERSION=v`,
`releases/download/v`, `hydra-desktop_v`, `"softwareVersion"`, the Release line). Wails' own version
and the schema versions on the same pages do not trip it.

`cmd/hydra/docs_anchors_test.go` is the existing precedent for testing `docs/` from Go, so this runs
in ordinary CI with no new workflow.

CLAUDE.md now carries the one-liner that bumps them together and the test to run before the release
PR.

Refs #674