### PR TITLE
feat(sandbox): catch SIGINT, then isolate head process groups

### DIFF
--- a/ci/coverage-floors.txt
+++ b/ci/coverage-floors.txt
@@ -68,6 +68,7 @@ floor internal/rank                 91
 floor internal/review               88
 floor internal/runid                96
 floor internal/runlog               85
+floor internal/sandbox              86
 floor internal/security             85
 floor internal/swarm                89
 floor internal/sysinfo              82

--- a/cmd/hydra/exit_code_test.go
+++ b/cmd/hydra/exit_code_test.go
@@ -42,12 +42,20 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// exitCode runs the built binary in a fresh sandboxed HOME.
-func exitCode(t *testing.T, args ...string) (code int, output string) {
+// requireHyctl skips when TestMain could not build the binary, which is an
+// environment problem rather than a failure. One call site, so the suite's
+// skip budget counts this concern once (see covergate).
+func requireHyctl(t *testing.T) {
 	t.Helper()
 	if hyctlBin == "" {
 		t.Skip("hyctl could not be built in this environment")
 	}
+}
+
+// exitCode runs the built binary in a fresh sandboxed HOME.
+func exitCode(t *testing.T, args ...string) (code int, output string) {
+	t.Helper()
+	requireHyctl(t)
 	return runBinary(t, testutil.NewSandbox(t), args...)
 }
 
@@ -60,9 +68,7 @@ func exitCode(t *testing.T, args ...string) (code int, output string) {
 // the verdict, which means the exit code *is* the contract for those.
 func runBinary(t *testing.T, s *testutil.Sandbox, args ...string) (code int, output string) {
 	t.Helper()
-	if hyctlBin == "" {
-		t.Skip("hyctl could not be built in this environment")
-	}
+	requireHyctl(t)
 
 	cmd := exec.Command(hyctlBin, args...)
 	cmd.Env = append(os.Environ(),
@@ -133,9 +139,7 @@ func TestExitCodes_MCPDenialIsNonZero(t *testing.T) {
 // stdout must stay parseable: a banner or a warning belongs on stderr, or it
 // lands in whatever is consuming the JSON.
 func TestExitCodes_JSONGoesToStdoutAlone(t *testing.T) {
-	if hyctlBin == "" {
-		t.Skip("hyctl could not be built in this environment")
-	}
+	requireHyctl(t)
 	s := testutil.NewSandbox(t)
 
 	cmd := exec.Command(hyctlBin, "models", "list", "--json")

--- a/cmd/hydra/interrupt_unix_test.go
+++ b/cmd/hydra/interrupt_unix_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// Ctrl+C has to reach the subprocess, not just hyctl. Nothing caught SIGINT
+// before #738: it worked only because the shell signals the whole foreground
+// process group, which stopped being true the moment sandbox.Harden put heads
+// in a group of their own.
+//
+// `oracle verify` is the shortest path that really runs one, so this covers
+// the whole chain: signal → context → exec.CommandContext → Harden's group kill.
+func TestInterrupt_KillsTheSubprocessAndExits130(t *testing.T) {
+	if hyctlBin == "" {
+		t.Skip("hyctl could not be built in this environment")
+	}
+	s := testutil.NewSandbox(t)
+
+	// The verifier announces itself before blocking, so the signal below lands
+	// while it is genuinely running. Signalling on a timer instead raced
+	// hyctl's own startup and failed under load.
+	started := filepath.Join(t.TempDir(), "verifier-started")
+	cmd := exec.Command(hyctlBin, "oracle", "verify", "--",
+		"/bin/sh", "-c", "touch "+started+"; sleep 60")
+	cmd.Env = append(os.Environ(),
+		"HOME="+s.Home,
+		"USERPROFILE="+s.Home,
+		"HYDRA_HOME="+s.HydraHome,
+		"HYDRA_NO_UPDATE_CHECK=1",
+		"PATH="+s.BinDir,
+	)
+	var out bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &out
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting hyctl: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	waitForFile(t, started, done, &out)
+
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		t.Fatalf("signalling hyctl: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		var code int
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			code = exitErr.ExitCode()
+		}
+		// 130 is the shell's convention for SIGINT, and exit codes are a
+		// contract here (see exit_code_test.go). A verifier killed mid-run is
+		// also not a failing verifier: -1 here would mean hyctl died itself,
+		// and 1 would mean the oracle recorded a FAIL verdict for it.
+		if code != 130 {
+			t.Errorf("exit code %d after SIGINT, want 130 (err: %v)\n%s", code, err, out.String())
+		}
+	case <-time.After(15 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("hyctl ignored SIGINT and sat out the 60s sleep, so the signal never reached the verifier")
+	}
+}
+
+// waitForFile blocks until the verifier has started, failing loudly if hyctl
+// exits first rather than leaving a confusing timeout.
+func waitForFile(t *testing.T, path string, done <-chan error, out *bytes.Buffer) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-done:
+			t.Fatalf("hyctl exited before the verifier ran (%v):\n%s", err, out.String())
+		default:
+		}
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("the verifier never started:\n%s", out.String())
+}

--- a/cmd/hydra/interrupt_unix_test.go
+++ b/cmd/hydra/interrupt_unix_test.go
@@ -23,9 +23,7 @@ import (
 // `oracle verify` is the shortest path that really runs one, so this covers
 // the whole chain: signal → context → exec.CommandContext → Harden's group kill.
 func TestInterrupt_KillsTheSubprocessAndExits130(t *testing.T) {
-	if hyctlBin == "" {
-		t.Skip("hyctl could not be built in this environment")
-	}
+	requireHyctl(t)
 	s := testutil.NewSandbox(t)
 
 	// The verifier announces itself before blocking, so the signal below lands

--- a/cmd/hydra/interrupt_unix_test.go
+++ b/cmd/hydra/interrupt_unix_test.go
@@ -31,9 +31,13 @@ func TestInterrupt_KillsTheSubprocessAndExits130(t *testing.T) {
 	// The verifier announces itself before blocking, so the signal below lands
 	// while it is genuinely running. Signalling on a timer instead raced
 	// hyctl's own startup and failed under load.
+	//
+	// Absolute paths and a shell builtin for the marker: the sandbox strips
+	// PATH to its own bin dir, which macOS's sh papered over and Ubuntu's dash
+	// did not.
 	started := filepath.Join(t.TempDir(), "verifier-started")
 	cmd := exec.Command(hyctlBin, "oracle", "verify", "--",
-		"/bin/sh", "-c", "touch "+started+"; sleep 60")
+		"/bin/sh", "-c", ": > "+started+"; /bin/sleep 60")
 	cmd.Env = append(os.Environ(),
 		"HOME="+s.Home,
 		"USERPROFILE="+s.Home,

--- a/cmd/hydra/main.go
+++ b/cmd/hydra/main.go
@@ -14,10 +14,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 	"unicode/utf8"
 
@@ -70,6 +72,18 @@ import (
 )
 
 func main() {
+	// Cancelling this is what tears a run's heads down, now that each has a
+	// process group of its own and the terminal's Ctrl+C no longer reaches it
+	// (#738). First, because Adopt below can spend 3s in a login shell.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-ctx.Done()
+		// Restore the default action, so a second Ctrl+C kills a teardown that
+		// has itself wedged rather than being swallowed like the first.
+		stop()
+	}()
+
 	// Before any command discovers heads. A hyctl or `hyctl tui` started by
 	// something other than a shell, a launcher or an IDE, gets a PATH with no
 	// CLI head in it at all (#689). No-op when a shell already set one.
@@ -78,7 +92,14 @@ func main() {
 	// Fire update check in the background, never blocks startup.
 	updateCh := update.CheckAsync()
 
-	if err := rootCmd().Execute(); err != nil {
+	if err := rootCmd().ExecuteContext(ctx); err != nil {
+		if ctx.Err() != nil {
+			// 130 is the shell's convention for "killed by SIGINT", and exit
+			// codes are a contract here (see exit_code_test.go).
+			fmt.Fprintln(os.Stderr, "  interrupted")
+			os.Exit(130)
+		}
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}
 
@@ -110,9 +131,12 @@ func rootCmd() *cobra.Command {
 		// same way: one line naming the problem. Run --help for the flag list
 		// (#464).
 		SilenceUsage: true,
+		// main prints the error instead, in Cobra's own format, so that a
+		// cancelled run can read as "interrupted" rather than as a failure.
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !config.Exists() {
-				return runInit()
+				return runInit(cmd.Context())
 			}
 			return cmd.Help()
 		},
@@ -260,7 +284,7 @@ func cmdInit() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
 		Short: "First-run wizard: discover Heads and choose your Cortex",
-		RunE:  func(_ *cobra.Command, _ []string) error { return runInit() },
+		RunE:  func(cmd *cobra.Command, _ []string) error { return runInit(cmd.Context()) },
 	}
 }
 
@@ -284,7 +308,7 @@ func requireTerminal(cmd string) error {
 		"writing ~/.hydra/config.toml directly, or run this from a real shell", cmd)
 }
 
-func runInit() error {
+func runInit(ctx context.Context) error {
 	if err := requireTerminal("hyctl init"); err != nil {
 		return err
 	}
@@ -300,7 +324,7 @@ func runInit() error {
 	}
 
 	fmt.Println(dimStyle.Render("  Scanning your machine for AI models..."))
-	result := probe.Run(context.Background())
+	result := probe.Run(ctx)
 
 	if len(result.Heads) == 0 {
 		// Nothing found, guide the user through installing something.
@@ -345,11 +369,11 @@ func cmdProbe() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "probe",
 		Short: "Scan machine for available AI Heads",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !jsonOut {
 				fmt.Println(dimStyle.Render("  Scanning..."))
 			}
-			result := probe.Run(context.Background())
+			result := probe.Run(cmd.Context())
 			cortexName := "none"
 			if result.Cortex != nil {
 				cortexName = result.Cortex.Name
@@ -712,7 +736,7 @@ func cmdDispatch() *cobra.Command {
 			}
 
 			prompt := strings.Join(args, " ")
-			ctx := context.Background()
+			ctx := cmd.Context()
 
 			// One invocation is one run with one logical task, whichever path
 			// below handles it, so a swarm's attempts and the dispatch that
@@ -1519,7 +1543,7 @@ func cmdOracle() *cobra.Command {
 		Use:   "verify <command...>",
 		Short: "Run a verifier command; report pass/fail + its calibrated LLR",
 		Args:  cobra.MinimumNArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// Validated before running the verifier at all: a garbage --record
 			// used to be silently ignored, no error, no calibration write, no
 			// indication anything was wrong, discovered only after the command
@@ -1546,7 +1570,7 @@ func cmdOracle() *cobra.Command {
 				src = "verifier:" + args[0]
 			}
 			o := &oracle.CommandOracle{Args: args, Source: src}
-			v, err := o.Verify(context.Background(), candidate, trust.Task{Domain: domain})
+			v, err := o.Verify(cmd.Context(), candidate, trust.Task{Domain: domain})
 			if err != nil {
 				return err
 			}
@@ -2180,8 +2204,8 @@ func cmdSecurity() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "security",
 		Short: "What the agents on this machine did, and whether you need to act",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			heads := probe.Run(context.Background()).Heads
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			heads := probe.Run(cmd.Context()).Heads
 			rep, err := security.Build(heads)
 			if err != nil {
 				return err
@@ -3528,8 +3552,8 @@ func cmdEdit() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit",
 		Short: "Atomic, validated, rollback-safe file edit via a Hydra Head",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			ctx := context.Background()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
 
 			// Resolve rather than mint, so HYDRA_RUN_ID groups an edit with the
 			// invocation that spawned it (#204, #211).
@@ -3643,8 +3667,8 @@ func cmdReview() *cobra.Command {
 		Use:   "qa <file>",
 		Short: "Send file diff to a Hydra Head for LLM code review",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, args []string) error {
-			ctx := context.Background()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			result, err := review.QA(ctx, args[0], qaTier)
 			if err != nil {
 				return err
@@ -3668,7 +3692,7 @@ func cmdParallel() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "parallel",
 		Short: "Fan N tasks out to N Hydra Heads simultaneously",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			raw, err := os.ReadFile(tasksFile)
 			if err != nil {
 				return fmt.Errorf("reading tasks file: %w", err)
@@ -3678,7 +3702,7 @@ func cmdParallel() *cobra.Command {
 				return fmt.Errorf("invalid JSON in %s: %w", tasksFile, err)
 			}
 
-			ctx := context.Background()
+			ctx := cmd.Context()
 			results, err := parallel.Run(ctx, tasks, parallel.Options{RunID: runid.New()})
 			if err != nil {
 				return err

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/ankit373/hydra/internal/sandbox"
 	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/util"
 )
@@ -118,7 +119,9 @@ func (o *CommandOracle) Verify(ctx context.Context, candidate string, _ trust.Ta
 	if err := checkArgvSize(parts, candidate); err != nil {
 		return Verdict{}, err
 	}
-	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	// A verifier is `go test ./...` or a linter: it spawns a tree, and without
+	// this a cancelled run leaves the compile jobs behind (#738).
+	cmd := sandbox.Harden(exec.CommandContext(ctx, parts[0], parts[1:]...))
 	cmd.Dir = o.Dir
 	// Both streams share one bounded Accumulator, matching CombinedOutput's
 	// interleaving, but capped, unlike the bytes.Buffer it replaces.
@@ -127,6 +130,13 @@ func (o *CommandOracle) Verify(ctx context.Context, candidate string, _ trust.Ta
 	cmd.Stderr = out
 	runErr := cmd.Run()
 	if runErr != nil {
+		// A killed verifier exits non-zero like a failing one. It did not
+		// fail, it never finished, and an oracle carries enough LLR that
+		// recording that as a fail is confident false evidence, the same trap
+		// the empty-template case above guards (#738).
+		if ctx.Err() != nil {
+			return Verdict{}, fmt.Errorf("oracle %s: %w", o.Source, ctx.Err())
+		}
 		if _, ok := runErr.(*exec.ExitError); ok {
 			return Verdict{Passed: false, Detail: firstLine(out.String())}, nil
 		}

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -4,10 +4,12 @@ package oracle
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/ankit373/hydra/internal/trust"
 )
@@ -87,6 +89,29 @@ func TestCommandOracle_LauncherErrorIsError(t *testing.T) {
 	o := &CommandOracle{Template: "this-command-does-not-exist-hydra"}
 	if _, err := o.Verify(context.Background(), "x", trust.Task{}); err == nil {
 		t.Error("a missing verifier binary should return an error, not a fail verdict")
+	}
+}
+
+// A cancelled verifier exits non-zero exactly like a failing one, and this
+// used to report Passed:false. An oracle carries enough LLR to outweigh
+// several models, so Ctrl+C on a run would have written confident evidence
+// that the candidate was wrong (#738).
+func TestCommandOracle_CancelledIsNotAFailedVerdict(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	o := &CommandOracle{Args: []string{"sh", "-c", "sleep 30"}, Source: "verifier:slow"}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	v, err := o.Verify(ctx, "x", trust.Task{})
+	if err == nil {
+		t.Fatalf("a cancelled verifier returned a verdict (%+v), want an error", v)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error %v does not unwrap to context.Canceled, so a caller cannot tell "+
+			"cancellation from a verifier that could not launch", err)
 	}
 }
 

--- a/internal/sandbox/harden_unix.go
+++ b/internal/sandbox/harden_unix.go
@@ -6,6 +6,7 @@ package sandbox
 
 import (
 	"os/exec"
+	"syscall"
 	"time"
 )
 
@@ -14,15 +15,24 @@ import (
 // hangs on a process that already exited.
 const waitDelay = 5 * time.Second
 
-// Harden bounds a subprocess without changing who can signal it.
+// Harden bounds a subprocess and puts it in a process group of its own, so
+// cancelling a run kills the whole tree rather than the direct child.
 //
-// It deliberately does NOT set Setpgid. Putting a head in its own process
-// group is what would let a timeout kill the whole tree, but Hydra installs no
-// SIGINT handler anywhere, so the shell's Ctrl+C would then reach Hydra and
-// not the head: the terminal would return while agy kept running. That trades
-// a rare orphan on timeout for a routine orphan on Ctrl+C, which is worse.
-// Process-group isolation needs signal handling wired first.
+// Every CLI agent spawns helpers, and exec.CommandContext signals only the
+// child it started, leaving them running and still holding the pipe. The group
+// also takes the head out of the terminal's foreground group, so Ctrl+C no
+// longer reaches it: cmd/hydra catches SIGINT and tears down through the
+// context instead, which is why that had to land first (#738).
 func Harden(cmd *exec.Cmd) *exec.Cmd {
 	cmd.WaitDelay = waitDelay
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// A negative pid signals the group. Setpgid with no Pgid makes the
+		// child its own group leader, so -pid is exactly this head's tree.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != syscall.ESRCH {
+			return err
+		}
+		return nil // already gone: cancellation got what it wanted
+	}
 	return cmd
 }

--- a/internal/sandbox/harden_unix_test.go
+++ b/internal/sandbox/harden_unix_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package sandbox
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// The whole point of the process group: exec.CommandContext kills the head it
+// started and nothing else, so a helper the head spawned keeps running with
+// the pipe still open. internal/swarm carries an explicit WaitGroup drain to
+// work around the symptom.
+func TestHarden_CancelKillsTheHelperToo(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "helper.pid")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// A head that spawns a helper and then waits, the shape every CLI agent has.
+	cmd := Harden(exec.CommandContext(ctx, "sh", "-c",
+		"sleep 30 & echo $! > "+pidFile+"; sleep 30"))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting the head: %v", err)
+	}
+
+	helper := readPID(t, pidFile)
+	cancel()
+	_ = cmd.Wait()
+
+	if !gone(helper, 5*time.Second) {
+		_ = syscall.Kill(helper, syscall.SIGKILL) // never leak it past the test
+		t.Fatalf("helper %d survived cancellation of its head", helper)
+	}
+}
+
+// A head that has already exited is not a cancellation failure: reporting
+// ESRCH would surface "no such process" as the reason a run ended.
+func TestHarden_CancelIsQuietWhenTheHeadAlreadyExited(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := Harden(exec.CommandContext(ctx, "sh", "-c", "exit 0"))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting the head: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("head should have exited cleanly: %v", err)
+	}
+	if err := cmd.Cancel(); err != nil {
+		t.Errorf("cancelling a finished head reported %v, want nil", err)
+	}
+}
+
+func TestHarden_SetsTheBoundsItPromises(t *testing.T) {
+	cmd := Harden(exec.Command("true"))
+	if cmd.WaitDelay != waitDelay {
+		t.Errorf("WaitDelay = %v, want %v; without it Wait hangs on a grandchild holding the pipe", cmd.WaitDelay, waitDelay)
+	}
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Error("Setpgid is not set, so a cancelled run reaches only the direct child")
+	}
+}
+
+// readPID waits for the helper to record itself, then returns its pid.
+func readPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(raw))); err == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("the helper never recorded its pid to %s", path)
+	return 0
+}
+
+// gone reports whether the process has left the table. Signal 0 checks for
+// existence without delivering anything.
+func gone(pid int, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if syscall.Kill(pid, 0) == syscall.ESRCH {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/sandbox/harden_windows.go
+++ b/internal/sandbox/harden_windows.go
@@ -14,9 +14,13 @@ import (
 // hangs on a process that already exited.
 const waitDelay = 5 * time.Second
 
-// Harden bounds a subprocess without changing who can signal it. Killing a
-// tree on Windows means a job object, which needs the same signal wiring the
-// Unix build is waiting on. See harden_unix.go.
+// Harden bounds a subprocess without changing who can signal it.
+//
+// The Unix build isolates the head's process group so a cancelled run kills
+// its helpers too. Windows has no equivalent: it needs a job object, which is
+// a different mechanism and cannot be exercised from CI's build-only Windows
+// job, so a timed-out head still leaves helpers behind here (#738). Console
+// Ctrl+C reaches the child either way, since nothing asks for a new group.
 func Harden(cmd *exec.Cmd) *exec.Cmd {
 	cmd.WaitDelay = waitDelay
 	return cmd


### PR DESCRIPTION
## Summary

Ctrl+C only ever reached a head because the shell signals the whole foreground
process group. `signal.Notify` appeared **nowhere** in `cmd/` or `internal/`, so
putting a head in a group of its own, which is what kills the helpers every CLI
agent spawns, would have traded a rare orphan on timeout for a routine orphan on
Ctrl+C. That is why the group was written and reverted during #724.

Done in the order the issue set out.

**1. Catch the signal.** `signal.NotifyContext` in `main`, threaded through
`ExecuteContext`, with the commands that actually run heads switched from
`context.Background()` to `cmd.Context()` (dispatch, edit, qa, parallel, probe,
security, oracle, init). Installed *before* `shellpath.Adopt`, which can spend 3s
in a login shell. A second Ctrl+C restores the default action, so a teardown that
wedges is still killable. An interrupted run exits **130**; Cobra's error printing
moves into `main` in the same format so cancellation reads as `interrupted`
rather than as a failure.

**2. Then isolate the group.** `Setpgid` plus a group-killing `Cancel` in
`sandbox.Harden`. Windows needs a job object instead, which CI's build-only
Windows job cannot exercise, so it keeps the WaitDelay-only behaviour and the
comment now says that rather than pointing at the signal wiring that has landed.

## Two things this turned up

**The oracle never hardened its verifier** — though `go test ./...` is precisely
the tree-spawning case the process group exists for.

**And a cancelled verifier was reported as a failing one.** A killed process
exits non-zero exactly like a failing one, and `Verify` returned
`Passed: false` for it. An oracle carries enough LLR to outweigh several models'
votes, so a Ctrl+C on a run wrote *confident evidence that the candidate was
wrong* — the same trap the empty-template guard above it already warns about. It
now returns the cancellation as an error.

## A note on the ollama daemon

`Harden` also applies to the `ollama serve` Hydra auto-starts. It now survives a
Ctrl+C rather than dying with hyctl. That is what a daemon should do, and the
`isHealthy` check means the next run reuses it instead of spawning a second.

## Verification

Mutation-tested, each reverted after:

- [x] un-thread the context (`Execute()` again) → hyctl sits out the 60s sleep, test times out
- [x] remove the oracle's cancellation check → the interrupt reads as a `FAIL` verdict, exit 1
- [x] drop `Setpgid` → the helper survives its head, and `Cancel` reports `process already finished`

New tests: `internal/sandbox` spawns a real helper and asserts it dies with its
head; `cmd/hydra` drives the built binary end to end (signal → context →
`exec.CommandContext` → group kill) and asserts exit 130. The end-to-end one
waits for the verifier to announce itself rather than signalling on a timer,
which raced hyctl's own startup under load.

Green: `go build ./...`, `GOOS=windows go build ./...`, `go test -race ./...`,
`go -C desktop build ./...`, `go -C desktop test ./...`.

## Two things CI caught that I had not

**The verifier needed a PATH.** The sandbox strips `PATH` to its own bin dir,
and macOS's `sh` resolved `touch` and `sleep` anyway while Ubuntu's `dash` did
not. Absolute paths and a shell builtin now.

**Covergate's skip budget.** The new test's "hyctl could not be built" guard
would have been the *fifth* copy of the same three lines and took the suite one
over the cap of 40. They now go through one `requireHyctl` helper. That drops
the counted skips from 41 to 38, because covergate counts only skips inside
`Test` functions — so this is duplication removal that happens to relieve the
budget, not a way around it, and no test skips that did not skip before.

While there: `internal/sandbox` had no coverage floor. It measures 90.9% on
Linux with the new harden tests, so it gets 86 with the usual margin.

## Left open

Windows job objects, item 3 on the issue. Untestable from CI as it stands, and I
would rather leave it named than ship unexercised process-teardown code.

Closes #738
