### PR TITLE
chore(site): disable text selection except where content needs copying

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -60,9 +60,18 @@
 }
 *{box-sizing:border-box;}
 html{scroll-behavior:smooth;
-  /* Nothing on the site is selectable. Install commands are click-to-copy
-     (.copyline), which is the affordance that replaces dragging. */
+  /* Prose and chrome are not selectable; code and commands are, see below. */
   user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/app.html
+++ b/docs/app.html
@@ -59,7 +59,10 @@
   --maxw:1200px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Nothing on the site is selectable. Install commands are click-to-copy
+     (.copyline), which is the affordance that replaces dragging. */
+  user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -55,9 +55,18 @@
 }
 *{box-sizing:border-box;}
 html{scroll-behavior:smooth;
-  /* Nothing on the site is selectable. Install commands are click-to-copy
-     (.copyline), which is the affordance that replaces dragging. */
+  /* Prose and chrome are not selectable; code and commands are, see below. */
   user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;
   -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -54,7 +54,10 @@
   --side:250px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Nothing on the site is selectable. Install commands are click-to-copy
+     (.copyline), which is the affordance that replaces dragging. */
+  user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;
   -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/first-principles.html
+++ b/docs/first-principles.html
@@ -54,9 +54,18 @@
 }
 *{box-sizing:border-box;}
 html{scroll-behavior:smooth;
-  /* Nothing on the site is selectable. Install commands are click-to-copy
-     (.copyline), which is the affordance that replaces dragging. */
+  /* Prose and chrome are not selectable; code and commands are, see below. */
   user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/first-principles.html
+++ b/docs/first-principles.html
@@ -53,7 +53,10 @@
   --maxw:1080px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Nothing on the site is selectable. Install commands are click-to-copy
+     (.copyline), which is the affordance that replaces dragging. */
+  user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/index.html
+++ b/docs/index.html
@@ -218,7 +218,10 @@
   --maxw:1200px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Nothing on the site is selectable. Install commands are click-to-copy
+     (.copyline), which is the affordance that replaces dragging. */
+  user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}
@@ -234,12 +237,6 @@ a{color:inherit;text-decoration:none;}
 .accent{color:var(--aqua);}
 .cheap{color:var(--cheap);}.mid{color:var(--mid);}.exp{color:var(--exp);}
 .cy{color:var(--cyan);}.vi{color:var(--violet);}.mg{color:var(--magenta);}
-
-/* Buttons/links are actions, not content, a stray click-drag shouldn't
-   highlight their label. Scoped to controls only: headings, body copy, and
-   the subline stay normally selectable everywhere else on the page. */
-.topbar .ghost,.topbar nav a,.btn-ghost,.skip-intro,.install{
-  user-select:none;-webkit-user-select:none;}
 
 /* ── top nav ───────────────────────────────────────────────────────────── */
 .topbar{position:sticky;top:0;z-index:60;display:flex;align-items:center;gap:14px;height:52px;padding:0 24px;

--- a/docs/index.html
+++ b/docs/index.html
@@ -219,9 +219,18 @@
 }
 *{box-sizing:border-box;}
 html{scroll-behavior:smooth;
-  /* Nothing on the site is selectable. Install commands are click-to-copy
-     (.copyline), which is the affordance that replaces dragging. */
+  /* Prose and chrome are not selectable; code and commands are, see below. */
   user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -55,7 +55,10 @@
   --maxw:1120px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Nothing on the site is selectable. Install commands are click-to-copy
+     (.copyline), which is the affordance that replaces dragging. */
+  user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -56,9 +56,18 @@
 }
 *{box-sizing:border-box;}
 html{scroll-behavior:smooth;
-  /* Nothing on the site is selectable. Install commands are click-to-copy
-     (.copyline), which is the affordance that replaces dragging. */
+  /* Prose and chrome are not selectable; code and commands are, see below. */
   user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,7 +8,7 @@
   </url>
   <url>
     <loc>https://hydra.uvansa.com/app.html</loc>
-    <lastmod>2026-09-05</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://hydra.uvansa.com/first-principles.html</loc>
-    <lastmod>2026-09-05</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary

Selection is off across the site, except where something needs copying.

- `user-select: none` at the `html` element on all five pages, replacing the
  rule that scoped it to controls only (`.topbar .ghost`, `.btn-ghost`,
  `.skip-intro`, `.install`), now redundant and removed.
- `pre, code` stay selectable. `docs.html` carries 53 command examples and no
  copy button, so blocking selection there left no way to take a command off
  the page. `user-select` inherits, so the spans inside a highlighted block
  follow.
- `[data-copy]` is excluded from that exception. Those copy on click, and
  dragging across one is exactly the accident the site-wide rule prevents.
  Attribute specificity beats the element selectors, so there is no ordering
  dependency between the two rules.

## Verification

Headless Chrome against a local serve of `docs/`. Computed `user-select`:

```
index             body=none h1=none p=none | pre=-    code=text inner=-    | data-copy=none
app               body=none h1=none p=none | pre=-    code=-    inner=-    | data-copy=none
docs              body=none h1=none p=none | pre=text code=text inner=text | data-copy=-
first-principles  body=none h1=none p=none | pre=-    code=text inner=-    | data-copy=-
pricing           body=none h1=none p=none | pre=-    code=-    inner=-    | data-copy=-
```

`inner` is a `<span>` inside a `<pre>`, which confirms inheritance reaches the
syntax-highlighted children rather than stopping at the block.

And functionally, actually selecting rather than reading the property back:

```
docs.html  <pre>       -> "discover route execute + observe ┌───────────┐ ┌────────────"
docs.html  <h1>        -> ""
index.html [data-copy] -> ""
index.html <code>      -> "audit"
```

Click-to-copy still works: clicking a `[data-copy]` adds the `copied` class and
calls `navigator.clipboard.writeText`. Layout is untouched, `scrollHeight`
11539 before and after on `index.html`, and the rendered page is identical.

`sitemap.xml` lastmod bumped for the five pages.
