### PR TITLE
feat(probe): carry the quantization a local model actually loaded

### DIFF
--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -333,6 +334,10 @@ type probeHeadJSON struct {
 	// same distinction the human table marks with ✗ (#248).
 	Routable         bool   `json:"routable"`
 	UnroutableReason string `json:"unroutable_reason,omitempty"`
+	// What the provider reports about the weights actually loaded, omitted
+	// when it reports nothing. Ollama is the only source of these today.
+	Quant  string `json:"quant,omitempty"`
+	Params string `json:"params,omitempty"`
 }
 
 func cmdProbe() *cobra.Command {
@@ -359,6 +364,7 @@ func cmdProbe() *cobra.Command {
 						CapScore: h.CapScore, LocalOnly: h.LocalOnly,
 						IsCortex: result.Cortex != nil && h.ID == result.Cortex.ID,
 						Routable: why == "", UnroutableReason: why,
+						Quant: h.Meta["model_quant"], Params: h.Meta["model_params"],
 					}
 				}
 				warnings := result.Warnings
@@ -387,8 +393,34 @@ func cmdProbe() *cobra.Command {
 				fmt.Println("  No models found.")
 				return nil
 			}
-			fmt.Printf("  %-30s  %-5s  %-5s  %s\n", "Head", "Score", "Src", "Provider")
-			fmt.Println("  " + strings.Repeat("─", 56))
+			// Only Ollama reports a quant today, so the column is dead space
+			// on a machine with no local models (#762).
+			var anyQuant bool
+			// A name past the column pushed every later column right. The fixed
+			// width had always done that; adding one made it plain, so size the
+			// column to the names, capped to stay inside a normal terminal.
+			const minHead, maxHead = 30, 44
+			headWidth := minHead
+			for _, h := range result.Heads {
+				anyQuant = anyQuant || h.Meta["model_quant"] != ""
+				if n := utf8.RuneCountInString(h.Name); n > headWidth {
+					headWidth = min(n, maxHead)
+				}
+			}
+			header := fmt.Sprintf("  %-*s  %-5s  %-5s  %s", headWidth, "Head", "Score", "Src", "Provider")
+			rowOf := func(h provider.Head) string {
+				return fmt.Sprintf("%-*s  %-5d  %-5s  %s", headWidth, h.Name, h.CapScore, h.Source, h.Provider)
+			}
+			if anyQuant {
+				header = fmt.Sprintf("  %-*s  %-8s  %-5s  %-5s  %s", headWidth, "Head", "Quant", "Score", "Src", "Provider")
+				rowOf = func(h provider.Head) string {
+					return fmt.Sprintf("%-*s  %-8s  %-5d  %-5s  %s",
+						headWidth, h.Name, h.Meta["model_quant"], h.CapScore, h.Source, h.Provider)
+				}
+			}
+			fmt.Println(header)
+			// Derived, not a second constant to keep in sync with the widths.
+			fmt.Println("  " + strings.Repeat("─", len(strings.TrimSpace(header))))
 			// Discovery finding a head is not the same as Hydra being able to
 			// drive it. Listing both identically is what let `probe` advertise
 			// the Ollama binary that `dispatch --local` then refused (#248), so
@@ -405,7 +437,7 @@ func cmdProbe() *cobra.Command {
 					marker = warnStyle.Render("✗ ")
 					unroutable++
 				}
