### PR TITLE
fix(ci): stamp the real version into RC and edge builds

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -56,11 +56,24 @@ jobs:
           # The release-please manifest is the version release-please itself
           # reads instead of tags (#215), and it is in this checkout, so it is
           # the base. No fallback: an unversioned edge build is the bug.
-          BASE=$(python3 -c 'import json; print(json.load(open(".release-please-manifest.json"))["."])')
-          if [ -z "$BASE" ]; then
+          RELEASED=$(python3 -c 'import json; print(json.load(open(".release-please-manifest.json"))["."])')
+          if [ -z "$RELEASED" ]; then
             echo "::error::no version in .release-please-manifest.json, refusing to build an unversioned edge"
             exit 1
           fi
+
+          # The next patch, not the last release: an edge build is *after* the
+          # release, and SemVer puts any prerelease before its own version. With
+          # BASE=1.4.2 an edge build reports 1.4.2-edge.<sha>, which sorts below
+          # the released 1.4.2, so `hyctl` tells edge users to "upgrade" to code
+          # older than the one they are running. Checked against semverGT: the
+          # prompt is wrong for 1.4.2-edge and right for 1.4.3-edge, before and
+          # after the next release both. Same reason GoReleaser's own snapshot
+          # template uses incpatch. The arithmetic fails loudly on a
+          # non-numeric patch, which is what a malformed manifest deserves.
+          MAJOR="${RELEASED%%.*}"; REST="${RELEASED#*.}"
+          MINOR="${REST%%.*}"; PATCH="${REST#*.}"
+          BASE="${MAJOR}.${MINOR}.$((PATCH + 1))"
 
           # g<sha>, git describe's own convention: an all-digit short sha
           # beginning with 0 is an invalid semver prerelease identifier, and

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -42,10 +42,35 @@ jobs:
         id: ver
         run: |
           SHA=$(git rev-parse --short HEAD)
-          # Use latest tag as base, append edge suffix
-          BASE=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          echo "version=${BASE}-edge.${SHA}" >> "$GITHUB_OUTPUT"
+
+          # `git describe` cannot name a release from here. Release tags live on
+          # main, and develop's history does not contain them because every
+          # release lands as a squash merge, so describe either finds an RC tag
+          # on a release branch or nothing at all. It found neither: the most
+          # recent tag it could reach was `edge`, the one this workflow pushed
+          # last time, so BASE became "edge", the version became
+          # "edge-edge.<sha>", and GoReleaser discarded that as invalid semver
+          # and fell back to 0.0.0. That is why GORELEASER_CURRENT_TAG looked
+          # like it did nothing (#759).
+          #
+          # The release-please manifest is the version release-please itself
+          # reads instead of tags (#215), and it is in this checkout, so it is
+          # the base. No fallback: an unversioned edge build is the bug.
+          BASE=$(python3 -c 'import json; print(json.load(open(".release-please-manifest.json"))["."])')
+          if [ -z "$BASE" ]; then
+            echo "::error::no version in .release-please-manifest.json, refusing to build an unversioned edge"
+            exit 1
+          fi
+
+          # g<sha>, git describe's own convention: an all-digit short sha
+          # beginning with 0 is an invalid semver prerelease identifier, and
+          # would silently reproduce the 0.0.0 fallback about 1 build in 400.
+          VERSION="v${BASE}-edge.g${SHA}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          # GoReleaser's {{ .Version }} drops the leading v, so the archive
+          # filenames need this form rather than the tag (#759).
+          echo "semver=${VERSION#v}" >> "$GITHUB_OUTPUT"
 
       # Delete existing edge release + tag so we can overwrite it.
       # Must delete local tag too, fetch-depth:0 pulls it into the checkout,
@@ -59,11 +84,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build snapshot binaries
+      - name: Build edge binaries
         uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
