### PR TITLE
fix(routing): let routing.yaml actually route

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,10 @@ registry/               ← Routing data, compiled into the binary via `go:embed
                           and overridable on disk at `$HYDRA_HOME/registry/<file>`. Nothing ships
                           these files as separate artifacts, brew/npm/pip/curl install the binary
                           alone, so before #238 every install ran with no registry at all.
-  routing.yaml          ← Enum → tier reference table, and what `hyctl init` writes. NOTE: the
-                          runtime mapping is `dispatch.EnumToTier`, a hardcoded Go switch, editing
-                          this file alone does NOT change how a dispatch routes.
+  routing.yaml          ← Enum → tier map. The router reads it (`registry.EnumTiers`), so editing
+                          it, or a copy at `$HYDRA_HOME/registry/routing.yaml`, does change how a
+                          dispatch routes. An override must list every enum; a partial one is
+                          refused rather than silently falling back (#720).
   models.yaml           ← Model definitions, token pools, context windows (flags are
                           install-specific defaults, verify against your providers). Read by
                           the agy provider and the budget governor.
@@ -83,8 +84,9 @@ logs/                   ← Dispatch log + state.json (claude_pct, claude_pct_hi
 ### Step 1, Classify
 Read `registry/domains.yaml` to identify the domain and task type.
 Look up the enum key (e.g. `SIMPLE`, `COMPLEX`).
-`registry/routing.yaml` documents which tier that enum resolves to; the mapping the router
-actually applies is `dispatch.EnumToTier`.
+`registry/routing.yaml` defines which tier that enum resolves to, and is what `dispatch.EnumToTier`
+reads, so the two cannot disagree. `domains.yaml` is still a reference table for this step only:
+nothing at runtime reads it.
 
 ### Step 2, Check State
 ```bash

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -643,6 +643,13 @@ func cmdDispatch() *cobra.Command {
 		Short: "Route a prompt to the best available Head",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Checked before the enum name: IsKnownEnum reports false when the
+			// routing table could not be loaded at all, so a broken routing.yaml
+			// otherwise came back as "unknown --enum SIMPLE", blaming a valid key
+			// for a file problem (#720).
+			if err := dispatch.RoutingError(); err != nil {
+				return err
+			}
 			// An unrecognized --enum must fail here, before anything routes: its
 			// zero value is byte-identical to "no enum given" everywhere else in
 			// this function, so a typo silently routed to the single strongest

--- a/desktop/api/chat.go
+++ b/desktop/api/chat.go
@@ -207,12 +207,11 @@ func preview(s string) string {
 
 // ChatEnums lists the routing keys the dock offers, weakest head first.
 //
-// Taken from dispatch.EnumToTier's own table rather than restated, so the
-// picker cannot offer a key the router does not understand. The dock's "auto"
-// choice is the absence of an enum, not a member of this list.
+// Read from the router's own table, so the picker cannot offer a key the router
+// does not understand. It used to claim exactly that while being a hardcoded
+// restatement, a fourth copy of the enum list that drifts the moment
+// routing.yaml changes (#720). The dock's "auto" choice is the absence of an
+// enum, not a member of this list.
 func (a *API) ChatEnums() []string {
-	return []string{
-		"GRUNT", "TRIVIAL", "SIMPLE", "STANDARD", "MODERATE",
-		"COMPLEX", "HARD", "VERY_HARD", "EXPERT", "CORE",
-	}
+	return dispatch.EnumKeys()
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -301,6 +301,11 @@ func New(ctx context.Context) (*Dispatcher, error) {
 	if err != nil {
 		return nil, fmt.Errorf("no hydra config, run: hyctl init")
 	}
+	// Before any probing or routing: an unusable routing.yaml stops the
+	// dispatch rather than being papered over with the shipped rule (#720).
+	if err := RoutingError(); err != nil {
+		return nil, err
+	}
 
 	result := cachedProbe(ctx)
 	localOnly := piiLocalOnly(cfg)
@@ -1124,20 +1129,20 @@ func truncate(s string, n int) string {
 	return s[:n] + "…"
 }
 
-// enumTiers maps each routing enum key to its tier number, the single
-// source of truth EnumToTier and IsKnownEnum both read, so editor, parallel,
-// and cmd/hydra's --enum validation can never drift apart.
-var enumTiers = map[string]string{
-	"GRUNT":     "10",
-	"TRIVIAL":   "9",
-	"SIMPLE":    "8",
-	"STANDARD":  "7",
-	"MODERATE":  "6",
-	"COMPLEX":   "5",
-	"HARD":      "4",
-	"VERY_HARD": "3",
-	"EXPERT":    "2",
-	"CORE":      "1",
+// enumTiers reads the map from registry/routing.yaml, the file whose own header
+// has always claimed to define it. It used to be a Go literal here, so the
+// on-disk override every other registry file honours did nothing for the one
+// file named after routing (#720).
+func enumTiers() (map[string]int, error) {
+	return registry.EnumTiers(config.ScriptHome())
+}
+
+// RoutingError reports an unusable routing.yaml. New returns it, so no surface
+// routes on a map it could not load, and a bad override is refused rather than
+// quietly reverting to the shipped rule.
+func RoutingError() error {
+	_, err := enumTiers()
+	return err
 }
 
 // EnumToTier maps a routing enum key (e.g. "SIMPLE") to a tier number string.
@@ -1145,15 +1150,36 @@ var enumTiers = map[string]string{
 // why a caller that must reject a typo instead of silently routing
 // unrestricted checks IsKnownEnum first (#501).
 func EnumToTier(enum string) string {
-	return enumTiers[enum]
+	tiers, err := enumTiers()
+	if err != nil {
+		return ""
+	}
+	if n, ok := tiers[enum]; ok {
+		return strconv.Itoa(n)
+	}
+	return ""
 }
 
 // IsKnownEnum reports whether enum is a recognized routing enum key.
 // EnumToTier's "" result is ambiguous between "no enum given" and
 // "unrecognized key", this is how a caller tells the two apart.
 func IsKnownEnum(enum string) bool {
-	_, ok := enumTiers[enum]
+	tiers, err := enumTiers()
+	if err != nil {
+		return false
+	}
+	_, ok := tiers[enum]
 	return ok
+}
+
+// EnumKeys lists the routing keys weakest head first, for a picker that must
+// not offer a key the router does not understand.
+func EnumKeys() []string {
+	keys, err := registry.EnumKeys(config.ScriptHome())
+	if err != nil {
+		return nil
+	}
+	return keys
 }
 
 // headPool is the token pool a cost row should be filed under. Provider

--- a/registry/routing.go
+++ b/registry/routing.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// routing.yaml's first lines have always told operators that changing a value
+// there updates every domain. Nothing read it: the map lived in a Go literal,
+// so the on-disk override models.yaml and pricing.yaml honour did nothing for
+// the one file named after routing (#720).
+
+const (
+	minEnumTier = 1
+	maxEnumTier = 10
+)
+
+type routingFile struct {
+	RoutingMap map[string]int `yaml:"routing_map"`
+}
+
+type routingResult struct {
+	tiers map[string]int
+	err   error
+}
+
+// Keyed by home rather than a package-level sync.Once, so a process that reads
+// more than one registry root (tests, mainly) gets each one's real answer.
+var routingCache struct {
+	sync.Mutex
+	byHome map[string]routingResult
+}
+
+// EnumTiers returns the routing enum to tier-number map, preferring home's
+// override and falling back to the embedded copy.
+//
+// The returned map is a copy: it is handed to the router on every dispatch and
+// a shared one would be one careless write away from retuning routing globally.
+func EnumTiers(home string) (map[string]int, error) {
+	routingCache.Lock()
+	defer routingCache.Unlock()
+	r, ok := routingCache.byHome[home]
+	if !ok {
+		r.tiers, r.err = loadEnumTiers(home)
+		if routingCache.byHome == nil {
+			routingCache.byHome = map[string]routingResult{}
+		}
+		routingCache.byHome[home] = r
+	}
+	return cloneTiers(r.tiers), r.err
+}
+
+// EnumKeys lists the enum keys weakest head first, which is the order a picker
+// offers them in. Ties break alphabetically so the order is stable.
+func EnumKeys(home string) ([]string, error) {
+	tiers, err := EnumTiers(home)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(tiers))
+	for k := range tiers {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if tiers[keys[i]] != tiers[keys[j]] {
+			return tiers[keys[i]] > tiers[keys[j]]
+		}
+		return keys[i] < keys[j]
+	})
+	return keys, nil
+}
+
+func loadEnumTiers(home string) (map[string]int, error) {
+	// The embedded copy defines which enums exist, so the check below is derived
+	// from the shipped file rather than a second list in Go, which is the
+	// duplication this change exists to remove.
+	shipped, err := embedded.ReadFile("routing.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("embedded routing.yaml is unreadable: %w", err)
+	}
+	base, err := parseRoutingMap(shipped)
+	if err != nil {
+		return nil, fmt.Errorf("embedded routing.yaml is unusable: %w", err)
+	}
+
+	// Read falls back to the embedded copy, so with no override this parses the
+	// same bytes twice and the coverage check passes trivially. One path.
+	raw, err := Read(home, "routing.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("cannot read routing.yaml: %w", err)
+	}
+	got, err := parseRoutingMap(raw)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkCoversBase(base, got); err != nil {
+		return nil, err
+	}
+	return got, nil
+}
+
+func parseRoutingMap(raw []byte) (map[string]int, error) {
+	var f routingFile
+	if err := yaml.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("routing.yaml is not valid YAML: %w", err)
+	}
+	if len(f.RoutingMap) == 0 {
+		return nil, errors.New("routing.yaml declares no routing_map")
+	}
+	for _, k := range sortedKeys(f.RoutingMap) {
+		if v := f.RoutingMap[k]; v < minEnumTier || v > maxEnumTier {
+			return nil, fmt.Errorf("routing.yaml: %s is tier %d, outside the valid range %d-%d",
+				k, v, minEnumTier, maxEnumTier)
+		}
+	}
+	return f.RoutingMap, nil
+}
+
+// checkCoversBase refuses a partial or inventive override. A missing key would
+// route by the shipped rule with nothing to say so, and a stray one would mint
+// a new enum out of a typo, which is exactly what IsKnownEnum exists to catch
+// (#501).
+func checkCoversBase(base, got map[string]int) error {
+	var missing, extra []string
+	for _, k := range sortedKeys(base) {
+		if _, ok := got[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	for _, k := range sortedKeys(got) {
+		if _, ok := base[k]; !ok {
+			extra = append(extra, k)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("routing.yaml override is missing %s; every enum must be listed, "+
+			"a missing one would keep routing by the shipped rule with nothing to say so",
+			strings.Join(missing, ", "))
+	}
+	if len(extra) > 0 {
+		return fmt.Errorf("routing.yaml override declares unrecognized enum %s; recognized keys are %s",
+			strings.Join(extra, ", "), strings.Join(sortedKeys(base), ", "))
+	}
+	return nil
+}
+
+func sortedKeys(m map[string]int) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func cloneTiers(m map[string]int) map[string]int {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]int, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/registry/routing.yaml
+++ b/registry/routing.yaml
@@ -7,6 +7,10 @@
 # Example: change GRUNT from 10 to 9 → boilerplate now goes to Flash Low not Qwen
 #
 # Keys map to tier numbers defined in models.yaml
+#
+# The router reads this file. A copy at $HYDRA_HOME/registry/routing.yaml wins
+# over the one in the binary, and must list every key below: a partial override
+# is refused rather than silently falling back for the keys it omits.
 # ─────────────────────────────────────────────────────────────────────────────
 
 version: "1.0"

--- a/registry/routing_test.go
+++ b/registry/routing_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeOverride puts a routing.yaml in a fresh home and returns that home.
+// A distinct directory per case matters: EnumTiers caches per home, so reusing
+// one would answer the first case's question for every later one.
+func writeOverride(t *testing.T, body string) string {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, "registry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "routing.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// allTen renders a complete routing_map, with overrides applied on top.
+func allTen(over map[string]int) string {
+	base := map[string]int{
+		"GRUNT": 10, "TRIVIAL": 9, "SIMPLE": 8, "STANDARD": 7, "MODERATE": 6,
+		"COMPLEX": 5, "HARD": 4, "VERY_HARD": 3, "EXPERT": 2, "CORE": 1,
+	}
+	for k, v := range over {
+		base[k] = v
+	}
+	var b strings.Builder
+	b.WriteString("routing_map:\n")
+	for _, k := range sortedKeys(base) {
+		b.WriteString("  " + k + ": " + itoa(base[k]) + "\n")
+	}
+	return b.String()
+}
+
+func itoa(n int) string {
+	if n >= 10 {
+		return string(rune('0'+n/10)) + string(rune('0'+n%10))
+	}
+	return string(rune('0' + n))
+}
+
+// The shipped file must be loadable, or an installed binary cannot route at
+// all. Nothing else in this package is meaningful if this fails.
+func TestEnumTiers_EmbeddedCopyIsUsable(t *testing.T) {
+	tiers, err := EnumTiers("")
+	if err != nil {
+		t.Fatalf("embedded routing.yaml does not load: %v", err)
+	}
+	if got := tiers["SIMPLE"]; got != 8 {
+		t.Errorf("SIMPLE = %d, want 8 from the shipped routing.yaml", got)
+	}
+	if len(tiers) != 10 {
+		t.Errorf("got %d enums, want the 10 routing.yaml declares", len(tiers))
+	}
+}
+
+// The defect: routing.yaml's header promises that changing a value there
+// changes routing. Nothing read it.
+func TestEnumTiers_AnOverrideActuallyChangesRouting(t *testing.T) {
+	home := writeOverride(t, allTen(map[string]int{"SIMPLE": 10}))
+	tiers, err := EnumTiers(home)
+	if err != nil {
+		t.Fatalf("a complete override was refused: %v", err)
+	}
+	if tiers["SIMPLE"] != 10 {
+		t.Errorf("SIMPLE = %d, want 10; the override did not take effect, "+
+			"which is the whole bug", tiers["SIMPLE"])
+	}
+	if tiers["CORE"] != 1 {
+		t.Errorf("CORE = %d, want 1; an override must not disturb keys it did "+
+			"not change", tiers["CORE"])
+	}
+}
+
+// A missing key would keep routing by the shipped rule with nothing to say so,
+// which is the same silent-staleness shape as #714.
+func TestEnumTiers_RefusesAPartialOverride(t *testing.T) {
+	home := writeOverride(t, "routing_map:\n  SIMPLE: 10\n")
+	_, err := EnumTiers(home)
+	if err == nil {
+		t.Fatal("a routing_map with one key was accepted; the other nine would " +
+			"silently route by the shipped rule")
+	}
+	for _, want := range []string{"missing", "CORE", "GRUNT"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not name %q, so it cannot be acted on: %v", want, err)
+		}
+	}
+}
+
+// A typo must not mint a new enum, which is what IsKnownEnum exists to catch.
+func TestEnumTiers_RefusesAnUnrecognizedKey(t *testing.T) {
+	home := writeOverride(t, allTen(nil)+"  SIMPEL: 8\n")
+	_, err := EnumTiers(home)
+	if err == nil {
+		t.Fatal("a misspelled enum was accepted as a new routing key")
+	}
+	if !strings.Contains(err.Error(), "SIMPEL") {
+		t.Errorf("error does not name the offending key: %v", err)
+	}
+}
+
+func TestEnumTiers_RefusesATierOutsideTheRange(t *testing.T) {
+	for _, tc := range []struct{ name, body string }{
+		{"zero", allTen(map[string]int{"CORE": 0})},
+		{"eleven", allTen(map[string]int{"GRUNT": 11})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := EnumTiers(writeOverride(t, tc.body))
+			if err == nil {
+				t.Fatal("a tier outside 1-10 was accepted")
+			}
+			if !strings.Contains(err.Error(), "outside the valid range") {
+				t.Errorf("error does not say what is wrong: %v", err)
+			}
+		})
+	}
+}
+
+func TestEnumTiers_RefusesMalformedAndEmpty(t *testing.T) {
+	for _, tc := range []struct{ name, body, want string }{
+		{"not yaml", "routing_map: [this is: a list", "not valid YAML"},
+		{"no routing_map", "version: \"1.0\"\n", "no routing_map"},
+		{"empty map", "routing_map:\n", "no routing_map"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := EnumTiers(writeOverride(t, tc.body))
+			if err == nil {
+				t.Fatalf("%s was accepted", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("want an error mentioning %q, got: %v", tc.want, err)
+			}
+		})
+	}
+}
+
+// A home with no registry/ at all is the normal installed case: Read falls back
+// to the embedded copy and routing must work.
+func TestEnumTiers_NoOverrideFallsBackToEmbedded(t *testing.T) {
+	tiers, err := EnumTiers(t.TempDir())
+	if err != nil {
+		t.Fatalf("a home with no override must still route: %v", err)
+	}
+	if tiers["SIMPLE"] != 8 {
+		t.Errorf("SIMPLE = %d, want the shipped 8", tiers["SIMPLE"])
+	}
+}
+
+// The map reaches the router on every dispatch. Handing out the cached one
+// would put a global retune one careless write away.
+func TestEnumTiers_ReturnsACopy(t *testing.T) {
+	home := t.TempDir()
+	first, err := EnumTiers(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first["SIMPLE"] = 1
+	second, err := EnumTiers(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second["SIMPLE"] != 8 {
+		t.Errorf("SIMPLE = %d after a caller mutated its copy; the cache is shared",
+			second["SIMPLE"])
+	}
+}
+
+// Weakest first is the order a picker offers, so GRUNT (tier 10) leads and
+// CORE (tier 1) is last.
+func TestEnumKeys_OrderedWeakestFirst(t *testing.T) {
+	keys, err := EnumKeys("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"GRUNT", "TRIVIAL", "SIMPLE", "STANDARD", "MODERATE",
+		"COMPLEX", "HARD", "VERY_HARD", "EXPERT", "CORE"}
+	if len(keys) != len(want) {
+		t.Fatalf("got %d keys, want %d", len(keys), len(want))
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Errorf("position %d is %s, want %s", i, keys[i], want[i])
+		}
+	}
+}
+
+// The order must follow the file, not a literal: an override that inverts the
+// tiers inverts the picker.
+func TestEnumKeys_FollowsTheFileNotAHardcodedOrder(t *testing.T) {
+	home := writeOverride(t, allTen(map[string]int{"CORE": 10, "GRUNT": 1}))
+	keys, err := EnumKeys(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if keys[0] != "CORE" {
+		t.Errorf("first key is %s, want CORE now that it is tier 10", keys[0])
+	}
+	if keys[len(keys)-1] != "GRUNT" {
+		t.Errorf("last key is %s, want GRUNT now that it is tier 1", keys[len(keys)-1])
+	}
+}


### PR DESCRIPTION
Phase 2 of #716.

## Summary

`registry/routing.yaml` opens with:

> This is your single enum. Change a value here → every domain updates.

Nothing read it. The map was a Go literal in `internal/dispatch`, so the on-disk
override that `models.yaml` and `pricing.yaml` both honour did nothing for the
one file named after routing.

Proven through the documented override path, before the change, by retuning
`SIMPLE` from tier 8 to tier 10 (asking for the free local head instead of a
paid remote one):

```
$ grep SIMPLE $HYDRA_HOME/registry/routing.yaml
  SIMPLE:     10
$ hyctl dispatch --dry-run --enum SIMPLE "x"
  Primary  →  Gemini 3.8 Flash (Medium)  (score 70, registry)
```

Four things in the repo described routing. One governed. `domains.yaml`, 224
lines mapping every domain and task to an enum, is opened only by
`config.BreadcrumbFiles`, which hashes it, while CLAUDE.md's protocol opens with
"Step 1, Classify. Read `registry/domains.yaml`".

That last part matters beyond tidiness: `config.Breadcrumb()` is stamped into
every ledger, trust and cost row so a run can be tied back to "the exact routing
rules in effect", and two of the four files it hashes were not the rules in
effect.

## After

```
$ hyctl dispatch --dry-run --enum SIMPLE "x"          # embedded, unchanged
  Primary  →  Gemini 3.8 Flash (Medium)  (score 70, registry)

$ HYDRA_HOME=... hyctl dispatch --dry-run --enum SIMPLE "x"   # SIMPLE: 10
  Primary  →  Qwen2.5-Coder:7b (Ollama)  (score 66, port)
```

## Changes

- `registry/routing.go`, new. `EnumTiers(home)` reads `routing_map` through
  `registry.Read`, so an override wins and the embedded copy is the default.
  `EnumKeys(home)` gives the same table ordered weakest head first.
- `internal/dispatch`, `EnumToTier` and `IsKnownEnum` read it instead of a Go
  literal. `RoutingError()` reports an unusable table and `New` returns it, so
  no surface routes on a table it could not load.
- `desktop/api/chat.go`, `ChatEnums` claimed to be "taken from
  dispatch.EnumToTier's own table rather than restated" and was a hardcoded
  restatement, a fourth copy that drifts the moment routing.yaml changes. It
  now calls `dispatch.EnumKeys()`.

### Refused, by name, never silently

An override must cover every enum the shipped file declares and invent none. A
missing key would keep routing by the shipped rule with nothing to say so, and a
stray one would mint an enum out of a typo, which is exactly what `IsKnownEnum`
exists to catch (#501). `ledger.LoadPolicy` sets the precedent: reject an
unparseable rule rather than void it.

```
Error: routing.yaml override is missing COMPLEX, CORE, EXPERT, GRUNT, HARD,
       MODERATE, STANDARD, TRIVIAL, VERY_HARD; every enum must be listed, a
       missing one would keep routing by the shipped rule with nothing to say so

Error: routing.yaml override declares unrecognized enum SIMPEL; recognized keys
       are COMPLEX, CORE, EXPERT, GRUNT, HARD, MODERATE, SIMPLE, STANDARD, ...

Error: routing.yaml: CORE is tier 0, outside the valid range 1-10
```

## Found by running the binary, not by the tests

A broken `routing.yaml` first surfaced as `unknown --enum "SIMPLE"`. `IsKnownEnum`
reports false when the table cannot load at all, and the `--enum` check runs
before `dispatch.New`, so the message blamed a valid key for a file problem.
`cmdDispatch` now checks `RoutingError()` first. A genuinely misspelled enum
still reads as one.

## Verification

- Mutation-tested: making the loader ignore the override (the original bug)
  fails 6 of the new tests, including
  `TestEnumTiers_AnOverrideActuallyChangesRouting`. All pass on revert.
- Every error path exercised against the real binary through `$HYDRA_HOME`,
  not only in unit tests.
- `go test -race -count=1 ./...` green, plus `desktop/api`. `gofmt`, `go vet`,
  `staticcheck` clean.
- The map is returned as a copy: it reaches the router on every dispatch and a
  shared one would put a global retune one careless write away. Guarded by
  `TestEnumTiers_ReturnsACopy`.

## Docs

`routing.yaml`'s header now documents the override path and the all-or-nothing
rule. CLAUDE.md said "editing this file alone does NOT change how a dispatch
routes", which was true and is now not, and no longer implies `domains.yaml`
routes anything.

## Not in scope

`domains.yaml` gets its own issue: it either becomes reachable
(`hyctl dispatch --domain backend --task dto_schema`) or stops claiming to
adjust routing. It must not stay hashed as a routing rule while being read by
nothing.

Closes #720