### PR TITLE
fix(security): stop reporting ordinary history as tampering

### DIFF
--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -133,6 +133,52 @@ type Event struct {
 	Config string `json:"config,omitempty"`
 }
 
+// maxFieldLen bounds an identity field. The value that prompted this was a
+// captured progress line, not a name, and no real agent or tool needs more.
+const maxFieldLen = 256
+
+// SafeText strips control characters from a value that will be recorded or
+// displayed as an identity.
+//
+// A real ledger on a real machine held a tool name of
+// "gpt\x1b[2K\r  VERDICT  OK  no findings", captured terminal output complete
+// with an erase-line escape. Printed into a report that is read in a terminal,
+// ESC[2K\r erases the line and returns the carriage, so the value can hide the
+// findings around it. An accountability record that can rewrite its own
+// presentation is not one (#688 QA).
+func SafeText(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == '\t':
+			b.WriteByte(' ')
+		case r < 0x20 || r == 0x7f: // C0 and DEL
+			b.WriteByte(' ')
+		case r >= 0x80 && r <= 0x9f: // C1, where ESC-less escapes live
+			b.WriteByte(' ')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if len(out) > maxFieldLen {
+		out = out[:maxFieldLen] + "…"
+	}
+	return out
+}
+
+// sanitize cleans every field an event carries that is rendered as text.
+// Applied in Record, before the hash is computed, so the stored value and the
+// hashed value are the same thing.
+func (e Event) sanitize() Event {
+	e.Agent = SafeText(e.Agent)
+	e.Tool = SafeText(e.Tool)
+	e.Resource = SafeText(e.Resource)
+	e.Reason = SafeText(e.Reason)
+	e.FlagReason = SafeText(e.FlagReason)
+	return e
+}
+
 // HashParams returns a SHA256 hex hash of params, for tamper-evident binding
 // between an access decision and the parameters actually used at execution
 // time. Go's json.Marshal sorts map[string]any keys, so this is canonical
@@ -240,6 +286,7 @@ func Record(path string, e Event) error {
 	}
 	defer lock.unlock()
 
+	e = e.sanitize()
 	if e.PrevHash == "" {
 		e.PrevHash = readChainHash(chainHashPath(path))
 	}
@@ -313,6 +360,18 @@ type ChainResult struct {
 	// AnchorMissing is true when there is no sidecar to verify against, so
 	// truncation cannot be ruled out either way. Never reported as intact.
 	AnchorMissing bool `json:"anchor_missing,omitempty"`
+
+	// Restarts counts chained events that carry no PrevHash, each of which
+	// begins a fresh segment. Record leaves PrevHash empty whenever the
+	// sidecar anchor is unreadable, so this is an ordinary consequence of a
+	// best-effort write, not evidence of tampering (#688 QA).
+	Restarts int `json:"restarts,omitempty"`
+
+	// Forks counts events whose PrevHash names an earlier event that is still
+	// in the log, rather than the immediately preceding one. Two concurrent
+	// Record calls that read the anchor before either wrote it both link to
+	// the same predecessor; nothing was removed or altered.
+	Forks int `json:"forks,omitempty"`
 }
 
 // VerifyChain walks path's events in order, recomputing each chained event's