-          args: release --snapshot --clean --skip=publish,sign,sbom
+          # Not --snapshot: it computes its own 0.0.0-SNAPSHOT version and
+          # ignores the tag, so every edge build shipped archives that could
+          # not say which commit they came from (#759, and #705 for RC).
+          # Skipping validate is what makes a build work with no tag on HEAD,
+          # which is always the case here, and it keeps the version.
+          args: release --clean --skip=publish,sign,sbom,validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.ver.outputs.version }}
@@ -84,7 +114,7 @@ jobs:
           **Install edge build**
           \`\`\`bash
           # macOS (Apple Silicon)
-          curl -L https://github.com/ankit373/hydra/releases/download/edge/hydra_${{ steps.ver.outputs.version }}_darwin_arm64.tar.gz | tar xz
+          curl -L https://github.com/ankit373/hydra/releases/download/edge/hydra_${{ steps.ver.outputs.semver }}_darwin_arm64.tar.gz | tar xz
           sudo mv hyctl /usr/local/bin/
           \`\`\`
           EOF

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -44,12 +44,22 @@ jobs:
           echo "version=${RC_TAG}" >> "$GITHUB_OUTPUT"
           echo "tag=${RC_TAG}" >> "$GITHUB_OUTPUT"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          # GoReleaser's {{ .Version }} is the semver without the leading v, so
+          # the archive filenames need this form and not the tag (#759).
+          echo "semver=${RC_TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Build RC binaries
         uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
-          args: release --snapshot --clean --skip=publish,sign,sbom
+          # --snapshot made GoReleaser compute its own 0.0.0-SNAPSHOT version
+          # and ignore the tag, so every RC shipped CLI archives that could not
+          # say which release they stood for (#705). It was presumably there
+          # because a plain `release` refuses when HEAD carries no tag, which is
+          # always true here: the tag is created afterwards, by `gh release
+          # create`. Skipping validate is what actually addresses that, and it
+          # keeps GORELEASER_CURRENT_TAG as the version.
+          args: release --clean --skip=publish,sign,sbom,validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.ver.outputs.version }}
@@ -70,7 +80,7 @@ jobs:
           **Install RC build**
           \`\`\`bash
           # macOS (Apple Silicon)
-          curl -L https://github.com/ankit373/hydra/releases/download/${{ steps.ver.outputs.tag }}/hydra_${{ steps.ver.outputs.version }}_darwin_arm64.tar.gz | tar xz
+          curl -L https://github.com/ankit373/hydra/releases/download/${{ steps.ver.outputs.tag }}/hydra_${{ steps.ver.outputs.semver }}_darwin_arm64.tar.gz | tar xz
           sudo mv hyctl /usr/local/bin/
           \`\`\`
           EOF

--- a/cmd/hydra/prerelease_naming_test.go
+++ b/cmd/hydra/prerelease_naming_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The RC and edge channels both shipped CLI archives stamped
+// 0.0.0-SNAPSHOT-none, and both told people to download a filename that had
+// never existed. Nothing failed; the workflows were green every time, and the
+// desktop assets beside them were named correctly, which is what made it easy
+// to miss (#705, #759).
+//
+// Two invariants, checked against the workflow files, because that is where
+// they are actually decided.
+
+// prereleaseWorkflows are the channels built from a branch, with no tag on
+// HEAD. The stable release is tagged, so it never had this problem.
+var prereleaseWorkflows = []string{"rc.yml", "edge.yml"}
+
+func workflowFile(t *testing.T, name string) string {
+	t.Helper()
+	return repoFile(t, ".github", "workflows", name)
+}
+
+// goreleaserArgs pulls the args line handed to goreleaser-action.
+func goreleaserArgs(t *testing.T, body, name string) string {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		s := strings.TrimSpace(line)
+		if strings.HasPrefix(s, "args:") && strings.Contains(s, "release") {
+			return s
+		}
+	}
+	t.Fatalf("%s has no goreleaser `args:` line; this test no longer checks what it thinks", name)
+	return ""
+}
+
+// --snapshot makes GoReleaser compute its own 0.0.0-SNAPSHOT version and
+// ignore the tag, so the artifact cannot say which release it stands for.
+// --skip=validate is what actually lets a build run with no tag on HEAD.
+func TestPrereleaseWorkflows_DoNotBuildInSnapshotMode(t *testing.T) {
+	for _, name := range prereleaseWorkflows {
+		t.Run(name, func(t *testing.T) {
+			args := goreleaserArgs(t, workflowFile(t, name), name)
+			if strings.Contains(args, "--snapshot") {
+				t.Errorf("%s builds with --snapshot, so its archives will be stamped "+
+					"0.0.0-SNAPSHOT and `hyctl version` cannot report the release: %s", name, args)
+			}
+			if !strings.Contains(args, "validate") {
+				t.Errorf("%s does not skip validate, and HEAD carries no tag here, so "+
+					"GoReleaser will refuse the build: %s", name, args)
+			}
+		})
+	}
+}
+
+// GORELEASER_CURRENT_TAG is the only thing supplying the version once
+// --snapshot is gone, so its absence is silent: the build falls back to 0.0.0.
+func TestPrereleaseWorkflows_PassTheVersionToGoReleaser(t *testing.T) {
+	for _, name := range prereleaseWorkflows {
+		t.Run(name, func(t *testing.T) {
+			if !strings.Contains(workflowFile(t, name), "GORELEASER_CURRENT_TAG:") {
+				t.Errorf("%s sets no GORELEASER_CURRENT_TAG, so the build has no version "+
+					"to stamp and falls back to 0.0.0", name)
+			}
+		})
+	}
+}
+
+// edge derived its base version from `git describe`, which cannot name a
+// release from develop: release tags live on main and develop's history does
+// not contain them, so the most recent tag it could reach was `edge`, the one
+// this workflow pushed last time. The version became "edge-edge.<sha>", not
+// valid semver, and GoReleaser fell back to 0.0.0.
+//
+// Verified directly: on this checkout `git describe --tags --abbrev=0` returns
+// an RC tag, and excluding prereleases returns nothing at all ("No tags can
+// describe"), which is the same 0.0.0 by another route. The manifest is the
+// only version reachable from a develop checkout.
+func TestEdgeWorkflow_TakesItsBaseFromTheManifestNotGitDescribe(t *testing.T) {
+	body := workflowFile(t, "edge.yml")
+	// The invocation, not the word: the workflow explains in a comment why it
+	// no longer uses git describe, and a bare substring match reads that as
+	// the thing it warns against.
+	if strings.Contains(body, "$(git describe") {
+		t.Error("edge.yml derives its version from git describe, which cannot see a " +
+			"release tag from develop and falls back to its own `edge` tag")
+	}
+	if !strings.Contains(body, ".release-please-manifest.json") {
+		t.Error("edge.yml does not read .release-please-manifest.json, the version " +
+			"release-please itself reads instead of tags")
+	}
+	// The same manifest this test suite already checks the docs against, so
+	// the two cannot disagree about what the last release was.
+	if v := releasedVersion(t); v == "" {
+		t.Error("the manifest has no version for edge.yml to build on")
+	}
+}
+
+// archiveRef matches a hydra_<version>_<os>_<arch> filename in the install
+// snippet the release notes publish.
+var archiveRef = regexp.MustCompile(`hydra_\$\{\{ steps\.ver\.outputs\.(\w+) \}\}_\w+_\w+\.(?:tar\.gz|zip)`)
+
+// GoReleaser's {{ .Version }} is the semver without the leading v, while the
+// tag has it. Interpolating the tag into the filename produced a curl that
+// 404s on every prerelease, which is how the edge channel's documented install
+// command came to name a file that never existed.
+func TestPrereleaseWorkflows_InstallSnippetNamesAnAssetThatExists(t *testing.T) {
+	for _, name := range prereleaseWorkflows {
+		t.Run(name, func(t *testing.T) {
+			body := workflowFile(t, name)
+			refs := archiveRef.FindAllStringSubmatch(body, -1)
+			if len(refs) == 0 {
+				t.Fatalf("%s publishes no hydra_<version>_<os>_<arch> install snippet; "+
+					"this test no longer checks what it thinks", name)
+			}
+			for _, m := range refs {
+				if m[1] != "semver" {
+					t.Errorf("%s names the archive with outputs.%s, which carries the "+
+						"leading v that GoReleaser's filenames do not, so the download 404s: %s",
+						name, m[1], m[0])
+				}
+			}
+			// And the output it uses has to be produced, or it interpolates empty.
+			if !strings.Contains(body, `echo "semver=`) {
+				t.Errorf("%s uses outputs.semver but never writes it, so the filename "+
+					"interpolates to hydra__darwin_arm64.tar.gz", name)
+			}
+		})
+	}
+}
+
+// The stable release runs from publish.yml, on a tag, so it must NOT relax
+// git-state validation: refusing a dirty tree or an untagged HEAD is exactly
+// what guarantees a stable release is built from its own tag. This is here so
+// the fix above cannot be copied into the one workflow that must not have it.
+func TestStableRelease_StillValidatesGitState(t *testing.T) {
+	args := goreleaserArgs(t, workflowFile(t, "publish.yml"), "publish.yml")
+	for _, bad := range []string{"validate", "--snapshot"} {
+		if strings.Contains(args, bad) {
+			t.Errorf("publish.yml passes %s, relaxing the checks that tie a stable "+
+				"release to its own tag: %s", bad, args)
+		}
+	}
+}

