### PR TITLE
docs: point the downloads at v1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,7 +831,7 @@ curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh 
 It resolves the newest release (the asset names embed their version, so GitHub's `/latest/download/`
 shortcut cannot address them), verifies the download against the published `.sha256`, installs the
 `.app` to `/Applications`, or the binary to `~/.local/share/hydra` with a `~/.local/bin` symlink on
-Linux, and clears the macOS quarantine flag so the first launch works. `HYDRA_VERSION=v1.4.1` pins
+Linux, and clears the macOS quarantine flag so the first launch works. `HYDRA_VERSION=v1.4.2` pins
 a release; `HYDRA_APP_DIR` changes where it lands.
 
 **Or take the artifact directly**, from the

--- a/docs/app.html
+++ b/docs/app.html
@@ -577,13 +577,13 @@ footer a{color:var(--dim);}
 
   <div class="term" style="margin-top:22px;">
     <div class="copyline" data-copy="curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh | sh"><span><span class="p">$</span> curl -fsSL https://raw.githubusercontent.com/ankit373/hydra/main/install-app.sh | sh</span><span class="cp">copy</span></div>
-    <div class="o">&nbsp;&nbsp;Release&nbsp;: <span class="g">v1.4.1</span></div>
+    <div class="o">&nbsp;&nbsp;Release&nbsp;: <span class="g">v1.4.2</span></div>
     <div class="o">&nbsp;&nbsp;Target&nbsp;&nbsp;: darwin_universal</div>
     <div class="o">&nbsp;&nbsp;Checksum: <span class="g">verified</span></div>
     <div class="o">&nbsp;&nbsp;Installed: /Applications/Hydra.app</div>
   </div>
   <p style="font-size:13.5px;color:var(--faint);margin-top:12px;">
-    Pin a version with <span class="mono">HYDRA_VERSION=v1.4.1</span>, or change where it
+    Pin a version with <span class="mono">HYDRA_VERSION=v1.4.2</span>, or change where it
     lands with <span class="mono">HYDRA_APP_DIR=~/Applications</span>.
     <a href="https://github.com/ankit373/hydra/blob/main/install-app.sh">Read the script</a>
     before you pipe it to a shell, it is under 200 lines and you should.
@@ -595,41 +595,41 @@ footer a{color:var(--dim);}
       <div class="os">macOS</div>
       <div class="meta">universal · Apple Silicon + Intel</div>
       <div class="sz">8.8 MB</div>
-      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_darwin_universal.zip">.zip</a>
-      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_darwin_universal.zip.sha256">sha256</a>
+      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_darwin_universal.zip">.zip</a>
+      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_darwin_universal.zip.sha256">sha256</a>
     </div>
     <div class="row">
       <div class="os">Linux x86-64</div>
       <div class="meta">x86-64</div>
       <div class="sz">4.4 MB</div>
-      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_linux_amd64.tar.gz">.tar.gz</a>
-      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_linux_amd64.tar.gz.sha256">sha256</a>
+      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_linux_amd64.tar.gz">.tar.gz</a>
+      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_linux_amd64.tar.gz.sha256">sha256</a>
     </div>
     <div class="row">
       <div class="os">Linux ARM64</div>
       <div class="meta">aarch64</div>
       <div class="sz">4.0 MB</div>
-      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_linux_arm64.tar.gz">.tar.gz</a>
-      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_linux_arm64.tar.gz.sha256">sha256</a>
+      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_linux_arm64.tar.gz">.tar.gz</a>
+      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_linux_arm64.tar.gz.sha256">sha256</a>
     </div>
     <div class="row">
       <div class="os">Windows x86-64</div>
       <div class="meta">x86-64 · unzip and run Hydra.exe</div>
       <div class="sz">4.9 MB</div>
-      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_windows_amd64.zip">.zip</a>
-      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_windows_amd64.zip.sha256">sha256</a>
+      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_windows_amd64.zip">.zip</a>
+      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_windows_amd64.zip.sha256">sha256</a>
     </div>
     <div class="row">
       <div class="os">Windows ARM64</div>
       <div class="meta">aarch64 · unzip and run Hydra.exe</div>
       <div class="sz">4.4 MB</div>
-      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_windows_arm64.zip">.zip</a>
-      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.1/hydra-desktop_v1.4.1_windows_arm64.zip.sha256">sha256</a>
+      <a class="get" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_windows_arm64.zip">.zip</a>
+      <a class="sum" href="https://github.com/ankit373/hydra/releases/download/v1.4.2/hydra-desktop_v1.4.2_windows_arm64.zip.sha256">sha256</a>
     </div>
   </div>
   </div>
   <p style="font-size:13px;color:var(--faint);margin-top:12px;font-family:var(--mono);">
-    links pinned to v1.4.1 · <a href="https://github.com/ankit373/hydra/releases">all releases</a> ·
+    links pinned to v1.4.2 · <a href="https://github.com/ankit373/hydra/releases">all releases</a> ·
     the command above always takes the newest
   </p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
     "description": "Hydra is the Trust Control Plane for AI development: it routes tasks across every model on your machine to a target confidence of correctness, sampling models adaptively (SPRT) and stopping once the evidence is strong enough, while cutting AI API costs 70-85% along the way.",
     "url": "https://hydra.uvansa.com/",
     "downloadUrl": "https://github.com/ankit373/hydra",
-    "softwareVersion": "1.4.1",
+    "softwareVersion": "1.4.2",
     "datePublished": "2026-01-01",
     "dateModified": "2026-09-04",
     "license": "https://github.com/ankit373/hydra/blob/main/LICENSE",

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/app.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>


### PR DESCRIPTION
## Summary

The site publishes from `main`, and `app.html`'s desktop download links are
version-pinned by necessity (asset names embed the version, so GitHub's
`/releases/latest/download/` shortcut cannot address them). After v1.4.2
shipped, the live page was still offering v1.4.1:

```
$ curl -s https://hydra.uvansa.com/app.html | grep -oE 'v1\.4\.[0-9]+' | uniq -c
  23 v1.4.1
```

Also bumps the two version markers the docs guard requires to agree:
`index.html`'s `softwareVersion` and the `HYDRA_VERSION` example in
`README.md`.

## Verification

All three linked asset shapes resolve on the new tag:

```
hydra-desktop_v1.4.2_darwin_universal.zip   200
hydra-desktop_v1.4.2_windows_amd64.zip      200
hydra-desktop_v1.4.2_linux_arm64.tar.gz     200
```

`TestDocs_VersionIsNotBehindTheRelease` and `TestDocs_VersionReferencesAgree`
both pass. Those two guards are what caught this: the second flagged a partial
bump when only `app.html` had been updated.

Same change is already on `develop`, carried in with the v1.4.2 back-merge.