### PR TITLE
fix(status): list the heads that can run, not a frozen config echo

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ The wizard scans your machine, ranks every model it finds, walks you through pic
 # Discovery & state
 hyctl init                              # first-run wizard
 hyctl probe                             # scan and display all available models
-hyctl status                            # live system state (heads, budget bars, burn-rate risk)
+hyctl status                            # live state: heads that can run, budget bars, burn-rate risk
 hyctl tui                               # interactive cockpit, six views (see below), `?` for shortcuts
 hyctl version                           # version, commit, build info
 hyctl upgrade                           # self-update via install.sh (curl installs only; brew installs: `brew upgrade hyctl`)

--- a/cmd/hydra/cli_contract_test.go
+++ b/cmd/hydra/cli_contract_test.go
@@ -420,7 +420,7 @@ func TestPrintBudgetStatus_SurvivesEveryStateShape(t *testing.T) {
 				}
 			}
 			// The assertion is that this returns at all.
-			_ = captureStdout(t, printBudgetStatus)
+			_ = captureStdout(t, func() { printBudgetStatus(nil) })
 		})
 	}
 }

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -414,7 +414,7 @@ func cmdStatus() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Show current Cortex, Head configuration, and budget utilisation",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := config.Load()
 			if err != nil {
 				return fmt.Errorf("no config found, run: hyctl init")
@@ -437,23 +437,35 @@ func cmdStatus() *cobra.Command {
 					)
 				}
 			}
+			// Discovery, not cfg.Tiers: that is a snapshot `hyctl init` wrote
+			// once, and it advertised three heads that could not serve (#714).
+			// Measured at 10-40ms, so there is nothing to save by trusting it.
+			result := probe.Run(cmd.Context())
+			hs, now := health.Open(health.DefaultPath()), time.Now()
+			reason := func(h provider.Head) string { return health.Reason(hs, h, now) }
+
 			fmt.Println()
-			fmt.Println(dimStyle.Render("  " + strings.Repeat("─", 48)))
-			fmt.Printf("  %-14s  %s\n", "Tier", "Heads")
-			fmt.Println(dimStyle.Render("  " + strings.Repeat("─", 48)))
-			for _, t := range cfg.Tiers {
-				fmt.Printf("  %-14s  %s\n", t.Name, strings.Join(t.Heads, ", "))
+			for _, w := range result.Warnings {
+				fmt.Printf("  %s %s\n", warnStyle.Render("⚠"), dimStyle.Render(w))
 			}
+			fmt.Print(headTiers(result.Heads, reason))
+			fmt.Println()
+			fmt.Print(tierAliases(cfg.Tiers, result.Heads, reason))
 			fmt.Println()
 
 			// Budget section, read from state.json (written by dispatcher).
-			printBudgetStatus()
+			names := make(map[string]string, len(result.Heads))
+			for _, h := range result.Heads {
+				names[h.ID] = h.Name
+			}
+			printBudgetStatus(names)
 			return nil
 		},
 	}
 }
 