-				row := fmt.Sprintf("%-30s  %-5d  %-5s  %s", h.Name, h.CapScore, h.Source, h.Provider)
+				row := rowOf(h)
 				if why == "" {
 					fmt.Printf("%s%s\n", marker, row)
 					continue

--- a/cmd/hydra/probe_quant_test.go
+++ b/cmd/hydra/probe_quant_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubOllama points $OLLAMA_HOST at a server answering /api/tags with body,
+// so port discovery finds exactly the models a test declares. The sandbox
+// already aims the variable at a dead port, this aims it somewhere alive.
+func stubOllama(t *testing.T, body string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("OLLAMA_HOST", srv.URL)
+}
+
+// Which weights are loaded is a routing input, not trivia: the same model id
+// at Q4_K_M and Q8_0 differs in accuracy, VRAM and tokens/sec, and probe used
+// to report both identically because it dropped Ollama's details object (#762).
+func TestCLI_Probe_ShowsTheQuantOfALocalHead(t *testing.T) {
+	dispatchable(t, "answered")
+	stubOllama(t, `{"models":[{"name":"qwen2.5-coder:7b","capabilities":["completion"],
+		"details":{"parameter_size":"7.6B","quantization_level":"Q4_K_M"}}]}`)
+
+	out, cobraOut, err := run(t, "probe")
+	if err != nil {
+		t.Fatalf("`hyctl probe` failed: %v (%s)", err, cobraOut)
+	}
+	combined := out + cobraOut
+	if !strings.Contains(combined, "Quant") {
+		t.Errorf("the table has no Quant column though a head reports one:\n%s", combined)
+	}
+	if !strings.Contains(combined, "Q4_K_M") {
+		t.Errorf("probe does not show the quant it discovered:\n%s", combined)
+	}
+}
+
+// A JSON consumer is the one most likely to route on this, so the value has to
+// survive as a field rather than only as table text.
+func TestCLI_Probe_JSONCarriesQuantAndParams(t *testing.T) {
+	dispatchable(t, "answered")
+	stubOllama(t, `{"models":[{"name":"qwen2.5-coder:7b","capabilities":["completion"],
+		"details":{"parameter_size":"7.6B","quantization_level":"Q4_K_M"}}]}`)
+
+	out, cobraOut, err := run(t, "probe", "--json")
+	if err != nil {
+		t.Fatalf("`hyctl probe --json` failed: %v (%s)", err, cobraOut)
+	}
+	var parsed struct {
+		Heads []struct {
+			ID     string `json:"id"`
+			Quant  string `json:"quant"`
+			Params string `json:"params"`
+		} `json:"heads"`
+	}
+	if err := json.Unmarshal([]byte(out+cobraOut), &parsed); err != nil {
+		t.Fatalf("probe --json did not parse: %v\n%s", err, out+cobraOut)
+	}
+	var found bool
+	for _, h := range parsed.Heads {
+		if h.ID != "ollama/qwen2.5-coder:7b" {
+			continue
+		}
+		found = true
+		if h.Quant != "Q4_K_M" || h.Params != "7.6B" {
+			t.Errorf("got quant %q params %q, want Q4_K_M / 7.6B", h.Quant, h.Params)
+		}
+	}
+	if !found {
+		t.Fatalf("the stubbed local head is missing from --json:\n%s", out+cobraOut)
+	}
+}
+
+// The column is conditional, and the other branch has to stay honest too: a
+// server that reports no quant must not get an empty column, and must not get
+// an invented value in --json either.
+func TestCLI_Probe_NoQuantMeansNoColumn(t *testing.T) {
+	dispatchable(t, "answered")
+	stubOllama(t, `{"models":[{"name":"llama3.2:3b","capabilities":["completion"]}]}`)
+
+	out, cobraOut, err := run(t, "probe")
+	if err != nil {
+		t.Fatalf("`hyctl probe` failed: %v (%s)", err, cobraOut)
+	}
+	if combined := out + cobraOut; strings.Contains(combined, "Quant") {
+		t.Errorf("empty Quant column on a machine where nothing reports one:\n%s", combined)
+	}
+
+	jsonOut, jsonCobra, err := run(t, "probe", "--json")
+	if err != nil {
+		t.Fatalf("`hyctl probe --json` failed: %v (%s)", err, jsonCobra)
+	}
+	if strings.Contains(jsonOut+jsonCobra, `"quant"`) {
+		t.Errorf("--json emitted a quant field for a server that reported none:\n%s", jsonOut+jsonCobra)
+	}
+}

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -666,7 +666,7 @@ models = ["anthropic/claude-sonnet-4.5", "google/gemini-2.5-pro"]</pre><p><span 
 
     <section class="doc" id="probe">
       <h2><span class="cmd">hyctl probe</span> <span class="tagline">discover every head</span></h2>
-      <p class="sum">Runs the three discovery channels concurrently and lists every head with its CapScore and status.</p>
+      <p class="sum">Runs the three discovery channels concurrently and lists every head with its CapScore and status. For a local model it also shows the <b>quantization actually loaded</b>, because the same model id at Q4_K_M and at Q8_0 is not the same head: it differs in accuracy, VRAM and tokens/sec.</p>
       <div class="sub"><div class="lbl">Usage</div><pre>hyctl probe</pre></div>
     </section>
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -26,7 +26,7 @@
 ## CLI Commands
 
 - `hyctl dispatch`: route a task to the cheapest head that clears the bar (`--enum`/`--tier`, `--swarm`, `--confidence`, `--file`, `--local`, `--dry-run`, `--a2a`)
-- `hyctl probe`: scan the machine for every available head (CLI agents, API keys, local servers)
+- `hyctl probe`: scan the machine for every available head (CLI agents, API keys, local servers). For a local model it reports the quantization the server actually loaded (`Q4_K_M`, `Q8_0`, `F16`) and the parameter count, read from what the server reports rather than guessed: the same model id at two quants differs in accuracy, VRAM and tokens/sec, so routing them as one head hides the tradeoff. A server that reports no quantization gets no column and no invented value
 - `hyctl status`: session state, the rate-aware `claude_pct` budget governor, and the heads that can actually run right now, grouped by the tier they would route at
 - `hyctl tui`: interactive cockpit whose chat executes (Auto/Plan/Edit/Ask, plus Architect/Careful/Unattended), plus five more views over the same data: Agents, Models, Activity, Usage, Audit
 - `hyctl cost`: spend report (estimated vs actual) from the dispatch cost log

--- a/internal/provider/port/provider.go
+++ b/internal/provider/port/provider.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -145,7 +146,14 @@ func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]pro
 			// digest is the only handle on which weights are actually loaded.
 			// Carried so internal/security can detect a swap the way it
 			// already detects a replaced head binary.
