### PR TITLE
fix(desktop): derive the wire-parity check instead of hand-listing it

### DIFF
--- a/desktop/api/typesparity_test.go
+++ b/desktop/api/typesparity_test.go
@@ -3,9 +3,14 @@
 package api
 
 import (
+	"go/ast"
+	"go/parser"
+	gotoken "go/token"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -17,8 +22,133 @@ import (
 // invisible to the desktop because TypeScript had never heard of them (#435).
 //
 // dto_test.go guards the Go side of the wire. This guards the mirror.
+//
+// Everything below is *derived*, from reflection and from the Go source. The
+// first cut listed the types and the union members by hand, so it could only
+// catch drift its author had already thought to enumerate: security.Partial
+// went missing from both this file and types.ts at once, and stayed green (#753).
 
 var tsFieldRE = regexp.MustCompile(`(?m)^\s*([A-Za-z0-9_]+)\??:`)
+
+// wireRoots are the payloads the API returns. Every other type is reached from
+// these, never listed.
+func wireRoots() []any {
+	return []any{
+		security.Report{},
+		Model{}, Pool{}, ModelRegistry{}, GovernorPanel{}, Run{}, Fleet{},
+		DiffLine{}, ReviewOutcome{}, MCPServer{}, MCPPanel{}, MCPSyncResult{},
+		Head{}, HeadPanel{}, Span{}, Diff{}, Session{}, ChatReply{},
+		PendingQuestion{}, QuestionQueue{}, HyctlStatus{}, InstallResult{},
+	}
+}
+
+const modulePath = "github.com/ankit373/hydra"
+
+// tsNames maps a Go type to its TypeScript name where the two differ, because
+// a name that reads fine inside a Go package can be far too generic in one
+// flat frontend namespace, or already taken there. Keyed by import path, since
+// security.Action (a UI card) and ledger.Action (an enum) share a bare name.
+//
+// This is a rename table, not the enumeration this file used to be: a missing
+// entry fails loudly with "declares no interface", so it can never make a
+// check silently pass.
+var tsNames = map[string]string{
+	modulePath + "/internal/security.Report": "SecurityReport",
+	modulePath + "/internal/security.Count":  "SecurityCount",
+	modulePath + "/internal/ledger.Event":    "LedgerEvent",
+	modulePath + "/internal/ledger.Action":   "LedgerAction",
+}
+
+func tsName(rt reflect.Type) string {
+	if ts, ok := tsNames[rt.PkgPath()+"."+rt.Name()]; ok {
+		return ts
+	}
+	return rt.Name()
+}
+
+// ours excludes stdlib structs such as time.Time, which marshal as a scalar
+// and have no interface to mirror.
+func ours(rt reflect.Type) bool {
+	return rt.PkgPath() == modulePath || strings.HasPrefix(rt.PkgPath(), modulePath+"/")
+}
+
+// sourceDir maps a package's import path to its directory, relative to here.
+func sourceDir(pkgPath string) string {
+	return filepath.Join("../..", strings.TrimPrefix(pkgPath, modulePath+"/"))
+}
+
+// elem unwraps pointers, slices, arrays and maps down to the type a JSON field
+// ultimately carries.
+func elem(rt reflect.Type) reflect.Type {
+	for {
+		switch rt.Kind() {
+		case reflect.Pointer, reflect.Slice, reflect.Array, reflect.Map:
+			rt = rt.Elem()
+		default:
+			return rt
+		}
+	}
+}
+
+// wireStructs returns every struct reachable from the roots through fields
+// that actually ship, keyed by type name.
+//
+// The hand-listed table this replaces only ever checked the roots, so a field
+// on a *nested* type was unguarded. security.Coverage.partial was nested, which
+// is how it shipped invisible to the desktop.
+func wireStructs(t *testing.T) map[string]reflect.Type {
+	t.Helper()
+	out := map[string]reflect.Type{}
+	var walk func(reflect.Type)
+	walk = func(rt reflect.Type) {
+		rt = elem(rt)
+		// An anonymous struct has no name to mirror against an interface.
+		if rt.Kind() != reflect.Struct || !ours(rt) || rt.Name() == "" {
+			return
+		}
+		if prev, seen := out[rt.Name()]; seen {
+			if prev != rt {
+				t.Fatalf("two wire types are both named %s (%s and %s), "+
+					"one TypeScript interface cannot mirror both",
+					rt.Name(), prev.PkgPath(), rt.PkgPath())
+			}
+			return
+		}
+		out[rt.Name()] = rt
+		eachWireField(rt, func(_ string, ft reflect.Type) { walk(ft) })
+	}
+	for _, r := range wireRoots() {
+		walk(reflect.TypeOf(r))
+	}
+	return out
+}
+
+// eachWireField visits every field a struct puts on the wire, descending
+// through embedded structs, whose fields JSON promotes into the parent.
+func eachWireField(rt reflect.Type, fn func(name string, ft reflect.Type)) {
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		tag := f.Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if f.Anonymous && name == "" {
+			if e := elem(f.Type); e.Kind() == reflect.Struct {
+				eachWireField(e, fn)
+			}
+			continue
+		}
+		if name == "" || name == "-" {
+			continue
+		}
+		fn(name, f.Type)
+	}
+}
+
+// jsonFields returns the wire names of a Go struct.
+func jsonFields(rt reflect.Type) map[string]bool {
+	out := map[string]bool{}
+	eachWireField(rt, func(name string, _ reflect.Type) { out[name] = true })
+	return out
+}
 
 // tsInterface returns the field names declared on a TypeScript interface.
 func tsInterface(t *testing.T, src, name string) map[string]bool {
@@ -35,22 +165,6 @@ func tsInterface(t *testing.T, src, name string) map[string]bool {
 	return out
 }
 
-// jsonFields returns the wire names of a Go struct, skipping anything the
-// encoder drops entirely.
-func jsonFields(v any) map[string]bool {
-	out := map[string]bool{}
-	rt := reflect.TypeOf(v)
-	for i := 0; i < rt.NumField(); i++ {
-		tag := rt.Field(i).Tag.Get("json")
-		name, _, _ := strings.Cut(tag, ",")
-		if name == "" || name == "-" {
-			continue
-		}
-		out[name] = true
-	}
-	return out
-}
-
 func readTypesTS(t *testing.T) string {
 	t.Helper()
 	raw, err := os.ReadFile("../frontend/src/types.ts")
@@ -62,49 +176,13 @@ func readTypesTS(t *testing.T) string {
 
 func TestTypesTS_MirrorsEveryFieldOnTheWire(t *testing.T) {
 	src := readTypesTS(t)
-
-	for _, c := range []struct {
-		iface string
-		goVal any
-	}{
-		{"SecurityReport", security.Report{}},
-		{"Attestation", security.Attestation{}},
-		{"AttestedEvidence", security.AttestedEvidence{}},
-		{"BOMEntry", security.BOMEntry{}},
-		{"AgentPrivilege", security.AgentPrivilege{}},
-		{"Incident", security.Incident{}},
-		{"Risk", security.Risk{}},
-		{"RiskRegister", security.RiskRegister{}},
-		{"Posture", security.Posture{}},
-		{"Model", Model{}},
-		{"Pool", Pool{}},
-		{"ModelRegistry", ModelRegistry{}},
-		{"GovernorPanel", GovernorPanel{}},
-		{"Run", Run{}},
-		{"Fleet", Fleet{}},
-		{"DiffLine", DiffLine{}},
-		{"ReviewOutcome", ReviewOutcome{}},
-		{"MCPServer", MCPServer{}},
-		{"MCPPanel", MCPPanel{}},
-		{"MCPSyncResult", MCPSyncResult{}},
-		{"Head", Head{}},
-		{"HeadPanel", HeadPanel{}},
-		{"Span", Span{}},
-		{"Diff", Diff{}},
-		{"Session", Session{}},
-		{"ChatReply", ChatReply{}},
-		{"PendingQuestion", PendingQuestion{}},
-		{"QuestionQueue", QuestionQueue{}},
-		{"HyctlStatus", HyctlStatus{}},
-		{"InstallResult", InstallResult{}},
-	} {
-		t.Run(c.iface, func(t *testing.T) {
-			ts := tsInterface(t, src, c.iface)
-			for name := range jsonFields(c.goVal) {
-				if !ts[name] {
+	for name, rt := range wireStructs(t) {
+		t.Run(name, func(t *testing.T) {
+			ts := tsInterface(t, src, tsName(rt))
+			for field := range jsonFields(rt) {
+				if !ts[field] {
 					t.Errorf("%s.%s ships on the wire but types.ts does not declare it, "+
-						"the desktop cannot render a field it has never heard of",
-						c.iface, name)
+						"the desktop cannot render a field it has never heard of", name, field)
 				}
 			}
 		})
@@ -115,42 +193,13 @@ func TestTypesTS_MirrorsEveryFieldOnTheWire(t *testing.T) {
 // undefined at runtime, which typechecks and then renders nothing.
 func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
 	src := readTypesTS(t)
-	for _, c := range []struct {
-		iface string
-		goVal any
-	}{
-		{"SecurityReport", security.Report{}},
-		{"Attestation", security.Attestation{}},
-		{"BOMEntry", security.BOMEntry{}},
-		{"AgentPrivilege", security.AgentPrivilege{}},
-		{"Model", Model{}},
-		{"Pool", Pool{}},
-		{"ModelRegistry", ModelRegistry{}},
-		{"GovernorPanel", GovernorPanel{}},
-		{"Run", Run{}},
-		{"Fleet", Fleet{}},
-		{"DiffLine", DiffLine{}},
-		{"ReviewOutcome", ReviewOutcome{}},
-		{"MCPServer", MCPServer{}},
-		{"MCPPanel", MCPPanel{}},
-		{"MCPSyncResult", MCPSyncResult{}},
-		{"Head", Head{}},
-		{"HeadPanel", HeadPanel{}},
-		{"Span", Span{}},
-		{"Diff", Diff{}},
-		{"Session", Session{}},
-		{"ChatReply", ChatReply{}},
-		{"PendingQuestion", PendingQuestion{}},
-		{"QuestionQueue", QuestionQueue{}},
-		{"HyctlStatus", HyctlStatus{}},
-		{"InstallResult", InstallResult{}},
-	} {
-		t.Run(c.iface, func(t *testing.T) {
-			g := jsonFields(c.goVal)
-			for name := range tsInterface(t, src, c.iface) {
-				if !g[name] {
+	for name, rt := range wireStructs(t) {
+		t.Run(name, func(t *testing.T) {
+			g := jsonFields(rt)
+			for field := range tsInterface(t, src, tsName(rt)) {
+				if !g[field] {
 					t.Errorf("types.ts declares %s.%s but the backend never sends it, "+
-						"it is permanently undefined", c.iface, name)
+						"it is permanently undefined", name, field)
 				}
 			}
 		})
@@ -160,78 +209,159 @@ func TestTypesTS_DeclaresNoFieldTheBackendNeverSends(t *testing.T) {
 // The tests above guard field *names*. They say nothing about the *values* a
 // string enum carries, and a value is just as load-bearing: the Audit view
 // looked two checks up by names internal/security never emitted, and both
-// cards silently never rendered (#634). Those were free strings rather than a
-// declared union, but a union can drift the same way, a TypeScript union is
-// only a compile-time promise about the frontend, never a claim about Go.
+// cards silently never rendered (#634).
 //
-// So: every union in types.ts that mirrors a Go string type must hold exactly
-// that type's values.
+// So: every named string type that ships must be declared in types.ts as a
+// union holding exactly its members. Both sides are derived, the Go members
+// from source and the shipping types from reflection, so neither can go stale
+// the way the hand-written lists did.
 
-var tsUnionRE = func(name string) *regexp.Regexp {
-	return regexp.MustCompile(`export type ` + regexp.QuoteMeta(name) + ` =([^\n]+)`)
+var (
+	tsUnionRE   = regexp.MustCompile(`^export type ([A-Za-z0-9_]+) =(.*)$`)
+	tsLiteralRE = regexp.MustCompile(`'([^']*)'`)
+)
+
+// tsUnionValues returns the quoted members of a TypeScript string union,
+// following the wrapped form (members on their own `|` lines) as well as the
+// one-liner, so reformatting a long union cannot quietly unhook this check.
+func tsUnionValues(t *testing.T, src, name string) (map[string]bool, bool) {
+	t.Helper()
+	lines := strings.Split(src, "\n")
+	for i, line := range lines {
+		m := tsUnionRE.FindStringSubmatch(line)
+		if m == nil || m[1] != name {
+			continue
+		}
+		body := m[2]
+		for _, next := range lines[i+1:] {
+			if !strings.HasPrefix(strings.TrimSpace(next), "|") {
+				break
+			}
+			body += next
+		}
+		out := map[string]bool{}
+		for _, q := range tsLiteralRE.FindAllStringSubmatch(body, -1) {
+			out[q[1]] = true
+		}
+		return out, true
+	}
+	return nil, false
 }
 
-// tsUnionValues returns the quoted members of a TypeScript string union.
-func tsUnionValues(t *testing.T, src, name string) map[string]bool {
+// goUnionValues reads a named string type's members straight out of the Go
+// source. Parsing beats a hand-kept list for one reason: a member is checked
+// from the moment it is declared, with nothing left to remember.
+func goUnionValues(t *testing.T, dir, typeName string) []string {
 	t.Helper()
-	m := tsUnionRE(name).FindStringSubmatch(src)
-	if m == nil {
-		t.Fatalf("types.ts declares no union %q", name)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("cannot read %s to derive %s's members: %v", dir, typeName, err)
 	}
-	out := map[string]bool{}
-	for _, q := range regexp.MustCompile(`'([^']+)'`).FindAllStringSubmatch(m[1], -1) {
-		out[q[1]] = true
+	fset := gotoken.NewFileSet()
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(dir, e.Name()), nil, 0)
+		if err != nil {
+			t.Fatalf("cannot parse %s: %v", e.Name(), err)
+		}
+		for _, d := range f.Decls {
+			gd, ok := d.(*ast.GenDecl)
+			if !ok || gd.Tok != gotoken.CONST {
+				continue
+			}
+			// Within one const block a spec with neither type nor value
+			// repeats the previous line, so the type carries forward.
+			var mine bool
+			for _, s := range gd.Specs {
+				vs, ok := s.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				switch {
+				case vs.Type != nil:
+					id, isIdent := vs.Type.(*ast.Ident)
+					mine = isIdent && id.Name == typeName
+				case len(vs.Values) > 0:
+					mine = false // an untyped const sharing the block
+				}
+				if !mine {
+					continue
+				}
+				for _, v := range vs.Values {
+					lit, ok := v.(*ast.BasicLit)
+					if !ok || lit.Kind != gotoken.STRING {
+						continue
+					}
+					val, err := strconv.Unquote(lit.Value)
+					if err != nil {
+						t.Fatalf("cannot read %s member %s: %v", typeName, lit.Value, err)
+					}
+					out = append(out, val)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// wireStringTypes returns every named string type carried by a field that
+// ships, keyed by type name.
+func wireStringTypes(t *testing.T) map[string]reflect.Type {
+	t.Helper()
+	out := map[string]reflect.Type{}
+	for _, rt := range wireStructs(t) {
+		eachWireField(rt, func(_ string, ft reflect.Type) {
+			if e := elem(ft); e.Kind() == reflect.String && ours(e) {
+				out[e.Name()] = e
+			}
+		})
 	}
 	return out
 }
 
 func TestTypesTS_UnionValuesMatchGo(t *testing.T) {
 	src := readTypesTS(t)
-
-	for _, c := range []struct {
-		union  string
-		goVals []string
-	}{
-		{"Verdict", []string{
-			string(security.VerdictActNow),
-			string(security.VerdictAttention),
-			string(security.VerdictOK),
-		}},
-		{"Severity", []string{
-			string(security.SeverityCritical),
-			string(security.SeverityHigh),
-			string(security.SeverityMedium),
-			string(security.SeverityLow),
-		}},
-		{"CoverageStatus", []string{
-			string(security.Enforced),
-			string(security.Configured),
-			// Added in #722 and missed here, which is this test's own blind
-			// spot: both sides are hand-written, so a value absent from both
-			// drifts in step and stays green.
-			string(security.Partial),
-			string(security.Gap),
-			string(security.NotApplicable),
-		}},
-		{"ActionPriority", []string{
-			string(security.PriorityNow),
-			string(security.PrioritySoon),
-			string(security.PriorityWatch),
-		}},
-	} {
-		t.Run(c.union, func(t *testing.T) {
-			ts := tsUnionValues(t, src, c.union)
-			for _, v := range c.goVals {
+	checked := 0
+	for name, rt := range wireStringTypes(t) {
+		goVals := goUnionValues(t, sourceDir(rt.PkgPath()), name)
+		if len(goVals) == 0 {
+			continue // a free-form string type, nothing to mirror
+		}
+		checked++
+		t.Run(name, func(t *testing.T) {
+			ts, declared := tsUnionValues(t, src, tsName(rt))
+			if !declared {
+				t.Fatalf("Go ships %s as a %d-value enum but types.ts types it as a bare "+
+					"string, so the frontend cannot branch on it and a typo'd comparison "+
+					"still typechecks: declare `export type %s = %s`",
+					name, len(goVals), tsName(rt), tsUnionLiteral(goVals))
+			}
+			for _, v := range goVals {
 				if !ts[v] {
 					t.Errorf("Go emits %s %q but types.ts does not list it, "+
-						"a value the view can receive and never match", c.union, v)
+						"a value the view can receive and never match", name, v)
 				}
 				delete(ts, v)
 			}
 			for extra := range ts {
 				t.Errorf("types.ts lists %s %q, which Go never emits, "+
-					"any branch on it is unreachable", c.union, extra)
+					"any branch on it is unreachable", name, extra)
 			}
 		})
 	}
+	// A derivation that finds nothing must fail rather than pass vacuously.
+	if checked == 0 {
+		t.Fatal("found no string enums on the wire, the derivation is broken")
+	}
+}
+
+func tsUnionLiteral(vals []string) string {
+	q := make([]string, len(vals))
+	for i, v := range vals {
+		q[i] = "'" + v + "'"
+	}
+	return strings.Join(q, " | ")
 }

--- a/desktop/frontend/src/types.ts
+++ b/desktop/frontend/src/types.ts
@@ -591,13 +591,16 @@ export interface Posture {
   checked: string[]
 }
 
+/** How far a correlated attack sequence got. */
+export type Stage = 'injection' | 'recon' | 'escalation' | 'audit-tampering' | 'succeeded'
+
 export interface Incident {
   id: string
   actor: string
   agent?: string
   start: string
   end: string
-  stages: string[]
+  stages: Stage[]
   /** OWASP Risk Rating factors, kept separate so severity can be argued with. */
   likelihood: number
   impact: number
@@ -613,13 +616,24 @@ export interface FrameworkRef {
   curated: boolean
 }
 
+/** What kind of thing the risk is about, which is what groups the register. */
+export type RiskClass =
+  | 'exposure'
+  | 'incident'
+  | 'control'
+  | 'policy'
+  | 'supply-chain'
+  | 'coverage'
+  | 'evidence'
+export type RiskStatus = 'open' | 'accepted' | 'mitigated'
+
 export interface Risk {
   id: string
-  class: string
+  class: RiskClass
   title: string
   detail: string
   severity: Severity
-  status: string
+  status: RiskStatus
   firstSeen?: string
   ageDays: number
   dueInDays: number
@@ -729,19 +743,43 @@ export interface Threats {
   byAction?: SecurityCount[]
 }
 
+export type LedgerAction = 'read' | 'write' | 'exec' | 'network'
+export type Decision = 'allow' | 'deny' | 'ask'
+
+/** What a dispatch's payload was assembled from and where it went. */
+export interface EventProvenance {
+  /** Provenance kinds carried: user, file, head, mcp, web, env. */
+  sources?: string[]
+  /** The files and heads the payload was assembled from. */
+  origins?: string[]
+  /** public | internal | secret. */
+  sensitivity?: string
+  /** Where it went. 'local' never left the machine, 'remote' did. */
+  sink?: string
+}
+
 /** One raw ledger row, the evidence behind a finding. */
 export interface LedgerEvent {
   ts: string
   agent: string
   tool: string
   resource: string
-  action: string
-  decision: string
+  action: LedgerAction
+  decision: Decision
   reason?: string
+  /** Binds the decision to the exact parameters it was made for. */
+  parameters_hash?: string
   classification?: string
   pii_types?: string[]
   flagged?: boolean
   flag_reason?: string
+  /** The local hash chain. Both empty means unchained, not tampered. */
+  prev_hash?: string
+  hash?: string
+  /** The deployment-identity breadcrumb in effect when this was recorded. */
+  config?: string
+  /** Set on dispatch events only. */
+  provenance?: EventProvenance
 }
 
 /** One model that was tried and did not answer. */

--- a/desktop/frontend/src/views/Security.test.tsx
+++ b/desktop/frontend/src/views/Security.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { Category, CoverageStatus } from '../types'
 import { Security } from './Security'
 import { attestation, check, policyAudit, posture, securityReport } from './Security.fixture'
 
@@ -19,6 +20,31 @@ describe('the verdict and the measurement', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Detailed' }))
     fireEvent.click(screen.getByRole('button', { name: 'Evidence' }))
     expect(screen.getByText(/audit log is empty/i)).toBeInTheDocument()
+  })
+})
+
+// The Record in Security.tsx makes tsc demand a slice for every status. This
+// pins what that is for: the donut is a part-to-whole, so its slices have to
+// sum to the applicable categories. 'partial' was missing from the hand-listed
+// four and the whole quietly stopped being whole (#753).
+describe('coverage by category', () => {
+  it('draws every applicable category into exactly one slice', () => {
+    const categories: Category[] = (
+      ['enforced', 'configured', 'partial', 'gap', 'n/a'] as CoverageStatus[]
+    ).map((status, i) => ({ id: `C${i}`, name: status, status, detail: '' }))
+
+    render(
+      <Security
+        data={securityReport({
+          coverage: { categories, applicable: 4, covered: 2, partial: 1, percentCovered: 50 },
+        })}
+      />,
+    )
+
+    // n/a is excluded from scoring, so it is excluded from the whole too.
+    expect(screen.getByRole('img', { name: /^Enforced: / })).toHaveAccessibleName(
+      'Enforced: 1, Configured: 1, Partial: 1, Gap: 1',
+    )
   })
 })
 

--- a/desktop/frontend/src/views/Security.tsx
+++ b/desktop/frontend/src/views/Security.tsx
@@ -8,6 +8,7 @@ import type {
   Check,
   ConfigDrift,
   Control,
+  CoverageStatus,
   EvidenceQuality,
   SupplyChain,
   BlastReport,
@@ -41,26 +42,27 @@ function findCheckStatus(checks: Check[], name: string): string | undefined {
   return checks.find((c) => c.name === name)?.status
 }
 
-// Every applicable category lands in exactly one slice. Partial has its own:
-// dropping it left the slices summing to less than the category count, so a
-// donut drawn as a part-to-whole was quietly missing part of the whole.
+// One slice per status, in draw order; null is excluded from the part-to-whole
+// exactly as it is from scoring. A Record rather than a hand-listed four, so a
+// status added to the union fails to compile until it is given a slice:
+// 'partial' was dropped here and the donut's slices quietly stopped summing to
+// the category count (#753).
+const COVERAGE_SLICES: Record<CoverageStatus, Omit<DonutSegment, 'value'> | null> = {
+  enforced: { label: 'Enforced', colorVar: 'var(--hy-cheap)' },
+  configured: { label: 'Configured', colorVar: 'var(--hy-aqua)' },
+  partial: { label: 'Partial', colorVar: 'var(--hy-mid)' },
+  gap: { label: 'Gap', colorVar: 'var(--hy-expensive)' },
+  'n/a': null,
+}
+
 function coverageSegments(categories: Category[]): DonutSegment[] {
-  const counts = { enforced: 0, configured: 0, partial: 0, gap: 0 }
-  for (const c of categories) {
-    if (
-      c.status === 'enforced' ||
-      c.status === 'configured' ||
-      c.status === 'partial' ||
-      c.status === 'gap'
-    )
-      counts[c.status]++
-  }
-  return [
-    { label: 'Enforced', value: counts.enforced, colorVar: 'var(--hy-cheap)' },
-    { label: 'Configured', value: counts.configured, colorVar: 'var(--hy-aqua)' },
-    { label: 'Partial', value: counts.partial, colorVar: 'var(--hy-mid)' },
-    { label: 'Gap', value: counts.gap, colorVar: 'var(--hy-expensive)' },
-  ]
+  const counts = new Map<CoverageStatus, number>()
+  for (const c of categories) counts.set(c.status, (counts.get(c.status) ?? 0) + 1)
+  const order = Object.keys(COVERAGE_SLICES) as CoverageStatus[]
+  return order.flatMap((s) => {
+    const slice = COVERAGE_SLICES[s]
+    return slice ? [{ ...slice, value: counts.get(s) ?? 0 }] : []
+  })
 }
 
 // Allowed/Denied are mutually exclusive (Decision is one or the other) and

--- a/desktop/frontend/src/views/SecurityCharts.tsx
+++ b/desktop/frontend/src/views/SecurityCharts.tsx
@@ -153,22 +153,17 @@ export function StatusDonut({ segments }: { segments: DonutSegment[] }) {
   )
 }
 
-function statusFill(status: CoverageStatus): number {
-  switch (status) {
-    case 'enforced':
-      return 1
-    case 'configured':
-      return 2 / 3
-    // Detective, not preventive: real, and short of configured. Without this
-    // it fell to the default and drew identically to n/a, which reads as
-    // "does not apply" rather than "applies and is only half met".
-    case 'partial':
-      return 1 / 2
-    case 'gap':
-      return 1 / 3
-    default:
-      return 0
-  }
+// How full each status draws its bar. A Record rather than a switch, so a
+// status added to the union fails to compile until it is given a fill: the
+// switch this replaces had a `default`, and 'partial' fell into it and drew
+// identically to n/a, reading as "does not apply" rather than "applies and is
+// only half met" (#753).
+const STATUS_FILL: Record<CoverageStatus, number> = {
+  enforced: 1,
+  configured: 2 / 3,
+  partial: 1 / 2, // detective, not preventive: real, and short of configured
+  gap: 1 / 3,
+  'n/a': 0,
 }
 
 /**
@@ -188,7 +183,7 @@ export function CategoryGrid({ categories }: { categories: Category[] }) {
         <div key={c.id} className={`sec-tile sec-tile--${c.status}`} title={c.name}>
           <div className="sec-tile__id">{c.id}</div>
           <div className="sec-tile__bar">
-            <div className="sec-tile__fill" style={{ width: `${statusFill(c.status) * 100}%` }} />
+            <div className="sec-tile__fill" style={{ width: `${STATUS_FILL[c.status] * 100}%` }} />
           </div>
           <div className="sec-tile__status">{c.status}</div>
         </div>

--- a/internal/security/agentic.go
+++ b/internal/security/agentic.go
@@ -49,23 +49,7 @@ func computeAgentic(pol ledger.Policy, sc SupplyChain, integrityIntact bool) Age
 		asi10RogueAgents(sc, integrityIntact),
 	}
 
-	var applicable, covered, partial int
-	for _, c := range cats {
-		if c.Status == NotApplicable {
-			continue
-		}
-		applicable++
-		switch c.Status {
-		case Enforced, Configured:
-			covered++
-		case Partial:
-			partial++
-		}
-	}
-	pct := 0.0
-	if applicable > 0 {
-		pct = 100 * float64(covered) / float64(applicable)
-	}
+	applicable, covered, partial, pct := tally(cats)
 	return AgenticCoverage{
 		Categories: cats, Applicable: applicable,
 		Covered: covered, Partial: partial, PercentCovered: pct,

--- a/internal/security/owasp.go
+++ b/internal/security/owasp.go
@@ -89,24 +89,34 @@ func computeCoverage(pol ledger.Policy, sc SupplyChain, runs []trust.RunLog, cos
 		llm10UnboundedConsumption(costCeilingDenials),
 	}
 
-	var applicable, covered, partial int
+	applicable, covered, partial, pct := tally(cats)
+	return Coverage{Categories: cats, Applicable: applicable, Covered: covered, Partial: partial, PercentCovered: pct}
+}
+
+// tally counts categories into the numbers both Top-10 scores report. One
+// copy: computeCoverage and computeAgentic ran this identical loop twice.
+//
+// Every declared CoverageStatus is named below, Gap included even though it
+// feeds no counter, so the switch reads as the exhaustive thing it has to be.
+// A status added to the enum and not here is scored as applicable and
+// reported nowhere, which is the shape of the bug in #753.
+func tally(cats []Category) (applicable, covered, partial int, pct float64) {
 	for _, c := range cats {
-		if c.Status == NotApplicable {
-			continue
-		}
-		applicable++
 		switch c.Status {
+		case NotApplicable:
+			continue // excluded from the denominator, not just from the numerator
 		case Enforced, Configured:
 			covered++
 		case Partial:
 			partial++
+		case Gap:
 		}
+		applicable++
 	}
-	pct := 0.0
 	if applicable > 0 {
 		pct = 100 * float64(covered) / float64(applicable)
 	}
-	return Coverage{Categories: cats, Applicable: applicable, Covered: covered, Partial: partial, PercentCovered: pct}
+	return applicable, covered, partial, pct
 }
 
 // llm02SensitiveInfo reads the egress gate's real state rather than asserting


### PR DESCRIPTION
## Summary

The wire-parity test compared **two hand-maintained lists**, so a value missing
from both drifted in step and stayed green. `security.Partial` went missing
from four derived copies of the `CoverageStatus` list at once, and every check
passed. Two of the resulting render bugs failed nothing at all, and surfaced
only because an unrelated build break sent someone looking for consumers.

Both sides are derived now.

- **Types are reached by reflection** from the API's root payloads instead of a
  hand-listed table. That table only ever checked the roots, so a field on a
  nested type like `security.Coverage` was unguarded, which is exactly where
  `partial` was.
- **Union members are parsed out of the Go source** with `go/ast`, so a member
  is checked from the moment it is declared.
- `tsNames` stays hand-written, but it *renames* rather than enumerates: a
  missing entry fails loudly with "declares no interface", so it can never make
  a check silently pass.

## What that immediately found

Nine real drifts the old test could not see:

| Drift | Consequence |
|---|---|
| `LedgerEvent` missing `parameters_hash`, `prev_hash`, `hash`, `config`, `provenance` | `provenance` shipped in #744; the desktop could not see the field at all |
| `Stage`, `RiskClass`, `RiskStatus`, `ledger.Action`, `ledger.Decision` typed as bare `string` | no view can branch on them, and a typo'd comparison still typechecks |

## The two render sites

Both move from a hand-listed enumeration to `Record<CoverageStatus, …>`, so a
new status is a **typecheck failure** rather than a bar that draws identically
to `n/a` or a donut slice that quietly vanishes:

- `SecurityCharts.tsx` `statusFill` — a `switch` whose `default` swallowed `partial`
- `Security.tsx` `coverageSegments` — four hand-listed statuses

A test pins what the compile error is *for*: the donut is a part-to-whole, so
its slices have to sum to the applicable categories. The compiler guarantees a
slice exists; only the test guarantees it is counted.

## Also

`computeCoverage` and `computeAgentic` ran the same tally loop twice, byte for
byte. One copy now, with every declared status named in the switch.

## Verification

Mutation-tested, each reverted after:

- [x] drop `'partial'` from the TS union → union test fails (the #722 miss)
- [x] add a field to nested `security.Coverage` → mirror test fails (invisible to the old table)
- [x] add a status to the union → `npm run typecheck` fails at **both** render sites
- [x] drop the partial donut slice → the new render test fails

Green: `go build ./...`, `go test ./...`, `go test -race ./internal/security/`,
`go -C desktop build ./...`, `go -C desktop test ./...`, `npm run typecheck`,
`npm test` (135), `npm run build`.

Closes #753
