### PR TITLE
feat(executor): stream output as it arrives

### DIFF
--- a/internal/executor/cli_stream.go
+++ b/internal/executor/cli_stream.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/ankit373/hydra/internal/sandbox"
+	"github.com/ankit373/hydra/internal/util"
+)
+
+// ExecuteStream forwards the child's stdout as it arrives.
+//
+// The only difference from Execute is where cmd.Stdout points: exec already
+// copies a non-*os.File Stdout through a pipe while the child runs, so the
+// output was always arriving incrementally and simply had nowhere to go.
+func (e *CLIExecutor) ExecuteStream(ctx context.Context, req Request, onDelta OnDelta) (*Response, error) {
+	tmpl, ok := cliTemplates[req.Head.Provider]
+	if !ok {
+		tmpl, ok = cliTemplates[req.Head.ID]
+	}
+	if !ok {
+		// Same refusal as Execute, and worded identically on purpose: a head
+		// with no template is unrunnable either way, and two paths reporting
+		// it differently is how a surface starts guessing.
+		return nil, fmt.Errorf("no CLI template for head %q (provider %q)", req.Head.ID, req.Head.Provider)
+	}
+
+	args := tmpl.buildArgs(req.Prompt)
+	cmd := sandbox.Harden(exec.CommandContext(ctx, req.Head.Executable, args...))
+	cmd.Env = headEnv(req.Head)
+	if tmpl.stdinPrompt {
+		cmd.Stdin = strings.NewReader(req.Prompt)
+	}
+
+	start := time.Now()
+	sink := newDeltaSink(onDelta, start)
+	stderr := util.NewAccumulator(64 << 10)
+	cmd.Stdout = sink
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("cli exec %s: %w, stderr: %s", req.Head.ID, err, stderr.String())
+	}
+
+	// Trimmed for the Response the same way Execute trims it, while the deltas
+	// already forwarded are untrimmed: a surface renders what arrived, and
+	// trailing whitespace it already printed is not worth retracting.
+	output := strings.TrimSpace(sink.output())
+
+	promptTokens := EstimateTokens(req.Prompt)
+	responseTokens := EstimateTokens(output)
+	writeTokenSidecar(req.Head.ID, "cli", "estimate", promptTokens, responseTokens)
+
+	return &Response{
+		Output:       output,
+		Duration:     time.Since(start),
+		Model:        req.Head.ID,
+		InputTokens:  promptTokens,
+		OutputTokens: responseTokens,
+		Truncated:    sink.truncated(),
+		// Measured here, unlike Execute which has no first-token moment to
+		// observe. A tool that block-buffers its stdout reports its exit as
+		// the first token, which is honest: that is when output appeared.
+		TTFT:            sink.firstTokenAt(),
+		TokensEstimated: true,
+	}, nil
+}
+
+var _ StreamingExecutor = (*CLIExecutor)(nil)

