### PR TITLE
fix(rank): route to the better quant, not to a coin flip

### DIFF
--- a/internal/rank/quant.go
+++ b/internal/rank/quant.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+package rank
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// unknownQuantBits is the sort position of a head whose quantization nothing
+// reported. It sorts after every head that reported one.
+//
+// Not a claim that such a head is worse. It is a fixed position, and the thing
+// it replaces is an arbitrary one: a comparator that skipped the key whenever
+// either side was unknown stopped being transitive (Q8 before Q4 by bits, Q4
+// before an unknown by id, that unknown before Q8 by id, a cycle), and an
+// intransitive comparator is how #765 happened in the first place.
+const unknownQuantBits = -1
+
+// quantBits reads bits-per-weight off a quantization label: Q4_K_M → 4,
+// Q8_0 → 8, F16/BF16 → 16, IQ2_XXS → 2, MXFP4 → 4. It reports ok=false for a
+// label it cannot read, which is the only honest answer for one it has not seen.
+//
+// A label parse, deliberately not a quality score. "More bits is not worse for
+// the same base model" is well founded; any particular magnitude would not be.
+func quantBits(label string) (int, bool) {
+	s := strings.ToUpper(strings.TrimSpace(label))
+	if s == "" {
+		return 0, false
+	}
+	// FP first, and by search rather than by prefix: the microscale formats
+	// carry a vendor prefix (MXFP4, NVFP4), so anchoring at the start misses
+	// them and falling through to "F" would read MXFP4 as unparseable.
+	if i := strings.Index(s, "FP"); i >= 0 {
+		return digitsAt(s, i+len("FP"))
+	}
+	for _, p := range []string{"BF", "F"} {
+		if strings.HasPrefix(s, p) {
+			return digitsAt(s, len(p))
+		}
+	}
+	// Integer quants are Q<n>_… or IQ<n>_…, where n is the nominal width. The
+	// K/S/M/XXS suffixes vary the per-block layout, not the nominal width, so
+	// they are not read: Q4_K_M and Q4_0 are both 4-bit, and separating them
+	// on this key would claim a precision this parse does not have.
+	s = strings.TrimPrefix(s, "I")
+	if strings.HasPrefix(s, "Q") {
+		return digitsAt(s, len("Q"))
+	}
+	return 0, false
+}
+
+// digitsAt parses the run of digits starting at i, and reports whether there
+// was one and it was positive.
+func digitsAt(s string, i int) (int, bool) {
+	end := i
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == i {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[i:end])
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// quantRank is a head's position on the quantization key: its bits per weight,
+// or unknownQuantBits when nothing reported one. Higher sorts first.
+func quantRank(h provider.Head) int {
+	if bits, ok := quantBits(h.Meta["model_quant"]); ok {
+		return bits
+	}
+	return unknownQuantBits
+}

--- a/internal/rank/quant_test.go
+++ b/internal/rank/quant_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+
+package rank
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+func TestQuantBits_ReadsTheLabelAndAdmitsWhenItCannot(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		bits  int
+		ok    bool
+	}{
+		// The labels a live Ollama actually reports.
+		{"Q4_K_M", 4, true},
+		{"Q8_0", 8, true},
+		{"F16", 16, true},
+		// Other GGUF quants in common circulation.
+		{"Q4_0", 4, true},
+		{"Q5_K_S", 5, true},
+		{"Q6_K", 6, true},
+		{"Q2_K", 2, true},
+		{"Q3_K_L", 3, true},
+		{"IQ2_XXS", 2, true},
+		{"IQ4_NL", 4, true},
+		{"BF16", 16, true},
+		{"F32", 32, true},
+		// FP-prefixed microscale formats must not read as F followed by a
+		// width: MXFP4 is 4-bit, and "F" then "P4" would parse as nothing.
+		{"FP8", 8, true},
+		{"NVFP4", 4, true},
+		{"MXFP4", 4, true},
+		// Case and padding are the server's business, not ours.
+		{"q4_k_m", 4, true},
+		{"  Q8_0  ", 8, true},
+		// Nothing readable. A guess here would pick a head on no evidence.
+		{"", 0, false},
+		{"unknown", 0, false},
+		{"Q", 0, false},
+		{"Q_K_M", 0, false},
+		{"Q0", 0, false},
+	} {
+		bits, ok := quantBits(tc.label)
+		if bits != tc.bits || ok != tc.ok {
+			t.Errorf("quantBits(%q) = (%d, %v), want (%d, %v)", tc.label, bits, ok, tc.bits, tc.ok)
+		}
+	}
+}
+
+// MXFP4 is the case that made the prefix order load-bearing: read "F" first
+// and it becomes an unparseable label rather than a 4-bit one.
+func TestQuantBits_MicroscaleFormatsAreNotMisreadAsFloats(t *testing.T) {
+	for _, label := range []string{"MXFP4", "NVFP4", "MXFP8"} {
+		if _, ok := quantBits(label); !ok {
+			t.Errorf("quantBits(%q) failed to parse, the FP prefix is being read as F", label)
+		}
+	}
+	if bits, _ := quantBits("MXFP4"); bits != 4 {
+		t.Errorf("MXFP4 read as %d bits, want 4", bits)
+	}
+}
+
+func localHead(id, quant string, score int) provider.Head {
+	h := provider.Head{
+		ID: id, Name: id, Provider: "local", Source: "port",
+		CapScore: score, LocalOnly: true, AuthReady: true,
+		Meta: map[string]string{"model_source": "ollama"},
+	}
+	if quant != "" {
+		h.Meta["model_quant"] = quant
+	}
+	return h
+}
+
+// The bug: both quants of one model score the same (ScoreOllama matches on the
+// family pattern) and share a source, so score-then-source left them
+// incomparable, and an unstable sort picked between them (#765).
+func TestByCapScore_PrefersTheBetterQuantOfTheSameModel(t *testing.T) {
+	q4 := localHead("ollama/qwen2.5-coder:7b", "Q4_K_M", 66)
+	q8 := localHead("ollama/qwen2.5-coder:7b-q8_0", "Q8_0", 66)
+
+	for _, in := range [][]provider.Head{{q4, q8}, {q8, q4}} {
+		ranked := ByCapScore(in)
+		var firstLocal string
+		for _, h := range ranked {
+			if h.LocalOnly {
+				firstLocal = h.ID
+				break
+			}
+		}
+		if firstLocal != q8.ID {
+			t.Errorf("input order %s first: ranked %s ahead of the Q8, want %s",
+				in[0].ID, firstLocal, q8.ID)
+		}
+	}
+}
+
+// The measured symptom in #765: the winner of the tie flipped as unrelated
+// heads were added, crossing the boundary where sort.Slice stops behaving like
+// insertion sort. The fix has to hold at every size, so this sweeps it.
+func TestByCapScore_TieDoesNotDependOnHowManyOtherHeadsExist(t *testing.T) {
+	q4 := localHead("ollama/qwen2.5-coder:7b", "Q4_K_M", 66)
+	q8 := localHead("ollama/qwen2.5-coder:7b-q8_0", "Q8_0", 66)
+
+	for _, n := range []int{0, 1, 5, 10, 11, 12, 14, 18, 30, 50} {
+		for _, in := range [][]provider.Head{{q4, q8}, {q8, q4}} {
+			heads := append([]provider.Head(nil), in...)
+			for i := 0; i < n; i++ {
+				heads = append(heads, provider.Head{
+					ID: fmt.Sprintf("filler-%02d", i), Name: fmt.Sprintf("filler-%02d", i),
+					Provider: fmt.Sprintf("vendor-%02d", i), Source: "cli",
+					CapScore: 90 - i, AuthReady: true,
+					Meta: map[string]string{},
+				})
+			}
+			ranked := ByCapScore(heads)
+			var q4Pos, q8Pos = -1, -1
+			for i, h := range ranked {
+				switch h.ID {
+				case q4.ID:
+					q4Pos = i
+				case q8.ID:
+					q8Pos = i
+				}
+			}
+			if q4Pos < 0 || q8Pos < 0 {
+				t.Fatalf("n=%d: a quant head vanished from the ranking", n)
+			}
+			if q8Pos > q4Pos {
+				t.Errorf("n=%d input %s first: Q8 at %d ranked behind Q4 at %d",
+					n, in[0].ID, q8Pos, q4Pos)
+			}
+		}
+	}
+}
+
+// A comparator that is not a total order is what let the sort pick arbitrarily.
+// Two distinct heads must never compare as equal in both directions.
+func TestByCapScore_OrderIsTotalAndRepeatable(t *testing.T) {
+	heads := []provider.Head{
+		localHead("ollama/a:7b", "Q4_K_M", 66),
+		localHead("ollama/b:7b", "Q4_K_M", 66),
+		localHead("ollama/c:7b", "", 66),
+		localHead("ollama/d:7b", "", 66),
+		localHead("ollama/e:7b", "Q8_0", 66),
+	}
+	first := ByCapScore(heads)
+	// Bits descending, then id, with the two that reported nothing last. The
+	// last part is a fixed position rather than a judgement, see
+	// unknownQuantBits: what it replaces is an arbitrary position.
+	wantOrder := []string{"ollama/e:7b", "ollama/a:7b", "ollama/b:7b", "ollama/c:7b", "ollama/d:7b"}
+	for i, want := range wantOrder {
+		if first[i].ID != want {
+			t.Fatalf("position %d is %s, want %s (full order %v)", i, first[i].ID, want, ids(first))
+		}
+	}
+	// Every permutation of the same set has to rank identically, which is the
+	// property "the order is decided by the heads, not by their arrangement".
+	for _, perm := range [][]int{{4, 3, 2, 1, 0}, {2, 0, 4, 1, 3}, {1, 4, 0, 3, 2}} {
+		shuffled := make([]provider.Head, 0, len(heads))
+		for _, i := range perm {
+			shuffled = append(shuffled, heads[i])
+		}
+		got := ByCapScore(shuffled)
+		if len(got) != len(first) {
+			t.Fatalf("permutation changed the head count: %d vs %d", len(got), len(first))
+		}
+		for i := range got {
+			if got[i].ID != first[i].ID {
+				t.Fatalf("permutation %v reordered the result: position %d is %s, want %s",
+					perm, i, got[i].ID, first[i].ID)
+			}
+		}
+	}
+}
+
+// Nothing may be inferred from a model name: `qwen2.5-coder:7b` is Q4_K_M in
+// fact, but the name does not say so, and reading a quant out of a tag would
+// be a guess presented as a measurement.
+func TestByCapScore_NoQuantIsInferredFromTheName(t *testing.T) {
+	named := localHead("ollama/qwen2.5-coder:7b-q8_0", "", 66)
+	plain := localHead("ollama/qwen2.5-coder:7b", "", 66)
+
+	if quantRank(named) != unknownQuantBits || quantRank(plain) != unknownQuantBits {
+		t.Error("a quant was derived from the model name rather than from what the server reported")
+	}
+	// With nothing to go on, the order still has to be decided: by ID, so it
+	// is at least the same on every machine.
+	ranked := ByCapScore([]provider.Head{named, plain})
+	if ranked[0].ID != plain.ID {
+		t.Errorf("unquantified heads ranked %s first, want the ID order (%s)", ranked[0].ID, plain.ID)
+	}
+}
+
+// The dedup pass has its own tie, reached only when two heads share a dedupe
+// key. Local heads key on ID so they never collide there; a cloud provider's
+// entries do, and must not be decided arbitrarily either.
+func TestByCapScore_DedupeTieAlsoPrefersTheBetterQuant(t *testing.T) {
+	mk := func(id, quant string) provider.Head {
+		return provider.Head{
+			ID: id, Name: id, Provider: "acme", Source: "env",
+			CapScore: 70, AuthReady: true,
+			Meta: map[string]string{"model_quant": quant},
+		}
+	}
+	// Same provider, no Meta["model"], so both collapse onto the provider key.
+	for _, in := range [][]provider.Head{{mk("acme-lo", "Q4_K_M"), mk("acme-hi", "Q8_0")},
+		{mk("acme-hi", "Q8_0"), mk("acme-lo", "Q4_K_M")}} {
+		ranked := ByCapScore(in)
+		if len(ranked) != 1 {
+			t.Fatalf("expected the two to dedupe to one head, got %d", len(ranked))
+		}
+		if ranked[0].ID != "acme-hi" {
+			t.Errorf("dedupe kept %s, want the better-quantized acme-hi", ranked[0].ID)
+		}
+	}
+}
+
+func ids(hs []provider.Head) []string {
+	out := make([]string, len(hs))
+	for i, h := range hs {
+		out[i] = h.ID
+	}
+	return out
+}
+
+// ByCapScore round-trips through a map, and Go randomizes map iteration, so the
+// input reaching sort.Slice differs every call. That is what made the old
+// comparator a coin flip rather than merely arbitrary: measured on a real head
+// set, 40 runs of `hyctl probe` put the Q4 first 23 times and the Q8 17 times.
+// One call cannot catch it, so this repeats until randomization would have.
+func TestByCapScore_RepeatedCallsOnOneInputAgree(t *testing.T) {
+	heads := []provider.Head{
+		localHead("ollama/qwen3:0.6b", "Q4_K_M", 63),
+		localHead("ollama/qwen3:0.6b-q8_0", "Q8_0", 63),
+		localHead("ollama/llama3.2:3b", "Q4_K_M", 60),
+		localHead("ollama/mistral:7b", "Q4_K_M", 60),
+		localHead("ollama/gemma2:9b", "", 60),
+	}
+	want := ids(ByCapScore(heads))
+	for i := 0; i < 500; i++ {
+		if got := ids(ByCapScore(heads)); !slices.Equal(got, want) {
+			t.Fatalf("call %d ordered %v, first call ordered %v", i, got, want)
+		}
+	}
+	if want[0] != "ollama/qwen3:0.6b-q8_0" {
+		t.Errorf("ranked %s first, want the Q8", want[0])
+	}
+}

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -45,8 +45,7 @@ func ByCapScore(heads []provider.Head) []provider.Head {
 			best[key] = h
 			continue
 		}
