### PR TITLE
fix(policy): apply the caps policy.yaml declares, and stop misreporting them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,13 @@ registry/               ← Routing data, compiled into the binary via `go:embed
   domains.yaml          ← Domain → enum key routing (references routing.yaml).
   pricing.yaml          ← Tier pricing. Prices the CLI-agent heads that never appear in
                           OpenRouter's catalog, so it is load-bearing, not just an offline fallback.
-  policy.yaml           ← File-policy rules.  workspace.yaml ← workspace roots + validators.
+  policy.yaml           ← File-policy rules. Three of its fields take effect, and only in
+                          `hyctl parallel`: diff_size_cap_pct rolls an over-large edit back,
+                          max_cost_usd refuses a head before it runs, max_wall_seconds
+                          deadlines the dispatch (#424). The rest are declared and read by
+                          nothing, and `hyctl edit` does not consult the file at all (#769).
+                          `hyctl security` reports which, derived rather than hardcoded.
+  workspace.yaml        ← workspace roots + validators.
 logs/                   ← Dispatch log + state.json (claude_pct, claude_pct_history).
 ```
 

--- a/ci/coverage-floors.txt
+++ b/ci/coverage-floors.txt
@@ -68,6 +68,7 @@ floor internal/rank                 91
 floor internal/review               88
 floor internal/runid                96
 floor internal/runlog               85
+floor internal/security             85
 floor internal/swarm                89
 floor internal/sysinfo              82
 floor internal/testutil             81

--- a/internal/parallel/edit_test.go
+++ b/internal/parallel/edit_test.go
@@ -12,10 +12,12 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/ledger"
+	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/testutil"
 