--- a/internal/executor/cli_stream_test.go
+++ b/internal/executor/cli_stream_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// A CLI head streams by pointing cmd.Stdout at the sink, so the child's output
+// reaches a surface as exec copies it rather than only at exit.
+func TestCLIStream_ForwardsChildStdoutAndKeepsTheResponseIdentical(t *testing.T) {
+	s := testutil.NewSandbox(t)
+	head := cliHead(t, s, "codex", "openai", "the streamed answer")
+
+	var got []string
+	resp, err := (&CLIExecutor{}).ExecuteStream(context.Background(),
+		Request{Prompt: "hello", Head: head}, func(d string) { got = append(got, d) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("no deltas: the child's stdout never reached the callback")
+	}
+	// The deltas are the raw stream, the Response is trimmed, exactly as
+	// Execute trims it. Both must describe the same answer.
+	if strings.TrimSpace(strings.Join(got, "")) != resp.Output {
+		t.Errorf("deltas %q do not reassemble to Output %q", got, resp.Output)
+	}
+	if resp.Output != "the streamed answer" {
+		t.Errorf("Output %q", resp.Output)
+	}
+	if !resp.TokensEstimated {
+		t.Error("a CLI head reports no usage, so its counts must stay labelled estimated")
+	}
+	if resp.TTFT == 0 {
+		t.Error("TTFT is zero though output was observed arriving")
+	}
+}
+
+// A head with no template is unrunnable, and both paths have to say so the
+// same way rather than one erroring and the other answering.
+func TestCLIStream_NoTemplateIsRefusedLikeExecute(t *testing.T) {
+	head := provider.Head{
+		ID: "not-a-cli", Provider: "nowhere", Executable: "/nonexistent",
+		Meta: map[string]string{},
+	}
+	req := Request{Prompt: "p", Head: head}
+
+	_, streamErr := (&CLIExecutor{}).ExecuteStream(context.Background(), req, func(string) {})
+	_, execErr := (&CLIExecutor{}).Execute(context.Background(), req)
+	if streamErr == nil || execErr == nil {
+		t.Fatalf("expected both paths to refuse: stream=%v exec=%v", streamErr, execErr)
+	}
+	if streamErr.Error() != execErr.Error() {
+		t.Errorf("the two paths refuse differently:\n  stream: %v\n  exec:   %v", streamErr, execErr)
+	}
+}
+
+// Azure puts the deployment in the path and no model in the body, so a wrong
+// URL here fails at request time against a real endpoint and nowhere else.
+func TestAzureStreamTarget_BuildsTheDeploymentURL(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_ENDPOINT", "https://example.openai.azure.com/")
+	t.Setenv("AZURE_OPENAI_DEPLOYMENT", "my deployment")
+	t.Setenv("AZURE_OPENAI_API_KEY", "secret")
+
+	endpoint, model, headers, err := azureStreamTarget(Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(endpoint, "https://example.openai.azure.com/openai/deployments/") {
+		t.Errorf("endpoint %q: base was not preserved or the trailing slash doubled", endpoint)
+	}
+	// A deployment name with a space has to be escaped, not sent raw.
+	if !strings.Contains(endpoint, "my%20deployment") {
+		t.Errorf("endpoint %q did not escape the deployment name", endpoint)
+	}
+	if !strings.Contains(endpoint, "api-version=") {
+		t.Errorf("endpoint %q carries no api-version", endpoint)
+	}
+	if model != "" {
+		t.Errorf("model %q: Azure names the model by deployment path, not in the body", model)
+	}
+	if headers["api-key"] != "secret" {
+		t.Errorf("api-key header is %q", headers["api-key"])
+	}
+}

--- a/internal/executor/http_stream.go
+++ b/internal/executor/http_stream.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/ankit373/hydra/internal/util"
+)
+
+// streamOptions asks an OpenAI-compatible server to report usage on a streamed
+// response. Without it there is no usage block at all, and the dispatch is
+// logged with zero tokens and therefore zero cost (#787).
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+// openAIChatChunk is one SSE `data:` payload. Usage arrives on a final chunk
+// whose Choices array is empty, so a reader that requires a choice per chunk
+// throws the counts away.
+type openAIChatChunk struct {
+	Model   string `json:"model"`
+	Choices []struct {
+		Delta struct {
+			Content string `json:"content"`
+		} `json:"delta"`
+		FinishReason *string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+// ExecuteStream streams the OpenAI-compatible and Azure paths, which share a
+// wire shape. The other dialects (Anthropic, Gemini, Cohere, Bedrock) each
+// carry usage somewhere else in a differently-shaped event, and Replicate is a
+// polling API rather than a stream, so they keep taking Execute until each is
+// done deliberately rather than in a batch (#787).
+func (e *HTTPExecutor) ExecuteStream(ctx context.Context, req Request, onDelta OnDelta) (*Response, error) {
+	switch req.Head.Provider {
+	case "azure":
+		return e.streamOpenAILike(ctx, req, onDelta, azureStreamTarget)
+	case "anthropic", "google", "cohere", "bedrock", "replicate":
+		// Dialects this does not stream yet. Falling back rather than failing:
+		// the caller asked for output, not specifically for a stream, and
+		// executor.Stream already delivers a non-streamed answer as one delta.
+		return e.Execute(ctx, req)
+	default:
+		cfg, err := openAICompatConfigFor(req.Head)
+		if err != nil {
+			return nil, fmt.Errorf("http exec %s: %w", req.Head.ID, err)
+		}
+		return e.streamOpenAILike(ctx, req, onDelta, func(Request) (string, string, map[string]string, error) {
+			return strings.TrimRight(cfg.BaseURL, "/") + "/v1/chat/completions", cfg.Model, cfg.Headers, nil
+		})
+	}
+}
+
+// streamTarget resolves the endpoint, model and headers for one dialect.
+type streamTarget func(req Request) (endpoint, model string, headers map[string]string, err error)
+
+func (e *HTTPExecutor) streamOpenAILike(ctx context.Context, req Request, onDelta OnDelta, target streamTarget) (*Response, error) {
+	endpoint, model, headers, err := target(req)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := json.Marshal(struct {
+		openAIChatRequest
+		StreamOptions *streamOptions `json:"stream_options,omitempty"`
+	}{
+		openAIChatRequest: openAIChatRequest{
+			Model:     model,
+			Messages:  buildMessages(req),
+			MaxTokens: req.MaxTokens,
+			Stream:    true,
+		},
+		StreamOptions: &streamOptions{IncludeUsage: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+
+	start := time.Now()
+	// A whole-request timeout would cut a long answer off mid-sentence rather
+	// than bound a stall, so a stream is bounded by the caller's context.
+	client := *e.httpClient()
+	client.Timeout = 0
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http exec %s: %w", req.Head.ID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, httpStatusError(req.Head.ID, resp)
+	}
+
+	sink := newDeltaSink(onDelta, start)
+	var gotModel string
+	var inTok, outTok int
+	var sawUsage bool
+
+	sc := bufio.NewScanner(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1))
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		// Comment keep-alives (":" prefixed) and the blank lines separating
+		// events are part of SSE, not content.
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+		payload, ok := strings.CutPrefix(line, "data:")
+		if !ok {
+			continue // `event:` and `id:` lines carry nothing we need
+		}
+		payload = strings.TrimSpace(payload)
+		if payload == "[DONE]" {
+			break
+		}
+		var chunk openAIChatChunk
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			return nil, fmt.Errorf("http exec %s: decode chunk: %w", req.Head.ID, err)
+		}
+		if chunk.Model != "" {
+			gotModel = chunk.Model
+		}
+		if chunk.Usage != nil {
+			inTok, outTok, sawUsage = chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens, true
+		}
+		for _, c := range chunk.Choices {
+			sink.write(c.Delta.Content)
+		}
+	}
+	if err := sc.Err(); err != nil && ctx.Err() == nil {
+		return nil, fmt.Errorf("http exec %s: read: %w", req.Head.ID, err)
+	}
+
+	out := sink.output()
+	if out == "" {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("http exec %s: %w", req.Head.ID, ctxErr)
+		}
+		return nil, fmt.Errorf("http exec %s: empty response", req.Head.ID)
+	}
+
+	// A server that ignored stream_options, or a stream cut short, leaves no
+	// counts. Estimated and labelled beats reporting a call that answered as
+	// having cost nothing.
+	estimated := false
+	if !sawUsage || (inTok == 0 && outTok == 0) {
+		inTok, outTok = EstimateTokens(req.Prompt), EstimateTokens(out)
+		estimated = true
+	}
+
+	return &Response{
+		Output:          out,
+		InputTokens:     inTok,
+		OutputTokens:    outTok,
+		Duration:        time.Since(start),
+		Model:           firstNonEmpty(gotModel, model),
+		Truncated:       sink.truncated(),
+		TTFT:            sink.firstTokenAt(),
+		TokensEstimated: estimated,
+	}, nil
+}
+
+// azureStreamTarget mirrors executeAzureOpenAI's endpoint construction. Azure
+// puts the deployment in the path and the model nowhere, so the request body
+// carries no model at all.
+func azureStreamTarget(Request) (string, string, map[string]string, error) {
+	base := strings.TrimRight(azureEndpoint(), "/")
+	u := fmt.Sprintf("%s/openai/deployments/%s/chat/completions?api-version=%s",
+		base, url.PathEscape(azureDeployment()), url.QueryEscape(azureAPIVersion()))
+	return u, "", map[string]string{"api-key": apiKeyFor("azure")}, nil
+}
+
+var _ StreamingExecutor = (*HTTPExecutor)(nil)

--- a/internal/executor/http_stream_test.go
+++ b/internal/executor/http_stream_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ankit373/hydra/internal/provider"
+)
+
+// sseServer serves an OpenAI-compatible chat stream and records the request
+// body, so a test can assert what Hydra asked for as well as what it parsed.
+type sseServer struct {
+	*httptest.Server
+	body []byte
+}
+
+func newSSEServer(t *testing.T, fragments []string, withUsage bool) *sseServer {
+	t.Helper()
+	s := &sseServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, _ := w.(http.Flusher)
+		for _, f := range fragments {
+			fmt.Fprintf(w, "data: {\"model\":\"stub-1\",\"choices\":[{\"delta\":{\"content\":%q}}]}\n\n", f)
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+		if withUsage {
+			// The real shape: a final chunk with an EMPTY choices array whose
+			// only payload is usage. A reader that requires a choice per chunk
+			// drops the counts here.
+			fmt.Fprint(w, "data: {\"model\":\"stub-1\",\"choices\":[],"+
+				"\"usage\":{\"prompt_tokens\":31,\"completion_tokens\":64}}\n\n")
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		if fl != nil {
+			fl.Flush()
+		}
+	}))
+	t.Cleanup(s.Server.Close)
+	return s
+}
+
+// compatHead points the OpenAI-compatible path at a stub. Head.Endpoint takes
+// precedence in openAICompatConfigFor, which is how a self-hosted server is
+// addressed, so it needs no credentials and reaches no real provider.
+func compatHead(t *testing.T, base string) provider.Head {
+	t.Helper()
+	return provider.Head{
+		ID: "stub-1", Name: "stub", Provider: "openai", Source: "env",
+		Endpoint: base, AuthReady: true, Meta: map[string]string{},
+	}
+}
+
+// The whole reason this issue was filed with a warning: a streamed OpenAI
+// response carries no usage unless the request asks for it.
+func TestHTTPStream_AsksForUsageOnTheStream(t *testing.T) {
+	srv := newSSEServer(t, []string{"hi"}, true)
+	head := compatHead(t, srv.URL)
+
+	if _, err := (&HTTPExecutor{}).ExecuteStream(context.Background(),
+		Request{Prompt: "p", Head: head}, func(string) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	var sent map[string]any
+	if err := json.Unmarshal(srv.body, &sent); err != nil {
+		t.Fatalf("request body did not parse: %v (%s)", err, srv.body)
+	}
+	if sent["stream"] != true {
+		t.Error("stream was not requested")
+	}
+	opts, ok := sent["stream_options"].(map[string]any)
+	if !ok {
+		t.Fatalf("no stream_options in the request, so usage will not be reported: %s", srv.body)
+	}
+	if opts["include_usage"] != true {
+		t.Errorf("stream_options.include_usage is %v, want true", opts["include_usage"])
+	}
+}
+
+func TestHTTPStream_DeliversDeltasAndKeepsRealUsage(t *testing.T) {
+	srv := newSSEServer(t, []string{"Hel", "lo ", "there"}, true)
+	head := compatHead(t, srv.URL)
+
+	var got []string
+	resp, err := (&HTTPExecutor{}).ExecuteStream(context.Background(),
+		Request{Prompt: "p", Head: head}, func(d string) { got = append(got, d) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || strings.Join(got, "") != "Hello there" {
+		t.Errorf("deltas %q, want three fragments reassembling to the answer", got)
+	}
+	if resp.Output != "Hello there" {
+		t.Errorf("Output %q", resp.Output)
+	}
+	if resp.InputTokens != 31 || resp.OutputTokens != 64 {
+		t.Errorf("tokens %d/%d, want the reported 31/64 from the usage-only final chunk",
+			resp.InputTokens, resp.OutputTokens)
+	}
+	if resp.TokensEstimated {
+		t.Error("reported counts are labelled estimated")
+	}
+	if resp.Model != "stub-1" {
+		t.Errorf("Model %q, want the model the chunks named", resp.Model)
+	}
+}
+
+// A server that ignores stream_options must not produce a free dispatch.
+func TestHTTPStream_NoUsageIsEstimatedAndLabelled(t *testing.T) {
+	srv := newSSEServer(t, []string{"an answer"}, false)
+	head := compatHead(t, srv.URL)
+
+	resp, err := (&HTTPExecutor{}).ExecuteStream(context.Background(),
+		Request{Prompt: "a prompt", Head: head}, func(string) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.TokensEstimated {
+		t.Error("estimated counts are not labelled, so they read as measured spend")
+	}
+	if resp.InputTokens == 0 || resp.OutputTokens == 0 {
+		t.Errorf("tokens %d/%d: a call that answered must not report zero",
+			resp.InputTokens, resp.OutputTokens)
+	}
+}
+
+// SSE carries comment keep-alives and event/id lines. Rendering them as
+// content would put protocol noise in the answer.
+func TestHTTPStream_IgnoresKeepAlivesAndNonDataLines(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, _ := w.(http.Flusher)
+		fmt.Fprint(w, ": keep-alive\n\n")
+		fmt.Fprint(w, "event: message\nid: 1\n")
+		fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"only this\"}}]}\n\n")
+		fmt.Fprint(w, ": another keep-alive\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		if fl != nil {
+			fl.Flush()
+		}
+	}))
+	defer srv.Close()
+	head := compatHead(t, srv.URL)
+
+	var got []string
+	resp, err := (&HTTPExecutor{}).ExecuteStream(context.Background(),
+		Request{Prompt: "p", Head: head}, func(d string) { got = append(got, d) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Output != "only this" {
+		t.Errorf("Output %q: protocol lines leaked into the answer", resp.Output)
+	}
+	if len(got) != 1 {
+		t.Errorf("got %d deltas, want 1: a keep-alive fired a delta", len(got))
+	}
+}

--- a/internal/executor/ollama_stream.go
+++ b/internal/executor/ollama_stream.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ankit373/hydra/internal/util"
+)
+
+// ExecuteStream is Execute with `"stream": true`, which makes Ollama answer in
+// NDJSON: one object per line carrying a `response` fragment, then a final one
+// with `done` and the token counts.
+//
+// The counts are the reason the final object cannot be skipped. They arrive
+// only there, so a reader that stops at the last fragment reports zero tokens,
+// and the dispatch is then logged as free.
+func (e *OllamaExecutor) ExecuteStream(ctx context.Context, req Request, onDelta OnDelta) (*Response, error) {
+	host := ollamaHost()
+	if err := e.ensureRunning(host); err != nil {
+		return nil, fmt.Errorf("ollama executor: %w", err)
+	}
+
+	modelFlag := req.Head.Meta["model_flag"]
+	if modelFlag == "" {
+		modelFlag = req.Head.ID
+	}
+
+	raw, err := json.Marshal(ollamaGenerateRequest{
+		Model:  modelFlag,
+		Prompt: req.Prompt,
+		Stream: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, host+"/api/generate", bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	// The shared client's timeout is a whole-request deadline, which on a
+	// stream would cut a long answer off mid-sentence rather than bound a
+	// stall. Streaming is bounded by the context the caller passes instead.
+	client := *e.httpClient()
+	client.Timeout = 0
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("ollama exec %s: %w", req.Head.ID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, httpStatusError(req.Head.ID, resp)
+	}
+
+	sink := newDeltaSink(onDelta, start)
+	var final ollamaGenerateResponse
+	var sawDone bool
+
+	sc := bufio.NewScanner(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1))
+	// A single NDJSON line is one fragment, but Ollama's final object carries
+	// the whole context array on some versions, which overflows the default
+	// 64 KB token. Growing the buffer keeps that line readable instead of
+	// failing the stream at the point the token counts arrive.
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var chunk ollamaGenerateResponse
+		if err := json.Unmarshal(line, &chunk); err != nil {
+			return nil, fmt.Errorf("ollama exec %s: decode chunk: %w", req.Head.ID, err)
+		}
+		sink.write(chunk.Response)
+		if chunk.Done {
+			final, sawDone = chunk, true
+			break
+		}
+	}
+	if err := sc.Err(); err != nil {
+		// A cancelled context is the caller's own decision, so what arrived so
+		// far is the answer, not an error. Anything else is a real failure.
+		if ctx.Err() == nil {
+			return nil, fmt.Errorf("ollama exec %s: read: %w", req.Head.ID, err)
+		}
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil && !sawDone {
+		out := sink.output()
+		if out == "" {
+			return nil, fmt.Errorf("ollama exec %s: %w", req.Head.ID, ctxErr)
+		}
+		return e.streamResponse(sink, final, req.Prompt, modelFlag, start, false), nil
+	}
+	if sink.output() == "" {
+		return nil, fmt.Errorf("ollama exec %s: empty response", req.Head.ID)
+	}
+	if !sawDone {
+		return nil, fmt.Errorf("ollama exec %s: stream ended before done", req.Head.ID)
+	}
+
+	return e.streamResponse(sink, final, req.Prompt, modelFlag, start, true), nil
+}
+
+// streamResponse assembles the Response from a finished stream. counted says
+// whether the final object arrived: without it there are no provider counts,
+// so they are estimated and labelled as such rather than reported as zero.
+func (e *OllamaExecutor) streamResponse(sink *deltaSink, final ollamaGenerateResponse, prompt, modelFlag string, start time.Time, counted bool) *Response {
+	out := sink.output()
+	in, outTok, source := final.PromptEvalCount, final.EvalCount, "real"
+	estimated := false
+	if !counted || (in == 0 && outTok == 0) {
+		in, outTok = EstimateTokens(prompt), EstimateTokens(out)
+		source, estimated = "estimate", true
+	}
+	writeTokenSidecar(modelFlag, "ollama", source, in, outTok)
+
+	return &Response{
+		Output:       out,
+		Duration:     time.Since(start),
+		Model:        firstNonEmpty(final.Model, modelFlag),
+		InputTokens:  in,
+		OutputTokens: outTok,
+		Truncated:    sink.truncated(),
+		// Measured, not the provider's prompt-eval figure: the first delta
+		// landing is what TTFT means, and on a stream we watch it happen.
+		TTFT:            sink.firstTokenAt(),
+		TokensEstimated: estimated,
+	}
+}
+
+// compile-time proof the interface is satisfied, so a signature drift is a
+// build failure rather than a silent fall back to the non-streaming path.
+var _ StreamingExecutor = (*OllamaExecutor)(nil)

--- a/internal/executor/stream.go
+++ b/internal/executor/stream.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ankit373/hydra/internal/util"
+)
+
+// OnDelta receives output as it arrives. Called from the goroutine driving the
+// executor, in order, never concurrently with itself, so an implementation may
+// append to unsynchronised state. It must not block for long: a slow consumer
+// stalls the read loop and inflates the measured duration.
+type OnDelta func(delta string)
+
+// StreamingExecutor is an Executor that can deliver output incrementally.
+//
+// Optional on purpose. Making Execute itself streaming would change every
+// executor and every caller to serve the heads that can stream, and some
+// genuinely cannot: Replicate's prediction API is a polling interface, not a
+// stream, and a CLI head that buffers its own stdout has nothing to hand over
+// until it exits.
+type StreamingExecutor interface {
+	Executor
+	ExecuteStream(ctx context.Context, req Request, onDelta OnDelta) (*Response, error)
+}
+
+// Stream runs req against ex, delivering output through onDelta as it arrives.
+//
+// An executor that does not implement StreamingExecutor still works: its whole
+// output is delivered as one delta once Execute returns. That is what lets a
+// surface be written once. The alternative is every surface type-asserting for
+// itself and growing its own non-streaming branch, which is how two surfaces
+// end up disagreeing about what a non-streaming head looks like.
+//
+// A nil onDelta is allowed and means "no incremental delivery wanted", which
+// takes the plain Execute path rather than streaming into a discarded callback.
+func Stream(ctx context.Context, ex Executor, req Request, onDelta OnDelta) (*Response, error) {
+	se, ok := ex.(StreamingExecutor)
+	if !ok || onDelta == nil {
+		resp, err := ex.Execute(ctx, req)
+		if err != nil {
+			return resp, err
+		}
+		if onDelta != nil && resp != nil && resp.Output != "" {
+			onDelta(resp.Output)
+		}
+		return resp, nil
+	}
+	return se.ExecuteStream(ctx, req, onDelta)
+}
+
+// CanStream reports whether ex delivers output incrementally, so a surface can
+// tell a real token stream from one whole-output delta and render a cursor only
+// where there is genuinely more coming.
+func CanStream(ex Executor) bool {
+	_, ok := ex.(StreamingExecutor)
+	return ok
+}
+
+// deltaSink accumulates a streamed response while forwarding each delta on.
+//
+// It exists so every streaming executor gets the same three things right
+// without repeating them: output goes through util.Accumulator so the 33 MB cap
+// and Response.Truncated still hold (a hard invariant, and the reason this is
+// not a strings.Builder), TTFT is the time to the first non-empty delta rather
+// than a provider's own guess at it, and nothing is forwarded once the cap is
+// hit, since a consumer must not render text the Response will not contain.
+type deltaSink struct {
+	mu      sync.Mutex
+	acc     *util.Accumulator
+	onDelta OnDelta
+	started time.Time
+	ttft    time.Duration
+}
+
+// newDeltaSink starts measuring from started, which must be when the request
+// was issued, not when its response headers came back.
+//
+// Measured from headers, TTFT read as 1ms on a live call whose first token the
+// user waited 4.171s for: the headers themselves arrive only once the provider
+// begins producing, so the whole prefill had already happened and the number
+// said "instant" for a four-second wait.
+func newDeltaSink(onDelta OnDelta, started time.Time) *deltaSink {
+	return &deltaSink{
+		acc:     util.NewAccumulator(util.DefaultMaxBytes),
+		onDelta: onDelta,
+		started: started,
+	}
+}
+
+// write records a delta and forwards it. Empty deltas are recorded but never
+// forwarded: a provider emits them as keep-alives and role preambles, and a
+// surface that renders a cursor per delta would flicker on them.
+func (s *deltaSink) write(delta string) {
+	if delta == "" {
+		return
+	}
+	s.mu.Lock()
+	if s.ttft == 0 && strings.TrimSpace(delta) != "" {
+		s.ttft = time.Since(s.started)
+	}
+	truncated := s.acc.Truncated()
+	if !truncated {
+		_, _ = s.acc.Write([]byte(delta))
+		truncated = s.acc.Truncated()
+	}
+	cb := s.onDelta
+	s.mu.Unlock()
+
+	if truncated || cb == nil {
+		return
+	}
+	cb(delta)
+}
+
+// Write adapts the sink to io.Writer, for an executor whose output arrives as
+// subprocess stdout rather than as parsed chunks. exec already copies a
+// non-*os.File Stdout through a pipe as the child produces it, so a tee here is
+// the whole of what subprocess streaming needs.
+//
+// Chunks arrive on pipe boundaries, not token boundaries, and a child that
+// block-buffers its own stdout when it is not on a tty will still deliver
+// everything at exit. That is the child's behaviour, not something this can fix
+// without allocating a pty.
+func (s *deltaSink) Write(p []byte) (int, error) {
+	s.write(string(p))
+	return len(p), nil
+}
+
+func (s *deltaSink) output() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.acc.String()
+}
+
+func (s *deltaSink) truncated() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.acc.Truncated()
+}
+
+// firstTokenAt is the measured time to the first non-empty delta, or 0 when
+// nothing ever arrived. Zero means unknown, never instant, the same contract
+// Response.TTFT already carries.
+func (s *deltaSink) firstTokenAt() time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ttft
+}

