### PR TITLE
fix(budget): a declared window cannot un-fix #764, and claude follows its own

### DIFF
--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -248,8 +248,8 @@ func TestEffectiveMode(t *testing.T) {
 // binary, so context windows silently fell back to a flat 200k for everything
 // (#238). It is embedded now, so the honest contract is that a machine with no
 // on-disk registry still gets the real windows.
-func TestLoadWindows_UsesEmbeddedRegistryWhenNoneIsOnDisk(t *testing.T) {
-	windows := LoadWindows("/no/such/path")
+func TestDeclarations_UsesEmbeddedRegistryWhenNoneIsOnDisk(t *testing.T) {
+	windows := loadDeclarations("/no/such/path").byID
 	if len(windows) == 0 {
 		t.Fatal("no windows loaded, the embedded registry should always be readable")
 	}
@@ -263,7 +263,7 @@ func TestLoadWindows_UsesEmbeddedRegistryWhenNoneIsOnDisk(t *testing.T) {
 // The override is the reason the files stay editable YAML rather than becoming
 // Go constants; if it stops working, operators lose the ability to retune
 // routing without a rebuild and would have no way to tell.
-func TestLoadWindows_OnDiskRegistryOverridesTheEmbeddedCopy(t *testing.T) {
+func TestDeclarations_OnDiskRegistryOverridesTheEmbeddedCopy(t *testing.T) {
 	home := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(home, "registry"), 0o755); err != nil {
 		t.Fatal(err)
@@ -273,7 +273,7 @@ func TestLoadWindows_OnDiskRegistryOverridesTheEmbeddedCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	windows := LoadWindows(home)
+	windows := loadDeclarations(home).byID
 	if got := windows["only-model"]; got != 4242 {
 		t.Errorf("on-disk models.yaml ignored: only-model window = %d, want 4242", got)
 	}

--- a/internal/budget/coverage_test.go
+++ b/internal/budget/coverage_test.go
@@ -38,14 +38,14 @@ func TestMode_StringCoversEveryBand(t *testing.T) {
 	}
 }
 
-// LoadWindows resolves each model's context window; a missing or unusable
+// loadDeclarations resolves each model's context window; a missing or unusable
 // registry must yield an empty map, never a nil map a caller would panic on.
-func TestLoadWindows_DegradesToAnEmptyMap(t *testing.T) {
+func TestDeclarations_DegradesToAnEmptyMap(t *testing.T) {
 	dir := t.TempDir()
 
 	// No registry on disk at all → the embedded copy is used, which must parse.
-	if got := LoadWindows(dir); got == nil {
-		t.Fatal("LoadWindows returned a nil map")
+	if got := loadDeclarations(dir).byID; got == nil {
+		t.Fatal("loadDeclarations returned a nil map")
 	}
 
 	// A malformed on-disk registry must not panic or return nil.
@@ -56,7 +56,7 @@ func TestLoadWindows_DegradesToAnEmptyMap(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(reg, "models.yaml"), []byte("models: [oops"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	got := LoadWindows(dir)
+	got := loadDeclarations(dir).byID
 	if got == nil {
 		t.Fatal("malformed models.yaml returned a nil map")
 	}
@@ -65,8 +65,8 @@ func TestLoadWindows_DegradesToAnEmptyMap(t *testing.T) {
 	}
 }
 
-func TestLoadWindows_EmbeddedRegistryHasUsableWindows(t *testing.T) {
-	got := LoadWindows("")
+func TestDeclarations_EmbeddedRegistryHasUsableWindows(t *testing.T) {
+	got := loadDeclarations("").byID
 	if len(got) == 0 {
 		t.Fatal("no context windows from the embedded registry, the governor " +
 			"cannot compute a percentage without them")
@@ -79,9 +79,9 @@ func TestLoadWindows_EmbeddedRegistryHasUsableWindows(t *testing.T) {
 	}
 }
 
-// LoadWindows skips entries with no id, and supplies a fallback window for
+// loadDeclarations skips entries with no id, and supplies a fallback window for
 // ollama models that declare none.
-func TestLoadWindows_SkipsUnusableEntriesAndFallsBack(t *testing.T) {
+func TestDeclarations_SkipsUnusableEntriesAndFallsBack(t *testing.T) {
 	dir := t.TempDir()
 	reg := filepath.Join(dir, "registry")
 	if err := os.MkdirAll(reg, 0o700); err != nil {
@@ -97,7 +97,7 @@ models:
 		t.Fatal(err)
 	}
 
-	got := LoadWindows(dir)
+	got := loadDeclarations(dir).byID
 	if _, ok := got[""]; ok {
 		t.Error("an entry with no id produced a window keyed on the empty string")
 	}

--- a/internal/budget/heads.go
+++ b/internal/budget/heads.go
@@ -10,26 +10,33 @@ import (
 
 // WindowsForHeads returns the context window to budget each discovered head
 // against, keyed by head ID, which is what Registry.Record is called with.
+// Keying on registry/models.yaml ids alone did not work: those only partly
+// overlap head ids, so every local head missed, fell through to fallbackCloud,
+// and a 4096-token model was budgeted at 200000 with the 70/75/80% bands past
+// a ceiling it could never reach (#764).
 //
-// LoadWindows alone was not enough: it keys on registry/models.yaml ids, and
-// those only partly overlap head ids, so every local head missed and fell
-// through to fallbackCloud. A 4096-token model was budgeted at 200000, and the
-// 70/75/80% bands landed past a ceiling it could never reach (#764).
+// Where the truth lives differs by head, so the rule does too:
 //
-// The declared window and the reported ceiling are combined with min, because
-// a ceiling is a hard bound: a models.yaml entry claiming 32768 for a model
-// that can only do 2048 is wrong whoever wrote it.
+//   - A local head's window is decided by its server at runtime, and the
+//     registry cannot know it. Declarations are ignored rather than merely
+//     absent (#777): models.yaml already carries 32768 for a model measured at
+//     4096, and honouring that would undo #764 for it.
+//   - A cloud head reports nothing, so its declaration is the best evidence
+//     there is, resolved by declarations.windowFor.
+//
+// A reported ceiling caps either, because a ceiling is a hard bound.
 func WindowsForHeads(home string, heads []provider.Head) map[string]int {
-	declared := LoadWindows(home)
+	decls := loadDeclarations(home)
 
-	out := make(map[string]int, len(declared)+len(heads))
-	for id, w := range declared {
-		out[id] = w
-	}
+	// Only discovered heads go in. Record is called with a head id and nothing
+	// else, so seeding the registry-local ids too added keys nothing could look
+	// up, and one of them (qwen-grunt, 32768) is a local declaration that must
+	// never apply.
+	out := make(map[string]int, len(heads))
 	for _, h := range heads {
-		w, ok := declared[h.ID]
-		if !ok {
-			w = defaultWindowFor(h)
+		w := localDefaultCtx
+		if !h.LocalOnly {
+			w = decls.windowFor(h)
 		}
 		if ceil, ok := ContextCeiling(h); ok && ceil < w {
 			w = ceil
@@ -39,14 +46,33 @@ func WindowsForHeads(home string, heads []provider.Head) map[string]int {
 	return out
 }
 
-// defaultWindowFor is the window to assume for a head nothing declares. A
-// local head gets the local server's default rather than a cloud-sized one:
-// under-assuming makes the governor escalate early, over-assuming is what
-// silenced it, and for a budget governor the safe direction is the smaller
-// number.
-func defaultWindowFor(h provider.Head) int {
-	if h.LocalOnly {
-		return ollamaDefaultCtx
+// declarations indexes models.yaml the three ways a head can name an entry.
+// Kept separate so id beats model_flag beats name deterministically, rather
+// than collapsing into one map where load order decides.
+type declarations struct {
+	byID   map[string]int
+	byFlag map[string]int
+	byName map[string]int
+}
+
+// windowFor resolves a cloud head's declared window, falling back to
+// fallbackCloud when no entry names it.
+//
+// id, then provider/model_flag, then display name: the same three keys
+// internal/cost/canonical.go already bridges these two id namespaces with.
+// The head id is `claude` while the entry declaring 200000 is `claude-core`,
+// so keying on id alone missed and landed on fallbackCloud, which is also
+// 200000. Right answer, no mechanism: changing the declaration changed
+// nothing (#777).
+func (d declarations) windowFor(h provider.Head) int {
+	if w, ok := d.byID[h.ID]; ok {
+		return w
+	}
+	if w, ok := d.byFlag[h.ID]; ok {
+		return w
+	}
+	if w, ok := d.byName[h.Name]; ok {
+		return w
 	}
 	return fallbackCloud
 }
@@ -54,7 +80,7 @@ func defaultWindowFor(h provider.Head) int {
 // ContextCeiling is the architectural maximum a provider reported for a head,
 // and whether it reported one at all. Not the effective window: a model whose
 // ceiling is 40960 still runs at the server's 4096 default, so this caps a
-// declared window rather than replacing it.
+// window rather than replacing it.
 func ContextCeiling(h provider.Head) (int, bool) {
 	raw, ok := h.Meta["model_ctx_max"]
 	if !ok {

--- a/internal/budget/heads_test.go
+++ b/internal/budget/heads_test.go
@@ -66,31 +66,146 @@ func TestWindowsForHeads_LocalHeadsResolveInsteadOfFallingThroughToCloud(t *test
 	}
 }
 
-// A ceiling is a hard bound, so it caps a declaration rather than losing to
-// one: a models.yaml entry claiming 32768 for a 2048-token model is wrong
-// whoever wrote it.
-func TestWindowsForHeads_CeilingCapsADeclaredWindow(t *testing.T) {
-	home := writeModels(t, `models:
-  - id: ollama/small
-    provider: ollama
-    context_window: 32768
-  - id: ollama/large
-    provider: ollama
-    context_window: 2048
-`)
+// A ceiling is a hard bound, so it caps the assumed window, and a ceiling
+// above the assumption does NOT raise it: 40960 architectural does not mean
+// the server will allocate 40960, which is the whole reason min is used.
+func TestWindowsForHeads_CeilingCapsTheAssumedWindow(t *testing.T) {
 	heads := []provider.Head{
-		ollamaHead("ollama/small", 2048),  // declared above its ceiling
-		ollamaHead("ollama/large", 40960), // declared below its ceiling
+		ollamaHead("ollama/small", 2048),  // ceiling under the local default
+		ollamaHead("ollama/large", 40960), // ceiling over it
 	}
-	w := WindowsForHeads(home, heads)
+	w := WindowsForHeads(t.TempDir(), heads)
 
 	if got := windowFor(w, "ollama/small"); got != 2048 {
-		t.Errorf("declared 32768 over a 2048 ceiling gave %d, want the ceiling", got)
+		t.Errorf("a 2048 ceiling gave %d, want the ceiling", got)
 	}
-	// The other direction must NOT be raised: a ceiling of 40960 does not mean
-	// the server will allocate it, which is the whole reason min is used.
-	if got := windowFor(w, "ollama/large"); got != 2048 {
-		t.Errorf("declared 2048 under a 40960 ceiling gave %d, want the declaration", got)
+	if got := windowFor(w, "ollama/large"); got != localDefaultCtx {
+		t.Errorf("a 40960 ceiling gave %d, want the local default %d", got, localDefaultCtx)
+	}
+}
+
+// The #764 regression guard, and the reason #777 exists. models.yaml already
+// carries 32768 for Qwen2.5-Coder:7b, which is measured at 4096. #764's fix
+// held only because no models.yaml *id* happened to equal a local head id:
+// rename that entry's id and the head silently went back to 8x over.
+//
+// A local head's window is decided by its server at runtime and the registry
+// cannot know it, so a declaration is ignored rather than merely absent.
+func TestWindowsForHeads_ALocalDeclarationCannotUndoTheMeasuredDefault(t *testing.T) {
+	home := writeModels(t, `models:
+  - id: ollama/Qwen2.5-Coder:7b
+    name: Qwen2.5-Coder 7b
+    provider: ollama
+    model_flag: Qwen2.5-Coder:7b
+    context_window: 32768
+`)
+	// Named by id, by provider/model_flag and by display name at once: no
+	// route into the declaration may reach a local head.
+	head := ollamaHead("ollama/Qwen2.5-Coder:7b", 32768)
+	head.Name = "Qwen2.5-Coder 7b"
+
+	got := windowFor(WindowsForHeads(home, []provider.Head{head}), head.ID)
+	if got == 32768 {
+		t.Fatal("a models.yaml declaration overrode the measured local default, undoing #764")
+	}
+	if got != localDefaultCtx {
+		t.Errorf("window %d, want the measured local default %d", got, localDefaultCtx)
+	}
+}
+
+// The other half of #777: `claude` is the head id, `claude-core` is the entry
+// declaring the window, so keying on id alone missed and fell through to
+// fallbackCloud, which is also 200000. The right answer with no mechanism
+// behind it. A declaration has to be followed, so changing it must change the
+// budget, which is why the fixture uses a number nothing else could produce.
+func TestWindowsForHeads_CloudHeadFollowsItsDeclarationByName(t *testing.T) {
+	home := writeModels(t, `models:
+  - id: claude-core
+    name: Claude Code
+    provider: claude
+    context_window: 123456
+`)
+	head := provider.Head{
+		ID: "claude", Name: "Claude Code", Provider: "anthropic",
+		Source: "cli", Meta: map[string]string{},
+	}
+	got := windowFor(WindowsForHeads(home, []provider.Head{head}), "claude")
+	if got == fallbackCloud {
+		t.Fatal("still landing on fallbackCloud, so the declaration is not being followed")
+	}
+	if got != 123456 {
+		t.Errorf("window %d, want the declared 123456", got)
+	}
+}
+
+// A port-discovered head is named provider/model_flag, the third key, and the
+// one internal/cost already resolves entries by. Tested on a cloud-ish head
+// because a local one ignores declarations entirely.
+func TestWindowsForHeads_CloudHeadFollowsItsDeclarationByProviderModelFlag(t *testing.T) {
+	home := writeModels(t, `models:
+  - id: registry-local-id
+    name: Some Display Name
+    provider: acme
+    model_flag: turbo-9
+    context_window: 54321
+`)
+	head := provider.Head{
+		ID: "acme/turbo-9", Name: "something else entirely",
+		Provider: "acme", Source: "env", Meta: map[string]string{},
+	}
+	got := windowFor(WindowsForHeads(home, []provider.Head{head}), "acme/turbo-9")
+	if got != 54321 {
+		t.Errorf("window %d, want the declared 54321 resolved by provider/model_flag", got)
+	}
+}
+
+// Resolution order has to be fixed, not decided by map iteration: id beats
+// provider/model_flag beats name.
+func TestWindowsForHeads_ResolutionOrderIsIdThenFlagThenName(t *testing.T) {
+	home := writeModels(t, `models:
+  - id: acme/turbo-9
+    name: unrelated
+    provider: none
+    context_window: 111
+  - id: by-flag
+    name: Turbo Nine
+    provider: acme
+    model_flag: turbo-9
+    context_window: 222
+  - id: by-name
+    name: acme/turbo-9
+    provider: other
+    context_window: 333
+`)
+	head := provider.Head{
+		ID: "acme/turbo-9", Name: "Turbo Nine",
+		Provider: "acme", Source: "env", Meta: map[string]string{},
+	}
+	// id (111) must win over provider/model_flag (222) and over the entry
+	// whose *name* is this head's id (333).
+	if got := windowFor(WindowsForHeads(home, []provider.Head{head}), head.ID); got != 111 {
+		t.Errorf("window %d, want 111: id must outrank flag and name", got)
+	}
+}
+
+// A repeated key resolves in file order, so the same registry always gives
+// the same answer.
+func TestLoadDeclarations_FirstEntryWinsOnARepeatedName(t *testing.T) {
+	home := writeModels(t, `models:
+  - id: first
+    name: Same Name
+    provider: acme
+    context_window: 1000
+  - id: second
+    name: Same Name
+    provider: acme
+    context_window: 2000
+`)
+	d := loadDeclarations(home)
+	for i := 0; i < 50; i++ {
+		if got := d.byName["Same Name"]; got != 1000 {
+			t.Fatalf("repeated name resolved to %d, want the first entry's 1000", got)
+		}
 	}
 }
 
@@ -99,8 +214,8 @@ func TestWindowsForHeads_CeilingCapsADeclaredWindow(t *testing.T) {
 func TestWindowsForHeads_UndeclaredLocalHeadGetsTheLocalDefault(t *testing.T) {
 	w := WindowsForHeads(t.TempDir(), []provider.Head{ollamaHead("ollama/mystery:1b", 0)})
 	got := windowFor(w, "ollama/mystery:1b")
-	if got != ollamaDefaultCtx {
-		t.Errorf("window %d, want the local default %d", got, ollamaDefaultCtx)
+	if got != localDefaultCtx {
+		t.Errorf("window %d, want the local default %d", got, localDefaultCtx)
 	}
 	if got == fallbackCloud {
 		t.Error("an undeclared local head is still budgeted as cloud-sized")
@@ -186,5 +301,24 @@ func TestContextCeiling_OnlyReportsWhatWasActuallyReported(t *testing.T) {
 	// A head with no Meta at all must not panic or invent a ceiling.
 	if _, ok := ContextCeiling(provider.Head{}); ok {
 		t.Error("a head with no Meta reported a ceiling")
+	}
+}
+
+// LM Studio heads are LocalOnly too and report no ceiling, so they take the
+// same local default. Covered explicitly because the constant is measured on
+// Ollama and only assumed here, and because a local head must never reach the
+// cloud fallback whichever server it came from.
+func TestWindowsForHeads_LMStudioHeadsAreLocalToo(t *testing.T) {
+	head := provider.Head{
+		ID: "lmstudio/some-model", Name: "some-model (LM Studio)",
+		Provider: "local", Source: "port", LocalOnly: true, AuthReady: true,
+		Meta: map[string]string{},
+	}
+	got := windowFor(WindowsForHeads(t.TempDir(), []provider.Head{head}), head.ID)
+	if got == fallbackCloud {
+		t.Fatal("an LM Studio head is budgeted as cloud-sized")
+	}
+	if got != localDefaultCtx {
+		t.Errorf("window %d, want the local default %d", got, localDefaultCtx)
 	}
 }

--- a/internal/budget/windows.go
+++ b/internal/budget/windows.go
@@ -12,19 +12,23 @@ import (
 
 const (
 	fallbackCloud = 200_000
-	// ollamaDefaultCtx is what an Ollama server allocates when nothing asks for
-	// more, measured as 4096 on 0.33.2. Hydra never asks: the executor sends
-	// only model, prompt and stream, and OLLAMA_CONTEXT_LENGTH lives in the
-	// server's environment rather than ours. The 32768 that used to sit here
-	// was unreachable, and real lookups fell through to fallbackCloud, so a
-	// 4096-token head was budgeted at 200000 and the governor could never fire
-	// for one (#764).
-	ollamaDefaultCtx = 4_096
+	// localDefaultCtx is what a local server allocates when nothing asks for
+	// more, measured as 4096 on Ollama 0.33.2 and assumed for any other local
+	// server (LM Studio reports no ceiling either) since a smaller assumption
+	// is the safe direction for a governor. Hydra never asks: the executor
+	// sends only model, prompt and stream, and OLLAMA_CONTEXT_LENGTH lives in
+	// the server's environment rather than ours. The 32768 that used to sit
+	// here was unreachable, and real lookups fell through to fallbackCloud, so
+	// a 4096-token head was budgeted at 200000 and the governor could never
+	// fire for one (#764).
+	localDefaultCtx = 4_096
 )
 
 type modelEntry struct {
 	ID            string `yaml:"id"`
+	Name          string `yaml:"name"`
 	Provider      string `yaml:"provider"`
+	ModelFlag     string `yaml:"model_flag"`
 	ContextWindow int    `yaml:"context_window"`
 }
 
@@ -32,39 +36,31 @@ type modelsFile struct {
 	Models []modelEntry `yaml:"models"`
 }
 
-// LoadWindows reads registry/models.yaml, an on-disk copy under home if one
-// exists, otherwise the copy embedded in the binary, and returns a map of
-// model-id → context window size. Missing entries get provider-based fallbacks
-// (ollama → ollamaDefaultCtx, everything else → fallbackCloud).
-//
-// home is the Hydra home directory, not the registry directory: Read appends
-// "registry" itself so every caller resolves the override the same way.
-func LoadWindows(home string) map[string]int {
-	out := map[string]int{}
-
+// parseModels reads models.yaml, preferring an on-disk copy under home over the
+// embedded one. An unreadable or malformed file yields no entries rather than
+// an error: a broken registry must not stop a dispatch.
+func parseModels(home string) []modelEntry {
 	raw, err := registry.Read(home, "models.yaml")
 	if err != nil {
-		return out
+		return nil
 	}
 	var mf modelsFile
 	if err := yaml.Unmarshal(raw, &mf); err != nil {
-		return out
+		return nil
 	}
-	for _, m := range mf.Models {
-		if m.ID == "" {
-			continue
-		}
-		w := m.ContextWindow
-		if w <= 0 {
-			if m.Provider == "ollama" {
-				w = ollamaDefaultCtx
-			} else {
-				w = fallbackCloud
-			}
-		}
-		out[m.ID] = w
+	return mf.Models
+}
+
+// windowOf is an entry's declared window, or its provider's default when it
+// declares none.
+func windowOf(m modelEntry) int {
+	if m.ContextWindow > 0 {
+		return m.ContextWindow
 	}
-	return out
+	if m.Provider == "ollama" {
+		return localDefaultCtx
+	}
+	return fallbackCloud
 }
 
 // windowFor returns the context window for a model ID, with fallback.
@@ -73,4 +69,34 @@ func windowFor(windows map[string]int, modelID string) int {
 		return w
 	}
 	return fallbackCloud
+}
+
+// loadDeclarations reads models.yaml into the three indexes a head can name an
+// entry by. First entry wins on a repeated key, so a duplicated name resolves
+// in file order rather than by map iteration.
+func loadDeclarations(home string) declarations {
+	d := declarations{
+		byID:   map[string]int{},
+		byFlag: map[string]int{},
+		byName: map[string]int{},
+	}
+	put := func(m map[string]int, key string, w int) {
+		if key == "" {
+			return
+		}
+		if _, seen := m[key]; !seen {
+			m[key] = w
+		}
+	}
+	for _, m := range parseModels(home) {
+		w := windowOf(m)
+		put(d.byID, m.ID, w)
+		put(d.byName, m.Name, w)
+		// How a port-discovered head is identified, and how internal/cost
+		// already resolves one: provider/model_flag.
+		if m.Provider != "" && m.ModelFlag != "" {
+			put(d.byFlag, m.Provider+"/"+m.ModelFlag, w)
+		}
+	}
+	return d
 }


### PR DESCRIPTION
## Summary

Two faces of one thing, both noted as open in #774.

### #764's fix held only by accident

`WindowsForHeads` consulted `declared[h.ID]` first and fell back to the measured local default only
when the head id was **absent** from `models.yaml`. No `models.yaml` id currently equals a local
head id, and that is the entire reason it worked. The file already carries the entry that breaks it:

```yaml
- id: qwen-grunt
  provider: ollama
  model_flag: Qwen2.5-Coder:7b
  context_window: 32768
```

Rename that `id` to `ollama/Qwen2.5-Coder:7b`, the real head id, and that head goes from the
measured 4 096 straight back to 32 768 (`min(32768, 32768 ceiling)`), and the governor is inert for
it again. **Confirmed against the merged code**, not argued: the new guard test fails there with

```
a models.yaml declaration overrode the measured local default, undoing #764
```

**A declared context window is not trustworthy for a local head, by nature.** The effective window
is decided by the server at runtime (`num_ctx`, capped by the architecture) and the registry cannot
know it. A local head now **ignores** declarations rather than merely missing them, which is what
makes #764 hold under a `models.yaml` edit instead of by luck.

### `claude` had the right window by luck

Head id `claude`, entry declaring 200 000 is `claude-core`. The lookup missed and landed on
`fallbackCloud`, which is also 200 000. Right output, no mechanism: changing the declaration
changed nothing.

`internal/cost/canonical.go` already bridges these two id namespaces for cost rows, and its own
comment names this exact split:

> Both declare the name "Claude Code", and only `claude` is ever a live head, so letting
> `claude-core` win left 45 rows split across two canonical keys

So a cloud head now resolves by the same three keys, in a fixed order: `id` → `provider/model_flag`
→ `name`. `codex` and `agy` match none of the three and take `fallbackCloud` legitimately, which is
not a bug.

## Fallout handled rather than left behind

- **`LoadWindows` is deleted.** After this change it had no production callers, only its own tests.
  An exported function kept alive by its tests is noise that misleads the next reader. Its tests are
  re-pointed at `loadDeclarations`, which covers the same parsing paths (missing file, malformed
  YAML, no-id entries, provider fallback), so no property was lost.
- **The pre-seed of registry-local ids into the window map is gone.** `Record` is only ever called
  with a head id, so those keys were unreachable, and one of them was the local 32 768 that must
  never apply.
- **`ollamaDefaultCtx` → `localDefaultCtx`.** LM Studio heads are `LocalOnly` and report no ceiling
  either, so the constant was never Ollama-only. It is *measured* on Ollama 0.33.2 and *assumed*
  elsewhere, and the comment now says which is which. New test covers the LM Studio head shape.
- **Two stale doc comments fixed**, one naming the now-deleted `LoadWindows`, one naming a
  `DeclaredWindow` that never existed.

`qwen-grunt` stays in `models.yaml`: its `name` and `model_flag` feed the cost alias table, so
removing the entry would change cost canonicalization. Only its `context_window` stops being
authoritative, which needs no edit to the file at all.

## Tests

`go test -race ./...` green, `go vet ./...` clean. `internal/budget` at **97.5%** against its floor
of 92; full covergate **48/48 floors met**, no new skips.

Three tests were confirmed red against the merged code:

- `…_ALocalDeclarationCannotUndoTheMeasuredDefault` names the head by id, by `provider/model_flag`
  **and** by display name at once, so no route into the declaration can reach a local head.
- `…_CloudHeadFollowsItsDeclarationByName` uses a declared `123456`, a number nothing else could
  produce, so it cannot pass by coincidence the way the real 200 000 did.
- `…_CloudHeadFollowsItsDeclarationByProviderModelFlag`.

Plus `…_ResolutionOrderIsIdThenFlagThenName` (a fixture where all three keys match different
entries, so a wrong precedence gives a visibly wrong number) and
`TestDeclarations_FirstEntryWinsOnARepeatedName` run 50 times, so file order decides rather than map
iteration.

Verified with a real local dispatch end to end, not only in tests.

Closes #777
