### PR TITLE
fix(shellpath): recover PATH on a Linux desktop launch

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -59,7 +59,19 @@
   --maxw:1200px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Prose and chrome are not selectable; code and commands are, see below. */
+  user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -54,7 +54,19 @@
   --side:250px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Prose and chrome are not selectable; code and commands are, see below. */
+  user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.62;
   -webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/first-principles.html
+++ b/docs/first-principles.html
@@ -53,7 +53,19 @@
   --maxw:1080px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Prose and chrome are not selectable; code and commands are, see below. */
+  user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/index.html
+++ b/docs/index.html
@@ -218,7 +218,19 @@
   --maxw:1200px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Prose and chrome are not selectable; code and commands are, see below. */
+  user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.55;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}
@@ -234,12 +246,6 @@ a{color:inherit;text-decoration:none;}
 .accent{color:var(--aqua);}
 .cheap{color:var(--cheap);}.mid{color:var(--mid);}.exp{color:var(--exp);}
 .cy{color:var(--cyan);}.vi{color:var(--violet);}.mg{color:var(--magenta);}
-
-/* Buttons/links are actions, not content, a stray click-drag shouldn't
-   highlight their label. Scoped to controls only: headings, body copy, and
-   the subline stay normally selectable everywhere else on the page. */
-.topbar .ghost,.topbar nav a,.btn-ghost,.skip-intro,.install{
-  user-select:none;-webkit-user-select:none;}
 
 /* ── top nav ───────────────────────────────────────────────────────────── */
 .topbar{position:sticky;top:0;z-index:60;display:flex;align-items:center;gap:14px;height:52px;padding:0 24px;

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -55,7 +55,19 @@
   --maxw:1120px;
 }
 *{box-sizing:border-box;}
-html{scroll-behavior:smooth;}
+html{scroll-behavior:smooth;
+  /* Prose and chrome are not selectable; code and commands are, see below. */
+  user-select:none;-webkit-user-select:none;}
+
+/* Code and command examples stay selectable. docs.html carries 53 of them and
+   no copy button, so blocking selection there leaves no way to take a command
+   off the page. user-select inherits, so descendants follow. */
+pre,code{user-select:text;-webkit-user-select:text;}
+
+/* Except where a click already copies: dragging across one of those is the
+   accident the site-wide rule exists to prevent. Attribute specificity beats
+   the element selectors above. */
+[data-copy]{user-select:none;-webkit-user-select:none;}
 @media(prefers-reduced-motion:reduce){html{scroll-behavior:auto;}}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6;
   overflow-x:hidden;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;}

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,7 +8,7 @@
   </url>
   <url>
     <loc>https://hydra.uvansa.com/app.html</loc>
-    <lastmod>2026-09-05</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://hydra.uvansa.com/first-principles.html</loc>
-    <lastmod>2026-09-05</lastmod>
+    <lastmod>2026-09-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/internal/shellpath/shellpath.go
+++ b/internal/shellpath/shellpath.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -41,18 +42,27 @@ func Adopt() {
 	}
 }
 