--- a/internal/executor/stream_test.go
+++ b/internal/executor/stream_test.go
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/provider"
+	"github.com/ankit373/hydra/internal/util"
+)
+
+// nonStreaming is an Executor with no ExecuteStream, the case Stream has to
+// keep working for.
+type nonStreaming struct {
+	out  string
+	err  error
+	seen int
+}
+
+func (n *nonStreaming) Execute(context.Context, Request) (*Response, error) {
+	n.seen++
+	if n.err != nil {
+		return nil, n.err
+	}
+	return &Response{Output: n.out, OutputTokens: 3}, nil
+}
+
+// A surface must not have to branch on whether its head streams, so a
+// non-streaming executor delivers its whole output as one delta.
+func TestStream_NonStreamingExecutorStillDeliversOneDelta(t *testing.T) {
+	ex := &nonStreaming{out: "the whole answer"}
+	var got []string
+	resp, err := Stream(context.Background(), ex, Request{}, func(d string) { got = append(got, d) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "the whole answer" {
+		t.Errorf("deltas %q, want one delta with the whole output", got)
+	}
+	if resp.Output != "the whole answer" {
+		t.Errorf("Output %q, want the whole answer", resp.Output)
+	}
+	if CanStream(ex) {
+		t.Error("CanStream is true for an executor with no ExecuteStream")
+	}
+}
+
+// An error must not be reported as an empty answer, and must not fire a delta.
+func TestStream_NonStreamingErrorFiresNoDelta(t *testing.T) {
+	ex := &nonStreaming{err: fmt.Errorf("boom")}
+	fired := false
+	if _, err := Stream(context.Background(), ex, Request{}, func(string) { fired = true }); err == nil {
+		t.Fatal("expected the executor error to surface")
+	}
+	if fired {
+		t.Error("a delta fired for a failed execute")
+	}
+}
+
+// A nil callback means the caller wants no incremental delivery, so the plain
+// Execute path is taken rather than streaming into a discarded function.
+func TestStream_NilCallbackTakesThePlainPath(t *testing.T) {
+	ex := &nonStreaming{out: "x"}
+	if _, err := Stream(context.Background(), ex, Request{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if ex.seen != 1 {
+		t.Errorf("Execute called %d times, want 1", ex.seen)
+	}
+}
+
+// ── the delta sink ────────────────────────────────────────────────────────────
+
+// The cap is a hard invariant (CLAUDE.md: util.Accumulator, never a raw
+// buffer). Past it nothing more may be forwarded either: a surface must not
+// render text the Response will not contain.
+func TestDeltaSink_StopsForwardingAtTheCapAndReportsTruncation(t *testing.T) {
+	// The accumulator honours HYDRA_MAX_OUTPUT_BYTES over its argument, so a
+	// stray value in the environment would silently change the cap this test
+	// is about.
+	t.Setenv("HYDRA_MAX_OUTPUT_BYTES", "")
+
+	var forwarded int
+	s := newDeltaSink(func(string) { forwarded++ }, time.Now())
+	s.acc = util.NewAccumulator(8)
+
+	s.write("12345678") // exactly the cap
+	s.write("9")        // past it
+	s.write("10")
+
+	if !s.truncated() {
+		t.Error("Truncated is false after writing past the cap")
+	}
+	if forwarded != 1 {
+		t.Errorf("forwarded %d deltas, want 1: nothing past the cap may reach a surface", forwarded)
+	}
+	got := s.output()
+	if !strings.HasPrefix(got, "12345678") {
+		t.Errorf("output %q lost the content that fit under the cap", got)
+	}
+	// The accumulator appends its own marker, so the answer is longer than the
+	// cap by design; what must not be there is the content it refused.
+	if strings.Contains(got, "12345678910") {
+		t.Errorf("output %q kept content written past the cap", got)
+	}
+}
+
+// TTFT is the first delta that carries something. A provider's role preamble
+// and keep-alives are empty or whitespace, and counting one as the first token
+// would report a TTFT of nearly zero for a head that had not started.
+func TestDeltaSink_TTFTIgnoresEmptyAndWhitespaceDeltas(t *testing.T) {
+	s := newDeltaSink(nil, time.Now())
+	s.write("")
+	s.write("   ")
+	if s.firstTokenAt() != 0 {
+		t.Error("whitespace counted as the first token")
+	}
+	time.Sleep(2 * time.Millisecond)
+	s.write("real")
+	first := s.firstTokenAt()
+	if first == 0 {
+		t.Fatal("TTFT still zero after a real delta")
+	}
+	s.write("more")
+	if s.firstTokenAt() != first {
+		t.Error("TTFT moved after a later delta; it is the *first* token")
+	}
+	// Whitespace is still part of the answer even when it does not start it.
+	if got := s.output(); got != "   realmore" {
+		t.Errorf("output %q dropped a whitespace delta", got)
+	}
+}
+
+// ── Ollama ────────────────────────────────────────────────────────────────────
+
+// ndjsonOllama serves an /api/generate stream: one object per fragment, then a
+// final one with done and the counts, which is the real wire shape.
+func ndjsonOllama(t *testing.T, fragments []string, finalCounts bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path != "/api/generate" {
+			http.NotFound(w, r)
+			return
+		}
+		fl, _ := w.(http.Flusher)
+		for _, f := range fragments {
+			fmt.Fprintf(w, `{"model":"stub","response":%q,"done":false}`+"\n", f)
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+		if finalCounts {
+			fmt.Fprint(w, `{"model":"stub","response":"","done":true,`+
+				`"prompt_eval_count":11,"eval_count":22,"prompt_eval_duration":5000000}`+"\n")
+		} else {
+			fmt.Fprint(w, `{"model":"stub","response":"","done":true}`+"\n")
+		}
+		if fl != nil {
+			fl.Flush()
+		}
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("OLLAMA_HOST", srv.URL)
+	return srv
+}
+
+func ollamaReq() Request {
+	return Request{
+		Prompt: "a prompt long enough to estimate from",
+		Head: provider.Head{
+			ID: "ollama/stub", Name: "stub", Provider: "local", Source: "port",
+			LocalOnly: true, Meta: map[string]string{"model_flag": "stub"},
+		},
+	}
+}
+
+func TestOllamaStream_DeliversFragmentsInOrderAndAssemblesTheWhole(t *testing.T) {
+	ndjsonOllama(t, []string{"Hello", ", ", "world"}, true)
+
+	var mu sync.Mutex
+	var got []string
+	resp, err := (&OllamaExecutor{}).ExecuteStream(context.Background(), ollamaReq(),
+		func(d string) { mu.Lock(); got = append(got, d); mu.Unlock() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(got, "") != "Hello, world" {
+		t.Errorf("deltas %q do not reassemble to the answer", got)
+	}
+	if len(got) != 3 {
+		t.Errorf("got %d deltas, want 3: fragments must arrive as they come, not batched", len(got))
+	}
+	if resp.Output != "Hello, world" {
+		t.Errorf("Output %q, want the assembled answer", resp.Output)
+	}
+}
+
+// The trap this issue exists to avoid: token counts live only on the final
+// `done` object, so a reader that stops at the last fragment logs the dispatch
+// as free.
+func TestOllamaStream_RealTokenCountsSurviveTheStream(t *testing.T) {
+	ndjsonOllama(t, []string{"a", "b"}, true)
+
+	resp, err := (&OllamaExecutor{}).ExecuteStream(context.Background(), ollamaReq(), func(string) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.InputTokens != 11 || resp.OutputTokens != 22 {
+		t.Errorf("tokens %d/%d, want the reported 11/22", resp.InputTokens, resp.OutputTokens)
+	}
+	if resp.TokensEstimated {
+		t.Error("provider-reported counts are labelled estimated")
+	}
+	if resp.TTFT == 0 {
+		t.Error("TTFT is zero on a stream we watched arrive")
+	}
+}
+
+// A stream that ends without counts must estimate and say so, rather than
+// report zero tokens as though the call were free.
+func TestOllamaStream_MissingCountsAreEstimatedAndLabelled(t *testing.T) {
+	ndjsonOllama(t, []string{"some answer text"}, false)
+
+	resp, err := (&OllamaExecutor{}).ExecuteStream(context.Background(), ollamaReq(), func(string) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.TokensEstimated {
+		t.Error("estimated counts are not labelled, so they would read as measured")
+	}
+	if resp.InputTokens == 0 || resp.OutputTokens == 0 {
+		t.Errorf("tokens %d/%d: a call that answered must not report zero",
+			resp.InputTokens, resp.OutputTokens)
+	}
+}
+
+// Cancelling mid-stream is the user pressing ctrl-c. What arrived is the
+// answer; it must not be thrown away, and it must not hang.
+func TestOllamaStream_CancellationKeepsWhatArrived(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		fl, _ := w.(http.Flusher)
+		fmt.Fprint(w, `{"model":"stub","response":"partial","done":false}`+"\n")
+		if fl != nil {
+			fl.Flush()
+		}
+		<-r.Context().Done() // never sends done
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	done := make(chan struct{})
+	var resp *Response
+	var err error
+	go func() {
+		resp, err = (&OllamaExecutor{}).ExecuteStream(ctx, ollamaReq(),
+			func(string) { cancel() }) // cancel the moment the first delta lands
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("ExecuteStream did not return after its context was cancelled")
+	}
+	if err != nil {
+		t.Fatalf("cancellation reported as an error: %v", err)
+	}
+	if resp.Output != "partial" {
+		t.Errorf("Output %q, want the partial that had already arrived", resp.Output)
+	}
+	if !resp.TokensEstimated {
+		t.Error("a cancelled stream has no provider counts, so they must be labelled estimated")
+	}
+}
+
+// A body that is not NDJSON is a real failure, not an empty answer.
+func TestOllamaStream_GarbageBodyIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		fmt.Fprint(w, "not json at all\n")
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	if _, err := (&OllamaExecutor{}).ExecuteStream(context.Background(), ollamaReq(), func(string) {}); err == nil {
+		t.Fatal("a non-NDJSON body was accepted")
+	}
+}
+
+// Stream must pick the streaming path when the executor has one.
+func TestStream_PrefersTheStreamingPath(t *testing.T) {
+	ndjsonOllama(t, []string{"x", "y", "z"}, true)
+
+	ex := &OllamaExecutor{}
+	if !CanStream(ex) {
+		t.Fatal("CanStream is false for the Ollama executor")
+	}
+	var n int
+	if _, err := Stream(context.Background(), ex, ollamaReq(), func(string) { n++ }); err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Errorf("got %d deltas, want 3: Stream fell back to Execute", n)
+	}
+}


### PR DESCRIPTION
## Problem

A dispatch shows nothing until the head has finished. On a local 7B that is ten seconds of a blank
terminal, and the user cannot tell a slow answer from a hung one. Every executor already reads a
response incrementally, or could; the output simply had nowhere to go.

## Solution

`StreamingExecutor` as an **optional** interface, so `Execute` and every existing caller are
untouched. `executor.Stream` type-asserts and falls back to delivering the whole output as one
delta, which is what lets a surface be written once instead of each growing its own
non-streaming branch and then disagreeing about what a non-streaming head looks like.

Streaming implemented for:

- **Ollama**, NDJSON over `/api/generate`
- **OpenAI-compatible and Azure**, SSE
- **CLI subprocess**, by pointing `cmd.Stdout` at the sink (exec already copies a non-`*os.File`
  Stdout through a pipe as the child runs)

`deltaSink` is shared so all three get the same three things right: output goes through
`util.Accumulator`, so the 33 MB cap and `Response.Truncated` still hold; nothing is forwarded once
the cap is hit, since a consumer must not render text the `Response` will not contain; and TTFT is
measured from the request.

## Three things the live run caught that a stub could not

- **TTFT from response headers is wrong.** It read `1ms` on a call whose first token took
  **4.171s**: headers arrive only once the provider starts producing, so the whole prefill had
  already happened and the number said "instant" for a four-second wait. Measured from request
  issue now.
- **Usage disappears when you stream.** OpenAI reports none unless the request carries
  `stream_options.include_usage`, and it then arrives on a final chunk with an **empty** `choices`
  array; Ollama hides its counts on the final `done` object. Miss either and the dispatch logs as
  free. A server that ignores the option falls back to estimated counts, labelled.
- **SSE carries protocol noise.** Comment keep-alives and `event:`/`id:` lines would otherwise
  render as content, and a keep-alive would fire a delta and flicker a cursor.

## Verified live

Against local Ollama: **435 deltas spread over 9.909s of a 10.012s call**, mean inter-delta gap
22.8ms, real token counts preserved. Today that same call shows nothing for the full ten seconds.

`internal/executor` coverage 86.6% → **89.9%** (floor 86). `go test -race ./...` and `go vet ./...`
clean.

## Deliberately not in scope

- **agy does not stream.** Its `Execute` detects auth failure by scanning stderr *plus the first
  three lines of stdout*, and stderr is only readable after the process exits. Forwarding content
  before exit means forwarding it before auth detection can run, which renders an auth prompt as
  the model's answer. That needs a hold-back design, not a tee, so it is filed separately.
- **Anthropic, Gemini, Cohere, Bedrock** each carry usage somewhere else in a differently-shaped
  event, and **Replicate** is a polling API, not a stream. They fall back through `Stream`
  correctly and get done one at a time rather than in a batch.
- **No surface renders this yet.** CLI, TUI and desktop come next; this is the contract they share.

Closes #787