### PR TITLE
fix: file cost rows under the model's real token pool

### DIFF
--- a/desktop/api/models.go
+++ b/desktop/api/models.go
@@ -147,8 +147,9 @@ func (a *API) GetModels() ModelRegistry {
 		key := m.TokenPool
 		if key == "" {
 			// A model with no declared pool draws from nothing shared. Group
-			// them together rather than dropping them.
-			key = "unpooled"
+			// them together rather than dropping them, under the same key
+			// internal/cost files their rows by, or the spend reads as zero.
+			key = cost.UnknownPoolKey
 		}
 
 		idx, ok := seen[key]

--- a/desktop/api/models_test.go
+++ b/desktop/api/models_test.go
@@ -141,6 +141,41 @@ func TestGetModels_AggregatesObservedSpendPerPool(t *testing.T) {
 	}
 }
 
+// The card beside the chat read "0 calls" while the list under it said 26, for
+// the same model. The rows were written with pool="" because only the agy
+// provider attached token_pool metadata, so local_ollama never matched any
+// spend (#681). 90% of a real machine's rows were affected.
+func TestGetModels_LocalPoolSpendIsCounted(t *testing.T) {
+	home := sandbox(t)
+
+	writeCostRows(t, home, []map[string]any{
+		{"ts": "2026-09-05T10:00:00Z", "pool": "local_ollama", "tier": 10,
+			"prompt_tokens": 40, "response_tokens": 20, "est_cost_usd": 0},
+		{"ts": "2026-09-05T10:01:00Z", "pool": "local_ollama", "tier": 10,
+			"prompt_tokens": 60, "response_tokens": 30, "est_cost_usd": 0},
+		{"ts": "2026-09-05T10:02:00Z", "pool": "agy_claude", "tier": 2,
+			"prompt_tokens": 10, "response_tokens": 5, "est_cost_usd": 0.10},
+	})
+
+	var local *Pool
+	reg := New().GetModels()
+	for i := range reg.Pools {
+		if reg.Pools[i].Name == "local_ollama" {
+			local = &reg.Pools[i]
+		}
+	}
+	if local == nil {
+		t.Fatal("local_ollama pool missing; the registry declares it for the Ollama models")
+	}
+	if local.ObservedCalls != 2 {
+		t.Errorf("local_ollama ObservedCalls = %d, want 2. A free local call is still a call, "+
+			"and 0 next to a list saying 2 makes the number worthless", local.ObservedCalls)
+	}
+	if got := local.ObservedTokens; got != 150 {
+		t.Errorf("local_ollama ObservedTokens = %d, want 150", got)
+	}
+}
+
 // An operator's on-disk registry must win over the embedded copy, or retuning
 // routing without a rebuild (the whole point of registry.Read) silently fails.
 func TestGetModels_OnDiskRegistryOverridesEmbedded(t *testing.T) {

--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -207,6 +207,11 @@ func All() ([]GroupRow, error) {
 }
 
 // ByPool returns per-pool totals.
+// UnknownPoolKey is how ByPool groups a row whose model declared no token pool.
+// Exported because the desktop looked those rows up under its own literal and
+// found nothing; one constant is what stops the two drifting again (#681).
+const UnknownPoolKey = "unknown"
+
 func ByPool() ([]GroupRow, error) {
 	all, err := LoadAll()
 	if err != nil {
@@ -214,7 +219,7 @@ func ByPool() ([]GroupRow, error) {
 	}
 	return groupBy(all, func(r Row) string {
 		if r.Pool == "" {
-			return "unknown"
+			return UnknownPoolKey
 		}
 		return r.Pool
 	}), nil

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ankit373/hydra/internal/rank"
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/registry"
 )
 
 // ErrNoHeads marks a dispatch with no head to run, discovered or routable.
@@ -1050,7 +1051,7 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options, actProb
 			"enum":            opts.Enum,
 			"model":           r.Response.Model,
 			"executor":        r.Head.Provider,
-			"pool":            r.Head.Meta["token_pool"],
+			"pool":            headPool(r.Head),
 			"prompt_tokens":   r.Response.InputTokens,
 			"response_tokens": r.Response.OutputTokens,
 			"est_cost_usd":    estCost,
@@ -1131,4 +1132,15 @@ func EnumToTier(enum string) string {
 func IsKnownEnum(enum string) bool {
 	_, ok := enumTiers[enum]
 	return ok
+}
+
+// headPool is the token pool a cost row should be filed under. Provider
+// metadata wins when present; otherwise the registry is asked, because only
+// the agy provider ever set that metadata and every other provider's rows were
+// landing with no pool at all (#681).
+func headPool(h provider.Head) string {
+	if p := h.Meta["token_pool"]; p != "" {
+		return p
+	}
+	return registry.TokenPoolFor(config.ScriptHome(), h.ID)
 }

--- a/internal/dispatch/pin_test.go
+++ b/internal/dispatch/pin_test.go
@@ -151,3 +151,31 @@ func TestDispatch_PinnedHeadUnknownNamesIt(t *testing.T) {
 		t.Errorf("err = %q, want it to name the head that was asked for", err)
 	}
 }
+
+// The cost row's pool came only from head metadata, and exactly one provider
+// (agy) ever set it. Every other provider's rows landed with pool="" and their
+// pool card read 0 calls forever, on 90% of a real machine's rows (#681).
+func TestHeadPool_ResolvesFromTheRegistryWhenMetadataIsAbsent(t *testing.T) {
+	// The shape the port provider actually discovers: no metadata at all.
+	h := provider.Head{ID: "ollama/Qwen2.5-Coder:7b", Name: "Qwen2.5-Coder:7b (Ollama)"}
+	if got := headPool(h); got != "local_ollama" {
+		t.Errorf("headPool(%s) = %q, want local_ollama from the registry", h.ID, got)
+	}
+}
+
+// Metadata still wins where a provider does attach it, so agy keeps working
+// exactly as before.
+func TestHeadPool_ProviderMetadataWins(t *testing.T) {
+	h := provider.Head{ID: "ollama/Qwen2.5-Coder:7b", Meta: map[string]string{"token_pool": "explicit"}}
+	if got := headPool(h); got != "explicit" {
+		t.Errorf("headPool = %q, want the provider's own metadata to win", got)
+	}
+}
+
+// An unrecognised head records no pool rather than guessing one: a wrong pool
+// files spend against someone else's quota, which is worse than none.
+func TestHeadPool_UnknownHeadRecordsNoPool(t *testing.T) {
+	if got := headPool(provider.Head{ID: "nothing/we-know"}); got != "" {
+		t.Errorf("headPool = %q, want empty for an unknown head", got)
+	}
+}

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
 	"github.com/ankit373/hydra/internal/runid"
+	"github.com/ankit373/hydra/registry"
 )
 
 // PricingReader abstracts the per-tier cost lookup so swarm doesn't need to
@@ -105,7 +106,7 @@ func logAttempts(attempts []Attempt, mode SwarmMode, opts Options, promptPreview
 			"tier":            rank.UITier(a.Head),
 			"model":           a.Head.Name,
 			"executor":        a.Head.Provider,
-			"pool":            a.Head.Meta["token_pool"],
+			"pool":            headPool(a.Head),
 			"prompt_tokens":   a.InputTokens,
 			"response_tokens": a.OutputTokens,
 			"est_cost_usd":    a.EstCostUSD,
@@ -133,4 +134,13 @@ func logAttempts(attempts []Attempt, mode SwarmMode, opts Options, promptPreview
 
 func round6(f float64) float64 {
 	return math.Round(f*1_000_000) / 1_000_000
+}
+
+// headPool mirrors dispatch's: provider metadata when present, else the
+// registry, since only the agy provider ever attached it (#681).
+func headPool(h provider.Head) string {
+	if p := h.Meta["token_pool"]; p != "" {
+		return p
+	}
+	return registry.TokenPoolFor(config.ScriptHome(), h.ID)
 }

--- a/registry/pool.go
+++ b/registry/pool.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+
+package registry
+
+import (
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// A token pool is a property of the model, declared in models.yaml. It used to
+// reach a cost row only as head metadata, and exactly one provider (agy) set
+// that metadata, so every head discovered by the port, env or CLI providers
+// wrote an empty pool and its pool card read 0 calls forever. On a real machine
+// 72 of 80 rows were affected (#681).
+//
+// Reading it from the registry instead makes it right for every provider,
+// rather than each one having to remember to attach it.
+
+type poolModel struct {
+	ID        string `yaml:"id"`
+	Provider  string `yaml:"provider"`
+	ModelFlag string `yaml:"model_flag"`
+	TokenPool string `yaml:"token_pool"`
+}
+
+type poolFile struct {
+	Models []poolModel `yaml:"models"`
+}
+
+var poolOnce struct {
+	sync.Once
+	byID map[string]string
+}
+
+// TokenPoolFor resolves a discovered head's token pool. headID is matched two
+// ways, both exact: the registry model's own id, and provider/model_flag, which
+// is the shape a port-discovered head carries (ollama/Qwen2.5-Coder:7b for
+// model_flag "Qwen2.5-Coder:7b"). No fuzzy matching: a wrong pool would file
+// spend against someone else's quota, which is worse than none.
+//
+// Returns "" when nothing matches, which callers must treat as "not declared"
+// rather than substituting a default.
+func TokenPoolFor(home, headID string) string {
+	if headID == "" {
+		return ""
+	}
+	poolOnce.Do(func() { poolOnce.byID = loadPools(home) })
+	return poolOnce.byID[headID]
+}
+
+func loadPools(home string) map[string]string {
+	out := map[string]string{}
+	raw, err := Read(home, "models.yaml")
+	if err != nil {
+		return out
+	}
+	var f poolFile
+	if err := yaml.Unmarshal(raw, &f); err != nil {
+		return out
+	}
+	for _, m := range f.Models {
+		if m.TokenPool == "" {
+			continue
+		}
+		if m.ID != "" {
+			out[m.ID] = m.TokenPool
+		}
+		if m.Provider != "" && m.ModelFlag != "" {
+			out[m.Provider+"/"+m.ModelFlag] = m.TokenPool
+		}
+	}
+	return out
+}

--- a/registry/pool_test.go
+++ b/registry/pool_test.go
@@ -1,0 +1,29 @@
+package registry
+
+import "testing"
+
+// The head the port provider actually discovers is ollama/<model_flag>, not the
+// registry's own id, and it carries no metadata at all. Matching only on id is
+// what left every Ollama row with an empty pool (#681).
+func TestTokenPoolFor_MatchesAPortDiscoveredHead(t *testing.T) {
+	if got := TokenPoolFor("", "ollama/Qwen2.5-Coder:7b"); got != "local_ollama" {
+		t.Errorf("TokenPoolFor(ollama/Qwen2.5-Coder:7b) = %q, want local_ollama", got)
+	}
+}
+
+func TestTokenPoolFor_MatchesTheRegistryID(t *testing.T) {
+	if got := TokenPoolFor("", "qwen-grunt"); got != "local_ollama" {
+		t.Errorf("TokenPoolFor(qwen-grunt) = %q, want local_ollama", got)
+	}
+}
+
+// An unknown head must return "" so the caller records "not declared" rather
+// than filing spend against a pool that is not its own.
+func TestTokenPoolFor_UnknownHeadIsEmpty(t *testing.T) {
+	if got := TokenPoolFor("", "something/not-in-the-registry"); got != "" {
+		t.Errorf("TokenPoolFor(unknown) = %q, want empty", got)
+	}
+	if got := TokenPoolFor("", ""); got != "" {
+		t.Errorf("TokenPoolFor(\"\") = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## The report

The chat companion pane contradicted itself on one screen:

```
Qwen2.5-Coder:7b (Ollama)   T10
idle
OLLAMA
0 calls · $0 logged          <- the card
```
```
Qwen2.5-Coder:7b (Ollama)
26 calls                     <- the list directly below it
```

## Root cause

`internal/dispatch/dispatch.go` took the cost row's pool from head metadata:

```go
"pool": r.Head.Meta["token_pool"],
```

and that metadata is set in **exactly one place in the repo**:

```
internal/provider/agy/provider.go:77:   "token_pool": m.TokenPool,
```

Only the agy provider sets it. Heads discovered by the **port** provider (Ollama), the **env**
provider (API keys) and the **CLI** provider carry none, so every row they wrote landed with
`pool: ""` and the model's declared pool matched no spend at all.

Measured on a real machine's `~/.hydra/logs/cost.jsonl`:

```
total rows: 80
by pool: {'': 72, 'agy_flash': 6, 'agy_flash_thinking': 1, 'agy_gemini_pro': 1}
qwen rows by pool: {'': 34}
```

**72 of 80 rows.** The `agy_*` pools are the only counts that have ever been correct, which is why
this survived.

## The fix

A pool is a property of the model in `models.yaml`, not of whichever provider happened to discover
the head. `registry.TokenPoolFor` resolves it there.

Matching is **exact** on the two real shapes, never fuzzy:

| shape | example |
|---|---|
| the registry's own id | `qwen-grunt` |
| `provider/model_flag` | `ollama/Qwen2.5-Coder:7b` for `model_flag: "Qwen2.5-Coder:7b"` |

An unrecognised head records **no** pool rather than guessing: filing spend against the wrong quota
is worse than filing none. Provider metadata still wins where it exists, so agy is untouched.

## I had this wrong first, and the test caught me

My original diagnosis blamed a `"unknown"` vs `"unpooled"` key mismatch between `internal/cost` and
`desktop/api`. I wrote a test for it and **it skipped**, because every model in the registry declares
a pool, so that branch never fires. That is what sent me back to look properly. The issue carries the
correction.

That literal mismatch is real but latent, so it is fixed the conservative way: `internal/cost`'s
sentinel is now an exported constant at its **existing value**. Renaming it would have changed
`hyctl cost` output and broken a test that documents the current behaviour, for a path no registry
model currently reaches. Not worth it on a release-critical fix.

## Verification

```
main:     51 packages race-green, staticcheck clean
desktop:  build / vet / test green
frontend: typecheck clean, 134 tests
```

New tests, each asserting something that was untrue before:

- `TokenPoolFor` matches a port-discovered head, matches the registry id, and returns empty for an unknown one
- `headPool` resolves from the registry, lets provider metadata win, and records nothing for an unknown head
- `GetModels_LocalPoolSpendIsCounted` pins the actual reported symptom

Closes #681