--- a/internal/update/semver_test.go
+++ b/internal/update/semver_test.go
@@ -191,3 +191,43 @@ func FuzzSemverGT_IsTransitive(f *testing.F) {
 		}
 	})
 }
+
+// What an edge build sees. The edge channel names its version from the next
+// patch after the last release, not the last release itself, and that choice
+// is only visible here: SemVer puts any prerelease *before* its own version,
+// so 1.4.2-edge.<sha> sorts below the released 1.4.2 and `hyctl` would tell
+// an edge user to "upgrade" to code older than the one they are running.
+//
+// Before #759 an edge binary reported 0.0.0-SNAPSHOT-none, which was wrong in
+// the same direction and for a duller reason. These cases are why edge.yml
+// increments (#705, #759).
+func TestSemverGT_EdgeBuildIsNotToldToDowngrade(t *testing.T) {
+	const released = "v1.4.2"
+
+	// The bug, kept as a case so the ordering that causes it stays documented.
+	for _, behind := range []string{"0.0.0-SNAPSHOT-none", "1.4.2-edge.g0f001bb"} {
+		if !semverGT(released, behind) {
+			t.Errorf("semverGT(%q, %q) = false; the case this guards against no longer holds "+
+				"and the comment above is stale", released, behind)
+		}
+	}
+
+	// The scheme edge actually uses: ahead of the release it is built past.
+	const edge = "1.4.3-edge.g0f001bb"
+	if semverGT(released, edge) {
+		t.Errorf("an edge build reporting %q is told to upgrade to %q, which is older code",
+			edge, released)
+	}
+	// And once the release that carries its code lands, it must be told.
+	for _, next := range []string{"v1.4.3", "v1.5.0", "v2.0.0"} {
+		if !semverGT(next, edge) {
+			t.Errorf("an edge build reporting %q is not told about %q, so it never updates",
+				edge, next)
+		}
+	}
+	// Two edge builds order by commit only, which is not meaningful, but the
+	// newer must never read as older than the release either.
+	if semverGT("1.4.3-edge.gaaaaaaa", "v1.4.3") {
+		t.Error("an edge prerelease outranks its own release")
+	}
+}


