### PR TITLE
fix(tui): serialize git worktree add, and report why it failed

### DIFF
--- a/internal/tui/thread_worktree.go
+++ b/internal/tui/thread_worktree.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -69,6 +70,29 @@ func ckNewWorktreeTag(threadID int) string {
 	return fmt.Sprintf("t%d-%s", threadID, hex.EncodeToString(b[:]))
 }
 
+// ckGitFailure is the line of git's output that says why it failed: the last
+// non-empty one. ckFirstLine is wrong for these commands, `worktree add`
+// opens with "Preparing worktree (new branch 'x')" and puts the failure under
+// it, so every contended failure was reported as its own progress message and
+// the real reason never reached the log (#775).
+func ckGitFailure(out string) string {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if s := strings.TrimSpace(lines[i]); s != "" {
+			return s
+		}
+	}
+	return "no output"
+}
+
+// ckRepoLock serializes the git commands that take repository-level locks.
+// `worktree add` and `worktree remove` both write .git/worktrees and the
+// index, so threads cutting worktrees at the same moment contend and one
+// loses (#775). Work inside a worktree has its own index and stays parallel,
+// which is the concurrency that matters. One lock, not one per repo: the
+// cockpit drives a single repo at a time.
+var ckRepoLock sync.Mutex
+
 // ckCreateWorktree cuts a worktree of repo at HEAD on its own branch.
 func ckCreateWorktree(repo string, threadID int) (*ckWorktree, error) {
 	if err := os.MkdirAll(ckWorktreeBase(), 0o700); err != nil {
@@ -79,8 +103,11 @@ func ckCreateWorktree(repo string, threadID int) (*ckWorktree, error) {
 		tag: tag, dir: filepath.Join(ckWorktreeBase(), tag),
 		branch: "hydra/task-" + tag, repo: repo,
 	}
-	if out, err := ckGit(repo, "", "worktree", "add", wt.dir, "-b", wt.branch); err != nil {
-		return nil, fmt.Errorf("git worktree add: %s", ckFirstLine(out))
+	ckRepoLock.Lock()
+	out, err := ckGit(repo, "", "worktree", "add", wt.dir, "-b", wt.branch)
+	ckRepoLock.Unlock()
+	if err != nil {
+		return nil, fmt.Errorf("git worktree add: %s", ckGitFailure(out))
 	}
 	base, err := ckGit(wt.dir, "", "rev-parse", "HEAD")
 	if err != nil {
@@ -207,8 +234,11 @@ func ckNewPaths(before, after []string) []string {
 // ckCleanupWorktree removes the worktree checkout, and its branch too unless
 // keepBranch (a conflicted apply keeps it so nothing is lost while resolving).
 func ckCleanupWorktree(wt *ckWorktree, keepBranch bool) error {
-	if out, err := ckGit(wt.repo, "", "worktree", "remove", "--force", wt.dir); err != nil {
-		return fmt.Errorf("git worktree remove: %s", ckFirstLine(out))
+	ckRepoLock.Lock()
+	out, err := ckGit(wt.repo, "", "worktree", "remove", "--force", wt.dir)
+	ckRepoLock.Unlock()
+	if err != nil {
+		return fmt.Errorf("git worktree remove: %s", ckGitFailure(out))
 	}
 	if keepBranch {
 		return nil

--- a/internal/tui/thread_worktree_test.go
+++ b/internal/tui/thread_worktree_test.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/ankit373/hydra/internal/editor"
 	"github.com/ankit373/hydra/internal/runlog"
@@ -584,5 +586,98 @@ func TestThreadEdit_ApplyConflictThroughTheUI(t *testing.T) {
 	}
 	if bout, _ := ckGit(repo, "", "branch", "--list", branch); strings.TrimSpace(bout) == "" {
 		t.Error("the branch was deleted despite the conflict")
+	}
+}
+
+// Three threads cutting worktrees at once is the cockpit's normal case, and
+// `git worktree add` takes repository-level locks, so they contend. On a
+// loaded CI runner one lost and its thread never settled (#775). Six here
+// rather than three, so the test fails without the lock rather than only
+// sometimes.
+func TestCreateWorktree_ConcurrentCutsAllSucceed(t *testing.T) {
+	repo := threadRepo(t)
+
+	const n = 6
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	wts := make([]*ckWorktree, n)
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wts[i], errs[i] = ckCreateWorktree(repo, i+1)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("thread %d could not cut a worktree: %v", i+1, err)
+		}
+	}
+	// Distinct checkouts, not one shared directory: the isolation is the point.
+	seen := map[string]bool{}
+	for _, wt := range wts {
+		if wt == nil {
+			continue
+		}
+		if seen[wt.dir] {
+			t.Errorf("two threads were handed the same worktree %s", wt.dir)
+		}
+		seen[wt.dir] = true
+		if wt.base == "" {
+			t.Errorf("worktree %s recorded no base commit, so its diff has no left side", wt.tag)
+		}
+		_ = ckDiscardWorktree(wt)
+	}
+}
+
+// git leads `worktree add` with a progress line and puts the failure under it,
+// so reporting the first line named the progress message and lost the reason.
+func TestCkGitFailure_ReportsTheReasonNotTheProgress(t *testing.T) {
+	out := "Preparing worktree (new branch 'hydra/task-t3-abc')\n" +
+		"fatal: '/tmp/x' already exists\n"
+	if got, want := ckGitFailure(out), "fatal: '/tmp/x' already exists"; got != want {
+		t.Errorf("ckGitFailure = %q, want %q", got, want)
+	}
+	if got := ckGitFailure("   \n\n  "); got != "no output" {
+		t.Errorf("ckGitFailure on empty output = %q, want a stated absence", got)
+	}
+	if got, want := ckGitFailure("fatal: single line"), "fatal: single line"; got != want {
+		t.Errorf("ckGitFailure = %q, want %q", got, want)
+	}
+}
+
+// The deterministic half: `worktree add` must run under the repo lock. The
+// concurrent test above only reproduces the race at high fan-out and under
+// load, so on its own it would pass with the lock removed and prove nothing.
+//
+// The race it guards is real and was observed here at n=24: `git worktree add`
+// walks all of .git/worktrees to validate existing entries, so one add reads a
+// half-written entry another is still creating and dies with
+// "failed to read .git/worktrees/<other tag>/commondir".
+func TestCreateWorktree_TakesTheRepoLock(t *testing.T) {
+	repo := threadRepo(t)
+
+	ckRepoLock.Lock()
+	done := make(chan *ckWorktree, 1)
+	go func() {
+		wt, err := ckCreateWorktree(repo, 1)
+		if err != nil {
+			t.Errorf("creating a worktree once unblocked: %v", err)
+		}
+		done <- wt
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("a worktree was cut while the repo lock was held, so concurrent " +
+			"threads still race each other's .git/worktrees entries")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	ckRepoLock.Unlock()
+	if wt := <-done; wt != nil {
+		_ = ckDiscardWorktree(wt)
 	}
 }


### PR DESCRIPTION
## Summary

`TestThreads_ConcurrentWorkersSettleOnTheirOwnThreads` failed on two
consecutive, unrelated PRs (#768, #781). Both times the `-race` step passed and
the non-race coverage rerun failed on the same commit, and both times the whole
diagnosis available was:

```
worktree creation failed: git worktree add: Preparing worktree (new branch 'hydra/task-t3-...')
```

## That message is the second bug

`git worktree add` opens with a progress line and puts the failure **under** it.
`ckFirstLine` therefore reported the progress line every single time, and the
actual reason was never recorded anywhere. `ckGitFailure` takes the last
non-empty line instead.

With it, the cause appeared on the first local reproduction (n=24):

```
fatal: failed to read .git/worktrees/t19-360b53/commondir: Undefined error: 0
```

One `add` failing while reading **another thread's** entry. `worktree add` walks
all of `.git/worktrees` to validate what is already there, and races an `add`
that is still writing its own. That is repository-level, so a mutex around
`add` and `remove` fixes it. Work *inside* a worktree has its own index and
stays parallel, which is the concurrency the cockpit actually needs.

## Two tests, because the obvious one proves nothing

Six concurrent cuts **pass with the lock removed** on an idle machine — I
checked, and that is exactly the trap: shipping a mutex plus a test that is
green either way. It only reproduces at n=24 and even then 3 runs in 5.

So the concurrent test stays at n=6 as a plain "this works" check, and the real
guard is deterministic: hold `ckRepoLock`, assert `ckCreateWorktree` blocks,
release, assert it completes. Removing the lock fails it immediately.

## Verification

- [x] reproduced the underlying race locally (n=24, lock removed)
- [x] `ckGitFailure` is what made the cause visible; unit-tested against git's real output shape
- [x] removing the lock fails `TestCreateWorktree_TakesTheRepoLock` deterministically
- [x] the originally flaky test: 8 consecutive runs green
- [x] `go test -race ./...` green

Closes #775