-		if h.CapScore > existing.CapScore ||
-			(h.CapScore == existing.CapScore && sourceWeight[h.Source] > sourceWeight[existing.Source]) {
+		if rankLess(h, existing) {
 			best[key] = h
 		}
 	}
@@ -56,15 +55,31 @@ func ByCapScore(heads []provider.Head) []provider.Head {
 		ranked = append(ranked, h)
 	}
 
-	sort.Slice(ranked, func(i, j int) bool {
-		a, b := ranked[i], ranked[j]
-		if a.CapScore != b.CapScore {
-			return a.CapScore > b.CapScore
-		}
-		return sourceWeight[a.Source] > sourceWeight[b.Source]
-	})
+	sort.Slice(ranked, func(i, j int) bool { return rankLess(ranked[i], ranked[j]) })
 
 	return ranked
+}
+
+// rankLess reports whether a should rank ahead of b, as a total order: score,
+// then source, then bits per weight, then id.
+//
+// Total on purpose. Score and source alone left two quants of one model
+// incomparable, and `best` above is a map, whose iteration order Go
+// randomizes, so the unstable sort had a different input every call and picked
+// between them by coin flip: 23 of 40 real `probe` runs ranked the Q4 first,
+// 17 the Q8 (#765). The dedupe tie uses the same predicate so the two passes
+// cannot disagree about which of two heads is better.
+func rankLess(a, b provider.Head) bool {
+	if a.CapScore != b.CapScore {
+		return a.CapScore > b.CapScore
+	}
+	if sourceWeight[a.Source] != sourceWeight[b.Source] {
+		return sourceWeight[a.Source] > sourceWeight[b.Source]
+	}
+	if qa, qb := quantRank(a), quantRank(b); qa != qb {
+		return qa > qb
+	}
+	return a.ID < b.ID
 }
 
 func dedupeKey(h provider.Head) string {


### PR DESCRIPTION
## Summary

Which of two quants of one local model the router picks was a **coin flip, re-tossed every
invocation**. Measured on a real head set, 40 runs of `hyctl probe`:

```
  23 qwen3:0.6b        (Q4_K_M ranked first)
  17 qwen3:0.6b-q8_0   (Q8_0 ranked first)
```

Same machine, same models, same command. `dispatch` takes the first candidate at or under tier
(`dispatch.go:1047`), so whether a task ran on the lossy or the less lossy weights was decided
fresh each time and nothing reported it. After this change: **40 of 40 rank the Q8 first.**

## Why it happened

Three things compounded, and only the third makes it random rather than merely arbitrary:

1. `capabilities.ScoreOllama` is `strings.Contains(lower, f.Pattern)`, so `qwen3:0.6b` and
   `qwen3:0.6b-q8_0` both match `qwen` and both score **63**. `rank.dedupeKey` returns `h.ID`
   for `LocalOnly` heads, so both survive as separate heads.
2. `ByCapScore`'s comparator was `CapScore` desc then `sourceWeight[Source]` desc. Both are 63
   and both are source `port`, so it returned false in both directions. **Not a total order**,
   and `sort.Slice` is not stable.
3. `ByCapScore` dedupes through `best := map[string]provider.Head{}` and then iterates that map
   to build the slice it sorts. **Go randomizes map iteration**, so the sort's input differed on
   every call and an unstable sort had nothing to preserve.

Point 3 is easy to miss: testing the comparator against a fixed slice looks perfectly
deterministic. An earlier revision of #765 claimed exactly that, and was wrong. The repeat test
below is the one that actually catches this.

## Changes

- `internal/rank/rank.go`: `rankLess` is now a total order (score, source, bits per weight, id),
  and the dedupe tie uses **the same predicate**, so the two passes cannot disagree about which
  of two heads is better. Both former conditions are preserved exactly; the new keys only ever
  break ties that were previously unordered.
- `internal/rank/quant.go`: `quantBits` reads bits per weight off the label #762 started carrying.
  `Q4_K_M` → 4, `Q8_0` → 8, `F16`/`BF16` → 16, `IQ2_XXS` → 2, `MXFP4` → 4.

## Three judgement calls worth reviewing

**It parses a label, it does not score quality.** "More bits is not worse for the same base
model" is well founded. A magnitude ("Q4 is 7 points worse") would be a fabricated number, and
this repo already refuses those (`internal/mcpregistry` renders "insufficient evidence" rather
than inventing a category score). So no quantization penalty is applied to CapScore. A *measured*
penalty can come later from `internal/evalset` oracle history, which is the right source for it.
For the same reason the K/S/M/XXS suffixes are not read: `Q4_K_M` and `Q4_0` are both nominally
4-bit, and separating them would claim precision this parse does not have.

**Unknown takes a fixed position rather than being skipped.** Skipping the key whenever either
side is unknown was my first implementation, and it is **intransitive**: Q8 before Q4 by bits, Q4
before an unknown by id, that unknown before Q8 by id, a cycle. An intransitive comparator is the
same class of defect as the one being fixed. So a head that reported no quant sorts after one
that did. That is a fixed position, not a judgement about it, and what it replaces is a random
position. In practice it barely arises: the three source weights are distinct, so the bits key is
only ever reached between heads of the same source.

**`MXFP4` forced the parse order.** The FP search runs before the `F` prefix, because the
microscale formats carry a vendor prefix and anchoring `FP` at the start misses them, at which
point `F` reads `MXFP4` as unparseable. There is a test named for that specifically.

## Tests

`go test -race ./...` green, `go vet ./...` clean. Every new test was confirmed red without the
fix rather than assumed meaningful:

- `TestByCapScore_RepeatedCallsOnOneInputAgree` runs `ByCapScore` 500 times on one input and
  requires identical output. **This is the one that catches the real bug** (it failed on call 2
  without the fix); a single call agrees with itself by luck roughly half the time.
- `TestByCapScore_PrefersTheBetterQuantOfTheSameModel`, both input orders.
- `TestByCapScore_TieDoesNotDependOnHowManyOtherHeadsExist` sweeps 2 to 52 heads.
- `TestByCapScore_OrderIsTotalAndRepeatable` asserts the concrete order and that every
  permutation of one set ranks identically.
- `TestByCapScore_NoQuantIsInferredFromTheName`: `qwen2.5-coder:7b-q8_0` is Q8_0 in fact, but the
  name does not say so, and reading it out of the tag would be a guess presented as a measurement.
- `TestQuantBits_*` over the labels a live Ollama reports plus the wider GGUF set, including the
  ones that must fail to parse.

Verified end to end with two real quants pulled side by side, and against a stub serving a
controlled head set, comparing the pre-fix and post-fix binaries on the same input.

Closes #765