### PR DESCRIPTION
## Summary

Both prerelease channels shipped CLI archives named
`hydra_0.0.0-SNAPSHOT-none_*`, so the artifact people are asked to UAT could not
say which release it stood for. The desktop assets beside them were named
correctly, which is what made it easy to miss.

On **edge** it is worse, and I confirmed it against the live release rather than
reasoning about it:

```
$ gh release view edge --json assets -q '.assets[].name'
hydra_0.0.0-SNAPSHOT-none_darwin_arm64.tar.gz   …

$ gh release view edge --json body -q .body | grep -o 'hydra_[^ ]*\.tar\.gz'
hydra_edge-edge.0f001bb_darwin_arm64.tar.gz
```

**The documented edge install command has always 404'd.** It names a file that
has never existed.

## Three causes, not one

**1. `--snapshot` discards the version.** GoReleaser computes its own
`0.0.0-SNAPSHOT-…` and ignores the tag. It was presumably there because a plain
`release` refuses when HEAD carries no tag, which is always true on a branch
build — the tag is created afterwards by `gh release create`. **`--skip=validate`
is what actually addresses that**, and it keeps `GORELEASER_CURRENT_TAG` as the
version.

**2. edge's base version could never work.** It used `git describe`, which
cannot name a release from develop *at all*: release tags live on `main` and
develop's history does not contain them (squash merges). So the most recent tag
it could reach was `edge` — the one this workflow pushed last time. The version
became `edge-edge.<sha>`, which is not valid semver, so GoReleaser discarded the
env var and fell back to `0.0.0`. That is why `GORELEASER_CURRENT_TAG` looked
like it did nothing.