@@ -1041,5 +1043,152 @@ func TestPersistResults_RoundTripsThroughDisk(t *testing.T) {
 	// successes, since a failed edit may still have touched the file.
 	if got[0]["status"] != "ok" || got[1]["status"] != "fail" {
 		t.Errorf("statuses did not round-trip: %v", got)
+	}
+}
+
+// writePolicyApply writes a policy.yaml whose single always-matching rule
+// applies whatever fields the caller names, so a test can trip one cap without
+// tripping the others.
+func writePolicyApply(t *testing.T, apply string) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HYDRA_HOME"), "registry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: \"1.0\"\nrules:\n  - name: test_caps\n    when:\n      always: true\n    apply:\n" + apply
+	if err := os.WriteFile(filepath.Join(dir, "policy.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// max_cost_usd was declared in policy.yaml and read by nothing, so an operator
+// reading a $2 ceiling had none. The enforcement already existed in dispatch's
+// preflight; the policy's number simply never reached it (#424).
+func TestEdit_CostCeilingRefusesTheHeadBeforeItRuns(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n"))
+	// A ceiling no head can be under, so the refusal is the policy's and not
+	// a pricing accident.
+	writePolicyApply(t, "      max_cost_usd: 0.0000000001\n")
+
+	file := filepath.Join(repo, "a.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	original, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{
+		Label: "cost", Enum: "MODERATE", File: file,
+		Prompt: "grow this file", Validate: boolPtr(false),
+	})
+
+	if got.Status != "fail" {
+		t.Fatalf("result = %+v, want a failure: the policy's ceiling was not applied", got)
+	}
+	if !strings.Contains(got.Error, "route_failed") || !strings.Contains(got.Error, "exceeds limit") {
+		t.Errorf("Error = %q, want the cost ceiling's own refusal", got.Error)
+	}
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != string(original) {
+		t.Errorf("the file was written despite the ceiling refusing the head:\n%q", raw)
+	}
+}
+
+// max_wall_seconds likewise. Both caps are declared here, so this asserts the
+// pair does not let an edit through; which one refuses is a race and is
+// deliberately not asserted. The deadline's own wiring is tested by
+// TestPolicyDeadline_AppliesMaxWallSeconds, because a test that sets both caps
+// passes even with the deadline deleted, which is how the first version of
+// this let a surviving mutant through.
+func TestEdit_WallClockLimitDeadlinesTheDispatch(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n"))
+	writePolicyApply(t, "      max_wall_seconds: 1\n      max_cost_usd: 0.0000000001\n")
+
+	file := filepath.Join(repo, "a.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{
+		Label: "wall", Enum: "MODERATE", File: file,
+		Prompt: "grow this file", Validate: boolPtr(false),
+	})
+
+	// Either cap may win the race; what must not happen is the edit landing
+	// with both declared. The message has to name which one refused, or the
+	// operator cannot tell a policy refusal from a broken head.
+	if got.Status != "fail" {
+		t.Fatalf("result = %+v, want a failure with both caps set to the unmeetable", got)
+	}
+	if !strings.Contains(got.Error, "max_wall_seconds_exceeded") && !strings.Contains(got.Error, "exceeds limit") {
+		t.Errorf("Error = %q, want it to name the cap that refused", got.Error)
+	}
+}
+
+// And with no caps declared, an edit must still work: a policy.yaml that says
+// nothing must not become a policy that refuses everything.
+//
+// The file is deliberately large and the change small. A one-line file grown
+// to three lines is a 150% diff and trips the *default* 90% cap, which is
+// correct behaviour and not what this test is about.
+func TestEdit_NoCapsDeclaredStillEdits(t *testing.T) {
+	body := "package main\n\nfunc main() {\n"
+	for i := 0; i < 20; i++ {
+		body += "\tprintln(\"line\")\n"
+	}
+	body += "}\n"
+	repo := editSandbox(t, marked(body+"\n// one added line\n"))
+	writePolicyApply(t, "      atomic: true\n")
+
+	file := filepath.Join(repo, "a.go")
+	if err := os.WriteFile(file, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runEdit(t, Task{
+		Label: "nocaps", Enum: "MODERATE", File: file,
+		Prompt: "grow this file", Validate: boolPtr(false),
+	})
+
+	if got.Status != "ok" {
+		t.Fatalf("result = %+v, want ok: no cap was declared, so nothing should refuse", got)
+	}
+}
+
+// The deadline's wiring, deterministically. An end-to-end timeout needs a head
+// slow enough to miss it, which means `sleep`, which is Unix-only and racy;
+// this asserts the policy's number reaches a real deadline, which is the part
+// that was missing entirely.
+func TestPolicyDeadline_AppliesMaxWallSeconds(t *testing.T) {
+	t.Run("a declared limit becomes a deadline", func(t *testing.T) {
+		ctx, cancel := policyDeadline(context.Background(), policy.FilePolicy{MaxWallSeconds: 30})
+		defer cancel()
+		dl, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("no deadline was set, so max_wall_seconds bounds nothing")
+		}
+		if d := time.Until(dl); d > 30*time.Second || d < 29*time.Second {
+			t.Errorf("deadline is %v out, want about 30s", d)
+		}
+	})
+
+	// An absent cap must not become a zero one: a context that has already
+	// expired would refuse every edit on a policy that declared no limit.
+	for _, v := range []int{0, -1} {
+		t.Run(fmt.Sprintf("no limit at %d", v), func(t *testing.T) {
+			ctx, cancel := policyDeadline(context.Background(), policy.FilePolicy{MaxWallSeconds: v})
+			defer cancel()
+			if _, ok := ctx.Deadline(); ok {
+				t.Error("a deadline was set with no limit declared")
+			}
+			if err := ctx.Err(); err != nil {
+				t.Errorf("ctx is already done: %v", err)
+			}
+		})
 	}
 }

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -7,6 +7,7 @@ package parallel
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -222,6 +223,16 @@ func runTextTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 	})
 }
 
+// policyDeadline bounds a dispatch by policy.yaml's max_wall_seconds. Returns
+// ctx unchanged, with a no-op cancel, when no limit is declared, so an absent
+// cap is not a zero one.
+func policyDeadline(ctx context.Context, fp policy.FilePolicy) (context.Context, context.CancelFunc) {
+	if fp.MaxWallSeconds <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, time.Duration(fp.MaxWallSeconds)*time.Second)
+}
+
 // runEditTask performs an atomic file edit and returns the raw JSON result.
 // Self-contained port of edit.sh, its tests target this package's own
 // extractContent/diffStats/rollback, but shares the KindEdit emission with
@@ -294,14 +305,27 @@ func runEditTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 		cleanupBackup()
 		return failEdit(task, "dispatcher init: "+dispatchErr.Error())
 	}