-func printBudgetStatus() {
+// names maps a head ID to its display name; a nil map leaves every row on its ID.
+func printBudgetStatus(names map[string]string) {
 	statePath := filepath.Join(config.Dir(), "logs", "state.json")
 	raw, err := os.ReadFile(statePath)
 	if err != nil {
@@ -494,14 +506,37 @@ func printBudgetStatus() {
 	fmt.Println(dimStyle.Render("  " + strings.Repeat("─", 48)))
 	fmt.Printf("  %-20s  %6s  %8s  %s\n", "Model", "  Used", " Window", "Mode")
 	fmt.Println(dimStyle.Render("  " + strings.Repeat("─", 48)))
-	for modelID, snap := range state.Budget {
+	// Sorted on the label, because ranging the map reordered the table on every
+	// invocation, and ordering by an ID the table does not show reads as random.
+	type row struct {
+		label string
+		id    string
+	}
+	rows := make([]row, 0, len(state.Budget))
+	for id := range state.Budget {
+		// Discovery's display name where it has one, so this table names a head
+		// the way `probe` and the tier table above do (#714).
+		label := id
+		if n := names[id]; n != "" {
+			label = n
+		}
+		rows = append(rows, row{label: label, id: id})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].label != rows[j].label {
+			return rows[i].label < rows[j].label
+		}
+		return rows[i].id < rows[j].id
+	})
+	for _, r := range rows {
+		snap := state.Budget[r.id]
 		pct := int(toFloat(snap["pct"]))
 		used := int(toFloat(snap["used"]))
 		window := int(toFloat(snap["window"]))
 		mode, _ := snap["mode"].(string)
 		bar := budgetBar(pct)
 		fmt.Printf("  %-20s  %s %3d%%  %-8s  %s\n",
-			truncLabel(modelID, 20),
+			truncLabel(r.label, 20),
 			bar, pct,
 			tokenLabel(used, window),
 			budgetModeStyle(mode).Render(mode),

--- a/cmd/hydra/status_heads.go
+++ b/cmd/hydra/status_heads.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/rank"
+)
+
+// reasonFunc reports why a head cannot be dispatched to, or "" when it can.
+// health.Reason in production; a stub in tests. Taking it as a parameter is
+// what keeps this renderable without touching the machine.
+type reasonFunc func(provider.Head) string
+
+// headTiers renders the heads that can run right now, grouped by the tier they
+// would actually route at. Anything reason refuses is counted, not listed:
+// status advertised three heads that could not serve because it echoed a config
+// snapshot instead of asking (#714).
+func headTiers(heads []provider.Head, reason reasonFunc) string {
+	byTier := map[int][]string{}
+	var blocked []string
+	for _, h := range heads {
+		if why := reason(h); why != "" {
+			blocked = append(blocked, h.Name)
+			continue
+		}
+		t := rank.UITier(h)
+		byTier[t] = append(byTier[t], h.Name)
+	}
+
+	var b strings.Builder
+	b.WriteString(dimStyle.Render("  "+strings.Repeat("─", 48)) + "\n")
+	b.WriteString(fmt.Sprintf("  %-6s%s\n", "Tier", "Heads that can run now"))
+	b.WriteString(dimStyle.Render("  "+strings.Repeat("─", 48)) + "\n")
+
+	if len(byTier) == 0 {
+		b.WriteString("  " + warnStyle.Render("no routable heads") + "\n")
+	}
+	tiers := make([]int, 0, len(byTier))
+	for t := range byTier {
+		tiers = append(tiers, t)
+	}
+	sort.Ints(tiers)
+	for _, t := range tiers {
+		b.WriteString(fmt.Sprintf("  %-6s%s\n", strconv.Itoa(t), strings.Join(byTier[t], ", ")))
+	}
+
+	if len(blocked) > 0 {
+		b.WriteString("\n  " + dimStyle.Render(fmt.Sprintf(
+			"%d of %d discovered heads cannot run (%s); `hyctl probe` says why.",
+			len(blocked), len(heads), strings.Join(blocked, ", "))) + "\n")
+	}
+	return b.String()
+}
+
+// tierAliases renders cfg.Tiers as what it actually is: the names `--tier <name>`
+// accepts. It is written once by `hyctl init` and never refreshed, so entries
+// are resolved against discovery and dead ones are marked rather than listed as
+// available (#714).
+func tierAliases(tiers []config.Tier, heads []provider.Head, reason reasonFunc) string {
+	if len(tiers) == 0 {
+		return ""
+	}
+	live := map[string]provider.Head{}
+	for _, h := range heads {
+		live[h.ID] = h
+	}
+
+	var b strings.Builder
+	b.WriteString(dimStyle.Render("  "+strings.Repeat("─", 48)) + "\n")
+	b.WriteString(fmt.Sprintf("  %-14s  %s\n", "--tier <name>", "Heads it can reach"))
+	b.WriteString(dimStyle.Render("  "+strings.Repeat("─", 48)) + "\n")
+
+	for _, t := range tiers {
+		var ok, dead []string
+		for _, id := range t.Heads {
+			h, found := live[id]
+			switch {
+			case !found:
+				// Discovery never emitted it. Could be uninstalled, could be
+				// `enabled: false` in the registry; status cannot tell, so it
+				// says what it knows rather than guessing which.
+				dead = append(dead, id+": not discovered")
+			case reason(h) != "":
+				dead = append(dead, id+": "+reason(h))
+			default:
+				ok = append(ok, h.Name)
+			}
+		}
+		lineup := strings.Join(ok, ", ")
+		if lineup == "" {
+			lineup = warnStyle.Render("none can run")
+		}
+		b.WriteString(fmt.Sprintf("  %-14s  %s\n", t.Name, lineup))
+		for _, d := range dead {
+			b.WriteString(fmt.Sprintf("  %-14s  %s\n", "", dimStyle.Render("✗ "+d)))
+		}
+	}
+	return b.String()
+}

--- a/cmd/hydra/status_heads_test.go
+++ b/cmd/hydra/status_heads_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// The machine that produced #714: two heads discovery finds but nothing can
+// drive, and a config tier naming a third that discovery never emits at all.
+func liveHeads() []provider.Head {
+	return []provider.Head{
+		{ID: "claude", Name: "Claude Code", Provider: "anthropic", Source: "cli", CapScore: 95},
+		{ID: "pro-high", Name: "Gemini 3.1 Pro (High)", Provider: "antigravity", Source: "registry",
+			Executable: "/usr/bin/agy", CapScore: 80, Meta: map[string]string{"tier": "5"}},
+		{ID: "ollama/qwen3:0.6b", Name: "qwen3:0.6b (Ollama)", Provider: "local", Source: "port",
+			CapScore: 63, LocalOnly: true},
+		{ID: "ollama", Name: "Ollama", Provider: "local", Source: "cli", CapScore: 60, LocalOnly: true},
+		{ID: "ollama/nomic-embed-text:latest", Name: "nomic-embed-text:latest (Ollama)",
+			Provider: "local", Source: "port", CapScore: 55, LocalOnly: true,
+			Meta: map[string]string{"embedding_only": "true"}},
+	}
+}
+
+// refuses stands in for health.Reason over the fixture above.
+func refuses(h provider.Head) string {
+	switch h.ID {
+	case "ollama":
+		return "binary only, start its local server"
+	case "ollama/nomic-embed-text:latest":
+		return "embeddings only, never routed"
+	}
+	return ""
+}
+
+// tierRow matches a rendered tier row. The %-6s tier column leaves at least two
+// spaces, which is what separates a row from the "2 of 5 … cannot run" summary.
+var tierRow = regexp.MustCompile(`(?m)^  (\d{1,2}) {2,}(.+)$`)
+
+// listedHeads returns the head names headTiers presented as available. Exact
+// names, not a substring scan: "Ollama" is a substring of "qwen3:0.6b (Ollama)".
+func listedHeads(out string) map[string]bool {
+	names := map[string]bool{}
+	for _, m := range tierRow.FindAllStringSubmatch(out, -1) {
+		for _, n := range strings.Split(m[2], ", ") {
+			names[strings.TrimSpace(n)] = true
+		}
+	}
+	return names
+}
+
+// The defect itself: status listed three heads that could not serve because it
+// echoed cfg.Tiers instead of asking. Nothing reason refuses may appear as an
+// available head, on any surface, ever again.
+func TestHeadTiers_NeverListsAHeadThatCannotRun(t *testing.T) {
+	listed := listedHeads(stripANSICodes(headTiers(liveHeads(), refuses)))
+	if len(listed) == 0 {
+		t.Fatal("parsed no rows at all; this test has stopped testing anything")
+	}
+	for _, h := range liveHeads() {
+		if refuses(h) != "" && listed[h.Name] {
+			t.Errorf("%q is listed as available but cannot run: %s", h.Name, refuses(h))
+		}
+		if refuses(h) == "" && !listed[h.Name] {
+			t.Errorf("routable head %q is missing from the table", h.Name)
+		}
+	}
+}
+
+// A head that cannot run is still accounted for. Dropping it silently would
+// make the list shorter and no more honest.
+func TestHeadTiers_CountsWhatItWouldNotList(t *testing.T) {
+	out := stripANSICodes(headTiers(liveHeads(), refuses))
+	if !strings.Contains(out, "2 of 5 discovered heads cannot run") {
+		t.Errorf("no count of the unroutable heads:\n%s", out)
+	}
+	if !strings.Contains(out, "hyctl probe") {
+		t.Error("does not point at the command that gives the reason")
+	}
+}
+
+// Grouping is rank.UITier, the same number dispatch selects on, so the table
+// says where a head would actually route.
+func TestHeadTiers_GroupsByTheTierDispatchWouldUse(t *testing.T) {
+	out := stripANSICodes(headTiers(liveHeads(), refuses))
+	for _, want := range []string{
+		"1     Claude Code",
+		"5     Gemini 3.1 Pro (High)",
+		"10    qwen3:0.6b (Ollama)", // LocalOnly ⇒ tier 10 regardless of score
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing row %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestHeadTiers_SaysSoWhenNothingCanRun(t *testing.T) {
+	out := stripANSICodes(headTiers(liveHeads(), func(provider.Head) string { return "nope" }))
+	if !strings.Contains(out, "no routable heads") {
+		t.Errorf("an empty table must say why it is empty:\n%s", out)
+	}
+}
+
+// cfg.Tiers is written once by `hyctl init`. Entries that have gone stale must
+// read as stale, not as available.
+func TestTierAliases_MarksEntriesThatCannotRun(t *testing.T) {
+	tiers := []config.Tier{
+		{Name: "complex", Heads: []string{"flash-thinking", "pro-high"}},
+		{Name: "simple", Heads: []string{"ollama/qwen3:0.6b", "ollama", "ollama/nomic-embed-text:latest"}},
+	}
+	out := stripANSICodes(tierAliases(tiers, liveHeads(), refuses))
+
+	for _, want := range []string{
+		"flash-thinking: not discovered",
+		"ollama: binary only, start its local server",
+		"ollama/nomic-embed-text:latest: embeddings only, never routed",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stale entry not marked: want %q in:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "complex") || !strings.Contains(out, "Gemini 3.1 Pro (High)") {
+		t.Errorf("the live half of a partly-stale tier must still be shown:\n%s", out)
+	}
+}
+
+func TestTierAliases_SaysNoneCanRunRatherThanShowingBlank(t *testing.T) {
+	tiers := []config.Tier{{Name: "expert", Heads: []string{"gone", "ollama"}}}
+	out := stripANSICodes(tierAliases(tiers, liveHeads(), refuses))
+	if !strings.Contains(out, "none can run") {
+		t.Errorf("a tier with nothing live must say so, not print an empty cell:\n%s", out)
+	}
+}
+
+// An unconfigured machine has no aliases to show, and an empty bordered table
+// with no rows is worse than no table.
+func TestTierAliases_EmptyWhenNoTiersConfigured(t *testing.T) {
+	if out := tierAliases(nil, liveHeads(), refuses); out != "" {
+		t.Errorf("want no output for an empty tier list, got:\n%s", out)
+	}
+}

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -669,8 +669,8 @@ hyctl probe                        <span class="c"># it shows up as a scored hea
 
     <section class="doc" id="status">
       <h2><span class="cmd">hyctl status</span> <span class="tagline">live state</span></h2>
-      <p class="sum">Heads, budget bars, and the <b>rate-aware</b> governor.</p>
-      <div class="sub"><div class="lbl">How it works</div><p>Models context usage as a drifting process and estimates the <b>first-passage probability</b> of crossing the ceiling before the task ends, escalating <i>before</i> a threshold is hit.</p></div>
+      <p class="sum">The heads that <b>can actually run</b>, budget bars, and the <b>rate-aware</b> governor.</p>
+      <div class="sub"><div class="lbl">How it works</div><p>Head list comes from live discovery, grouped by the tier each head would route at, so it cannot drift from the router; anything discovery found but nothing can drive is counted, not listed. The governor models context usage as a drifting process and estimates the <b>first-passage probability</b> of crossing the ceiling before the task ends, escalating <i>before</i> a threshold is hit.</p></div>
       <div class="sub"><div class="lbl">Usage</div><pre>hyctl status</pre></div>
       <a class="more" href="#governor">How the governor decides →</a>
     </section>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,7 +24,7 @@
 
 - `hyctl dispatch`: route a task to the cheapest head that clears the bar (`--enum`/`--tier`, `--swarm`, `--confidence`, `--file`, `--local`, `--dry-run`, `--a2a`)
 - `hyctl probe`: scan the machine for every available head (CLI agents, API keys, local servers)
-- `hyctl status`: session state, the rate-aware `claude_pct` budget governor and discovered heads
+- `hyctl status`: session state, the rate-aware `claude_pct` budget governor, and the heads that can actually run right now, grouped by the tier they would route at
 - `hyctl tui`: interactive cockpit whose chat executes (Auto/Plan/Edit/Ask, plus Architect/Careful/Unattended), plus five more views over the same data: Agents, Models, Activity, Usage, Audit
 - `hyctl cost`: spend report (estimated vs actual) from the dispatch cost log
 - `hyctl stats`: session cost rollup by model, tier, and day. `--latency` reports p50/p90/p99 per model from mergeable relative-error sketches held in per-day rollups, so a percentile is answered without rescanning the whole cost log and two machines' stats can be combined without shipping their traces

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,37 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hydra.uvansa.com/</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/app.html</loc>
-    <lastmod>2026-09-07</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/docs.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/first-principles.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/pricing.html</loc>
-    <lastmod>2026-09-06</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://hydra.uvansa.com/funding.json</loc>
-    <lastmod>2026-09-05</lastmod>
+    <lastmod>2026-09-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>


### PR DESCRIPTION
## Summary

`hyctl status` is the command the orchestration protocol tells you to run at
Step 2 to check "available heads". Its head list was not discovery. It was a
verbatim echo of `cfg.Tiers`, a snapshot `hyctl init` wrote once and nothing
refreshed since, so it advertised three heads that could not serve.

Measured on a live machine, config written 2026-09-03:

| Head status said was available | What `Unroutable` says |
|---|---|
| `ollama` | binary only, start its local server |
| `ollama/nomic-embed-text:latest` | embeddings only, never routed |
| `flash-thinking` | `enabled: false` in the registry since #693; discovery never emits it |

Every other head-listing surface in Hydra consults `health.Reason`. This one did
not, which is exactly the divergence #248 introduced that function to prevent.

### The part that costs money

The table was labelled `Tier / Heads`, so it read as the routing table. It is
not: enums resolve through the hardcoded `dispatch.EnumToTier` and then rank live
heads by score, while `cfg.Tiers` only turns a *named* `--tier` hint into a
numeric floor. The two disagreed on the same word:

```
$ hyctl dispatch --dry-run --tier simple "x"
  Primary  →  Qwen2.5-Coder:7b (Ollama)     port      local, free

$ hyctl dispatch --dry-run --enum SIMPLE "x"
  Primary  →  Gemini 3.8 Flash (Medium)     registry  paid, remote
```

Anyone reading `simple → ollama/…` had every reason to believe `--enum SIMPLE`
stayed on the machine and cost nothing.

## Changes

- `cmd/hydra/status_heads.go`, new. `headTiers` lists the heads that can run,
  grouped by `rank.UITier`, the number dispatch actually selects on, and counts
  the rest rather than listing them. `tierAliases` renders `cfg.Tiers` as what it
  is, the names `--tier <name>` accepts, with stale entries marked and their
  reason given. Both take the reason function as a parameter, which is what makes
  them renderable without touching the machine.
- `cmd/hydra/main.go`, `cmdStatus` runs `probe.Run` and passes `health.Reason`.
  Discovery measured at 10ms, so nothing was bought by trusting the snapshot.

Two more defects found in `status` while confirming it names heads the way
`probe` does:

- The budget table ranged a map, so its rows reordered on every invocation.
  Now sorted, on the label it actually displays.
- It labelled rows with registry IDs (`flash-med`) where every other table used
  display names (`Gemini 3.8 Flash (Medium)`). Same split as #696, in a surface
  #697 did not cover.

## Before / after

```
  Tier            Heads                        Tier  Heads that can run now
  ──────────────────────────                   ────────────────────────────────
  simple  ollama/qwen3:0.6b, ollama,           10    Qwen2.5-Coder:7b (Ollama),
          ollama/nomic-embed-text:latest             qwen3:0.6b (Ollama)
  complex flash-thinking, agy, pro-high,
          pro-low                              2 of 14 discovered heads cannot
                                               run (Ollama, nomic-embed-text:
                                               latest (Ollama)); `hyctl probe`
                                               says why.
```

## Verification

- The regression guard is mutation-tested: reintroducing the exact bug (listing
  blocked heads instead of counting them) fails
  `TestHeadTiers_NeverListsAHeadThatCannotRun`, naming both heads. It passes
  again on revert.
- `go test -race -count=1 ./...` green. `gofmt`, `go vet`, `staticcheck` clean.
  Desktop module builds.
- Verified by running the built binary, not only the tests.

## Deliberately not in scope

`--enum SIMPLE` and `--tier simple` resolving to different heads is a routing
semantics question, not a display bug. This PR makes the disagreement visible;
it does not change where anything routes. Worth deciding separately.

Docs updated in the same PR: `docs/docs.html`, `docs/llms.txt`, `README.md`,
`docs/sitemap.xml`.

Closes #714