### PR TITLE
fix(executor): tell the reader how to finish signing agy in

### DIFF
--- a/internal/executor/agy.go
+++ b/internal/executor/agy.go
@@ -26,9 +26,14 @@ type AuthRequiredError struct {
 }
 
 func (e *AuthRequiredError) Error() string {
-	msg := fmt.Sprintf("auth required for agy model %q (pool %q)", e.ModelFlag, e.Pool)
+	// Names the command, not just the URL. agy authenticates interactively and
+	// a --print run cannot complete the handshake, so following the link alone
+	// ends with an OAuth code and nowhere to paste it, which is exactly what
+	// happened to the first person who hit this (#702).
+	msg := fmt.Sprintf("agy is not signed in for model %q (pool %q); run `agy` in a terminal once to sign in",
+		e.ModelFlag, e.Pool)
 	if e.AuthURL != "" {
-		msg += ", authenticate at: " + e.AuthURL
+		msg += ", or open " + e.AuthURL
 	}
 	return msg
 }

--- a/internal/executor/agy_test.go
+++ b/internal/executor/agy_test.go
@@ -504,3 +504,19 @@ func TestAgyExecute_UnparsableTimeoutFallsBackToTheDefault(t *testing.T) {
 		t.Fatalf("a garbage AGY_TIMEOUT cancelled the run: %v", err)
 	}
 }
+
+// The message a person actually acts on. agy authenticates interactively and a
+// --print run cannot complete the handshake, so a bare URL sends the reader to
+// Google, hands them an OAuth code, and leaves nowhere to paste it. That
+// happened (#702).
+func TestAuthRequiredError_NamesTheCommandThatFixesIt(t *testing.T) {
+	e := &AuthRequiredError{ModelFlag: "gemini-3.8-flash-medium", Pool: "agy_flash",
+		AuthURL: "https://accounts.google.com/o/oauth2/auth?x=1"}
+	msg := e.Error()
+	if !strings.Contains(msg, "run `agy`") {
+		t.Errorf("Error() = %q, want it to name the command that completes sign-in", msg)
+	}
+	if !strings.Contains(msg, "gemini-3.8-flash-medium") {
+		t.Errorf("Error() = %q, want it to name the model", msg)
+	}
+}


### PR DESCRIPTION
## Summary

When agy needs re-authentication the message was a URL and nothing else:

```
auth required for agy model "gemini-3.8-flash-medium" (pool "agy_flash"),
authenticate at: https://accounts.google.com/o/oauth2/auth?access_type=offline&client_id=...
```

agy signs in interactively, and a `--print` run cannot complete the handshake.
So following the link signs you in, Google returns an authorization code, and
there is nowhere to put it. Someone did exactly what the message said and ended
up holding a credential with no next step.

## Change

```
agy is not signed in for model "gemini-3.8-flash-medium" (pool "agy_flash");
run `agy` in a terminal once to sign in, or open https://...
```

The command first, the URL second.

Worth noting the fallback behaved correctly throughout: the run reported both
failed attempts with their reasons and answered from another head, and #691's
breaker classified auth-required as transient rather than fatal, which was
right, both heads worked again minutes later without intervention.

Closes #702