+	// max_wall_seconds and max_cost_usd were declared in policy.yaml and
+	// enforced nowhere, so an operator reading a $2 ceiling had none (#424).
+	// Both enforcement mechanisms already existed and were simply not handed
+	// the policy's numbers: dispatch refuses a candidate over MaxCostUSD
+	// before executing it, and a deadline is what bounds a slow head.
+	ctx, cancel := policyDeadline(ctx, fp)
+	defer cancel()
 	dispResult, err := d.Dispatch(ctx, editPrompt, dispatch.Options{
-		TierHint: enumToTier(task.Enum),
-		RunID:    runID,
-		TaskID:   taskID,
-		Resource: file,
+		TierHint:   enumToTier(task.Enum),
+		RunID:      runID,
+		TaskID:     taskID,
+		Resource:   file,
+		MaxCostUSD: fp.MaxCostUSD,
 	})
 	if err != nil {
 		cleanupBackup()
+		// A deadline is the policy refusing, not the head failing, and the two
+		// want different answers from whoever reads the result.
+		if errors.Is(err, context.DeadlineExceeded) {
+			return failEdit(task, fmt.Sprintf("max_wall_seconds_exceeded: policy allows %ds", fp.MaxWallSeconds))
+		}
 		return failEdit(task, "route_failed: "+err.Error())
 	}
 

--- a/internal/security/controls.go
+++ b/internal/security/controls.go
@@ -5,6 +5,8 @@ package security
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
+	"strings"
 
 	"github.com/ankit373/hydra/internal/a2a"
 	"github.com/ankit373/hydra/internal/config"
@@ -70,16 +72,36 @@ func Controls(events []ledger.Event, audit PolicyAudit, chain ledger.ChainResult
 	}
 }
 
-// filePolicyEnforcementSite names the one call site that evaluates
-// registry/policy.yaml, and the fact that it throws the result away.
+// filePolicyEnforcementSite names where registry/policy.yaml's caps are
+// applied, and enforcedCaps names which of them take effect.
 //
-// This is the only claim in this file that cannot be checked at runtime: no
+// These are the only claims in this file that cannot be checked at runtime: no
 // amount of introspection tells a running binary whether its caller used a
-// return value. It was established by reading the source, is reported with
-// Verified:false so nobody mistakes it for an observation, and MUST be
-// updated by hand if the wiring lands, the same deliberate-drift discipline
+// return value. They are established by reading the source, reported with
+// Verified:false so nobody mistakes them for observations, and MUST be updated
+// by hand as the wiring changes, the same deliberate-drift discipline
 // desktop/api/dashboard_test.go already uses for its duplicated tier key.
-const filePolicyEnforcementSite = "internal/parallel/parallel.go:242"
+//
+// That hand-sync is exactly what drifted: #501 made the caps apply and this
+// text kept saying "none are applied … discards the result", so the one
+// surface whose purpose is an honest posture was understating it (#424).
+const filePolicyEnforcementSite = "internal/parallel/parallel.go"
+
+// enforcedCaps are the FilePolicy fields something actually reads, by their
+// policy.yaml names, so the line names what an operator can rely on rather
+// than listing the seventeen they cannot.
+//
+// Hand-maintained, and the reason this const block carries Verified:false. The
+// count it is measured against is *derived* from the struct, so adding a field
+// to FilePolicy cannot quietly inflate what this claims, and a test asserts
+// every name here is a real yaml tag.
+var enforcedCaps = []string{"diff_size_cap_pct", "max_cost_usd", "max_wall_seconds"}
+
+// policyFieldCount is how many knobs registry/policy.yaml can set, read off
+// the struct rather than written down: my first version of this line said
+// eight fields were unenforced when the real number was seventeen, which is
+// the same kind of stale hand-written claim this control exists to report.
+func policyFieldCount() int { return reflect.TypeOf(policy.FilePolicy{}).NumField() }
 
 func filePolicyControl() Control {
 	c := Control{Name: "File-policy caps", Verified: false}
@@ -94,9 +116,17 @@ func filePolicyControl() Control {
 		c.Detail = "registry/policy.yaml declares no rules"
 		return c
 	}
-	c.Detail = fmt.Sprintf("%d rule(s) declared (cost ceilings, diff-size caps, atomic writes, "+
-		"worktree isolation), none are applied: the only caller evaluates them and discards the "+
-		"result at %s, so no cap takes effect at runtime", n, filePolicyEnforcementSite)
+	// Wired, and deliberately Limited: the caps an operator is most likely to
+	// be relying on are applied, and several fields still are not. Reporting
+	// this as fully active would overstate it in the other direction.
+	c.Wired, c.Limited = true, true
+	c.Detail = fmt.Sprintf("%d rule(s) declared, and %d of %d policy fields take effect (%s) at %s: "+
+		"an over-large diff is rolled back, a head over the cost ceiling is refused before it runs, "+
+		"and the wall-clock limit deadlines the dispatch. The other %d are declared and read by "+
+		"nothing. `hyctl edit` does not consult this policy at all, so even these apply to "+
+		"`hyctl parallel` only",
+		n, len(enforcedCaps), policyFieldCount(), strings.Join(enforcedCaps, ", "),
+		filePolicyEnforcementSite, policyFieldCount()-len(enforcedCaps))
 	return c
 }
 