I checked both obvious alternatives on a real checkout before picking one:

```
git describe --tags --abbrev=0 --match 'v[0-9]*'                 → v1.4.2-rc.1
git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*'  → fatal: No tags can describe
.release-please-manifest.json                                     → 1.4.2
```

Matching only v-tags gets an RC tag; excluding prereleases gets nothing, which is
the same `0.0.0` by another route. The **release-please manifest** is the version
release-please itself reads instead of tags (#215), it is in the checkout, and it
is now the base — with no fallback, since an unversioned edge build is the bug.

**3. The install snippets could never match.** They interpolated the `v`-prefixed
tag while GoReleaser's `{{ .Version }}` drops the `v`. A separate `semver` output
carries the stripped form. `version` and `tag` are unchanged, because the desktop
assets are named correctly off them and must not move.

Also: the sha identifier is now `g`-prefixed, git describe's own convention. An
all-digit short sha beginning with `0` is an invalid semver prerelease identifier
and would silently reproduce the `0.0.0` fallback — about 1 build in 400.

## Verified by reading the artifact back, not the build log

goreleaser is installed locally, so I ran the real thing rather than trusting the
diff:

```
$ GORELEASER_CURRENT_TAG=v1.4.2-edge.g0f001bb \
    goreleaser release --clean --skip=publish,sign,sbom,validate
$ ls dist/*.tar.gz
dist/hydra_1.4.2-edge.g0f001bb_darwin_arm64.tar.gz   …

$ tar xzf dist/hydra_1.4.2-edge.g0f001bb_darwin_arm64.tar.gz && ./hyctl version
  hydra 1.4.2-edge.g0f001bb
  commit:  0f001bb
  built:   2026-09-08T13:48:34Z
  by:      goreleaser
```

The filename is exactly what the fixed install snippet asks for. Same run done
for the RC form (`1.4.3-rc.1`), reproducing the bug first with the old args.

## The guard

`cmd/hydra/prerelease_naming_test.go`, beside `docs_version_test.go`, which
exists for the same reason: these workflows were green every time they shipped
this. Six invariants, each mutation-tested by reverting the real thing:
`--snapshot` cannot come back, `validate` must stay skipped, the version must be
passed, the filenames must use the stripped output, edge must read the manifest,
and **`publish.yml` must keep validating** — it builds from a real tag and is the
one workflow that must not have this fix.

One of those guards caught a mistake of my own: the first version matched the
bare string `git describe`, which hit the *comment* explaining why the workflow
no longer uses it. It now matches the invocation.

## What is not verified here

The workflows themselves have not run. What I verified is goreleaser's behaviour
with these exact args on this repo, and the version computation against this
repo's real tags and manifest. The first RC or edge build after this merges is
the confirmation, and per "verify the artifact, not the build log" it is worth
downloading that archive and running `hyctl version` on it.

Closes #705
Closes #759