-// systemDirs are what a launcher hands a process when nothing has set PATH.
-// Anything outside this set means a shell profile has already been read.
-var systemDirs = map[string]bool{
-	"/usr/bin": true, "/bin": true, "/usr/sbin": true, "/sbin": true,
-	"/usr/local/bin": true, "/usr/local/sbin": true,
-}
-
-// looksBare reports whether PATH holds nothing but system directories, which is
-// the signature of a launcher start rather than a shell.
+// looksBare reports whether PATH looks like a launcher handed it over rather
+// than a shell, by asking whether anything on it lives under the user's home.
+//
+// A launcher-provided PATH never contains one; a shell profile worth having
+// almost always adds at least one (nvm, .local/bin, go/bin, cargo, rbenv).
+// This replaced an allowlist of system directories, which could only ever be
+// incomplete: it did not know about /usr/games and /usr/local/games, which are
+// on every Debian-family default PATH, so a .desktop launch on Linux was
+// treated as already configured and the recovery never ran.
 func looksBare(path string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false // cannot tell, so leave PATH alone
+	}
+	// Cleaned on both sides: Windows accepts either separator in a path, so a
+	// raw prefix test misses "C:\Users\me/.local/bin". Adopt returns early on
+	// Windows, but a predicate that is only accidentally right is worse than
+	// one that is right.
+	prefix := filepath.Clean(home) + string(os.PathSeparator)
 	for _, dir := range strings.Split(path, string(os.PathListSeparator)) {
-		if dir != "" && !systemDirs[dir] {
+		if dir != "" && strings.HasPrefix(filepath.Clean(dir), prefix) {
 			return false
 		}
 	}

--- a/internal/shellpath/shellpath_test.go
+++ b/internal/shellpath/shellpath_test.go
@@ -4,6 +4,7 @@ package shellpath
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -70,15 +71,22 @@ func TestAdopt_RecoversTheShellsPathFromABareOne(t *testing.T) {
 // shell costs about a second, and a process started from a terminal already
 // knows the answer.
 func TestLooksBare(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
 	cases := []struct {
 		name string
 		path string
 		want bool
 	}{
-		{"launchd's default", sep("/usr/bin", "/bin", "/usr/sbin", "/sbin"), true},
-		{"system dirs only", sep("/usr/bin", "/bin", "/usr/local/bin"), true},
-		{"a shell profile has run", sep("/Users/x/.local/bin", "/usr/bin", "/bin"), false},
-		{"homebrew present", sep("/opt/homebrew/bin", "/usr/bin"), false},
+		{"macOS launchd", sep("/usr/bin", "/bin", "/usr/sbin", "/sbin"), true},
+		// Every Debian-family default. The allowlist this replaced did not
+		// know /usr/games, so a .desktop launch looked already-configured and
+		// the recovery never ran.
+		{"Linux .desktop", sep("/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin", "/usr/games", "/usr/local/games"), true},
+		{"systemd user service", sep("/usr/local/bin", "/usr/bin", "/bin"), true},
+		{"a shell profile has run", sep(filepath.Join(home, ".local", "bin"), "/usr/bin", "/bin"), false},
 		{"empty", "", true},
 	}
 	for _, c := range cases {
@@ -92,7 +100,12 @@ func TestLooksBare(t *testing.T) {
 
 // A terminal-started process must not pay for a subprocess it does not need.
 func TestAdopt_LeavesARealPathUntouched(t *testing.T) {
-	real := sep("/Users/x/.local/bin", "/usr/bin", "/bin")
+	// The entry has to be under this test's HOME, because that is exactly what
+	// looksBare looks for.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	real := sep(filepath.Join(home, ".local", "bin"), "/usr/bin", "/bin")
 	t.Setenv("PATH", real)
 	Adopt()
 	if got := os.Getenv("PATH"); got != real {


### PR DESCRIPTION
## Why this is needed before v1.4.2 ships

v1.4.2's headline fix is PATH recovery, and **on Linux it never runs**. `main`
carries the version of the guard that tests PATH against an allowlist of system
directories, and that list does not include `/usr/games` or `/usr/local/games`,
which sit on every Debian-family default PATH:

```
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
```

So a `.desktop` launch reads as "a shell already configured this", the recovery
is skipped, and a Linux desktop user installs v1.4.2 and keeps the exact bug it
claims to fix, silently.

```
macOS launchd                          looksBare=true    (recovery runs)
Linux .desktop (Debian/Ubuntu default) looksBare=false   (recovery skipped)
```

Hydra ships Linux x86-64 and ARM64 desktop builds every release, so this is a
shipped platform.

## What changed

An allowlist of system directories can only ever be incomplete, and being wrong
fails in the unhelpful direction. Inverted: a launcher-provided PATH never
contains a directory under the user's home, and a shell profile worth having
almost always adds one (nvm, `.local/bin`, `go/bin`, cargo, rbenv). No list to
maintain. Home paths are compared with separators normalised, since Windows
accepts either.

Verified with `env -i` so nothing leaks in:

```
macOS launchd PATH   -> 14 heads, 2 unroutable
Debian .desktop PATH -> 14 heads, 2 unroutable   (was 0 CLI heads)
```

## Also carried

The docs site's selection behaviour (#707), which landed on `develop` after the
release cut and would otherwise miss v1.4.2: nothing on the site is selectable
except `pre`/`code`, which `docs.html` has 53 of and no copy button for.
`[data-copy]` stays unselectable because clicking it copies.

Both changes are already merged to `develop` (#709, #707); this carries them
onto `main` so v1.4.2 contains them. The files here are byte-identical to
`develop`.

## Sequence

1. Merge this.
2. release-please refreshes the open Release PR #710 with this in the changelog.
3. Merge #710, which creates the `v1.4.2` tag and fans the release out.

Full suite green under `-race`.