### PR TITLE
fix(trust): refuse a confidence run that cannot move the posterior

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -787,6 +787,9 @@ func cmdDispatch() *cobra.Command {
 					Classification: &promptClass,
 				})
 				if err != nil {
+					if errors.Is(err, trust.ErrNoEvidence) {
+						return noEvidenceError(domain)
+					}
 					return err
 				}
 				printSPRTResult(res)
@@ -2959,6 +2962,35 @@ func cmdGraph() *cobra.Command {
 
 // printSPRTResult renders an SPRT confidence run: the LLR ledger, the decision,
 // and the winning answer.
+// noEvidenceError turns the SPRT refusal into something the reader can act on.
+// The bare error names the domain; what they need is which domains do carry
+// evidence and how to give this one some.
+func noEvidenceError(domain string) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "nothing here can judge %q yet, so --confidence would sample every head, "+
+		"move the estimate nowhere and hand back 50%%.\n", domain)
+	b.WriteString("A source only carries evidence once its verdicts have been scored against outcomes.\n\n")
+
+	if cal, err := trust.New(trust.DefaultPath()); err == nil {
+		seen := map[string]bool{}
+		var domains []string
+		for _, st := range cal.Report() {
+			if st.D > 0 && !seen[st.Domain] {
+				seen[st.Domain] = true
+				domains = append(domains, st.Domain)
+			}
+		}
+		if len(domains) > 0 {
+			sort.Strings(domains)
+			fmt.Fprintf(&b, "  Domains with evidence: %s\n", strings.Join(domains, ", "))
+		}
+	}
+	b.WriteString("  Record an outcome:     hyctl trust record --source model:<id> --domain " + domain + " --said-correct --outcome correct\n")
+	b.WriteString("  Or verify with a test: hyctl oracle verify --candidate <file> --domain " + domain + " -- go test ./...\n")
+	b.WriteString("\nWithout --confidence the same prompt routes normally and costs one head.")
+	return errors.New(b.String())
+}
+
 func printSPRTResult(r *swarm.SPRTResult) {
 	sep := dimStyle.Render("  " + strings.Repeat("─", 60))
 	t := r.Trust

--- a/internal/swarm/run_test.go
+++ b/internal/swarm/run_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/provider"
 	"github.com/ankit373/hydra/internal/testutil"
+	"github.com/ankit373/hydra/internal/trust"
 )
 
 // Run fans one prompt out to N heads and charges the user for all of them. Its
@@ -423,6 +424,7 @@ func TestRunSPRT_AgreeingHeadsReachTheTargetAndRecordTheirAttempts(t *testing.T)
 		swarmHead(t, s, "b", 85, "the same answer"),
 		swarmHead(t, s, "c", 80, "the same answer"),
 	)
