### PR TITLE
fix(test): stop the swarm suite writing into a real ~/.hydra

### DIFF
--- a/internal/swarm/main_test.go
+++ b/internal/swarm/main_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain points HOME at a temp directory for the whole package.
+//
+// Swarm reaches trust.DefaultCoAgreementPath() and trust.DefaultPath(), which
+// resolve config.Dir() at call time, so a test that forgets to sandbox appends
+// to the developer's real ~/.hydra. That is not hypothetical: 701 rows of
+// fixture, including a fabricated "acme" model family, reached a real store
+// and drove a live "these heads vote as one" finding in `hyctl security`.
+//
+// Individual tests still call withTempConfig when they need a config file;
+// this is the floor beneath them, so forgetting cannot reach real user data.
+func TestMain(m *testing.M) {
+	home, err := os.MkdirTemp("", "hydra-swarm-test-home")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("HOME", home)
+	os.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
+	code := m.Run()
+	os.RemoveAll(home)
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary

Running the test suite wrote fixtures into the developer's real Hydra store,
and those fixtures were driving live findings in the security surfaces.

```
$ wc -l ~/.hydra/coagreement.jsonl
     701
$ go test ./internal/swarm/ -run TestCalibratedJudge
$ wc -l ~/.hydra/coagreement.jsonl
     705
```

The rows look like this:

```json
{"domain":"calibrated-judge-test","sources":[{"id":"model:reliable","family":"acme","cluster":0}, ...]}
```

`calibrated-judge-test` and `acme` come from
`internal/swarm/calibrated_judge_test.go`. They are why a real install with no
`acme` head anywhere reports:

- `hyctl trust calibration`: *"false-consensus warning: acme's members measured
  J=0.85, effectively one vote, not independent confirmation"*
- desktop Audit: *"Confidence evidence quality: 1 correlated family(ies). acme
  heads agree 86% beyond chance, they vote as one"*

A security panel reporting a finding about a test fixture.

## Cause

`calibrated_judge.go` calls `trust.DefaultCoAgreementPath()`, which resolves
`config.Dir()` at call time. The judge tests never sandboxed `HOME`.

The same shape bit again while fixing #698: a calibration seed placed before
its sandbox put 64 fixture rows into a real `calibration.jsonl`. Two instances
in one afternoon is a structural problem, not a discipline problem.

## Change

One file: a package-level `TestMain` for `internal/swarm` that points `HOME` at
a temp directory. A test that forgets to sandbox cannot reach real user data.

Per-test `withTempConfig` stays where a config file is actually needed. I first
added it to all six judge tests, then removed it again: with the floor in place
it changed nothing, and a redundant call in six tests is churn that suggests
the sandboxing is per-test when it is not.

## Verification

- With the six per-test sandboxes **removed entirely**, the store stays at 701
  rows. The floor holds on its own.
- Across the whole `./internal/...` suite, `coagreement.jsonl` +
  `calibration.jsonl` + `trust.jsonl` stay at 754 rows before and after.
- Full suite green under `-race`.

The fixture rows already on this machine are user data and are not touched by
this change; they need removing by hand.

Closes #700
