### PR TITLE
fix(registry): point the agy heads at models agy actually has

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -438,16 +438,15 @@ MODE                 <span class="tf">│</span>                                
 <span class="tf">│</span>                                                                 <span class="tf">│</span> <span class="tf">│</span>                             <span class="tf">│</span>
 <span class="tf">│</span> <span class="tf">▸</span> <span class="tf">▾</span> <span class="ta">●</span> anthropic                  1 model                        <span class="tf">│</span> <span class="tf">│</span>  anthropic                  <span class="tf">│</span>
 <span class="tf">│</span>      <span class="ta">●</span> Claude Code             <span class="tv">T1</span>                               <span class="tf">│</span> <span class="tf">│</span>                             <span class="tf">│</span>
-<span class="tf">│</span>   <span class="tf">▾</span> <span class="ta">●</span> antigravity                9 models                       <span class="tf">│</span> <span class="tf">│</span>  models      1 (1 routable) <span class="tf">│</span>
+<span class="tf">│</span>   <span class="tf">▾</span> <span class="ta">●</span> antigravity                8 models                       <span class="tf">│</span> <span class="tf">│</span>  models      1 (1 routable) <span class="tf">│</span>
 <span class="tf">│</span>      <span class="ta">●</span> Claude Opus 4.6 (Thin…  <span class="tv">T2</span>                               <span class="tf">│</span> <span class="tf">│</span>  state       up             <span class="tf">│</span>
 <span class="tf">│</span>      <span class="ta">●</span> Claude Sonnet 4.6 (Th…  <span class="tv">T3</span>                               <span class="tf">│</span> <span class="tf">╰─────────────────────────────╯</span>
-<span class="tf">│</span>      <span class="ta">●</span> Gemini 2.0 Flash Thin…  <span class="tv">T4</span>                               <span class="tf">│</span>
 <span class="tf">│</span>      <span class="ta">●</span> Antigravity             <span class="tv">T4</span>                               <span class="tf">│</span>
 <span class="tf">│</span>      <span class="ta">●</span> Gemini 3.1 Pro (High)   <span class="tv">T5</span>                               <span class="tf">│</span>
 <span class="tf">│</span>      <span class="ta">●</span> Gemini 3.1 Pro (Low)    <span class="tv">T6</span>                               <span class="tf">│</span>
-<span class="tf">│</span>      <span class="ta">●</span> …3.5 Flash (High)       <span class="tv">T7</span>                               <span class="tf">│</span>
-<span class="tf">│</span>      <span class="ta">●</span> …3.5 Flash (Medium)     <span class="tv">T8</span>                               <span class="tf">│</span>
-<span class="tf">│</span>      <span class="ta">●</span> …3.5 Flash (Low)        <span class="tv">T9</span>                               <span class="tf">│</span>
+<span class="tf">│</span>      <span class="ta">●</span> …3.8 Flash (High)       <span class="tv">T7</span>                               <span class="tf">│</span>
+<span class="tf">│</span>      <span class="ta">●</span> …3.8 Flash (Medium)     <span class="tv">T8</span>                               <span class="tf">│</span>
+<span class="tf">│</span>      <span class="ta">●</span> …3.8 Flash (Low)        <span class="tv">T9</span>                               <span class="tf">│</span>
 <span class="tf">│</span>   <span class="tf">▾</span> <span class="ta">●</span> openai                     1 model                        <span class="tf">│</span>
 <span class="tf">│</span>      <span class="ta">●</span> OpenAI Codex            <span class="tv">T3</span>                               <span class="tf">│</span>
 <span class="tf">│</span>   <span class="tf">▾</span> <span class="ta">●</span> Ollama                     3 models                       <span class="tf">│</span>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -86,7 +86,7 @@ git clone https://github.com/ankit373/hydra && cd hydra && go build ./cmd/hydra
 
 You pay the underlying model providers directly:
 - Claude Opus: ~$15/M output tokens (Anthropic)
-- Gemini 2.0 Flash: ~$0.075/M input (Google)
+- Gemini 3.8 Flash: $0.075-0.30/M input depending on tier (Google, via Antigravity)
 - Qwen local via Ollama: $0
 
 Typical savings: 75-85% vs routing everything through Claude. Run `hyctl pricing list` for live rates.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -24,7 +24,7 @@ Hydra itself is free. The underlying models charge per token:
 | Claude Opus 4.7 | 1 | ~$15/M tokens | ~$75/M tokens | Anthropic |
 | Claude Sonnet 4.6 | 2-3 | ~$3/M tokens | ~$15/M tokens | Anthropic |
 | Gemini 2.5 Pro | 4-5 | ~$1.25/M tokens | ~$10/M tokens | Google |
-| Gemini 2.0 Flash | 6-8 | ~$0.075/M tokens | ~$0.30/M tokens | Google |
+| Gemini 3.8 Flash | 7-9 | $0.075-0.30/M tokens | $0.63-2.50/M tokens | Google, via Antigravity |
 | Qwen3 (local) | 9-10 | $0 | $0 | Ollama, runs locally |
 
 Run `hyctl pricing list` for live rates fetched from OpenRouter.

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://hydra.uvansa.com/docs.html</loc>
-    <lastmod>2026-09-05</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://hydra.uvansa.com/pricing.html</loc>
-    <lastmod>2026-09-05</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/registry/models.yaml
+++ b/registry/models.yaml
@@ -134,7 +134,7 @@ models:
     name: "Claude Sonnet 4.6 (Thinking)"
     provider: antigravity
     executor: agy
-    model_flag: "claude-sonnet-4-6-thinking"
+    model_flag: "claude-sonnet-4-6"
     token_pool: agy_claude
     enabled: true
     context_window: 200000
@@ -158,7 +158,11 @@ models:
     executor: agy
     model_flag: "gemini-2.0-flash-thinking-exp"
     token_pool: agy_flash_thinking
-    enabled: true
+    # agy no longer offers a thinking-flash model, and nothing it does offer is
+    # a like-for-like replacement. Off rather than repointed: choosing a
+    # stand-in is a routing decision, not a data fix. `agy models` lists what
+    # this install actually has.
+    enabled: false
     context_window: 1000000
     tokens_per_call: medium
     speed: fast
@@ -178,7 +182,7 @@ models:
     name: "Gemini 3.1 Pro (High)"
     provider: antigravity
     executor: agy
-    model_flag: "gemini-3.1-pro"
+    model_flag: "gemini-3.1-pro-high"
     token_pool: agy_gemini_pro
     enabled: true
     context_window: 1000000
@@ -219,10 +223,10 @@ models:
 
   - tier: 7
     id: flash-high
-    name: "Gemini 3.5 Flash (High)"
+    name: "Gemini 3.8 Flash (High)"
     provider: antigravity
     executor: agy
-    model_flag: "gemini-3.5-flash-high"
+    model_flag: "gemini-3.8-flash-high"
     token_pool: agy_flash
     enabled: true
     context_window: 1000000
@@ -241,10 +245,10 @@ models:
 
   - tier: 8
     id: flash-med
-    name: "Gemini 3.5 Flash (Medium)"
+    name: "Gemini 3.8 Flash (Medium)"
     provider: antigravity
     executor: agy
-    model_flag: "gemini-3.5-flash"
+    model_flag: "gemini-3.8-flash-medium"
     token_pool: agy_flash
     enabled: true
     context_window: 1000000
@@ -263,10 +267,10 @@ models:
 
   - tier: 9
     id: flash-low
-    name: "Gemini 3.5 Flash (Low)"
+    name: "Gemini 3.8 Flash (Low)"
     provider: antigravity
     executor: agy
-    model_flag: "gemini-3.5-flash-low"
+    model_flag: "gemini-3.8-flash-low"
     token_pool: agy_flash
     enabled: true
     context_window: 1000000

--- a/registry/pricing.yaml
+++ b/registry/pricing.yaml
@@ -55,17 +55,17 @@ tiers:
     input_per_million: 1.25
     output_per_million: 5.00
 
-  7:  # Gemini 3.5 Flash (High)
+  7:  # Gemini 3.8 Flash (High)
     id: flash-high
     input_per_million: 0.30
     output_per_million: 2.50
 
-  8:  # Gemini 3.5 Flash (Medium)
+  8:  # Gemini 3.8 Flash (Medium)
     id: flash-med
     input_per_million: 0.15
     output_per_million: 1.25
 
-  9:  # Gemini 3.5 Flash (Low)
+  9:  # Gemini 3.8 Flash (Low)
     id: flash-low
     input_per_million: 0.075
     output_per_million: 0.625

--- a/registry/routing.yaml
+++ b/registry/routing.yaml
@@ -17,13 +17,13 @@ routing_map:
   GRUNT:      10   # → Qwen2.5-Coder:7b (Ollama, local)
 
   # Trivial agy work, enums, constants, simple types
-  TRIVIAL:    9    # → Gemini 3.5 Flash (Low)
+  TRIVIAL:    9    # → Gemini 3.8 Flash (Low)
 
   # Simple structured code, DTOs, schemas, interfaces
-  SIMPLE:     8    # → Gemini 3.5 Flash (Medium)
+  SIMPLE:     8    # → Gemini 3.8 Flash (Medium)
 
   # Standard patterns, controllers, handlers, basic CRUD
-  STANDARD:   7    # → Gemini 3.5 Flash (High)
+  STANDARD:   7    # → Gemini 3.8 Flash (High)
 
   # Moderate logic, services, repos, validators
   MODERATE:   6    # → Gemini 3.1 Pro (Low)


### PR DESCRIPTION
## Summary

Six of the eight agy heads named models agy 1.1.27 does not have, so each
failed at execution and the router fell through to Ollama. Reproduced straight
against the CLI, with the exact command the executor builds:

```
$ agy --print "..." --model gemini-3.5-flash --print-timeout 60s
Error: invalid model selection (--model "gemini-3.5-flash" --effort ""):
model gemini-3.5-flash is not recognized as a known model or custom model in settings
```

## Changes

Taken from `agy models`, which is agy's own catalogue:

| Head | Was | Now |
|---|---|---|
| sonnet-thinking | `claude-sonnet-4-6-thinking` | `claude-sonnet-4-6` |
| pro-high | `gemini-3.1-pro` | `gemini-3.1-pro-high` |
| flash-high | `gemini-3.5-flash-high` | `gemini-3.8-flash-high` |
| flash-med | `gemini-3.5-flash` | `gemini-3.8-flash-medium` |
| flash-low | `gemini-3.5-flash-low` | `gemini-3.8-flash-low` |
| opus-thinking | `claude-opus-4-6-thinking` | unchanged, still valid |
| pro-low | `gemini-3.1-pro-low` | unchanged, still valid |

`flash-thinking` is **disabled** rather than repointed. agy dropped the
thinking-flash line entirely and offers nothing like-for-like; choosing a
stand-in is a routing decision, not a data fix. `gpt-oss-120b-medium` is new in
agy's catalogue and has no head here, which is the same kind of call and is
left to you.

Docs shipped with it: the registry comments, the pricing rows in `pricing.md`
and `llms.txt`, and the TUI mock in `docs.html`, which listed the head that no
longer exists and an antigravity count of 9.

## Verification

Every enabled flag checked against `agy models`: 7 valid, 0 invalid.

A real dispatch through a head that was broken before this:

```
$ hyctl dispatch --tier 7 "Reply with exactly the word: OK"
  ▶ Gemini 3.8 Flash (High)  (7→0 tokens)  16043ms
OK
```

The two flags that could not be reached that way were invoked directly:

```
claude-sonnet-4-6          OK
gemini-3.1-pro-high        OK
```

## On preventing the next drift

This is the second time this file has gone stale, so I tried to add a test that
cross-checks `models.yaml` against `agy models`. I removed it: it can never run
where it matters. CI has no agy, and a test process here has no network, so it
skipped in both. A test that always skips is noise that misleads the next
reader.

The durable protection is #688 instead: `invalid model selection` is classified
as a fatal failure, so a head with a stale flag now parks itself on the first
attempt, is dropped from the candidate list, and shows in `hyctl probe` with the
real reason and when it will be retried. Drift becomes visible and harmless
instead of silent.

Closes #690