-			Digest string `json:"digest"`
+			Digest  string `json:"digest"`
+			Details struct {
+				// The same model id at Q4_K_M and at Q8_0 differs in accuracy,
+				// VRAM and tokens/sec. Routing them as one head hides exactly
+				// the tradeoff the router exists to make (#762).
+				QuantizationLevel string `json:"quantization_level"`
+				ParameterSize     string `json:"parameter_size"`
+			} `json:"details"`
 		} `json:"models"`
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
@@ -157,6 +165,14 @@ func (s *ollamaService) probe(ctx context.Context, caps *capabilities.DB) ([]pro
 		meta := map[string]string{"model_source": caps.SourceOllama(m.Name)}
 		if m.Digest != "" {
 			meta["model_digest"] = m.Digest
+		}
+		// Absent on older servers, which send no details at all. Left unset
+		// rather than defaulted: a fabricated quant would be read as measured.
+		if q := strings.TrimSpace(m.Details.QuantizationLevel); q != "" {
+			meta["model_quant"] = q
+		}
+		if p := strings.TrimSpace(m.Details.ParameterSize); p != "" {
+			meta["model_params"] = p
 		}
 		if !completionCapable(m.Capabilities) {
 			// Embedding-only models fail every dispatch (#532). Marked rather

--- a/internal/provider/port/quant_test.go
+++ b/internal/provider/port/quant_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+package port
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/executor"
+)
+
+// tagsServer answers /api/tags with body and 404s everything else, so a probe
+// that asks the wrong path fails loudly instead of matching by accident.
+func tagsServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The payload is the shape a live Ollama actually returns, details object and
+// all, so the field names are verified against the server not against docs.
+func TestOllama_CarriesTheQuantizationOfTheLoadedWeights(t *testing.T) {
+	srv := tagsServer(t, `{"models":[
+		{"name":"qwen2.5-coder:7b","details":{"format":"gguf","family":"qwen2",
+		 "parameter_size":"7.6B","quantization_level":"Q4_K_M"}},
+		{"name":"qwen2.5-coder:7b-q8_0","details":{"format":"gguf","family":"qwen2",
+		 "parameter_size":"7.6B","quantization_level":"Q8_0"}},
+		{"name":"nomic-embed-text:latest","details":{"parameter_size":"137M",
+		 "quantization_level":"F16"}}
+	]}`)
+
+	heads, err := (&ollamaService{base: srv.URL}).probe(context.Background(), caps(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string][2]string{}
+	for _, h := range heads {
+		got[h.ID] = [2]string{h.Meta["model_quant"], h.Meta["model_params"]}
+	}
+	want := map[string][2]string{
+		"ollama/qwen2.5-coder:7b":        {"Q4_K_M", "7.6B"},
+		"ollama/qwen2.5-coder:7b-q8_0":   {"Q8_0", "7.6B"},
+		"ollama/nomic-embed-text:latest": {"F16", "137M"},
+	}
+	for id, w := range want {
+		if got[id] != w {
+			t.Errorf("%s: got quant/params %v, want %v", id, got[id], w)
+		}
+	}
+	// Two quants of one model have to be distinguishable, which is the whole
+	// point: otherwise trust averages a lossy quant with a near-lossless one.
+	a, b := got["ollama/qwen2.5-coder:7b"][0], got["ollama/qwen2.5-coder:7b-q8_0"][0]
+	if a == b {
+		t.Errorf("both quants of the same model read as %q, the tradeoff is invisible", a)
+	}
+}
+
+// An older server sends no details at all, and a newer one can send a blank
+// field. A value invented there would be read as measured, so the keys stay
+// absent, and neither case may cost the head its routability.
+func TestOllama_NoDetailsInventsNoQuant(t *testing.T) {
+	srv := tagsServer(t, `{"models":[
+		{"name":"llama3.2:3b"},
+		{"name":"qwen3:0.6b","details":{"quantization_level":"  ","parameter_size":""}}
+	]}`)
+
+	heads, err := (&ollamaService{base: srv.URL}).probe(context.Background(), caps(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads) != 2 {
+		t.Fatalf("got %d heads, want 2: a missing details must not drop a head", len(heads))
+	}
+	for _, h := range heads {
+		if q, ok := h.Meta["model_quant"]; ok {
+			t.Errorf("%s: invented quant %q from a server that reported none", h.ID, q)
+		}
+		if p, ok := h.Meta["model_params"]; ok {
+			t.Errorf("%s: invented params %q from a server that reported none", h.ID, p)
+		}
+		if !executor.Supports(h) {
+			t.Errorf("%s became unroutable: %s", h.ID, executor.Unroutable(h))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Ollama's `/api/tags` reports, per model, the quantization and parameter count of the weights
it actually loaded. The port provider decoded only `name`, `capabilities` and `digest` and
dropped the `details` object, so `qwen2.5-coder:7b` at Q4_K_M and at Q8_0 arrived as two heads
with **no visible difference**: the same family-pattern CapScore, the same `internal/trust`
calibration bucket, and nothing in `probe` to tell them apart.

A quant is not cosmetic. It changes accuracy, VRAM and tokens/sec for one model id, which is
exactly the tradeoff the router exists to make. Before this, the only mention of quantization
anywhere in the tree was a hardcoded "assume Q4_K_M" RAM estimate in
`internal/sysinfo/recommend.go`, a guess about a value the server reports for real.

## Changes

- `internal/provider/port/provider.go`: decode `details.quantization_level` and
  `details.parameter_size`, stamp `model_quant` / `model_params` beside the existing
  `model_digest`.
- `cmd/hydra/main.go`: a `Quant` column in `hyctl probe`, and `quant` / `params` in
  `probe --json`.
- `docs/docs.html`, `docs/llms.txt`: describe what probe now reports.

An older server sends no `details` at all, and a newer one can send a blank field. Both leave
the keys unset rather than defaulting, because a fabricated quant reads as a measured one.
`details.family` is deliberately **not** carried: nothing reads it, and a `Meta` key with no
reader is noise.

The column is conditional. Only Ollama reports a quant today, so on a machine with no local
models it would be dead space.

## Verified against a live Ollama, not just the stub

```
  Head                              Quant     Score  Src    Provider
  ──────────────────────────────────────────────────────────────────
→ Claude Code                                 95     cli    anthropic
  Qwen2.5-Coder:7b (Ollama)         Q4_K_M    66     port   local
  qwen3:0.6b (Ollama)               Q4_K_M    63     port   local
✗ nomic-embed-text:latest (Ollama)  F16       55     port   local
    ↳ embeddings only, never routed
```

Those match what the server reports (`7.6B`/`Q4_K_M`, `137M`/`F16`). `probe --json` carries the
same values and omits the fields entirely on the 11 heads that report none. Both new tests were
confirmed red without the change rather than assumed to be meaningful.

## Table alignment, in passing

The `Head` column was a fixed `%-30s`, so a longer name (`nomic-embed-text:latest (Ollama)`, 34
chars) pushed every later column right. That was pre-existing, but the new column made it plain,
so the width now sizes to the names, capped at 44 to stay inside a normal terminal, and the rule
width is derived from the header rather than being a second constant to hand-sync.

`Src` is still ragged for the same reason (`registry` is 8 chars against a `%-5s`). Left alone
as genuinely unrelated to this change, recorded here rather than silently fixed or ignored.

## Not in scope

Making the quant a **calibration key** in `internal/trust` is the follow-up this unblocks, and
the reason the plumbing is worth landing on its own.

Separately, while reading the live payload: `details.context_length` is also reported per model
(`qwen3:0.6b` is 40960, `nomic-embed-text` is 2048), while `internal/budget/windows.go` uses a
hardcoded `fallbackOllama = 32_768` for every local model. That is a 16x overestimate for the
2048 case, so the governor cannot fire before the model truncates. Filed separately, it is a
behavioural fix with its own risk and does not belong in a plumbing PR.

## Tests

- `go test -race ./...` green, `go vet ./...` clean.
- `internal/provider/port/quant_test.go`: two quants of one model stay distinguishable; a
  server reporting nothing gets no invented value and stays routable.
- `cmd/hydra/probe_quant_test.go`: the column and the JSON fields appear when a head reports a
  quant, and the no-quant branch emits neither an empty column nor a `quant` field.

Closes #762