+	seedCalibration(t, "go", "a", "b", "c")
 
 	res, err := sw.RunSPRT(context.Background(), "q", Options{Confidence: 0.75, Domain: "go"})
 	if err != nil {
@@ -458,9 +460,41 @@ func TestRunSPRT_AgreeingHeadsReachTheTargetAndRecordTheirAttempts(t *testing.T)
 
 // A domain is required for calibration lookup; an empty one must default rather
 // than being written to the ledger as the empty-string domain.
+// seedCalibration gives the named sources measurable diagnostic power in a
+// domain, so RunSPRT is not refused for having no evidence to work with. A
+// sandbox starts with an empty calibration store, and a real install that has
+// never recorded an outcome is in the same position, which is the case #698
+// made refuse rather than spend.
+func seedCalibration(t *testing.T, domain string, sources ...string) {
+	t.Helper()
+	// DefaultPath resolves against HOME at call time, so calling this before
+	// the sandbox is in place writes to the developer's real calibration
+	// store. That happened while writing these tests, and 64 rows of fixture
+	// had to be removed by hand.
+	path := trust.DefaultPath()
+	if !strings.HasPrefix(path, os.TempDir()) && !strings.Contains(path, t.TempDir()[:8]) {
+		t.Fatalf("seedCalibration would write to %s, outside a sandbox; call it after the sandbox is set up", path)
+	}
+	cal, err := trust.New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, src := range sources {
+		for i := 0; i < 8; i++ {
+			if err := cal.Update(src, domain, true, trust.OutcomeCorrect); err != nil {
+				t.Fatal(err)
+			}
+			if err := cal.Update(src, domain, false, trust.OutcomeIncorrect); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
 func TestRunSPRT_EmptyDomainDefaults(t *testing.T) {
 	s := swarmSandbox(t)
 	sw := newSwarm(t, swarmHead(t, s, "a", 90, "answer"))
+	seedCalibration(t, "default", "a")
 
 	res, err := sw.RunSPRT(context.Background(), "q", Options{Confidence: 0.6})
 	if err != nil {
@@ -478,6 +512,7 @@ func TestRunSPRT_A2AFileInjectsHandoffIntoPrompt(t *testing.T) {
 	withTempConfig(t)
 	capturing := &capturingExecutor{}
 	withStubExecutor(t, capturing)
+	seedCalibration(t, "default", "h1")
 
 	s := New(nil, []provider.Head{registryHead("h1", "H1", 90)}, fakePricing{per: 0.01})
 	res, err := s.RunSPRT(context.Background(), "new instruction", Options{

--- a/internal/trust/sprt.go
+++ b/internal/trust/sprt.go
@@ -4,6 +4,7 @@ package trust
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -103,6 +104,17 @@ func Run(ctx context.Context, task Task, sources []Source, exec Executor, cal *C
 	alpha := 1 - t.Confidence
 	if alpha <= 0 || alpha >= 1 {
 		return nil, fmt.Errorf("sprt: confidence must be in (0,1), got %v", t.Confidence)
+	}
+	// An uncalibrated source has se=sp=0.5, so its verdict contributes exactly
+	// ln(0.5/0.5)=0 nats however emphatically it agrees. With no calibrated
+	// source for this domain the posterior cannot move at all, so the run
+	// samples every head, reaches neither threshold, exhausts its budget and
+	// reports the prior back as its answer. Observed live: five heads agreed
+	// unanimously, every LLR +0.000, "stopped_on_budget", confidence 50.0%,
+	// $0.0095 spent to learn nothing (#698). Refusing costs the user nothing
+	// they would have got.
+	if !cfg.allowUncalibrated && !anyEvidence(cal, sources, task.Domain) {
+		return nil, fmt.Errorf("%w in domain %q", ErrNoEvidence, task.Domain)
 	}
 	// Symmetric Wald thresholds (α = β for v1).
 	A := math.Log((1 - alpha) / alpha)
@@ -232,7 +244,39 @@ type AnswerEquivalence func(candidate, answer string) bool
 type RunOption func(*runConfig)
 
 type runConfig struct {
-	equiv AnswerEquivalence
+	equiv             AnswerEquivalence
+	allowUncalibrated bool
+}
+
+// AllowNoEvidence runs the ensemble even when no source can move the
+// posterior. For the benchmark harness, which runs precisely to produce the
+// calibration that does not exist yet, and for tests asserting that an
+// uninformative source contributes nothing. A caller routing real work wants
+// the refusal.
+func AllowNoEvidence() RunOption {
+	return func(c *runConfig) { c.allowUncalibrated = true }
+}
+
+// ErrNoEvidence is returned when no source carries diagnostic power for the
+// task's domain, either because none is calibrated there or because every one
+// of them is measured as uninformative. Either way no verdict can move the
+// posterior, so the run could only burn its budget and hand back the prior.
+var ErrNoEvidence = errors.New("no source carries evidence")
+
+// minD is the diagnostic power below which a source is treated as carrying no
+// evidence. Calibration is stored as float rates, so an exactly-uninformative
+// source lands near zero rather than on it.
+const minD = 1e-9
+
+// anyEvidence reports whether at least one source can contribute to the
+// posterior in this domain.
+func anyEvidence(cal *Calibrator, sources []Source, domain string) bool {
+	for _, s := range sources {
+		if cal.D(s.ID, domain) > minD {
+			return true
+		}
+	}
+	return false
 }
 
 // WithEquivalence overrides how answer agreement is decided (default:

--- a/internal/trust/sprt_test.go
+++ b/internal/trust/sprt_test.go
@@ -4,9 +4,11 @@ package trust
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
+	"strings"
 	"testing"
 )
 
@@ -133,8 +135,11 @@ func TestSPRT_MiscalibratedSourceContributesNothing(t *testing.T) {
 	for i := range seq {
 		seq[i] = "A"
 	}
+	// Forced past the no-evidence refusal on purpose: the point here is what a
+	// measured coin contributes once it is running, and a caller routing real
+	// work is now refused before it can spend anything on one.
 	res, err := Run(context.Background(), Task{Domain: "d"}, nSources("coin", 20, 1),
-		&scriptExec{seq: seq}, c, Target{Confidence: 0.95})
+		&scriptExec{seq: seq}, c, Target{Confidence: 0.95}, AllowNoEvidence())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,5 +281,52 @@ func TestSPRT_Law3_SamplesAndAccuracy(t *testing.T) {
 	if easyAcc < 0.95 || hardAcc < 0.95 || blendedAcc < 0.95 {
 		t.Errorf("accuracy below target: easy=%.4f hard=%.4f blended=%.4f, want ≥0.95",
 			easyAcc, hardAcc, blendedAcc)
+	}
+}
+
+// Observed live: --confidence on an uncalibrated domain sampled five heads,
+// every one agreed, every LLR was +0.000, and the run reported "stopped on
+// budget, confidence 50.0%" having spent $0.0095. The posterior cannot move
+// when no source carries evidence, so the only possible outcome is the prior,
+// reached by the most expensive path available.
+func TestSPRT_RefusesWhenNoSourceCarriesEvidence(t *testing.T) {
+	c, _ := New("")
+	seq := make([]string, 5)
+	for i := range seq {
+		seq[i] = "A"
+	}
+	_, err := Run(context.Background(), Task{Domain: "go"}, nSources("unknown", 5, 1),
+		&scriptExec{seq: seq}, c, Target{Confidence: 0.95})
+	if !errors.Is(err, ErrNoEvidence) {
+		t.Fatalf("err = %v, want ErrNoEvidence", err)
+	}
+	if !strings.Contains(err.Error(), "go") {
+		t.Errorf("err = %v, want it to name the domain", err)
+	}
+}
+
+// One calibrated source is enough to make the run worth paying for.
+func TestSPRT_RunsWhenOneSourceCarriesEvidence(t *testing.T) {
+	c, _ := New("")
+	calibrateSymmetric(c, "good", "go", 0.9, 100)
+	seq := make([]string, 6)
+	for i := range seq {
+		seq[i] = "A"
+	}
+	sources := append(nSources("coin", 3, 1), nSources("good", 3, 1)...)
+	if _, err := Run(context.Background(), Task{Domain: "go"}, sources,
+		&scriptExec{seq: seq}, c, Target{Confidence: 0.95}); err != nil {
+		t.Fatalf("Run refused a domain that has evidence: %v", err)
+	}
+}
+
+// The benchmark harness runs precisely to produce calibration that does not
+// exist yet, so it must be able to opt out.
+func TestSPRT_AllowNoEvidenceOptsOutOfTheRefusal(t *testing.T) {
+	c, _ := New("")
+	seq := []string{"A", "A"}
+	if _, err := Run(context.Background(), Task{Domain: "go"}, nSources("unknown", 2, 1),
+		&scriptExec{seq: seq}, c, Target{Confidence: 0.95}, AllowNoEvidence()); err != nil {
+		t.Fatalf("AllowNoEvidence did not lift the refusal: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`--confidence` on any real domain sampled every head, learned nothing from any
of them, and handed back the prior. Observed live before this change:

```
SOURCE            VERDICT     LLR    Λ AFTER
claude            agree    +0.000     +0.000
opus-thinking     agree    +0.000     +0.000
codex             agree    +0.000     +0.000
sonnet-thinking   agree    +0.000     +0.000
agy               agree    +0.000     +0.000

Decision → stopped_on_budget · confidence 50.0% · 5 samples · $0.0095
```

Five heads agreed unanimously and the answer was 50%, the prior.

## Cause

`Calibrator.rates` returns `se=sp=0.5` for a (source, domain) it has never
seen, so `LLR = ln(0.5/0.5) = 0` regardless of the verdict. With no calibrated
source the Wald thresholds are unreachable, so the run can only end by
exhausting its budget: the most expensive path available, taken every time.

This also explains what `hyctl trust stats` has been reporting all along:

```
confidence   target 85.3% → achieved 50.2%
auto-cleared 0%  (reached target without a human)
```

Not a separate problem. That is this, on every run.

## Changes

- `trust.Run` refuses with `ErrNoEvidence` before sampling anything when no
  source has diagnostic power in the domain. Refusing costs the caller nothing
  they would have received.
- `AllowNoEvidence()` lifts it for the benchmark harness, which runs precisely
  to produce calibration that does not exist yet, and for the test asserting
  that a measured coin contributes nothing.
- The CLI turns the refusal into something actionable:

```
Error: nothing here can judge "go" yet, so --confidence would sample every head,
move the estimate nowhere and hand back 50%.
A source only carries evidence once its verdicts have been scored against outcomes.

  Domains with evidence: gotest, trust-bench, trust-bench-v2
  Record an outcome:     hyctl trust record --source model:<id> --domain go --said-correct --outcome correct
  Or verify with a test: hyctl oracle verify --candidate <file> --domain go -- go test ./...

Without --confidence the same prompt routes normally and costs one head.
```

## A test-hygiene fix that came out of writing this

`seedCalibration` now refuses to run outside a sandbox. `trust.DefaultPath()`
resolves against `HOME` at call time, so placing the seed before the sandbox
was established wrote 64 fixture rows into a real calibration store. That
happened while writing these tests; the rows were removed by hand and the guard
reproduces the exact mistake:

```
seedCalibration would write to /Users/…/.hydra/calibration.jsonl, outside a
sandbox; call it after the sandbox is set up
```

It fails before writing, not after.

## Verification

`TestSPRT_RefusesWhenNoSourceCarriesEvidence`,
`TestSPRT_RunsWhenOneSourceCarriesEvidence` (one calibrated source among coins
is enough), `TestSPRT_AllowNoEvidenceOptsOutOfTheRefusal`. Full suite green
under `-race`.

Closes #698