--- a/internal/security/controls_test.go
+++ b/internal/security/controls_test.go
@@ -4,12 +4,14 @@ package security
 
 import (
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/ankit373/hydra/internal/a2a"
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/ledger"
+	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/testutil"
 )
 
@@ -24,28 +26,69 @@ func findControl(t *testing.T, cs []Control, name string) Control {
 	return Control{}
 }
 
-// The file-policy caps are the reason this whole section exists: policy.yaml
-// declares cost ceilings and diff-size limits that no runtime path applies.
-func TestControls_FilePolicyIsDeclaredButInert(t *testing.T) {
+// The file-policy caps are the reason this whole section exists. This test
+// asserted `inert` deliberately, because nothing applied the policy at all.
+// That stopped being true when #501 wired the diff-size cap, and this text did
+// not move with it: the one surface whose purpose is an honest posture spent
+// two releases understating it. The expectation is changed on purpose, and the
+// caps it reports on are now enforced (#424).
+//
+// `limited`, not `active`: three of the twenty policy fields take effect, and
+// `hyctl edit` still does not consult the policy at all.
+func TestControls_FilePolicyIsEnforcedButPartial(t *testing.T) {
 	testutil.NewSandbox(t)
 
 	c := findControl(t, Controls(nil, PolicyAudit{}, ledger.ChainResult{}), "File-policy caps")
 	if !c.Declared {
 		t.Fatal("the embedded registry/policy.yaml declares rules; Declared = false")
 	}
-	if c.Wired {
-		t.Error("Wired = true, but no runtime path applies the file policy")
+	if !c.Wired {
+		t.Error("Wired = false, but the diff-size, cost and wall-clock caps are applied")
 	}
-	if c.Status() != "inert" {
-		t.Errorf("Status() = %q, want inert", c.Status())
+	if c.Status() != "limited" {
+		t.Errorf("Status() = %q, want limited: partly enforced is neither inert nor active", c.Status())
 	}
-	// The finding is only actionable if it names where the decision is lost.
+	// Only actionable if it names where the caps do and do not apply.
 	if !strings.Contains(c.Detail, filePolicyEnforcementSite) {
-		t.Errorf("Detail = %q, want it to name the discarding call site", c.Detail)
+		t.Errorf("Detail = %q, want it to name the enforcing call site", c.Detail)
+	}
+	if !strings.Contains(c.Detail, "hyctl edit") {
+		t.Errorf("Detail = %q, want it to say the caps do not reach hyctl edit", c.Detail)
+	}
+	for _, cap := range enforcedCaps {
+		if !strings.Contains(c.Detail, cap) {
+			t.Errorf("Detail does not name the enforced cap %q: %s", cap, c.Detail)
+		}
 	}
 	// This is the one source-derived claim in the set and must say so.
 	if c.Verified {
-		t.Error("Verified = true, but 'the caller discards the result' cannot be checked at runtime")
+		t.Error("Verified = true, but 'which caps a caller reads' cannot be checked at runtime")
+	}
+}
+
+// The hand-maintained half of this control is what drifted, so both halves are
+// guarded: every name in enforcedCaps must be a real policy.yaml key, and the
+// count it is compared against comes off the struct so a new FilePolicy field
+// cannot silently join the "enforced" side of the ratio.
+func TestEnforcedCaps_AreRealPolicyFields(t *testing.T) {
+	tags := map[string]bool{}
+	rt := reflect.TypeOf(policy.FilePolicy{})
+	for i := range rt.NumField() {
+		if tag := rt.Field(i).Tag.Get("yaml"); tag != "" {
+			tags[tag] = true
+		}
+	}
+	for _, cap := range enforcedCaps {
+		if !tags[cap] {
+			t.Errorf("enforcedCaps names %q, which is not a policy.FilePolicy yaml key", cap)
+		}
+	}
+	if policyFieldCount() != rt.NumField() {
+		t.Errorf("policyFieldCount() = %d, want %d", policyFieldCount(), rt.NumField())
+	}
+	if len(enforcedCaps) >= policyFieldCount() {
+		t.Errorf("enforcedCaps claims %d of %d fields; that would mean everything is enforced",
+			len(enforcedCaps), policyFieldCount())
 	}
 }
 


### PR DESCRIPTION
## Summary

`registry/policy.yaml` declares `max_cost_usd: 2.00`, `max_wall_seconds` and
`diff_size_cap_pct: 30`. #501 wired the diff cap. The other two were read by
nothing, so **an operator reading a $2 ceiling had none**.

Both enforcement mechanisms already existed and were simply never handed the
policy's numbers — `dispatch` refuses a candidate over `MaxCostUSD` before
executing it, and a context deadline is what bounds a slow head. Two lines of
wiring, at the one call site that already evaluated the policy.

## The larger defect was the report

`hyctl security` still said, on develop, today:

```
INERT   File-policy caps [source-derived]
  none are applied: the only caller evaluates them and discards the result
  at internal/parallel/parallel.go:242
```

That stopped being true in #501. The comment above that constant says in so many
words that it **MUST be updated by hand if the wiring lands**. It was not. So the
one surface whose entire purpose is an honest posture spent two releases
*understating* it — and the line number it cited had moved too. That is the
inverse of the #716 pattern and, in a security audit, the more dangerous
direction: a real control reported as inert trains people to ignore the report.

After:

```
LIMITED File-policy caps [source-derived]
  24 rule(s) declared, and 3 of 21 policy fields take effect (diff_size_cap_pct,
  max_cost_usd, max_wall_seconds) at internal/parallel/parallel.go: an over-large
  diff is rolled back, a head over the cost ceiling is refused before it runs, and
  the wall-clock limit deadlines the dispatch. The other 18 are declared and read
  by nothing. `hyctl edit` does not consult this policy at all, so even these apply
  to `hyctl parallel` only
```

`limited`, not `active`: 3 of 21 is not "working", and claiming otherwise would
be the same mistake pointing the other way.

## A stale claim I wrote in the fix for stale claims

My first version of that line hardcoded eight unenforced field names. The real
number is **seventeen** — I checked all twenty-one against the source rather
than trusting my own list, and mine was wrong. So the count is now *derived*
(`reflect.TypeOf(policy.FilePolicy{}).NumField()`), which is why the line says
21 and not the 20 I had also miscounted. A new FilePolicy field therefore cannot
quietly join the enforced side of the ratio, and a test asserts every name in
`enforcedCaps` is a real yaml key on the struct.

## Verification

- Three mutants, each compiling and each caught: the cost ceiling not reaching
  dispatch, the deadline deleted, and an absent cap becoming a *zero* deadline
  (which would refuse every edit under a policy that declared no limit).
- **One mutant survived my first attempt.** The wall-clock test set both caps,
  so deleting the deadline entirely still passed — the cost cap won the race. The
  deadline is now extracted as `policyDeadline` and tested deterministically. I
  tried an end-to-end version with a sleeping fake head first; it needs `sleep`,
  so Unix-only, and the harness did not cooperate. What is tested is that the
  policy's number reaches a real deadline, which is the part that was missing
  entirely — stated plainly rather than implied.
- One test premise of mine was wrong and the code was right: a 1-line file grown
  to 3 lines is a 150% diff and correctly trips the *default* 90% cap. The test
  now uses a large file and a small change.
- An existing test asserted `inert` deliberately. Changed deliberately, with the
  reason recorded in it.
- `go test -race` clean; full suite green. `internal/parallel` 92.2% (floor 87).
- **Added a coverage floor for `internal/security`**, which had none and printed
  `(no floor)`, so it could slide without the gate noticing. Set to 85 against
  88.9% measured.
- `CLAUDE.md`'s `policy.yaml` entry now says which fields take effect and which
  do not, instead of "File-policy rules".

Closes #424
