### PR TITLE
fix(dispatch): never route to a head that cannot serve

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -34,8 +34,8 @@ import (
 	"github.com/ankit373/hydra/internal/editor"
 	"github.com/ankit373/hydra/internal/entropy"
 	"github.com/ankit373/hydra/internal/evalset"
-	"github.com/ankit373/hydra/internal/executor"
 	"github.com/ankit373/hydra/internal/graph"
+	"github.com/ankit373/hydra/internal/health"
 	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/mcpregistry"
 	"github.com/ankit373/hydra/internal/ope"
@@ -332,9 +332,10 @@ func cmdProbe() *cobra.Command {
 				cortexName = result.Cortex.Name
 			}
 			if jsonOut {
+				hs, now := health.Open(health.DefaultPath()), time.Now()
 				heads := make([]probeHeadJSON, len(result.Heads))
 				for i, h := range result.Heads {
-					why := executor.Unroutable(h)
+					why := health.Reason(hs, h, now)
 					heads[i] = probeHeadJSON{
 						ID: h.ID, Name: h.Name, Provider: h.Provider, Source: h.Source,
 						CapScore: h.CapScore, LocalOnly: h.LocalOnly,
@@ -370,12 +371,13 @@ func cmdProbe() *cobra.Command {
 			// the Ollama binary that `dispatch --local` then refused (#248), so
 			// unroutable heads are marked and carry their reason.
 			var unroutable int
+			hs, now := health.Open(health.DefaultPath()), time.Now()
 			for _, h := range result.Heads {
 				marker := "  "
 				if result.Cortex != nil && h.ID == result.Cortex.ID {
 					marker = cortexStyle.Render("→ ")
 				}
-				why := executor.Unroutable(h)
+				why := health.Reason(hs, h, now)
 				if why != "" {
 					marker = warnStyle.Render("✗ ")
 					unroutable++

--- a/desktop/api/heads.go
+++ b/desktop/api/heads.go
@@ -3,10 +3,11 @@
 package api
 
 import (
-	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/health"
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/rank"
+	"time"
 )
 
 // Head is one discovered head and whether anything can actually drive it.
@@ -60,8 +61,9 @@ func (a *API) GetHeads() HeadPanel {
 // nothing while passing.
 func headsFrom(discovered []provider.Head) HeadPanel {
 	out := HeadPanel{Heads: make([]Head, 0, len(discovered))}
+	hs, now := health.Open(health.DefaultPath()), time.Now()
 	for _, h := range discovered {
-		reason := executor.Unroutable(h)
+		reason := health.Reason(hs, h, now)
 		e := Head{
 			ID: h.ID, Name: h.Name, Provider: h.Provider, Source: h.Source,
 			Tier: rank.UITier(h), CapScore: h.CapScore,

--- a/desktop/api/heads_test.go
+++ b/desktop/api/heads_test.go
@@ -60,7 +60,7 @@ func TestGetHeads_RoutableCountMatchesTheRows(t *testing.T) {
 // whatever the host machine happens to have.
 func TestHeadsFrom_MarksRoutabilityAndSaysWhyNot(t *testing.T) {
 	// Source "registry" is the agy path: AgyExecutor drives it, so routable.
-	routable := provider.Head{ID: "opus", Name: "Opus", Provider: "agy", Source: "registry", CapScore: 98}
+	routable := provider.Head{ID: "opus", Name: "Opus", Provider: "agy", Source: "registry", Executable: "/usr/bin/agy", CapScore: 98}
 	// An embedding-only head is discovered and shown but never dispatched.
 	embedding := provider.Head{
 		ID: "embed", Name: "Embedder", Provider: "openai", Source: "env",
@@ -106,7 +106,7 @@ func TestHeadsFrom_MarksRoutabilityAndSaysWhyNot(t *testing.T) {
 // carry one, the view renders the reason instead of the tier.
 func TestHeadsFrom_ReasonAndRoutableAreNeverBothSet(t *testing.T) {
 	got := headsFrom([]provider.Head{
-		{ID: "a", Source: "registry"},
+		{ID: "a", Source: "registry", Executable: "/usr/bin/agy"},
 		{ID: "b", Source: "cli", Provider: "nobody-at-all"},
 	})
 	for _, h := range got.Heads {

--- a/internal/dispatch/coverage_test.go
+++ b/internal/dispatch/coverage_test.go
@@ -799,7 +799,7 @@ func TestAsIntAndAsIntSlice(t *testing.T) {
 func TestHeadsAndEstimateCost_AreExposedToCallers(t *testing.T) {
 	testutil.NewSandbox(t)
 
-	dd := liveDispatcher(provider.Head{ID: "a", Name: "a", Provider: "agy", Source: "registry", CapScore: 80})
+	dd := liveDispatcher(provider.Head{ID: "a", Name: "a", Provider: "agy", Source: "registry", Executable: "/usr/bin/agy", CapScore: 80})
 	dd.pricing = pricing.Load()
 	if heads := dd.Heads(); len(heads) != 1 || heads[0].ID != "a" {
 		t.Errorf("Heads() = %+v, want the one head it was built with", heads)

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/cost"
 	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/health"
 	"github.com/ankit373/hydra/internal/ledger"
 	"github.com/ankit373/hydra/internal/pending"
 	"github.com/ankit373/hydra/internal/policy"
@@ -226,6 +227,7 @@ type Dispatcher struct {
 	policy  *policy.Engine
 	pricing *pricing.DB
 	budget  *budget.Registry
+	health  *health.Store
 }
 
 // Heads returns the probed head list for external callers (e.g. swarm).
@@ -311,6 +313,7 @@ func New(ctx context.Context) (*Dispatcher, error) {
 		policy:  policy.New(policy.DefaultRules(localOnly)),
 		pricing: pricing.Load(),
 		budget:  budgetReg,
+		health:  health.Open(health.DefaultPath()),
 	}, nil
 }
 
@@ -319,6 +322,9 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 	if err := ValidateTierHint(d.cfg, opts.TierHint); err != nil {
 		return nil, err
 	}
+	// Written once per dispatch rather than per outcome. Breaker state is a
+	// cache of what was observed, so a lost update costs one retry, never work.
+	defer func() { _ = d.health.Flush() }()
 
 	// Resolve the hint to a capability number BEFORE the governor runs. A named
 	// config tier ("expert") is otherwise opaque to claudeMode's Atoi, which
@@ -525,6 +531,10 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 		})
 		if err != nil {
 			lastErr = err
+			// Parks the head so the rest of this run, and the next one, skip
+			// it. A missing binary or an unknown model opens the breaker at
+			// once; anything that might not recur gets a second chance first.
+			d.health.Fail(h.ID, truncate(err.Error(), 120), health.Classify(err), time.Now())
 			// A failed candidate is part of the run's shape: it is why the
 			// fallback chain advanced, and nothing else records it.
 			_ = rl.Append(runlog.Event{
@@ -537,6 +547,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, prompt string, opts Options) 
 				Reason: truncate(err.Error(), 200)})
 			continue
 		}
+		d.health.Pass(h.ID)
 		r := &Result{Output: resp.Output, Head: h, Retries: i, Attempts: attempts, Response: resp}
 		_ = rl.Append(runlog.Event{
 			Kind: runlog.KindDispatchFinished, TaskID: taskID,
@@ -801,6 +812,10 @@ func (d *Dispatcher) blockedHeads(localOnly bool) string {
 		}
 		if why := executor.Unroutable(h); why != "" {
 			fmt.Fprintf(&b, "  %s (%s): %s\n", h.Name, h.Provider, why)
+			continue
+		}
+		if why, parked := d.health.Blocked(h.ID, time.Now()); parked {
+			fmt.Fprintf(&b, "  %s (%s): %s\n", h.Name, h.Provider, why)
 		}
 	}
 	if b.Len() == 0 {
@@ -851,8 +866,14 @@ func (d *Dispatcher) pinHead(id string, localOnly bool) (provider.Head, error) {
 // A hint that matches nothing returns no candidates; the caller reports that
 // rather than silently widening to every head.
 func (d *Dispatcher) selectHeads(tierHint string, localOnly bool) []provider.Head {
+	now := time.Now()
 	filter := func(h provider.Head) bool {
 		if !executor.Supports(h) {
+			return false
+		}
+		// Dropped from the candidate list rather than tried and skipped: a
+		// head the breaker has parked must not be routed to at all (#688).
+		if _, parked := d.health.Blocked(h.ID, now); parked {
 			return false
 		}
 		if localOnly && !h.LocalOnly {

--- a/internal/dispatch/health_test.go
+++ b/internal/dispatch/health_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+
+package dispatch
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/health"
+)
+
+func parked(t *testing.T, id, reason string) *health.Store {
+	t.Helper()
+	s := health.Open(filepath.Join(t.TempDir(), "health.json"))
+	s.Fail(id, reason, health.Fatal, time.Now())
+	return s
+}
+
+// The reported failure: eight heads that had each already proven they could
+// not run were selected and dispatched to anyway. A parked head must not be a
+// candidate at all, rather than a candidate that is skipped.
+func TestSelectHeads_ParkedHeadIsNotACandidate(t *testing.T) {
+	d := routingDispatcher()
+	d.health = parked(t, "expert", "agy not found")
+
+	for _, h := range d.selectHeads("2", false) {
+		if h.ID == "expert" {
+			t.Fatal("a parked head was offered as a candidate")
+		}
+	}
+}
+
+func TestSelectHeads_ParkedHeadReturnsOnceItsCooldownElapses(t *testing.T) {
+	d := routingDispatcher()
+	d.health = parked(t, "expert", "agy not found")
+
+	// selectHeads reads the wall clock, so the elapsed cooldown is expressed by
+	// dating the failure far enough back that its retry time has already
+	// passed. Calling Pass here would assert nothing but the test's own setup.
+	d.health = health.Open(filepath.Join(t.TempDir(), "health.json"))
+	d.health.Fail("expert", "agy not found", health.Fatal, time.Now().Add(-24*time.Hour))
+
+	found := false
+	for _, h := range d.selectHeads("2", false) {
+		if h.ID == "expert" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a recovered head never came back into rotation")
+	}
+}
+
+// With everything parked the dispatch must say which heads and why, not
+// "no available heads", which sends the reader to `hyctl probe` to see a list
+// of heads that look fine (#248).
+func TestBlockedHeads_NamesParkedHeadsAndTheirReason(t *testing.T) {
+	d := routingDispatcher()
+	d.health = parked(t, "expert", "agy is not on PATH")
+
+	got := d.blockedHeads(false)
+	if !strings.Contains(got, "expert") {
+		t.Errorf("blockedHeads = %q, want it to name the parked head", got)
+	}
+	if !strings.Contains(got, "agy is not on PATH") {
+		t.Errorf("blockedHeads = %q, want it to carry the reason", got)
+	}
+}

--- a/internal/dispatch/identity_test.go
+++ b/internal/dispatch/identity_test.go
@@ -44,7 +44,7 @@ func readLog(t *testing.T, home, name string) []map[string]any {
 func logResult() *Result {
 	return &Result{
 		Output: "ok",
-		Head:   provider.Head{ID: "h1", Name: "H1", Provider: "agy", Source: "registry", CapScore: 90},
+		Head:   provider.Head{ID: "h1", Name: "H1", Provider: "agy", Source: "registry", Executable: "/usr/bin/agy", CapScore: 90},
 		Response: &executor.Response{
 			Output:       "ok",
 			Model:        "m",

--- a/internal/dispatch/routing_test.go
+++ b/internal/dispatch/routing_test.go
@@ -17,7 +17,7 @@ import (
 // tests exercise real selection rather than being filtered out wholesale.
 func registryHead(id string, capScore int, local bool) provider.Head {
 	return provider.Head{
-		ID: id, Name: id, Provider: "agy", Source: "registry",
+		ID: id, Name: id, Provider: "agy", Source: "registry", Executable: "/usr/bin/agy",
 		CapScore: capScore, LocalOnly: local, AuthReady: true,
 	}
 }

--- a/internal/dispatch/runlog_test.go
+++ b/internal/dispatch/runlog_test.go
@@ -17,7 +17,7 @@ import (
 // tests exercise real selection rather than being filtered out.
 func rlHead(id string, capScore int) provider.Head {
 	return provider.Head{
-		ID: id, Name: id, Provider: "agy", Source: "registry",
+		ID: id, Name: id, Provider: "agy", Source: "registry", Executable: "/usr/bin/agy",
 		CapScore: capScore, AuthReady: true,
 	}
 }

--- a/internal/executor/agy.go
+++ b/internal/executor/agy.go
@@ -76,7 +76,14 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 	// process can't exhaust memory through error output.
 	stderr := util.NewAccumulator(64 << 10)
 	stdout := util.NewAccumulator(0)
-	cmd := exec.CommandContext(ctx, "agy", "--print", req.Prompt,
+	// The path discovery already resolved. Re-resolving it here is what let
+	// execution and Unroutable disagree, so a head that arrived without one is
+	// refused rather than quietly looked up again (#688).
+	bin := req.Head.Executable
+	if bin == "" {
+		return nil, fmt.Errorf("agy executor: head %q carries no resolved agy path", req.Head.ID)
+	}
+	cmd := exec.CommandContext(ctx, bin, "--print", req.Prompt,
 		"--model", modelFlag, "--print-timeout", fmt.Sprintf("%ds", int(timeout.Seconds())))
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/internal/executor/agy_test.go
+++ b/internal/executor/agy_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -113,8 +114,11 @@ func readAgySettings(t *testing.T, path string) map[string]any {
 }
 
 func agyHead(modelFlag string) provider.Head {
+	// Mirrors discovery: the resolved path is what makes a registry head
+	// routable, and inside a sandbox that is the planted fake.
+	bin, _ := exec.LookPath("agy")
 	return provider.Head{
-		ID: "agy-tier-3", Name: "agy-tier-3", Provider: "antigravity", Source: "registry",
+		ID: "agy-tier-3", Name: "agy-tier-3", Provider: "antigravity", Source: "registry", Executable: bin,
 		Meta: map[string]string{"model_flag": modelFlag, "token_pool": "gemini"},
 	}
 }
@@ -300,7 +304,7 @@ func TestAgyExecute_MissingModelFlagIsRefused(t *testing.T) {
 
 	_, err := (&AgyExecutor{}).Execute(context.Background(), Request{
 		Prompt: "hi",
-		Head:   provider.Head{ID: "agy-tier-1", Provider: "antigravity", Source: "registry"},
+		Head:   provider.Head{ID: "agy-tier-1", Provider: "antigravity", Source: "registry", Executable: "/usr/bin/agy"},
 	})
 	if err == nil {
 		t.Fatal("a head with no model_flag was executed")

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -61,7 +61,13 @@ func Unroutable(h provider.Head) string {
 		// so every dispatch to it would fail (#532).
 		return "embeddings only, never routed"
 	case h.Source == "registry":
-		return "" // agy tiers, AgyExecutor handles them
+		// Every registry head is driven by AgyExecutor, which execs `agy`.
+		// Calling them routable without it turned one missing binary into a
+		// chain of eight identical failures per dispatch (#688).
+		if h.Executable == "" {
+			return "the agy CLI is not on PATH, so nothing can drive this head"
+		}
+		return ""
 	case h.Source == "port" || h.Source == "env" || h.Endpoint != "":
 		if SupportsHTTP(h) {
 			return ""

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -15,7 +15,7 @@ func TestFor_SelectsExecutorBySource(t *testing.T) {
 		head provider.Head
 		want interface{}
 	}{
-		{"registry → agy", provider.Head{Source: "registry", Provider: "anthropic"}, &AgyExecutor{}},
+		{"registry → agy", provider.Head{Source: "registry", Executable: "/usr/bin/agy", Provider: "anthropic"}, &AgyExecutor{}},
 		{"ollama source → ollama", provider.Head{Source: "ollama", ID: "ollama/qwen2.5"}, &OllamaExecutor{}},
 		{"ollama provider → ollama", provider.Head{Provider: "ollama", ID: "qwen2.5"}, &OllamaExecutor{}},
 		{"env → http", provider.Head{Source: "env", Provider: "anthropic", ID: "env/anthropic"}, &HTTPExecutor{}},
@@ -61,7 +61,7 @@ func TestSupports_EnvHeadsGateOnKey(t *testing.T) {
 }
 
 func TestSupports_NonEnvUnchanged(t *testing.T) {
-	if !Supports(provider.Head{Source: "registry", Provider: "anthropic"}) {
+	if !Supports(provider.Head{Source: "registry", Executable: "/usr/bin/agy", Provider: "anthropic"}) {
 		t.Fatal("registry head should be supported")
 	}
 	if !Supports(provider.Head{Source: "cli", Provider: "anthropic", Executable: "/usr/bin/claude"}) {
@@ -135,7 +135,7 @@ func TestUnroutable_EmbeddingOnlyIsNeverRouted(t *testing.T) {
 // branches, is exactly how a listing surface and a routing surface drift apart.
 func TestSupports_AlwaysAgreesWithUnroutable(t *testing.T) {
 	heads := []provider.Head{
-		{ID: "opus-thinking", Provider: "agy", Source: "registry"},
+		{ID: "opus-thinking", Provider: "agy", Source: "registry", Executable: "/usr/bin/agy"},
 		{ID: "ollama", Provider: "local", Source: "cli", LocalOnly: true},
 		{ID: "claude", Provider: "anthropic", Source: "cli"},
 		{ID: "mystery", Provider: "nobody", Source: "cli"},
@@ -191,4 +191,25 @@ func TestSupportsAndUnroutable_AgreeOverEveryHeadShape(t *testing.T) {
 		t.Fatal("no combinations checked")
 	}
 	t.Logf("agreement held over %d head shapes", checked)
+}
+
+// The reported failure (#688): with agy missing, eight registry heads were
+// still advertised as healthy and each was dispatched to in turn, failing
+// identically. Discovery resolves the binary; without one there is nothing to
+// drive the head and it must say so.
+func TestUnroutable_RegistryHeadWithoutAResolvedAgy(t *testing.T) {
+	why := Unroutable(provider.Head{ID: "opus-thinking", Provider: "antigravity", Source: "registry"})
+	if why == "" {
+		t.Fatal("a registry head with no agy binary was reported routable")
+	}
+	if !strings.Contains(why, "agy") {
+		t.Errorf("reason = %q, want it to name the missing CLI", why)
+	}
+}
+
+func TestUnroutable_RegistryHeadWithAResolvedAgy(t *testing.T) {
+	h := provider.Head{ID: "opus-thinking", Provider: "antigravity", Source: "registry", Executable: "/usr/bin/agy"}
+	if why := Unroutable(h); why != "" {
+		t.Errorf("Unroutable = %q, want routable", why)
+	}
 }

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MIT
+
+// Package health keeps heads that cannot serve out of rotation.
+//
+// Two questions, deliberately separate. Whether a head could ever work is a
+// precondition (executor.Unroutable); whether one that used to work still does
+// is this package, and the only honest answer to the second is "try it again
+// later", so a failure parks a head for a while rather than condemning it.
+package health
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// How long a head sits out. The first failure is cheap to retry, a head that
+// keeps failing is not, so the wait doubles up to a ceiling that still lets a
+// fixed head return without anyone restarting anything.
+const (
+	softFailuresBeforeOpen = 2
+	baseCooldown           = 1 * time.Minute
+	maxCooldown            = 30 * time.Minute
+)
+
+// Kind separates a failure that might not recur from one that certainly will
+// until something changes on the machine.
+type Kind int
+
+const (
+	// Transient is a timeout, a 5xx, a dropped connection.
+	Transient Kind = iota
+	// Fatal is a missing binary or a model the provider does not have. Retrying
+	// it in a second only produces the same error, so it opens on first sight.
+	Fatal
+)
+
+type entry struct {
+	Reason   string    `json:"reason"`
+	Kind     Kind      `json:"kind"`
+	Failures int       `json:"failures"`
+	LastFail time.Time `json:"lastFail"`
+	RetryAt  time.Time `json:"retryAt"`
+}
+
+// Store is the per-head breaker state, shared between the CLI and the app
+// through one file.
+type Store struct {
+	path  string
+	mu    sync.Mutex
+	heads map[string]*entry
+	dirty bool
+}
+
+// DefaultPath is the shared breaker file, beside the run logs.
+func DefaultPath() string { return filepath.Join(config.Dir(), "logs", "health.json") }
+
+// Open reads the store, and returns an empty one when it cannot.
+//
+// Unlike internal/pending this never fails loudly: breaker state is a cache of
+// what was observed, not work someone is waiting on. Refusing to dispatch
+// because a cache file is corrupt would turn a bad file into a total outage,
+// and starting empty only costs one retry of a head that is genuinely down.
+func Open(path string) *Store {
+	s := &Store{path: path, heads: map[string]*entry{}}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return s
+	}
+	var heads map[string]*entry
+	if err := json.Unmarshal(raw, &heads); err != nil || heads == nil {
+		return s
+	}
+	s.heads = heads
+	return s
+}
+
+// Blocked reports whether a head is parked, and why.
+//
+// Once RetryAt passes the head is let through on trial: the breaker is not
+// closed until something actually succeeds, so a still-broken head fails once
+// and backs off further rather than being retried on every dispatch.
+func (s *Store) Blocked(id string, now time.Time) (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.heads[id]
+	if !ok || !now.Before(e.RetryAt) {
+		return "", false
+	}
+	return e.Reason + ", retrying " + humanizeUntil(e.RetryAt, now), true
+}
+
+// Fail records a failed execution and parks the head if it has earned it.
+func (s *Store) Fail(id, reason string, k Kind, now time.Time) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.heads[id]
+	if !ok {
+		e = &entry{}
+		s.heads[id] = e
+	}
+	e.Failures++
+	e.Reason = reason
+	e.Kind = k
+	e.LastFail = now
+	if k == Fatal || e.Failures >= softFailuresBeforeOpen {
+		e.RetryAt = now.Add(cooldown(e.Failures))
+	}
+	s.dirty = true
+}
+
+// Pass clears a head's record. A success is the only thing that closes a
+// breaker, so a head recovers by working, not by waiting.
+func (s *Store) Pass(id string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.heads[id]; !ok {
+		return
+	}
+	delete(s.heads, id)
+	s.dirty = true
+}
+
+// Flush writes the store when something changed. Temp-then-rename, so a reader
+// racing a writer sees one whole file or the other, never a half-written one.
+func (s *Store) Flush() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.dirty {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(s.heads, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".health.*.tmp")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	if _, err := tmp.Write(raw); err != nil {
+		tmp.Close()
+		os.Remove(name)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(name)
+		return err
+	}
+	if err := os.Rename(name, s.path); err != nil {
+		os.Remove(name)
+		return err
+	}
+	s.dirty = false
+	return nil
+}
+
+// cooldown backs off from the first opened failure, capped so a head that was
+// fixed hours ago is not still parked.
+func cooldown(failures int) time.Duration {
+	d := baseCooldown
+	for i := softFailuresBeforeOpen; i < failures && d < maxCooldown; i++ {
+		d *= 2
+	}
+	if d > maxCooldown {
+		return maxCooldown
+	}
+	return d
+}
+
+// fatalSignals are stderr texts that mean the head cannot serve until the
+// machine changes. Matching text is unpleasant, but a CLI head's failure
+// arrives as a subprocess exit code and a line of stderr, and treating "this
+// model does not exist" as transient retries it every minute forever.
+var fatalSignals = []string{
+	"executable file not found",
+	"invalid model selection",
+	"is not recognized as a known model",
+	"no such model",
+	"model not found",
+}
+
+// Classify decides how long a failure should park a head.
+func Classify(err error) Kind {
+	if err == nil {
+		return Transient
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return Fatal
+	}
+	msg := strings.ToLower(err.Error())
+	for _, s := range fatalSignals {
+		if strings.Contains(msg, s) {
+			return Fatal
+		}
+	}
+	return Transient
+}
+
+// humanizeUntil renders the wait, not the wall-clock time: "retrying in 4m" is
+// actionable where a timestamp needs arithmetic to read.
+func humanizeUntil(at, now time.Time) string {
+	d := at.Sub(now)
+	switch {
+	case d < time.Minute:
+		return "in under a minute"
+	case d < time.Hour:
+		return "in " + strings.TrimSuffix(d.Round(time.Minute).String(), "0s")
+	default:
+		return "in " + d.Round(time.Minute).String()
+	}
+}
+
+// Reason explains why a head cannot be dispatched to right now, or returns ""
+// when it can.
+//
+// One function so a surface that lists heads and the router that skips them
+// cannot disagree, which is the same reason executor.Unroutable exists (#248).
+// The precondition is checked first: "agy is not installed" is a better answer
+// than "failed 3 minutes ago", and it is the cause of the other.
+func Reason(s *Store, h provider.Head, now time.Time) string {
+	if why := executor.Unroutable(h); why != "" {
+		return why
+	}
+	if why, parked := s.Blocked(h.ID, now); parked {
+		return why
+	}
+	return ""
+}

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+
+package health
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+func store(t *testing.T) *Store {
+	t.Helper()
+	return Open(filepath.Join(t.TempDir(), "health.json"))
+}
+
+// A missing binary is not going to appear in sixty seconds, and the run that
+// prompted all this tried eight heads that had each already proven it.
+func TestFatalFailureParksTheHeadOnFirstSight(t *testing.T) {
+	s, now := store(t), time.Now()
+	s.Fail("opus", "agy not found", Fatal, now)
+
+	why, parked := s.Blocked("opus", now)
+	if !parked {
+		t.Fatal("a fatal failure left the head in rotation")
+	}
+	if want := "agy not found"; !strings.Contains(why, want) {
+		t.Errorf("reason = %q, want it to carry %q", why, want)
+	}
+	if !strings.Contains(why, "retrying") {
+		t.Errorf("reason = %q, want it to say when it will be retried", why)
+	}
+}
+
+// A timeout or a 500 might not recur, and parking a head on one is how a
+// working fleet talks itself into having no heads left.
+func TestTransientFailureGetsASecondChance(t *testing.T) {
+	s, now := store(t), time.Now()
+	s.Fail("flash", "timeout", Transient, now)
+	if _, parked := s.Blocked("flash", now); parked {
+		t.Fatal("one transient failure parked the head")
+	}
+	s.Fail("flash", "timeout", Transient, now)
+	if _, parked := s.Blocked("flash", now); !parked {
+		t.Error("two transient failures did not park the head")
+	}
+}
+
+func TestAParkedHeadComesBackOnItsOwn(t *testing.T) {
+	s, now := store(t), time.Now()
+	s.Fail("opus", "agy not found", Fatal, now)
+
+	if _, parked := s.Blocked("opus", now.Add(baseCooldown-time.Second)); !parked {
+		t.Error("head was let back in before its cooldown elapsed")
+	}
+	if _, parked := s.Blocked("opus", now.Add(baseCooldown+time.Second)); parked {
+		t.Error("head never came back; a breaker with no exit is a permanent outage")
+	}
+}
+
+// The breaker is closed by something working, not by time passing: a head let
+// through on trial that fails again must back off further, not be retried on
+// every dispatch.
+func TestOnlySuccessClosesTheBreaker(t *testing.T) {
+	s, now := store(t), time.Now()
+	s.Fail("opus", "boom", Fatal, now)
+	after := now.Add(baseCooldown + time.Second)
+
+	s.Fail("opus", "boom", Fatal, after)
+	if _, parked := s.Blocked("opus", after); !parked {
+		t.Fatal("a failed trial did not re-park the head")
+	}
+
+	s.Pass("opus")
+	if _, parked := s.Blocked("opus", after); parked {
+		t.Error("a success did not clear the head")
+	}
+}
+
+func TestCooldownBacksOffAndIsCapped(t *testing.T) {
+	first, second := cooldown(softFailuresBeforeOpen), cooldown(softFailuresBeforeOpen+1)
+	if second <= first {
+		t.Errorf("cooldown did not grow: %v then %v", first, second)
+	}
+	if got := cooldown(100); got != maxCooldown {
+		t.Errorf("cooldown(100) = %v, want it capped at %v", got, maxCooldown)
+	}
+}
+
+func TestStateSurvivesTheProcess(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "health.json")
+	now := time.Now()
+
+	s := Open(path)
+	s.Fail("opus", "agy not found", Fatal, now)
+	if err := s.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	if _, parked := Open(path).Blocked("opus", now); !parked {
+		t.Error("a parked head was forgotten when the process ended")
+	}
+}
+
+// Breaker state is a cache, not work someone is waiting on. Refusing to
+// dispatch because this file is corrupt would turn a bad file into an outage.
+func TestACorruptStoreStartsEmptyRatherThanFailing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "health.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, parked := Open(path).Blocked("opus", time.Now()); parked {
+		t.Error("a corrupt store parked a head it knows nothing about")
+	}
+}
+
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want Kind
+	}{
+		{"missing binary", exec.ErrNotFound, Fatal},
+		{"wrapped missing binary", errors.New(`exec: "agy": executable file not found in $PATH`), Fatal},
+		{"model agy does not have", errors.New(`invalid model selection (--model "gemini-3.5-flash")`), Fatal},
+		{"timeout", errors.New("context deadline exceeded"), Transient},
+		{"overloaded", errors.New("model overloaded, try again"), Transient},
+		{"none", nil, Transient},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Classify(c.err); got != c.want {
+				t.Errorf("Classify(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+// "agy is not installed" is a better answer than "failed 3 minutes ago", and
+// it is the cause of the other.
+func TestReasonPrefersThePreconditionOverTheBreaker(t *testing.T) {
+	s, now := store(t), time.Now()
+	broken := provider.Head{ID: "opus", Source: "registry"} // no resolved binary
+	s.Fail("opus", "failed earlier", Fatal, now)
+
+	if why := Reason(s, broken, now); !strings.Contains(why, "agy CLI is not on PATH") {
+		t.Errorf("Reason = %q, want the precondition", why)
+	}
+}
+
+func TestReasonFallsThroughToTheBreaker(t *testing.T) {
+	s, now := store(t), time.Now()
+	ok := provider.Head{ID: "opus", Source: "registry", Executable: "/usr/bin/agy"}
+
+	if why := Reason(s, ok, now); why != "" {
+		t.Fatalf("a healthy head was reported unroutable: %q", why)
+	}
+	s.Fail("opus", "overloaded", Fatal, now)
+	if why := Reason(s, ok, now); !strings.Contains(why, "overloaded") {
+		t.Errorf("Reason = %q, want the breaker's reason", why)
+	}
+}
+
+// A nil store is what every caller gets before New has run. It must read as
+// "nothing known", never panic.
+func TestANilStoreIsInert(t *testing.T) {
+	var s *Store
+	if _, parked := s.Blocked("opus", time.Now()); parked {
+		t.Error("a nil store parked a head")
+	}
+	s.Fail("opus", "boom", Fatal, time.Now())
+	s.Pass("opus")
+	if err := s.Flush(); err != nil {
+		t.Errorf("Flush on a nil store = %v", err)
+	}
+}

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -57,7 +57,7 @@ func (f *fakeProvider) Discover(ctx context.Context) ([]provider.Head, error) {
 // The first version of these tests used Provider:"test" throughout and saw
 // three heads become two, which is the dedup contract working, not a bug.
 func head(id string, score int, local bool) provider.Head {
-	return provider.Head{ID: id, Name: id, Provider: id, Source: "registry",
+	return provider.Head{ID: id, Name: id, Provider: id, Source: "registry", Executable: "/usr/bin/agy",
 		CapScore: score, LocalOnly: local, AuthReady: true}
 }
 

--- a/internal/provider/agy/provider.go
+++ b/internal/provider/agy/provider.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os/exec"
 
 	"gopkg.in/yaml.v3"
 
@@ -61,17 +62,24 @@ func (p *Provider) Discover(_ context.Context) ([]provider.Head, error) {
 		return nil, nil
 	}
 
+	// Resolved once, not per head: every model here is executed through the
+	// same binary. Left empty when it is missing, so the heads are still listed
+	// and every one of them reads as unroutable with a reason, rather than
+	// looking healthy and failing eight times per dispatch (#688).
+	agyPath, _ := exec.LookPath("agy")
+
 	var heads []provider.Head
 	for _, m := range reg.Models {
 		if m.Executor != "agy" || !m.Enabled || m.ModelFlag == "" || m.ModelFlag == "null" {
 			continue
 		}
 		heads = append(heads, provider.Head{
-			ID:       m.ID,
-			Name:     m.Name,
-			Provider: "antigravity",
-			Source:   "registry",
-			CapScore: tierScore(m.Tier),
+			ID:         m.ID,
+			Name:       m.Name,
+			Provider:   "antigravity",
+			Source:     "registry",
+			Executable: agyPath,
+			CapScore:   tierScore(m.Tier),
 			Meta: map[string]string{
 				"model_flag": m.ModelFlag,
 				"token_pool": m.TokenPool,

--- a/internal/rank/coverage_test.go
+++ b/internal/rank/coverage_test.go
@@ -78,7 +78,7 @@ func TestUITier_LocalHeadsAreAlwaysTierTen(t *testing.T) {
 // models.yaml pins an agy tier regardless of its score.
 func TestUITier_RegistryMetaTierWins(t *testing.T) {
 	h := provider.Head{
-		ID: "opus", Provider: "antigravity", Source: "registry",
+		ID: "opus", Provider: "antigravity", Source: "registry", Executable: "/usr/bin/agy",
 		CapScore: 10, // would be tier 10 by score alone
 		Meta:     map[string]string{"tier": "2"},
 	}
@@ -134,7 +134,7 @@ func TestByCapScore_SuppressesTheGenericOllamaCLIWhenPortModelsExist(t *testing.
 func TestByCapScore_TiesBreakBySourceDeterministically(t *testing.T) {
 	heads := []provider.Head{
 		{ID: "a", Provider: "openai", Source: "env", CapScore: 80},
-		{ID: "b", Provider: "openai", Source: "registry", CapScore: 80},
+		{ID: "b", Provider: "openai", Source: "registry", Executable: "/usr/bin/agy", CapScore: 80},
 	}
 	first := ByCapScore(heads)
 	for i := 0; i < 20; i++ {

--- a/internal/rank/rank_test.go
+++ b/internal/rank/rank_test.go
@@ -77,7 +77,7 @@ func TestUITier_LocalHeadsAreAlwaysTheCheapestTier(t *testing.T) {
 // intent, and inferring over it would silently ignore their edit.
 func TestUITier_ExplicitRegistryTierBeatsTheLocalRule(t *testing.T) {
 	h := provider.Head{
-		ID: "qwen-grunt", Source: "registry", LocalOnly: true, CapScore: 60,
+		ID: "qwen-grunt", Source: "registry", Executable: "/usr/bin/agy", LocalOnly: true, CapScore: 60,
 		Meta: map[string]string{"tier": "7"},
 	}
 	if got := UITier(h); got != 7 {

--- a/internal/swarm/judge_test.go
+++ b/internal/swarm/judge_test.go
@@ -435,7 +435,7 @@ func TestIDSelector_ReportsAnUnknownID(t *testing.T) {
 
 func registryHeadFor(id string, capScore int) provider.Head {
 	return provider.Head{
-		ID: id, Name: id, Provider: "agy", Source: "registry",
+		ID: id, Name: id, Provider: "agy", Source: "registry", Executable: "/usr/bin/agy",
 		CapScore: capScore, AuthReady: true,
 	}
 }

--- a/internal/swarm/swarm_test.go
+++ b/internal/swarm/swarm_test.go
@@ -18,7 +18,7 @@ import (
 // registryHead returns a head that executor.Supports() accepts (Source=="registry"),
 // so selector tests exercise real executability filtering without network.
 func registryHead(id, name string, cap int) provider.Head {
-	return provider.Head{ID: id, Name: name, Provider: "agy", Source: "registry", CapScore: cap}
+	return provider.Head{ID: id, Name: name, Provider: "agy", Source: "registry", Executable: "/usr/bin/agy", CapScore: cap}
 }
 
 // ── Attempt / SwarmResult ──────────────────────────────────────────────────────

--- a/internal/tui/view_models.go
+++ b/internal/tui/view_models.go
@@ -17,7 +17,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/ankit373/hydra/internal/executor"
+	"github.com/ankit373/hydra/internal/health"
 	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/probe"
 	"github.com/ankit373/hydra/internal/provider"
@@ -72,16 +72,17 @@ func ckGroupHeads(heads []provider.Head) []ckModelGroup {
 		groups = append(groups, ckModelGroup{name: name})
 		return len(groups) - 1
 	}
+	hs, now := health.Open(health.DefaultPath()), time.Now()
 	for _, h := range heads {
 		name, isBinary := ckServerFor(h)
 		i := at(name)
 		if isBinary {
 			// The binary alone is not routable; keep its reason as the group's
 			// server-down note, used only if no routable child shows up.
-			groups[i].note = executor.Unroutable(h)
+			groups[i].note = health.Reason(hs, h, now)
 			continue
 		}
-		reason := executor.Unroutable(h)
+		reason := health.Reason(hs, h, now)
 		groups[i].rows = append(groups[i].rows, ckModelRow{
 			id:       h.ID,
 			name:     ckStripGroupSuffix(h.Name, name),

--- a/internal/tui/view_models_test.go
+++ b/internal/tui/view_models_test.go
@@ -112,9 +112,9 @@ func TestViewModels_TreeRendering(t *testing.T) {
 // distinguishing tail survives (the issue's own Gemini example).
 func TestViewModels_SmartTruncationInTree(t *testing.T) {
 	heads := []provider.Head{
-		{ID: "g1", Name: "Gemini 3.5 Flash (High) with an extremely long suffix", Provider: "antigravity", Source: "registry", AuthReady: true},
-		{ID: "g2", Name: "Gemini 3.5 Flash (Medium) with an extremely long suffix", Provider: "antigravity", Source: "registry", AuthReady: true},
-		{ID: "g3", Name: "Gemini 3.5 Flash (Low) with an extremely long suffix", Provider: "antigravity", Source: "registry", AuthReady: true},
+		{ID: "g1", Name: "Gemini 3.5 Flash (High) with an extremely long suffix", Provider: "antigravity", Source: "registry", Executable: "/usr/bin/agy", AuthReady: true},
+		{ID: "g2", Name: "Gemini 3.5 Flash (Medium) with an extremely long suffix", Provider: "antigravity", Source: "registry", Executable: "/usr/bin/agy", AuthReady: true},
+		{ID: "g3", Name: "Gemini 3.5 Flash (Low) with an extremely long suffix", Provider: "antigravity", Source: "registry", Executable: "/usr/bin/agy", AuthReady: true},
 	}
 	m := testCockpit()
 	m.groups = ckGroupHeads(heads)


### PR DESCRIPTION
## Summary

A run in the desktop app selected eight agy heads in sequence, each failing
identically, before landing on Ollama. All eight were reported healthy first.

```
HEAD SELECTED  Claude Opus 4.6 (Thinking)   T2  candidate 1 of 10
ERROR          agy exec opus-thinking: exec: "agy": executable file not found in $PATH
HEAD SELECTED  Claude Sonnet 4.6 (Thinking) T3  candidate 2 of 10
ERROR          agy exec sonnet-thinking: exec: "agy": executable file not found in $PATH
... six more ...
DISPATCH FINISHED  Qwen2.5-Coder:7b  T10  12.2s
```

## What was wrong

**Registry heads were routable by assertion.** `executor.Unroutable` returned
`""` for `Source == "registry"` with a comment saying AgyExecutor handles them.
Nothing checked that the binary AgyExecutor execs exists. `hyctl probe`
correctly marks Ollama-without-a-server as unroutable and gives a reason, then
reported eight agy heads as healthy when `agy` could not be found at all.

**Nothing remembered a failure.** The first `executable file not found` already
proved the next seven would fail the same way. Each candidate was tried on its
own merits, and the knowledge did not survive the run either.

## Changes

- `internal/provider/agy` resolves `agy` once and stamps the path on each head,
  the way `internal/provider/cli` already does. A head without one is
  unroutable with a reason.
- `internal/executor` uses that resolved path instead of resolving it again.
  Execution and `Unroutable` disagreeing is how this started, so a head that
  arrives without a path is refused rather than quietly looked up.
- `internal/health` is a per-head circuit breaker. A missing binary or an
  unknown model parks a head on sight; a timeout gets a second chance; the wait
  doubles from 1 minute to a 30 minute ceiling. Only a success closes a
  breaker, so a still-broken head backs off further rather than being retried
  every dispatch. State lives in one file, so the app and the CLI agree.
- Parked heads are filtered out of the candidate list, not tried and skipped.
- `probe`, the TUI models view and the desktop all read `health.Reason`, so
  nothing that cannot serve is shown as active anywhere.

## Verification

Built and run against this machine, not just the test suite.

With `agy` off PATH, which is exactly the app's situation:

```
✗ Claude Opus 4.6 (Thinking)   92  registry  antigravity
    ↳ the agy CLI is not on PATH, so nothing can drive this head
... all eight ...
✗ = discovered but not routable (9 of 11), dispatch will skip these.
```

With `agy` present, `--tier 7` hit the three flash heads, which fail for a
separate reason (#690). They parked themselves on the first failure:

```
flash-high | invalid model selection | kind 1 | retryAt 15:14:08
flash-med  | invalid model selection | kind 1 | retryAt 15:14:18
flash-low  | invalid model selection | kind 1 | retryAt 15:14:26
```

and the next dispatch no longer offered them at all:

```
Primary  →  Qwen2.5-Coder:7b (Ollama)  (score 66, port)
Fallback chain:
  1. qwen3:0.6b (Ollama)  score 63  port
```

The full suite passes with the race detector, and also with `agy` absent from
PATH, which it did not before: that configuration is what CI runs, and 24 tests
were passing only because `Unroutable` never checked anything.

## Note on the test churn

The fixture changes are one line each: a registry head now carries the resolved
path. A fixture without one represents a head that never went through
discovery, which is not a head Hydra would ever route to.

## Related

`agy` being absent in the app is #689. The stale model flags that break the
flash heads even when `agy` is present are #690. This PR makes both of them
visible instead of silent.

Closes #688