### PR TITLE
fix(cost): make today mean today, and count each head once

### DIFF
--- a/docs/funding.json
+++ b/docs/funding.json
@@ -49,7 +49,8 @@
       {
         "guid": "open-collective",
         "type": "payment-provider",
-        "description": "Open Collective, hosted by Open Source Collective, not yet created. Reserved slug: opencollective.com/hyctl."
+        "address": "https://opencollective.com/hyctl",
+        "description": "Open Collective, hosted by Open Source Collective. One-time or recurring, with transparent public ledger of how the money is spent."
       }
     ],
     "plans": [
@@ -61,7 +62,7 @@
         "amount": 0,
         "currency": "USD",
         "frequency": "monthly",
-        "channels": ["github-sponsors"]
+        "channels": ["github-sponsors", "open-collective"]
       }
     ]
   }

--- a/internal/cost/canonical.go
+++ b/internal/cost/canonical.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+
+package cost
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/ankit373/hydra/internal/capabilities"
+	"github.com/ankit373/hydra/internal/config"
+	"github.com/ankit373/hydra/registry"
+	"gopkg.in/yaml.v3"
+)
+
+// A cost row records the head under whatever name its writer used, and that
+// name has changed three times: registry ids, display names, and the Gemini
+// rename in #693. 106 of 117 rows on a real machine predate the Head field, so
+// one head rendered as two groups and neither was its spend: Claude Code showed
+// $0.004890 over 31 calls beside $0.077295 over 14 (#729).
+//
+// Resolved on read. Nothing rewrites a log the user did not ask to have edited.
+
+// aliasTable maps every declared spelling of a head to its canonical ID, and
+// remembers which IDs are canonical so a stale name can be told apart from a
+// live head.
+type aliasTable struct {
+	byName map[string]string
+	ids    map[string]bool
+}
+
+var aliasOnce struct {
+	sync.Once
+	table aliasTable
+}
+
+// localPrefixes inverts the port provider's own display construction
+// (ID "ollama/X" is shown as "X (Ollama)"), so it resolves a name that provider
+// built rather than guessing at one.
+var localPrefixes = map[string]string{
+	" (Ollama)":    "ollama/",
+	" (LM Studio)": "lmstudio/",
+}
+
+type aliasModel struct {
+	ID        string `yaml:"id"`
+	Name      string `yaml:"name"`
+	Provider  string `yaml:"provider"`
+	ModelFlag string `yaml:"model_flag"`
+}
+
+type aliasFile struct {
+	Models []aliasModel `yaml:"models"`
+}
+
+func aliases() aliasTable {
+	aliasOnce.Do(func() { aliasOnce.table = buildAliases(config.ScriptHome()) })
+	return aliasOnce.table
+}
+
+// CanonicalKey is the head a row should be counted under.
+func CanonicalKey(r Row) string { return canonicalKey(r, aliases()) }
+
+// ResolveHeadName returns the head ID a recorded name denotes, or "" when
+// nothing on this machine declares it.
+func ResolveHeadName(name string) string { return resolveName(name, aliases()) }
+
+// Attributable reports whether a group key names a head this machine declares.
+func Attributable(key string) bool { return attributable(key, aliases()) }
+
+// canonicalKey prefers the Head the writer recorded. Otherwise Model is
+// resolved through declared mappings only: an unrecognized name is returned
+// unchanged rather than matched approximately, because a wrong match files one
+// head's spend against another, which is worse than leaving it separate. Same
+// reason registry.TokenPoolFor refuses to match fuzzily.
+func canonicalKey(r Row, a aliasTable) string {
+	if r.Head != "" {
+		return r.Head
+	}
+	if r.Model == "" {
+		return UnknownPoolKey
+	}
+	if id := resolveName(r.Model, a); id != "" {
+		return id
+	}
+	return r.Model
+}
+
+func resolveName(name string, a aliasTable) string {
+	if id, ok := a.byName[name]; ok {
+		return id
+	}
+	for suffix, prefix := range localPrefixes {
+		if model, cut := strings.CutSuffix(name, suffix); cut && model != "" {
+			return prefix + model
+		}
+	}
+	return ""
+}
+
+func attributable(key string, a aliasTable) bool {
+	if key == UnknownPoolKey {
+		return false
+	}
+	if a.ids[key] {
+		return true
+	}
+	for _, prefix := range localPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildAliases(home string) aliasTable {
+	a := aliasTable{byName: map[string]string{}, ids: map[string]bool{}}
+	add := func(name, id string) {
+		if name != "" && id != "" {
+			a.byName[name] = id
+			a.ids[id] = true
+		}
+	}
+
+	if raw, err := registry.Read(home, "models.yaml"); err == nil {
+		var f aliasFile
+		if err := yaml.Unmarshal(raw, &f); err == nil {
+			for _, m := range f.Models {
+				add(m.ID, m.ID)
+				add(m.Name, m.ID)
+				// A port-discovered head is identified as provider/model_flag,
+				// which is how TokenPoolFor already resolves one, so a row
+				// logged under the bare model flag names that head by
+				// declaration rather than by resemblance.
+				if m.Provider != "" && m.ModelFlag != "" {
+					id := m.Provider + "/" + m.ModelFlag
+					add(m.ModelFlag, id)
+					add(id, id)
+				}
+			}
+		}
+	}
+
+	// Applied second so it wins: capabilities carries the ids the CLI and env
+	// providers actually discover, while models.yaml has registry-local ids for
+	// the same heads. Both declare the name "Claude Code", and only `claude` is
+	// ever a live head, so letting `claude-core` win left 45 rows split across
+	// two canonical keys instead of one.
+	if db, err := capabilities.Load(capabilities.DefaultOverlayPath()); err == nil {
+		for _, e := range db.Entries() {
+			add(e.ID, e.ID)
+			add(e.Name, e.ID)
+		}
+	}
+	return a
+}

--- a/internal/cost/canonical_test.go
+++ b/internal/cost/canonical_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+
+package cost
+
+import (
+	"testing"
+	"time"
+)
+
+// The three naming eras that coexist in a real log, and what each denotes.
+func table() aliasTable {
+	return aliasTable{
+		byName: map[string]string{
+			"claude": "claude", "Claude Code": "claude",
+			"codex": "codex", "OpenAI Codex": "codex",
+			"flash-med": "flash-med", "Gemini 3.8 Flash (Medium)": "flash-med",
+			"Qwen2.5-Coder:7b":        "ollama/Qwen2.5-Coder:7b",
+			"ollama/Qwen2.5-Coder:7b": "ollama/Qwen2.5-Coder:7b",
+		},
+		ids: map[string]bool{
+			"claude": true, "codex": true, "flash-med": true,
+			"ollama/Qwen2.5-Coder:7b": true,
+		},
+	}
+}
+
+// The defect: one head counted as several, so no per-head total was its spend.
+func TestCanonicalKey_EveryNameForAHeadLandsOnOneKey(t *testing.T) {
+	for _, name := range []string{"claude", "Claude Code"} {
+		if got := canonicalKey(Row{Model: name}, table()); got != "claude" {
+			t.Errorf("Model %q keyed as %q, want claude; splitting it understates "+
+				"every per-head total", name, got)
+		}
+	}
+	for _, name := range []string{"Qwen2.5-Coder:7b", "Qwen2.5-Coder:7b (Ollama)"} {
+		if got := canonicalKey(Row{Model: name}, table()); got != "ollama/Qwen2.5-Coder:7b" {
+			t.Errorf("Model %q keyed as %q, want ollama/Qwen2.5-Coder:7b", name, got)
+		}
+	}
+}
+
+// Head is what the writer recorded deliberately; a stale Model beside it must
+// not override it.
+func TestCanonicalKey_RecordedHeadWins(t *testing.T) {
+	r := Row{Head: "flash-med", Model: "Gemini 3.5 Flash (Medium)"}
+	if got := canonicalKey(r, table()); got != "flash-med" {
+		t.Errorf("keyed as %q, want the recorded head flash-med", got)
+	}
+}
+
+// A wrong match files one head's spend against another, which is worse than
+// leaving it separate. Names nothing declares are preserved, never guessed.
+func TestCanonicalKey_UnknownNameIsPreservedNotGuessed(t *testing.T) {
+	// Renamed away by #693, so nothing on the machine declares it any more.
+	r := Row{Model: "Gemini 3.5 Flash (High)"}
+	if got := canonicalKey(r, table()); got != "Gemini 3.5 Flash (High)" {
+		t.Errorf("keyed as %q; an unrecognized name must survive verbatim so it "+
+			"is not silently merged into another head", got)
+	}
+}
+
+func TestCanonicalKey_NoNameAtAllIsUnknown(t *testing.T) {
+	if got := canonicalKey(Row{}, table()); got != UnknownPoolKey {
+		t.Errorf("keyed as %q, want %q", got, UnknownPoolKey)
+	}
+}
+
+// The " (Ollama)" suffix is the port provider's own display construction over
+// ID "ollama/X", so inverting it resolves rather than guesses.
+func TestResolveHeadName_InvertsThePortProviderDisplayName(t *testing.T) {
+	for name, want := range map[string]string{
+		"qwen3:0.6b (Ollama)":   "ollama/qwen3:0.6b",
+		"phi-4 (LM Studio)":     "lmstudio/phi-4",
+		"nothing-declares-this": "",
+	} {
+		if got := resolveName(name, table()); got != want {
+			t.Errorf("resolveName(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// A bare " (Ollama)" is not a model name, and "ollama/" is not a head.
+func TestResolveHeadName_RefusesAnEmptyModelPart(t *testing.T) {
+	if got := resolveName(" (Ollama)", table()); got != "" {
+		t.Errorf("resolveName(%q) = %q, want \"\"", " (Ollama)", got)
+	}
+}
+
+func TestAttributable(t *testing.T) {
+	for key, want := range map[string]bool{
+		"claude":                  true,
+		"ollama/qwen3:0.6b":       true, // a local head, declared by prefix
+		"Gemini 3.5 Flash (High)": false,
+		UnknownPoolKey:            false,
+	} {
+		if got := attributable(key, table()); got != want {
+			t.Errorf("attributable(%q) = %v, want %v", key, got, want)
+		}
+	}
+}
+
+// Regrouping must move rows between groups, never lose or duplicate one: the
+// total is the number the user checks against their bill.
+func TestGroupByCanonicalKey_MovesRowsWithoutChangingTheTotal(t *testing.T) {
+	rows := []Row{
+		{Model: "Claude Code", EstCostUSD: 0.004890, PromptTokens: 31},
+		{Model: "claude", EstCostUSD: 0.077295, PromptTokens: 14},
+		{Model: "Qwen2.5-Coder:7b", EstCostUSD: 0.000009, PromptTokens: 17},
+		{Model: "Qwen2.5-Coder:7b (Ollama)", EstCostUSD: 0.005124, PromptTokens: 26},
+		{Model: "Gemini 3.5 Flash (High)", EstCostUSD: 0.000629, PromptTokens: 2},
+	}
+	groups := groupBy(rows, func(r Row) string { return canonicalKey(r, table()) })
+
+	var gotCalls, gotTokens int
+	var gotCost float64
+	byKey := map[string]GroupRow{}
+	for _, g := range groups {
+		gotCalls += g.Calls
+		gotTokens += g.PromptTokens
+		gotCost += g.EstCostUSD
+		byKey[g.Key] = g
+	}
+	if gotCalls != len(rows) {
+		t.Errorf("grouped %d calls from %d rows; regrouping must not lose or "+
+			"duplicate a row", gotCalls, len(rows))
+	}
+	if gotTokens != 90 {
+		t.Errorf("prompt tokens = %d, want 90", gotTokens)
+	}
+	if diff := gotCost - 0.087947; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("cost = %.6f, want 0.087947", gotCost)
+	}
+
+	// Claude Code's real spend, in one row rather than two.
+	if g := byKey["claude"]; g.Calls != 2 || g.EstCostUSD < 0.082184 || g.EstCostUSD > 0.082186 {
+		t.Errorf("claude = %d calls $%.6f, want 2 calls $0.082185", g.Calls, g.EstCostUSD)
+	}
+	if g := byKey["ollama/Qwen2.5-Coder:7b"]; g.Calls != 2 {
+		t.Errorf("qwen = %d calls, want the 2 spellings merged into 1 group", g.Calls)
+	}
+	// And the one nothing declares stays on its own, counted as unattributed.
+	if _, ok := byKey["Gemini 3.5 Flash (High)"]; !ok {
+		t.Error("the stale name was merged into another head instead of kept apart")
+	}
+}
+
+// FilterDays' own comment says "the last n calendar days (UTC)". It returned
+// n+1, so `--days 1` meant today and yesterday and `stats` reported "today" for
+// two days of spend while `cost` reported one (#729).
+func TestFilterDays_CountsNDaysIncludingToday(t *testing.T) {
+	day := func(n int) string {
+		return time.Now().UTC().AddDate(0, 0, -n).Format("2006-01-02") + "T12:00:00Z"
+	}
+	rows := []Row{
+		{TS: day(0), Model: "a"},
+		{TS: day(1), Model: "b"},
+		{TS: day(2), Model: "c"},
+		{TS: day(3), Model: "d"},
+	}
+	for n, want := range map[int]int{1: 1, 2: 2, 3: 3, 4: 4} {
+		if got := len(FilterDays(rows, n)); got != want {
+			t.Errorf("FilterDays(n=%d) returned %d rows, want %d calendar days", n, got, want)
+		}
+	}
+	if got := len(FilterDays(rows, 0)); got != 4 {
+		t.Errorf("n=0 must return everything, got %d", got)
+	}
+}
+
+// The two commands must answer the same question the same way: this is the
+// exact comparison that read 6 against 34 on a real log.
+func TestFilterDays_OneDayMatchesTheCalendarTodayFilter(t *testing.T) {
+	today := time.Now().UTC().Format("2006-01-02")
+	rows := []Row{
+		{TS: today + "T01:00:00Z", Model: "a"},
+		{TS: today + "T23:00:00Z", Model: "b"},
+		{TS: time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02") + "T23:00:00Z", Model: "c"},
+	}
+	var calendar int
+	for _, r := range rows {
+		if len(r.TS) >= 10 && r.TS[:10] == today {
+			calendar++
+		}
+	}
+	if got := len(FilterDays(rows, 1)); got != calendar {
+		t.Errorf("FilterDays(1) = %d rows but the calendar-today filter = %d; "+
+			"`hyctl cost` and `hyctl stats` disagree about today again", got, calendar)
+	}
+}

--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -329,12 +329,17 @@ func JSON(since string) ([]Row, error) {
 	return out, nil
 }
 
-// FilterDays returns rows from the last n calendar days (UTC). n=0 returns all.
+// FilterDays returns rows from the last n calendar days (UTC), today included.
+// n=0 returns all.
+//
+// n-1 because the window counts today: subtracting n returned n+1 days, so
+// `--days 1` meant today and yesterday, and `hyctl stats` reported 34 calls for
+// "today" where `hyctl cost` reported 6 for the same log (#729).
 func FilterDays(rows []Row, n int) []Row {
 	if n <= 0 {
 		return rows
 	}
-	cutoff := time.Now().UTC().AddDate(0, 0, -n).Format("2006-01-02")
+	cutoff := time.Now().UTC().AddDate(0, 0, -(n - 1)).Format("2006-01-02")
 	var out []Row
 	for _, r := range rows {
 		if len(r.TS) >= 10 && r.TS[:10] >= cutoff {
@@ -346,22 +351,26 @@ func FilterDays(rows []Row, n int) []Row {
 
 // ByModel returns per-head totals sorted by cost descending.
 //
-// Keyed on Head, not Model: Model is whatever the provider called itself, and
-// the two writers disagreed about it, so one head landed in two or three rows
-// ("Claude Code" beside "claude", "Qwen2.5-Coder:7b (Ollama)" beside
-// "Qwen2.5-Coder:7b") and every per-head total was understated. Rows written
-// before Head existed still group by Model.
+// Keyed on the canonical head (see CanonicalKey): Model is whatever that era's
+// writer called the head, and it changed three times, so one head landed in two
+// or three rows ("Claude Code" beside "claude") and no per-head total was its
+// spend. Names nothing on this machine declares are left as their own group
+// rather than guessed into one.
 func ByModel(rows []Row) []GroupRow {
-	return groupBy(rows, func(r Row) string {
-		switch {
-		case r.Head != "":
-			return r.Head
-		case r.Model != "":
-			return r.Model
-		default:
-			return "unknown"
+	return groupBy(rows, CanonicalKey)
+}
+
+// Unattributed counts groups whose key names no head this machine declares,
+// which is what a row from a superseded naming era looks like. Rendered as a
+// footnote so a stale name reads as stale rather than as a separate head.
+func Unattributed(groups []GroupRow) (n int, calls int) {
+	for _, g := range groups {
+		if !Attributable(g.Key) {
+			n++
+			calls += g.Calls
 		}
-	})
+	}
+	return n, calls
 }
 
 // ByDay returns per-day totals sorted by date ascending.
@@ -489,6 +498,13 @@ func RenderStatsTable(period string, rows []GroupRow) {
 		commaInt(totOut),
 		fmt.Sprintf("$%.3f", totCost),
 	)
+	// A row from a superseded naming era names a head nothing here declares.
+	// Said plainly, because silently merging it would misattribute spend and
+	// silently dropping it would understate the total.
+	if n, calls := Unattributed(rows); n > 0 {
+		fmt.Printf("\n  %d of these name a head this machine no longer declares (%d calls);\n"+
+			"  they are shown under the name they were logged with.\n", n, calls)
+	}
 	fmt.Println()
 }
 

--- a/internal/tui/cockpit_metrics.go
+++ b/internal/tui/cockpit_metrics.go
@@ -111,11 +111,14 @@ func (m *ckMetrics) fold(rows []cost.Row, pr ckPricer, now time.Time) {
 	nonLocal := map[string]bool{}
 
 	for _, r := range rows {
-		if r.Model != "" {
-			st := m.stats[r.Model]
+		// Keyed the way cost.ByModel keys its groups, so the per-model stats and
+		// the "local · free" marker still find their row after one head's three
+		// logged spellings collapse into one group (#729).
+		if key := cost.CanonicalKey(r); r.Model != "" {
+			st := m.stats[key]
 			if st == nil {
 				st = &ckModelStat{}
-				m.stats[r.Model] = st
+				m.stats[key] = st
 			}
 			if r.WallMS > 0 {
 				st.wall = append(st.wall, r.WallMS)
@@ -129,9 +132,9 @@ func (m *ckMetrics) fold(rows []cost.Row, pr ckPricer, now time.Time) {
 				st.costToday += r.EstCostUSD
 			}
 			if ckLocalExecutor(r.Executor) {
-				m.localModels[r.Model] = true
+				m.localModels[key] = true
 			} else {
-				nonLocal[r.Model] = true
+				nonLocal[key] = true
 			}
 		}
 		if r.RunID != "" {
@@ -214,16 +217,25 @@ func (m ckMetrics) ckBlastFor(file string) (radius float64, dependents int, kapp
 	return radius, dependents, kappa, true
 }
 
-// ckStatFor finds a model's cost aggregates. cost.jsonl records the model as
-// the executor reported it ("Qwen2.5-Coder:7b (Ollama)") while the scan names
-// it differently, so an exact match silently misses, matching is therefore
-// tolerant: exact, then either string containing the other, case-insensitively.
+// ckStatFor finds a model's cost aggregates.
+//
+// The fold keys on cost.CanonicalKey, so either the display name or the head id
+// resolves to the same row. The tolerant containment pass stays for names from
+// a superseded era that nothing declares any more, which resolve to nothing
+// (#729).
 func (m ckMetrics) ckStatFor(name, id string) ckModelStat {
-	if v, ok := m.stats[name]; ok {
-		return *v
-	}
-	if v, ok := m.stats[id]; ok {
-		return *v
+	for _, key := range []string{id, name} {
+		if key == "" {
+			continue
+		}
+		if v, ok := m.stats[key]; ok {
+			return *v
+		}
+		if c := cost.ResolveHeadName(key); c != "" {
+			if v, ok := m.stats[c]; ok {
+				return *v
+			}
+		}
 	}
 	for _, key := range []string{name, id} {
 		if key == "" {

--- a/internal/tui/cockpit_metrics_test.go
+++ b/internal/tui/cockpit_metrics_test.go
@@ -25,9 +25,12 @@ func TestFold_PerModelStatsAndRunJoin(t *testing.T) {
 		{TS: "2020-01-01T00:00:00Z", Model: "qwen (Ollama)", Executor: "local", Tier: 10, WallMS: 100},
 	}, stubPricer{}, now)
 
-	st := m.stats["qwen (Ollama)"]
+	// Keyed canonically, not by the logged name: "qwen (Ollama)" is the port
+	// provider's display form of head ollama/qwen, and the fold now keys the way
+	// cost.ByModel groups so a head's spellings share one row (#729).
+	st := m.stats["ollama/qwen"]
 	if st == nil {
-		t.Fatal("no per-model stat folded")
+		t.Fatalf("no per-model stat folded under the canonical key; got %v", keysOf(m.stats))
 	}
 	if len(st.wall) != 3 {
 		t.Errorf("wall samples = %d, want all 3 (p50 uses history)", len(st.wall))
@@ -38,8 +41,18 @@ func TestFold_PerModelStatsAndRunJoin(t *testing.T) {
 	if st.lastRunID != "r1" {
 		t.Errorf("lastRunID = %q", st.lastRunID)
 	}
-	if !m.localModels["qwen (Ollama)"] {
+	if !m.localModels["ollama/qwen"] {
 		t.Error("a purely-local model is not marked local")
+	}
+	// The contract the view depends on: the row is reachable by the name the log
+	// recorded and by the head's own id, whichever the caller happens to hold.
+	for _, k := range []struct{ name, id string }{
+		{"qwen (Ollama)", ""},
+		{"", "ollama/qwen"},
+	} {
+		if got := m.ckStatFor(k.name, k.id); got.reqsToday != 2 {
+			t.Errorf("ckStatFor(%q,%q) found reqsToday=%d, want 2", k.name, k.id, got.reqsToday)
+		}
 	}
 
 	rc, ok := m.runCost["r1"]
@@ -52,6 +65,14 @@ func TestFold_PerModelStatsAndRunJoin(t *testing.T) {
 	if rc.prompt != 200 || rc.resp != 100 || rc.actual != 300 || rc.est != 0 {
 		t.Errorf("run tokens = %+v", rc)
 	}
+}
+
+func keysOf(m map[string]*ckModelStat) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // A model that ever routed to a remote provider must not claim "local · free".


### PR DESCRIPTION
Phase 3 of #716. Two defects, both measured on a real 117-row cost log.

## 1. `cost` and `stats` disagreed about today

```
$ hyctl cost    | Today (2026-09-07)   6 calls
$ hyctl stats   | Period: today       34 calls
```

`cost` matches the calendar UTC date. `stats` calls `FilterDays(all, 1)`, whose
cutoff was a day too early, so it returned **n+1** calendar days:

| command | rows | covered |
|---|---|---|
| `cost` Today | 6 | 09-07 |
| `stats` "today" | 34 | 09-06 + 09-07 |
| `stats --days 1` | 34 | 2 days |
| `stats --days 2` | 46 | 3 days |

Every `--days N` window was one day too wide and the TUI's 14-day metric was 15.
`FilterDays`' own comment already said "the last n calendar days (UTC)", so this
was code disagreeing with its stated contract, not an undefined edge.

**After:** both report 6.

## 2. One head counted as several, so no per-head total was its spend

A cost row records the head under whatever name that era's writer used, and the
name changed three times: registry ids, display names, and #693's Gemini
rename. #697 added a `Head` field and keyed `ByModel` on it, which fixed the
**writer**. Only 11 of 117 rows have it; the other 106 fall back to `Model`.

```
Claude Code   $0.004890 (31 calls)  +  claude   $0.077295 (14)  =  45 calls, $0.082185
Qwen 7b       $0.005124 (26)        +  bare     $0.000009 (17)  =  43 calls
OpenAI Codex  $0.000408 ( 3)        +  codex    $0.000021 ( 1)  =   4 calls
```

`hyctl stats` rendered 16 groups for about 11 heads. The row with most of
Claude Code's money had a third of its calls.

**After**, on the same log:

```
  claude                     45   1,999    696   $0.082
  ollama/Qwen2.5-Coder:7b    43   8,109  4,733   $0.005
  codex                       4      33     22   $0.000
  ─────────────────────────────────────────────────────
  Total                     117  11,536  6,790   $0.094

  2 of these name a head this machine no longer declares (3 calls);
  they are shown under the name they were logged with.
```

Total unchanged at 117 calls and $0.094: rows moved between groups, none were
lost or double-counted.

### Declared mappings only

- capabilities entries, name to id
- `models.yaml` `name` to `id`
- `models.yaml` `model_flag` to `provider/model_flag`, already how
  `TokenPoolFor` identifies a port-discovered head
- the port provider's own display construction (`ID "ollama/X"` shown as
  `"X (Ollama)"`), inverted

Nothing is matched approximately. A wrong match files one head's spend against
another, which is worse than leaving it separate, the same reason
`registry.TokenPoolFor` refuses to match fuzzily. Names nothing on this machine
declares (the `Gemini 3.5 …` era) keep their logged name and are counted in a
footnote rather than guessed into a group.

**No log is rewritten.** This is a reader change; the 106 historical rows stay
exactly as written.

### A precedence bug found by running it

The first cut resolved `Claude Code` to `claude-core`, the registry's tier-1 id,
which is never a live head, leaving the 45 rows split across two canonical keys
instead of one. Capabilities is now applied second so it wins: it carries the
ids the CLI and env providers actually discover.

### The TUI folds the same rows

Its per-model stats and the "local · free" marker were keyed on the raw
`Model`, so canonical grouping broke the marker, caught by the existing
`TestUsageBreakdown_LocalFreeAndGroupings`. Both now key the same way, and
`ckStatFor` resolves its inputs instead of pattern-matching them, which its own
comment described as a workaround for exactly this mismatch.

## Verification

- Both guards mutation-tested: restoring the `n+1` window fails 2 tests,
  restoring the `Head`-or-`Model` fallback fails 3. All pass on revert.
- The pre-existing `TestFilterDays_Windows` asserted only `got > 3`, which is
  why the off-by-one survived; the new test pins the boundary exactly.
- `go test -race -count=1 ./...` exit 0, 53 packages, plus `desktop/api`.
  `gofmt`, `go vet`, `staticcheck` clean.
- Verified against the real log through the built binary, not only in tests.

## Also

`docs/funding.json` gains the now-live Open Collective address
(`https://opencollective.com/hyctl`, verified 200) and lists it on the sponsor
plan; the entry previously said "not yet created". Validated as JSON, and every
plan channel resolves to a declared channel. The file contains no em dashes.

Closes #729