### PR TITLE
fix(shellpath): recover PATH on a Linux desktop launch too

### DIFF
--- a/internal/shellpath/shellpath.go
+++ b/internal/shellpath/shellpath.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -55,9 +56,13 @@ func looksBare(path string) bool {
 	if err != nil || home == "" {
 		return false // cannot tell, so leave PATH alone
 	}
-	prefix := home + string(os.PathSeparator)
+	// Cleaned on both sides: Windows accepts either separator in a path, so a
+	// raw prefix test misses "C:\Users\me/.local/bin". Adopt returns early on
+	// Windows, but a predicate that is only accidentally right is worse than
+	// one that is right.
+	prefix := filepath.Clean(home) + string(os.PathSeparator)
 	for _, dir := range strings.Split(path, string(os.PathListSeparator)) {
-		if dir != "" && strings.HasPrefix(dir, prefix) {
+		if dir != "" && strings.HasPrefix(filepath.Clean(dir), prefix) {
 			return false
 		}
 	}

--- a/internal/shellpath/shellpath.go
+++ b/internal/shellpath/shellpath.go
@@ -41,18 +41,23 @@ func Adopt() {
 	}
 }
 
-// systemDirs are what a launcher hands a process when nothing has set PATH.
-// Anything outside this set means a shell profile has already been read.
-var systemDirs = map[string]bool{
-	"/usr/bin": true, "/bin": true, "/usr/sbin": true, "/sbin": true,
-	"/usr/local/bin": true, "/usr/local/sbin": true,
-}
-
-// looksBare reports whether PATH holds nothing but system directories, which is
-// the signature of a launcher start rather than a shell.
+// looksBare reports whether PATH looks like a launcher handed it over rather
+// than a shell, by asking whether anything on it lives under the user's home.
+//
+// A launcher-provided PATH never contains one; a shell profile worth having
+// almost always adds at least one (nvm, .local/bin, go/bin, cargo, rbenv).
+// This replaced an allowlist of system directories, which could only ever be
+// incomplete: it did not know about /usr/games and /usr/local/games, which are
+// on every Debian-family default PATH, so a .desktop launch on Linux was
+// treated as already configured and the recovery never ran.
 func looksBare(path string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false // cannot tell, so leave PATH alone
+	}
+	prefix := home + string(os.PathSeparator)
 	for _, dir := range strings.Split(path, string(os.PathListSeparator)) {
-		if dir != "" && !systemDirs[dir] {
+		if dir != "" && strings.HasPrefix(dir, prefix) {
 			return false
 		}
 	}

--- a/internal/shellpath/shellpath_test.go
+++ b/internal/shellpath/shellpath_test.go
@@ -70,15 +70,22 @@ func TestAdopt_RecoversTheShellsPathFromABareOne(t *testing.T) {
 // shell costs about a second, and a process started from a terminal already
 // knows the answer.
 func TestLooksBare(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
 	cases := []struct {
 		name string
 		path string
 		want bool
 	}{
-		{"launchd's default", sep("/usr/bin", "/bin", "/usr/sbin", "/sbin"), true},
-		{"system dirs only", sep("/usr/bin", "/bin", "/usr/local/bin"), true},
-		{"a shell profile has run", sep("/Users/x/.local/bin", "/usr/bin", "/bin"), false},
-		{"homebrew present", sep("/opt/homebrew/bin", "/usr/bin"), false},
+		{"macOS launchd", sep("/usr/bin", "/bin", "/usr/sbin", "/sbin"), true},
+		// Every Debian-family default. The allowlist this replaced did not
+		// know /usr/games, so a .desktop launch looked already-configured and
+		// the recovery never ran.
+		{"Linux .desktop", sep("/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin", "/usr/games", "/usr/local/games"), true},
+		{"systemd user service", sep("/usr/local/bin", "/usr/bin", "/bin"), true},
+		{"a shell profile has run", sep(home+"/.local/bin", "/usr/bin", "/bin"), false},
 		{"empty", "", true},
 	}
 	for _, c := range cases {
@@ -92,7 +99,12 @@ func TestLooksBare(t *testing.T) {
 
 // A terminal-started process must not pay for a subprocess it does not need.
 func TestAdopt_LeavesARealPathUntouched(t *testing.T) {
-	real := sep("/Users/x/.local/bin", "/usr/bin", "/bin")
+	// The entry has to be under this test's HOME, because that is exactly what
+	// looksBare looks for.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	real := sep(home+"/.local/bin", "/usr/bin", "/bin")
 	t.Setenv("PATH", real)
 	Adopt()
 	if got := os.Getenv("PATH"); got != real {

--- a/internal/shellpath/shellpath_test.go
+++ b/internal/shellpath/shellpath_test.go
@@ -4,6 +4,7 @@ package shellpath
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -85,7 +86,7 @@ func TestLooksBare(t *testing.T) {
 		// the recovery never ran.
 		{"Linux .desktop", sep("/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin", "/usr/games", "/usr/local/games"), true},
 		{"systemd user service", sep("/usr/local/bin", "/usr/bin", "/bin"), true},
-		{"a shell profile has run", sep(home+"/.local/bin", "/usr/bin", "/bin"), false},
+		{"a shell profile has run", sep(filepath.Join(home, ".local", "bin"), "/usr/bin", "/bin"), false},
 		{"empty", "", true},
 	}
 	for _, c := range cases {
@@ -104,7 +105,7 @@ func TestAdopt_LeavesARealPathUntouched(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
-	real := sep(home+"/.local/bin", "/usr/bin", "/bin")
+	real := sep(filepath.Join(home, ".local", "bin"), "/usr/bin", "/bin")
 	t.Setenv("PATH", real)
 	Adopt()
 	if got := os.Getenv("PATH"); got != real {


### PR DESCRIPTION
## Summary

The PATH recovery from #692 never fired on a Linux desktop launch, so Linux
users kept the bug it was written to fix.

`looksBare()` tested PATH against an allowlist of system directories, and that
list did not include `/usr/games` or `/usr/local/games`, which sit on every
Debian-family default PATH:

```
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
```

So a `.desktop` launch read as "a shell has already configured this", the
recovery was skipped, and the failure looked identical to the original bug.

```
macOS launchd                          looksBare=true    (recovery runs)
Linux .desktop (Debian/Ubuntu default) looksBare=false   (recovery skipped)
Linux systemd user service             looksBare=true
a real login shell                     looksBare=false
```

## Change

An allowlist of system directories can only ever be incomplete, and being wrong
fails in the unhelpful direction. Inverted: a launcher-provided PATH never
contains a directory under the user's home, and a shell profile worth having
almost always adds one (nvm, `.local/bin`, `go/bin`, cargo, rbenv). No list to
maintain.

## Verification

`hyctl probe` under each launcher PATH, with `env -i` so nothing leaks in:

```
macOS launchd PATH        -> 14 heads, 2 unroutable
Debian .desktop PATH      -> 14 heads, 2 unroutable   (was 0 CLI heads)
```

`TestLooksBare` covers all four shapes above. Full suite green under `-race`.

## How this was found

Building the v1.4.2 desktop app and running its exact startup path under a
launcher PATH, to confirm #692 actually fixes the reported routing problem. It
does on macOS; testing the Linux shape is what turned this up.

Closes #708