### PR TITLE
perf(provider): dial local model servers concurrently

### DIFF
--- a/internal/provider/port/fanout_test.go
+++ b/internal/provider/port/fanout_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+
+package port
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/capabilities"
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// stubService stands in for a real one so the fan-out's cost and ordering can
+// be asserted without depending on what is listening on the machine.
+type stubService struct {
+	dial  string
+	delay time.Duration
+	head  string
+	err   error
+}
+
+func (s stubService) addr() string { return s.dial }
+
+func (s stubService) probe(ctx context.Context, _ *capabilities.DB) ([]provider.Head, error) {
+	select {
+	case <-time.After(s.delay):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return []provider.Head{{ID: s.head}}, nil
+}
+
+// listening returns an address that isOpen accepts, so these tests measure the
+// fan-out rather than a dial timeout, which varies with the network.
+func listening(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(srv.Close)
+	return strings.TrimPrefix(srv.URL, "http://")
+}
+
+// Serially, each service's dial and probe was paid before the next one began,
+// so the floor grew with the service list on every probe, status and dispatch
+// (#750). Eight services that each take 150ms must cost about 150ms, not 1.2s.
+func TestDiscover_ServicesAreProbedConcurrently(t *testing.T) {
+	addr := listening(t)
+	var services []portService
+	for i := range 8 {
+		services = append(services, stubService{dial: addr, delay: 150 * time.Millisecond, head: fmt.Sprintf("h%d", i)})
+	}
+
+	start := time.Now()
+	heads := discover(context.Background(), caps(t), services)
+	elapsed := time.Since(start)
+
+	if len(heads) != 8 {
+		t.Fatalf("got %d heads, want one per service: %+v", len(heads), heads)
+	}
+	// Halfway between one probe and two, so neither a slow machine nor a fast
+	// serial loop can decide the result.
+	if elapsed > 700*time.Millisecond {
+		t.Errorf("8 services of 150ms took %v; they are still being probed one at a time", elapsed)
+	}
+}
+
+// Head order decides display order and rank tie-breaks, so it must be the
+// service order however the goroutines happen to interleave. The delays are
+// descending, so an append-as-they-finish fan-out returns exactly backwards.
+func TestDiscover_KeepsServiceOrderRegardlessOfCompletion(t *testing.T) {
+	addr := listening(t)
+	services := []portService{
+		stubService{dial: addr, delay: 120 * time.Millisecond, head: "slowest"},
+		stubService{dial: addr, delay: 60 * time.Millisecond, head: "middle"},
+		stubService{dial: addr, head: "fastest"},
+	}
+
+	heads := discover(context.Background(), caps(t), services)
+
+	want := []string{"slowest", "middle", "fastest"}
+	if len(heads) != len(want) {
+		t.Fatalf("got %d heads, want %d: %+v", len(heads), len(want), heads)
+	}
+	for i, id := range want {
+		if heads[i].ID != id {
+			t.Errorf("heads[%d] = %q, want %q (order is completion order, not service order)", i, heads[i].ID, id)
+		}
+	}
+}
+
+// One service failing must cost only that service's heads. Concurrently this
+// is the case that a shared error slot or an early return would break.
+func TestDiscover_SkipsUnprobeableAndClosedServices(t *testing.T) {
+	addr := listening(t)
+	services := []portService{
+		stubService{dial: addr, head: "good"},
+		stubService{dial: addr, head: "broken", err: errors.New("up but unprobeable")},
+		stubService{dial: "127.0.0.1:1", head: "nothing-listening"},
+		stubService{dial: "not-an-address", head: "malformed"},
+		stubService{dial: addr, head: "also-good"},
+	}
+
+	heads := discover(context.Background(), caps(t), services)
+
+	if len(heads) != 2 {
+		t.Fatalf("got %d heads, want the two probeable ones: %+v", len(heads), heads)
+	}
+	if heads[0].ID != "good" || heads[1].ID != "also-good" {
+		t.Errorf("got %q and %q, want good and also-good", heads[0].ID, heads[1].ID)
+	}
+}
+
+func TestDiscover_NoServicesIsNoHeads(t *testing.T) {
+	if got := discover(context.Background(), caps(t), nil); len(got) != 0 {
+		t.Errorf("got %d heads from no services", len(got))
+	}
+}

--- a/internal/provider/port/provider.go
+++ b/internal/provider/port/provider.go
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 // Package port discovers AI heads running as local HTTP services.
-// To add a new local service: implement a portService and add it to services.
+// To add a new local service: implement a portService and add it to the list
+// Discover hands to discover, which dials and probes them all concurrently.
 package port
 
 import (
@@ -12,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/ankit373/hydra/internal/capabilities"
@@ -47,23 +49,42 @@ func (p *Provider) Discover(ctx context.Context) ([]provider.Head, error) {
 	// service can be constructed against a test server, and so the address the
 	// liveness dial uses is provably the same one the probe and the head's
 	// Endpoint use.
-	services := []portService{
+	return discover(ctx, caps, []portService{
 		&ollamaService{base: provider.OllamaHost()},
 		&lmStudioService{base: defaultLMStudioHost},
+	}), nil
+}
+
+// discover dials and probes every service concurrently. Serially, a dead
+// service cost the whole dial timeout before the next dial began, so the floor
+// grew with the service list on every probe, status and dispatch (#750).
+//
+// Results land in a per-service slot rather than a shared append, so head
+// order stays the service order however the dials interleave.
+func discover(ctx context.Context, caps *capabilities.DB, services []portService) []provider.Head {
+	found := make([][]provider.Head, len(services))
+	var wg sync.WaitGroup
+	for i, svc := range services {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if !isOpen(svc.addr()) {
+				return
+			}
+			heads, err := svc.probe(ctx, caps)
+			if err != nil {
+				return // service is up but probe failed; skip gracefully
+			}
+			found[i] = heads
+		}()
 	}
+	wg.Wait()
 
 	var heads []provider.Head
-	for _, svc := range services {
-		if !isOpen(svc.addr()) {
-			continue
-		}
-		found, err := svc.probe(ctx, caps)
-		if err != nil {
-			continue // service is up but probe failed; skip gracefully
-		}
-		heads = append(heads, found...)
+	for _, f := range found {
+		heads = append(heads, f...)
 	}
-	return heads, nil
+	return heads
 }
 
 // isOpen is a cheap liveness check before the real probe, so a machine with


### PR DESCRIPTION
## Summary

`internal/provider/port.Discover` walked its service list serially, so each
dead service cost its whole dial and probe before the next one started. Two
services today, but #717 adds LiteLLM, vLLM and llama.cpp's server, and the
floor grows with the list on every `hyctl probe`, every `hyctl status` and
every dispatch that discovers heads. #717 calls this trap 3: the dials want to
be concurrent before the list grows, not after.

## Changes

- `internal/provider/port/provider.go`: the service list becomes a parameter
  of a new `discover`, which fans the dial-and-probe out per service and
  joins. Results land in a per-service slot rather than a shared append, so
  head order stays the service order however the goroutines interleave.
- `internal/provider/port/fanout_test.go`: stub services make the wall-clock
  and ordering guarantees testable without depending on what is listening.

## Measured

- 8 services of 150ms: **1.211s serially, 0.15s now** (the test asserts this).
- `hyctl probe` end to end, Ollama up and LM Studio down: **20ms to 14ms**,
  mean of 7 runs. Small, and worth saying plainly: a dead *localhost* port
  refuses instantly, so the 400ms dial timeout only bites on an unreachable
  address. The point of this change is that the floor stops growing, not the
  6ms.

## Verification

- `go test -race ./...` clean. The probes share one `capabilities.DB`; its
  lookups are read-only, and the race detector confirms it.
- Mutation tested twice, each mutant compiling: a serial loop fails the
  timing test at 1.211s, and an append-as-completed fan-out fails the
  ordering test with the heads exactly backwards.
- `internal/provider/port` coverage 94.9% against a floor of 89%. No `t.Skip`
  added; the suite is at 40/40.

Closes #750
