### PR TITLE
fix(app,tui): recover the user's PATH when started without one

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/security"
+	"github.com/ankit373/hydra/internal/shellpath"
 	"github.com/ankit373/hydra/internal/swarm"
 	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/tui"
@@ -68,6 +69,11 @@ import (
 )
 
 func main() {
+	// Before any command discovers heads. A hyctl or `hyctl tui` started by
+	// something other than a shell, a launcher or an IDE, gets a PATH with no
+	// CLI head in it at all (#689). No-op when a shell already set one.
+	shellpath.Adopt()
+
 	// Fire update check in the background, never blocks startup.
 	updateCh := update.CheckAsync()
 

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 
 	"github.com/ankit373/hydra/desktop/api"
+	"github.com/ankit373/hydra/internal/shellpath"
 
 	// Self-registering discovery plugins. Without these, provider.All() is
 	// empty and every chat dispatch reports zero heads, no matter what is
@@ -42,6 +43,10 @@ import (
 var assets embed.FS
 
 func main() {
+	// Before anything discovers heads. launchd starts this process with a PATH
+	// that contains no CLI head at all (#689).
+	shellpath.Adopt()
+
 	a := api.New()
 
 	err := wails.Run(&options.App{

--- a/internal/shellpath/shellpath.go
+++ b/internal/shellpath/shellpath.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+
+package shellpath
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// A login shell is a subprocess and startup waits on it, so the budget is small
+// and a slow shell costs nothing but the CLI heads it would have found.
+const loginPathTimeout = 3 * time.Second
+
+// Adopt merges the PATH a login shell would have into this process's, when the
+// process was started without one.
+//
+// A program launched from Finder, the Dock or a .desktop file is started by the
+// system launcher, which never reads a shell profile, so it gets
+// PATH=/usr/bin:/bin:/usr/sbin:/sbin. Every CLI head lives outside that, and
+// internal/provider/cli discovers heads with exec.LookPath, so the desktop app
+// silently found none of them while the same hyctl in a terminal found them all
+// (#689).
+//
+// Guarded on the PATH already being bare, because asking a shell costs about a
+// second and a process started from a terminal already has the answer.
+func Adopt() {
+	if runtime.GOOS == "windows" {
+		return // PATH comes from the registry, not a shell profile
+	}
+	if !looksBare(os.Getenv("PATH")) {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), loginPathTimeout)
+	defer cancel()
+	if merged := mergePath(os.Getenv("PATH"), loginPath(ctx)); merged != "" {
+		os.Setenv("PATH", merged)
+	}
+}
+
+// systemDirs are what a launcher hands a process when nothing has set PATH.
+// Anything outside this set means a shell profile has already been read.
+var systemDirs = map[string]bool{
+	"/usr/bin": true, "/bin": true, "/usr/sbin": true, "/sbin": true,
+	"/usr/local/bin": true, "/usr/local/sbin": true,
+}
+
+// looksBare reports whether PATH holds nothing but system directories, which is
+// the signature of a launcher start rather than a shell.
+func looksBare(path string) bool {
+	for _, dir := range strings.Split(path, string(os.PathListSeparator)) {
+		if dir != "" && !systemDirs[dir] {
+			return false
+		}
+	}
+	return true
+}
+
+// loginPath asks the user's shell what PATH it sets up, or returns "" if it
+// cannot say. Interactive as well as login: a great many people set PATH in
+// .zshrc, which a login shell alone does not read.
+func loginPath(ctx context.Context) string {
+	sh := os.Getenv("SHELL")
+	if sh == "" {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, sh, "-ilc", "printf %s \"$PATH\"").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// mergePath appends whatever the login shell knows that this process does not,
+// preserving order and dropping duplicates.
+//
+// Appended rather than replaced: the running process's PATH may carry entries
+// the shell has no idea about, and losing one to gain another is not a fix.
+func mergePath(current, login string) string {
+	if login == "" {
+		return ""
+	}
+	seen := map[string]bool{}
+	var out []string
+	add := func(list string) {
+		for _, dir := range strings.Split(list, string(os.PathListSeparator)) {
+			if dir == "" || seen[dir] {
+				continue
+			}
+			seen[dir] = true
+			out = append(out, dir)
+		}
+	}
+	add(current)
+	add(login)
+	if len(out) == 0 {
+		return ""
+	}
+	return strings.Join(out, string(os.PathListSeparator))
+}

--- a/internal/shellpath/shellpath_test.go
+++ b/internal/shellpath/shellpath_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+
+package shellpath
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func sep(parts ...string) string { return strings.Join(parts, string(os.PathListSeparator)) }
+
+// The reported case: launchd's PATH has none of the directories a CLI head
+// lives in, so discovery finds nothing the same machine's terminal finds.
+func TestMergePath_AddsWhatTheShellKnows(t *testing.T) {
+	got := mergePath(sep("/usr/bin", "/bin"), sep("/usr/bin", "/Users/x/.local/bin", "/opt/homebrew/bin"))
+	want := sep("/usr/bin", "/bin", "/Users/x/.local/bin", "/opt/homebrew/bin")
+	if got != want {
+		t.Errorf("mergePath =\n %q\nwant\n %q", got, want)
+	}
+}
+
+// The process may hold entries the shell has never heard of. Replacing rather
+// than merging would trade one missing head for another.
+func TestMergePath_KeepsEntriesTheShellDoesNotHave(t *testing.T) {
+	got := mergePath(sep("/opt/only-in-process"), sep("/usr/bin"))
+	if !strings.Contains(got, "/opt/only-in-process") {
+		t.Errorf("mergePath = %q, dropped an entry the process already had", got)
+	}
+}
+
+func TestMergePath_NoDuplicates(t *testing.T) {
+	got := mergePath(sep("/usr/bin", "/bin"), sep("/bin", "/usr/bin"))
+	if got != sep("/usr/bin", "/bin") {
+		t.Errorf("mergePath = %q, want the duplicates collapsed", got)
+	}
+}
+
+// A shell that cannot be run, or is not configured, must leave PATH alone
+// rather than truncating it to nothing.
+func TestMergePath_NoLoginPathChangesNothing(t *testing.T) {
+	if got := mergePath(sep("/usr/bin", "/bin"), ""); got != "" {
+		t.Errorf("mergePath = %q, want \"\" so the caller leaves PATH untouched", got)
+	}
+}
+
+// Exercised through a deliberately bare PATH, which is the only state Adopt
+// acts on: with this machine's real PATH the guard returns first and the test
+// would assert nothing while passing.
+func TestAdopt_RecoversTheShellsPathFromABareOne(t *testing.T) {
+	bare := sep("/usr/bin", "/bin", "/usr/sbin", "/sbin")
+	t.Setenv("PATH", bare)
+	Adopt()
+
+	got := os.Getenv("PATH")
+	if got == "" {
+		t.Fatal("Adopt emptied PATH")
+	}
+	for _, dir := range strings.Split(bare, string(os.PathListSeparator)) {
+		if !strings.Contains(got, dir) {
+			t.Errorf("Adopt dropped %q from PATH", dir)
+		}
+	}
+	if os.Getenv("SHELL") != "" && got == bare {
+		t.Errorf("PATH = %q, want the shell's own entries merged in", got)
+	}
+}
+
+// The guard is what makes this safe to call from every hyctl command: asking a
+// shell costs about a second, and a process started from a terminal already
+// knows the answer.
+func TestLooksBare(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"launchd's default", sep("/usr/bin", "/bin", "/usr/sbin", "/sbin"), true},
+		{"system dirs only", sep("/usr/bin", "/bin", "/usr/local/bin"), true},
+		{"a shell profile has run", sep("/Users/x/.local/bin", "/usr/bin", "/bin"), false},
+		{"homebrew present", sep("/opt/homebrew/bin", "/usr/bin"), false},
+		{"empty", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := looksBare(c.path); got != c.want {
+				t.Errorf("looksBare(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+}
+
+// A terminal-started process must not pay for a subprocess it does not need.
+func TestAdopt_LeavesARealPathUntouched(t *testing.T) {
+	real := sep("/Users/x/.local/bin", "/usr/bin", "/bin")
+	t.Setenv("PATH", real)
+	Adopt()
+	if got := os.Getenv("PATH"); got != real {
+		t.Errorf("PATH = %q, want it untouched at %q", got, real)
+	}
+}


### PR DESCRIPTION
## Summary

The desktop app discovers no CLI heads at all, and it is not a routing bug.
A program launched from Finder, the Dock or a `.desktop` file is started by the
system launcher, which never reads a shell profile:

```
Hydra.app   PATH=/usr/bin:/bin:/usr/sbin:/sbin
login shell PATH=~/.local/bin:~/go/bin:/opt/homebrew/bin:...
```

`internal/provider/cli` resolves each head with `exec.LookPath` and skips it on
failure, so `agy`, `codex` and `claude` are never discovered. They are not
filtered out, they do not exist.

The candidate count in a real run confirmed it exactly. The app reported
"candidate 1 of 10":

| Source | Heads | Seen by the app |
|---|---|---|
| cli (claude, codex, agy) | 3 | 0, no binary on PATH |
| registry (8 agy tiers) | 8 | 8, read from models.yaml, needs no binary |
| port (Ollama) | 2 | 2, reached over HTTP |

Ollama answered only because it is HTTP and needs no binary.

## Changes

- `internal/shellpath` asks the user's shell for its PATH and merges it in.
  Appended rather than replaced: the process may hold entries the shell has
  never heard of, and losing one to gain another is not a fix.
- Guarded on the current PATH holding nothing but system directories, which is
  the signature of a launcher start. A process started from a terminal already
  has the answer and pays nothing.
- Called from `desktop/main.go` and from `cmd/hydra`, so `hyctl tui` gets the
  same recovery whatever launched it. The guard is what makes it safe on every
  hyctl invocation: asking a shell costs about a second.

## Verification

Both binaries run with the app's exact PATH.

Patched:

```
$ env PATH=/usr/bin:/bin:/usr/sbin:/sbin ./hyctl probe
   ⚡ CORTEX  ──▶ Claude Code
→ Claude Code      95  cli  anthropic
  OpenAI Codex     88  cli  openai
  Antigravity      80  cli  antigravity
```

Released v1.4.1, same command: none of those three appear.

`TestAdopt_RecoversTheShellsPathFromABareOne` drives a deliberately bare PATH,
since with a real one the guard returns first and the test would assert nothing
while passing.

## Related

#688 makes a head that cannot be executed report as unroutable instead of
healthy, which is what let this stay invisible. #690 is the stale agy model
flags, which break the agy heads even once this lands.

Closes #689