### PR TITLE
fix(cost): key spend on the head, and never estimate zero tokens

### DIFF
--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -31,6 +31,7 @@ type Row struct {
 	Tier           int     `json:"tier"`
 	Enum           string  `json:"enum"`
 	Model          string  `json:"model"`
+	Head           string  `json:"head,omitempty"`
 	Executor       string  `json:"executor"`
 	Pool           string  `json:"pool"`
 	PromptTokens   int     `json:"prompt_tokens"`
@@ -343,13 +344,23 @@ func FilterDays(rows []Row, n int) []Row {
 	return out
 }
 
-// ByModel returns per-model totals sorted by cost descending.
+// ByModel returns per-head totals sorted by cost descending.
+//
+// Keyed on Head, not Model: Model is whatever the provider called itself, and
+// the two writers disagreed about it, so one head landed in two or three rows
+// ("Claude Code" beside "claude", "Qwen2.5-Coder:7b (Ollama)" beside
+// "Qwen2.5-Coder:7b") and every per-head total was understated. Rows written
+// before Head existed still group by Model.
 func ByModel(rows []Row) []GroupRow {
 	return groupBy(rows, func(r Row) string {
-		if r.Model == "" {
+		switch {
+		case r.Head != "":
+			return r.Head
+		case r.Model != "":
+			return r.Model
+		default:
 			return "unknown"
 		}
-		return r.Model
 	})
 }
 

--- a/internal/cost/cost_test.go
+++ b/internal/cost/cost_test.go
@@ -216,3 +216,35 @@ func TestGroupBy_Exported(t *testing.T) {
 		t.Fatalf("expected tier-1 first (highest cost), got %s", groups[0].Key)
 	}
 }
+
+// The two writers disagreed about what "model" meant: dispatch logged the
+// head id, swarm logged the display name. One head landed in two rows and
+// every per-head total was understated (#696).
+func TestByModel_OneHeadIsOneRowAcrossBothWriters(t *testing.T) {
+	rows := []Row{
+		{Head: "claude", Model: "claude", EstCostUSD: 0.01},
+		{Head: "claude", Model: "Claude Code", EstCostUSD: 0.02},
+	}
+	got := ByModel(rows)
+	if len(got) != 1 {
+		t.Fatalf("ByModel returned %d groups, want 1: %+v", len(got), got)
+	}
+	if got[0].Key != "claude" {
+		t.Errorf("Key = %q, want the stable head id", got[0].Key)
+	}
+	if got[0].Calls != 2 {
+		t.Errorf("Calls = %d, want 2", got[0].Calls)
+	}
+}
+
+// Rows written before the head field existed must still group somewhere
+// sensible rather than collapsing into one "unknown" bucket.
+func TestByModel_FallsBackToModelForOlderRows(t *testing.T) {
+	got := ByModel([]Row{
+		{Model: "Claude Code", EstCostUSD: 0.01},
+		{Model: "Qwen2.5-Coder:7b", EstCostUSD: 0.02},
+	})
+	if len(got) != 2 {
+		t.Fatalf("ByModel returned %d groups, want 2", len(got))
+	}
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -1071,6 +1071,7 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options, actProb
 			"tier":            tier,
 			"enum":            opts.Enum,
 			"model":           r.Response.Model,
+			"head":            r.Head.ID,
 			"executor":        r.Head.Provider,
 			"pool":            headPool(r.Head),
 			"prompt_tokens":   r.Response.InputTokens,

--- a/internal/executor/agy.go
+++ b/internal/executor/agy.go
@@ -119,8 +119,8 @@ func (e *AgyExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 
 	output := strings.TrimSpace(outStr)
 
-	promptTokens := len(req.Prompt) / 4
-	responseTokens := len(output) / 4
+	promptTokens := EstimateTokens(req.Prompt)
+	responseTokens := EstimateTokens(output)
 	writeTokenSidecar(modelFlag, "agy", "estimate", promptTokens, responseTokens)
 
 	return &Response{

--- a/internal/executor/cli.go
+++ b/internal/executor/cli.go
@@ -43,8 +43,8 @@ func (e *CLIExecutor) Execute(ctx context.Context, req Request) (*Response, erro
 
 	output := strings.TrimSpace(stdout.String())
 
-	promptTokens := len(req.Prompt) / 4
-	responseTokens := len(output) / 4
+	promptTokens := EstimateTokens(req.Prompt)
+	responseTokens := EstimateTokens(output)
 	writeTokenSidecar(req.Head.ID, "cli", "estimate", promptTokens, responseTokens)
 
 	return &Response{

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -40,6 +40,22 @@ type Response struct {
 	TokensEstimated bool
 }
 
+// EstimateTokens approximates a token count from text length, for the CLI
+// heads that report no usage of their own.
+//
+// Never returns 0 for text that exists. len(s)/4 truncated a reply of "OK" to
+// zero tokens, so a call that answered was reported as producing nothing and
+// its cost rounded to $0.000 (#696).
+func EstimateTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	if n := len(s) / 4; n > 0 {
+		return n
+	}
+	return 1
+}
+
 // Executor runs a prompt and returns a response.
 type Executor interface {
 	Execute(ctx context.Context, req Request) (*Response, error)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -213,3 +213,24 @@ func TestUnroutable_RegistryHeadWithAResolvedAgy(t *testing.T) {
 		t.Errorf("Unroutable = %q, want routable", why)
 	}
 }
+
+// A reply of "OK" is two characters, and len/4 made it zero tokens, so a call
+// that answered was reported as producing nothing and its cost rounded to
+// $0.000 in `hyctl stats` (#696).
+func TestEstimateTokens_NeverZeroForTextThatExists(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"OK", 1},
+		{"a", 1},
+		{"abcd", 1},
+		{"abcdefgh", 2},
+	}
+	for _, c := range cases {
+		if got := EstimateTokens(c.in); got != c.want {
+			t.Errorf("EstimateTokens(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -105,6 +105,7 @@ func logAttempts(attempts []Attempt, mode SwarmMode, opts Options, promptPreview
 			"ts":              a.FinishedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
 			"tier":            rank.UITier(a.Head),
 			"model":           a.Head.Name,
+			"head":            a.Head.ID,
 			"executor":        a.Head.Provider,
 			"pool":            headPool(a.Head),
 			"prompt_tokens":   a.InputTokens,


### PR DESCRIPTION
## Summary

Two spend-reporting defects found in a QA pass over a real machine.

## One head, several rows

`cost.jsonl` held the same head under two or three keys:

```
30  Claude Code                 2  claude
26  Qwen2.5-Coder:7b (Ollama)  15  Qwen2.5-Coder:7b
 2  Gemini 3.5 Flash (High)     1  flash-high
```

`internal/dispatch` logs `r.Response.Model` (the head id, as executors set it).
`internal/swarm/cost.go` logs `a.Head.Name` (the display name). `ByModel`
groups on that field, so per-head totals were understated and the desktop
Models panel reported `claude_direct: 0 requests` for a pool with real spend.

`dispatch` already wrote a stable `head` id, but into the **dispatch log**, not
the cost row beside it, and `cost.Row` had no field to parse one into. Now both
writers record it, `cost.Row` carries it, and `ByModel` keys on it. Rows
written before the field existed still group by `model`, so old history does
not collapse into one bucket.

Display names being unstable is not hypothetical: #693 renamed five heads last
week, which would have forked their history again.

## Zero tokens for an answer that existed

`len(output) / 4` in `agy.go` and `cli.go`. `OK` is two characters, so zero
tokens, so the cost rounded to `$0.000`:

```
codex        1 call    7 In Tok    0 Out Tok   $0.000
flash-high   1 call    7 In Tok    0 Out Tok   $0.000
```

`EstimateTokens` returns zero only for text that is genuinely empty.

## Verification

New rows written by both paths on this machine, after the change:

```
head=flash-med  model=flash-med                 in=5 out=1   (dispatch)
head=flash-med  model=Gemini 3.8 Flash (Medium) in=5 out=1   (swarm, mode=all)
head=flash-low  model=Gemini 3.8 Flash (Low)    in=5 out=1   (swarm, mode=all)
```

`head` present from both writers, and `out=1` rather than `out=0`. Before this,
swarm rows had no `head` at all and both reported `out=0`.

Full suite green under `-race`.

Closes #696