@@ -345,7 +404,24 @@ func VerifyChainEvents(events []Event, path string) ChainResult {
 		res.Chained++
 		seen[e.Hash] = true
 		broken := hashEvent(e) != e.Hash
-		if chainStarted && e.PrevHash != prevHash {
+		switch {
+		case !chainStarted:
+			// Nothing to link to yet.
+		case e.PrevHash == "":
+			// A fresh segment, not a break. Record writes PrevHash from the
+			// sidecar anchor and leaves it empty when that read fails, so an
+			// unlinked event is the documented outcome of a best-effort write.
+			// Safe to allow: PrevHash is covered by the event's own Hash, so
+			// stripping one to hide a deletion fails the hash check above.
+			res.Restarts++
+		case e.PrevHash != prevHash && seen[e.PrevHash]:
+			// A fork: this event links to an earlier event that is still
+			// present, which is what two concurrent appends produce. A
+			// deletion cannot look like this, because the record it removed
+			// is by definition no longer in the log, and an attacker cannot
+			// re-point the link without breaking this event's own hash.
+			res.Forks++
+		case e.PrevHash != prevHash:
 			broken = true
 		}
 		if broken && res.Intact {
@@ -833,7 +909,10 @@ func ByHeadRisk(events []Event) []HeadRisk {
 	}
 	out := make([]HeadRisk, 0, len(byHead))
 	for head, a := range byHead {
-		out = append(out, HeadRisk{Head: head, Denied: a.denied, Flagged: a.flagged})
+		// Events recorded before Record sanitized are still in the log and
+		// cannot be rewritten without invalidating their hashes, so the value
+		// is cleaned on the way out too.
+		out = append(out, HeadRisk{Head: SafeText(head), Denied: a.denied, Flagged: a.flagged})
 	}
 	sort.Slice(out, func(i, j int) bool {
 		ri, rj := out[i].Denied+out[i].Flagged, out[j].Denied+out[j].Flagged

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -1075,3 +1075,209 @@ func TestCheck_UnhashableParamsStillDeniesNeverAsks(t *testing.T) {
 		t.Errorf("Check = %q on unhashable params, want %q, a failure path must not ask", got, Deny)
 	}
 }
+
+// Record leaves PrevHash empty whenever the sidecar anchor cannot be read,
+// which is a documented best-effort outcome, and the verifier called the next
+// event a break. On a real machine that surfaced as "BROKEN: tampering
+// detected at event index 29" on a ledger nobody had touched. A security check
+// that cries wolf on ordinary history is one people learn to ignore.
+func TestVerifyChain_AMissingPrevHashIsARestartNotTampering(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	for i := 0; i < 3; i++ {
+		if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Exactly what a lost anchor produces: an event with its own valid hash
+	// and no link back.
+	os.Remove(chainHashPath(path))
+	if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Intact {
+		t.Errorf("ChainResult = %+v, want intact: an unlinked event is a restart, not tampering", res)
+	}
+	if res.Restarts != 1 {
+		t.Errorf("Restarts = %d, want 1", res.Restarts)
+	}
+}
+
+// The reason the restart above is safe to allow: PrevHash is covered by the
+// event's own Hash, so an attacker who deletes a record and strips the next
+// event's link to hide the gap invalidates that event's hash and is caught
+// anyway. If this ever fails, the restart allowance has become a way to
+// launder a deletion.
+func TestVerifyChain_StrippingPrevHashToHideADeletionIsStillCaught(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	for i := 0; i < 4; i++ {
+		if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+
+	// Delete a middle event, then strip the following event's PrevHash so the
+	// walk has nothing to compare.
+	var e Event
+	if err := json.Unmarshal([]byte(lines[2]), &e); err != nil {
+		t.Fatal(err)
+	}
+	e.PrevHash = ""
+	relinked, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines = append(lines[:1], append([]string{string(relinked)}, lines[3:]...)...)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Intact {
+		t.Fatal("a deletion hidden by stripping PrevHash reported as intact")
+	}
+}
+
+// A real ledger held a tool name of "gpt\x1b[2K\r  VERDICT  OK  no findings":
+// captured terminal output, escape codes and all, stored as an identity and
+// rendered verbatim in the security report. ESC[2K\r erases the line and
+// returns the carriage, so the value can hide the findings printed around it.
+func TestSafeText_StripsTerminalControlCharacters(t *testing.T) {
+	got := SafeText("gpt\x1b[2K\r  VERDICT  OK  no findings")
+	if strings.ContainsRune(got, 0x1b) || strings.ContainsRune(got, '\r') {
+		t.Errorf("SafeText = %q, still carries control characters", got)
+	}
+	if !strings.HasPrefix(got, "gpt") {
+		t.Errorf("SafeText = %q, want the readable text kept", got)
+	}
+}
+
+func TestSafeText_BoundsRunawayValues(t *testing.T) {
+	if got := SafeText(strings.Repeat("x", maxFieldLen*2)); len(got) > maxFieldLen+4 {
+		t.Errorf("SafeText returned %d bytes, want it bounded near %d", len(got), maxFieldLen)
+	}
+}
+
+func TestRecord_StoresIdentitiesWithoutControlCharacters(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	if err := Record(path, Event{Agent: "claude", Tool: "gpt\x1b[2K\rVERDICT OK", Decision: Deny}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.ContainsRune(events[0].Tool, 0x1b) {
+		t.Errorf("Tool = %q, an escape sequence was stored verbatim", events[0].Tool)
+	}
+	// Sanitizing must happen before the hash, or every sanitized event reads
+	// as tampered.
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Intact {
+		t.Errorf("ChainResult = %+v, want intact: sanitizing must precede hashing", res)
+	}
+}
+
+// The events already on disk cannot be rewritten, so the risk table cleans
+// them as it renders.
+func TestByHeadRisk_CleansIdentitiesFromExistingHistory(t *testing.T) {
+	got := ByHeadRisk([]Event{{Tool: "gpt\x1b[2K\rVERDICT OK", Decision: Deny}})
+	if len(got) != 1 {
+		t.Fatalf("ByHeadRisk returned %d rows, want 1", len(got))
+	}
+	if strings.ContainsRune(got[0].Head, 0x1b) {
+		t.Errorf("Head = %q, rendered an escape sequence from stored history", got[0].Head)
+	}
+}
+
+// Two concurrent appends that both read the anchor before either wrote it
+// link to the same predecessor. Nothing was removed or altered, and a real
+// ledger carries exactly this shape twice, from hydra-swarm inside one second,
+// written before Record took a lock. It reported as "the log was modified
+// after recording".
+func TestVerifyChain_AConcurrentForkIsNotTampering(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	for i := 0; i < 3; i++ {
+		if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A fourth event linking to the second, as a lost race would produce.
+	events, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	forked := Event{Agent: "a", Tool: "concurrent", Decision: Allow, PrevHash: events[1].Hash}
+	forked.Hash = hashEvent(forked)
+	appendEvent(t, path, forked)
+
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Intact {
+		t.Errorf("ChainResult = %+v, want intact: a fork is a lost race, not an edit", res)
+	}
+	if res.Forks != 1 {
+		t.Errorf("Forks = %d, want 1", res.Forks)
+	}
+}
+
+// The fork allowance turns on the referenced event still being present. A
+// deletion removes it, so the link points at nothing and must still break.
+func TestVerifyChain_DeletingAMiddleRecordIsStillCaught(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp_ledger.jsonl")
+	for i := 0; i < 4; i++ {
+		if err := Record(path, Event{Agent: "a", Tool: "t", Decision: Allow}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	lines = append(lines[:1], lines[2:]...) // drop one from the middle, touch nothing else
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := VerifyChain(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Intact {
+		t.Fatal("deleting a record from the middle reported as intact")
+	}
+}
+
+func appendEvent(t *testing.T, path string, e Event) {
+	t.Helper()
+	raw, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(raw, '\n')); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/security/incident.go
+++ b/internal/security/incident.go
@@ -206,7 +206,7 @@ func widelyDependedFiles(blast BlastReport) map[string]bool {
 
 func buildIncident(actor string, evs []ledger.Event, widelyDepended map[string]bool) Incident {
 	in := Incident{
-		Actor:  actor,
+		Actor:  ledger.SafeText(actor),
 		Start:  evs[0].TS,
 		End:    evs[len(evs)-1].TS,
 		Events: evs,

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -261,6 +261,20 @@ func chainCheck(res ledger.ChainResult) Check {
 		return Check{Name: name, Status: "no anchor",
 			Detail: fmt.Sprintf("%d chained event(s) verify, but with no chain anchor deletion from the end cannot be ruled out", res.Chained)}
 	}
+	if res.Restarts > 0 || res.Forks > 0 {
+		// Said plainly rather than as a warning: every event still verifies,
+		// and a reader who sees anything alarming here learns to ignore the
+		// check that matters.
+		var notes []string
+		if res.Restarts > 0 {
+			notes = append(notes, fmt.Sprintf("%d restart(s) where the chain anchor could not be read", res.Restarts))
+		}
+		if res.Forks > 0 {
+			notes = append(notes, fmt.Sprintf("%d fork(s) from concurrent recording", res.Forks))
+		}
+		return Check{Name: name, Status: "intact",
+			Detail: fmt.Sprintf("%d chained event(s), %d unchained, %s", res.Chained, res.Unchained, strings.Join(notes, " and "))}
+	}
 	return Check{Name: name, Status: "intact",
 		Detail: fmt.Sprintf("%d chained event(s), %d unchained", res.Chained, res.Unchained)}
 }


### PR DESCRIPTION
## Summary

A QA pass over a real 772-event ledger produced `VERDICT ACT NOW` and
`BROKEN, the log was modified after recording`. Nothing had been tampered with.

## The false alarm

Two ordinary causes, neither an edit:

**Chain restarts.** `Record` sets `PrevHash` from the sidecar anchor and leaves
it empty when that read fails. Its own comment already said so: *"a failed
chainhash write costs the next Record a fresh chain start (reported as a false
break at verify time)"*. That known false break was rendering as tampering.

**Concurrent forks.** Two `hydra-swarm` events in the same second both link to
the same predecessor, because both read the anchor before either wrote it:

```
line 31 ts=2026-08-10T11:43:27Z agent=hydra-swarm prev=6f82ae691fac hash=99532aec0037
line 32 ts=2026-08-10T11:43:27Z agent=hydra-swarm prev=6f82ae691fac hash=49bb35416aba
```

The flagged event recomputes its own hash correctly; only the link differs.
`Record` takes a lock now and `TestRecord_ConcurrentCallsDoNotForkTheChain`
passes, so this is historical, but the events are permanently in the log.

## Why tolerating them does not weaken detection

`PrevHash` is covered by the event's own `Hash`, so an attacker who deletes a
record and re-points the next link to hide the gap breaks that event's
self-hash. And the fork allowance requires the referenced event to still be
present, which a deleted one is not. Both are asserted:

- `TestVerifyChain_StrippingPrevHashToHideADeletionIsStillCaught`
- `TestVerifyChain_DeletingAMiddleRecordIsStillCaught`

plus the existing edit and tail-truncation tests, all still passing.

## The control characters

The same ledger stored a tool identity of `gpt`, a literal ESC, `[2K`, a
carriage return, then `  VERDICT  OK  no findings`. Captured terminal output
kept as a name, against resource `/etc/shadow`, and printed verbatim into the
desktop `byHead` table and the "Correlated incidents" finding.

`ESC [2K` erases the line and the carriage return sends the cursor to column
zero, so the value can hide the findings printed around it. Identity fields are
now stripped on write, before hashing so the stored and hashed values agree,
and on the way out for history already on disk.

## Verification

Against the actual ledger that produced the report, before and after:

```
before: VERDICT ACT NOW    evidence 772 event(s), 736 hash-chained, BROKEN, the log was modified after recording
after:  VERDICT ATTENTION  evidence 772 event(s), 736 hash-chained, intact
```

and the incident line renders inert instead of carrying escapes. Full suite
green under `-race`.

Closes #694
