### PR TITLE
fix(executor): the OpenRouter default model id does not exist in OpenRouter's catalogue

### DIFF
--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -687,9 +687,12 @@ func defaultModelFor(providerID string) string {
 		envs     []string
 	}
 	specs := map[string]modelSpec{
-		"anthropic":  {fallback: "claude-sonnet-4-20250514", envs: []string{"ANTHROPIC_MODEL", "HYDRA_MODEL_ANTHROPIC"}},
-		"openai":     {fallback: "gpt-4o", envs: []string{"OPENAI_MODEL", "HYDRA_MODEL_OPENAI"}},
-		"openrouter": {fallback: "anthropic/claude-sonnet-4-5", envs: []string{"OPENROUTER_MODEL", "HYDRA_MODEL_OPENROUTER"}},
+		"anthropic": {fallback: "claude-sonnet-4-20250514", envs: []string{"ANTHROPIC_MODEL", "HYDRA_MODEL_ANTHROPIC"}},
+		"openai":    {fallback: "gpt-4o", envs: []string{"OPENAI_MODEL", "HYDRA_MODEL_OPENAI"}},
+		// OpenRouter spells Claude point releases with a dot; the dashed form
+		// above is Anthropic's own convention, and crossing the two left this
+		// pointing at an id the catalogue has never held (#755).
+		"openrouter": {fallback: "anthropic/claude-sonnet-4.5", envs: []string{"OPENROUTER_MODEL", "HYDRA_MODEL_OPENROUTER"}},
 		"google":     {fallback: "gemini-2.5-flash", envs: []string{"GEMINI_MODEL", "GOOGLE_MODEL", "HYDRA_MODEL_GOOGLE"}},
 		"xai":        {fallback: "grok-3-latest", envs: []string{"XAI_MODEL", "HYDRA_MODEL_XAI"}},
 		"groq":       {fallback: "llama-3.3-70b-versatile", envs: []string{"GROQ_MODEL", "HYDRA_MODEL_GROQ"}},

--- a/internal/executor/openrouter_test.go
+++ b/internal/executor/openrouter_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ankit373/hydra/internal/pricing"
 	"github.com/ankit373/hydra/internal/provider"
 )
 
@@ -149,5 +150,35 @@ func TestEveryOpenAICompatProviderIsFullyWired(t *testing.T) {
 				t.Errorf("%q Authorization = %q, want %q", p.id, cfg.Headers["Authorization"], "Bearer test-key")
 			}
 		})
+	}
+}
+
+// The default was `anthropic/claude-sonnet-4-5`, which OpenRouter has never
+// held: it spells that model with a dot. The test above passed it happily,
+// because non-empty and vendor-prefixed is exactly what a plausible wrong id
+// looks like, so the head read as routable and failed at the point of use
+// (#755).
+//
+// This asserts against the catalogue OpenRouter itself publishes, read from
+// the pricing cache this machine already keeps. With no cache it asserts
+// nothing: a network call in the test suite would be flaky and would reach
+// out on every run, which is worse than a guard that fires wherever pricing
+// has been fetched, including every developer machine.
+func TestOpenRouter_DefaultModelExistsInTheCatalogue(t *testing.T) {
+	catalogue := pricing.Load().Models()
+	if len(catalogue) == 0 {
+		t.Log("no pricing cache on this machine, so the catalogue cannot be checked here")
+		return
+	}
+
+	known := make(map[string]bool, len(catalogue))
+	for _, id := range catalogue {
+		known[strings.ToLower(id)] = true
+	}
+	got := strings.ToLower(defaultModelFor("openrouter"))
+	if !known[got] {
+		t.Errorf("defaultModelFor(openrouter) = %q, which is not one of the %d models "+
+			"OpenRouter publishes; a dispatch to env/openrouter with no OPENROUTER_MODEL "+
+			"set would send an id that does not exist", got, len(catalogue))
 	}
 }


### PR DESCRIPTION
## Summary

`defaultModelFor`'s openrouter fallback was `anthropic/claude-sonnet-4-5`, and
**OpenRouter has never held that id.** It spells Claude point releases with a
dot. Checked against the live public catalogue (`openrouter.ai/api/v1/models`,
the same endpoint `internal/pricing` already fetches, 428 models):

```
'anthropic/claude-sonnet-4-5'   present=False
'anthropic/claude-sonnet-4.5'   present=True
```

The dashed form is Anthropic's *native* convention, which the `anthropic` entry
in the same table correctly uses (`claude-sonnet-4-20250514`, for the Anthropic
API). The two conventions got crossed.

`SupportsHTTP` only checks the default is non-empty, so `env/openrouter` read as
perfectly routable and would fail at the point of use — the #248 defect class one
layer down. Anyone who set `OPENROUTER_MODEL` never saw it, which is probably how
it survived.

Found while building #752, which needed real catalogue ids to test against.

## Changes

- `internal/executor/http.go`: `anthropic/claude-sonnet-4-5` →
  `anthropic/claude-sonnet-4.5`.
- `internal/executor/openrouter_test.go`: a guard so it cannot silently rot
  again. `TestOpenRouter_ModelIsOverridable` already asserted the default was
  non-empty and vendor-prefixed, and the broken id satisfied both — that is
  exactly what a plausible wrong id looks like. The new test checks it against
  the catalogue OpenRouter publishes, read from the pricing cache this machine
  already keeps.

## On that guard's limit, stated plainly

**With no pricing cache it asserts nothing, so it does not run in CI.** That is
the deliberate trade: the alternative is a network call in the test suite, which
would be flaky and would reach out on every run. It fires wherever pricing has
been fetched, which is every developer machine and every real install. I
confirmed it actually runs rather than silently no-opping (423 models on this
machine) and that it fails on the old id:

```
defaultModelFor(openrouter) = "anthropic/claude-sonnet-4-5", which is not one of
the 423 models OpenRouter publishes; a dispatch to env/openrouter with no
OPENROUTER_MODEL set would send an id that does not exist
```

## What I did not do

- **No dispatch was executed**, since there is no `OPENROUTER_API_KEY` on this
  machine. What is confirmed is that the id is absent from OpenRouter's own
  published catalogue, not the exact shape of the API's rejection.
- **Not switching to `openrouter/auto`**, which does exist and would never go
  stale: handing model choice to the vendor is the opposite of what Hydra is
  for.
- **The other providers' defaults are unchecked.** Their ids live in each
  vendor's own namespace rather than OpenRouter's, so cross-referencing them
  against this catalogue would produce false alarms rather than findings. They
  need their own keys to verify.

Closes #755
