### PR TITLE
feat(sandbox): thread a context into workspace validators, then harden them

### DIFF
--- a/internal/editor/atomic_test.go
+++ b/internal/editor/atomic_test.go
@@ -3,6 +3,7 @@
 package editor
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -247,18 +248,18 @@ func TestRunValidatorCmd_PathWithSpacesStaysOneArgument(t *testing.T) {
 	}
 
 	// `test -f {file}` exits 0 only if the path arrived intact.
-	out, code := runValidatorCmd("test -f {file}", spaced)
-	if code != 0 {
-		t.Errorf("validator exit %d (%s), the path was fragmented into separate args", code, out)
+	out, code, err := runValidatorCmd(context.Background(), "test -f {file}", spaced)
+	if code != 0 || err != nil {
+		t.Errorf("validator exit %d (%s, err %v), the path was fragmented into separate args", code, out, err)
 	}
-	out, code = runValidatorCmd("test -f {file}", filepath.Join(dir, "does not exist.txt"))
-	if code == 0 {
-		t.Errorf("validator passed for a missing file (%s)", out)
+	out, code, err = runValidatorCmd(context.Background(), "test -f {file}", filepath.Join(dir, "does not exist.txt"))
+	if code == 0 || err != nil {
+		t.Errorf("validator passed for a missing file (%s, err %v)", out, err)
 	}
 }
 
 func TestRunValidatorCmd_EmptyTemplateIsANoOp(t *testing.T) {
-	if out, code := runValidatorCmd("", "/tmp/x"); code != 0 || out != "" {
-		t.Errorf("empty template gave (%q, %d), want a clean no-op", out, code)
+	if out, code, err := runValidatorCmd(context.Background(), "", "/tmp/x"); code != 0 || out != "" || err != nil {
+		t.Errorf("empty template gave (%q, %d, %v), want a clean no-op", out, code, err)
 	}
 }

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/diff"
 	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/sandbox"
 	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/util"
 	"github.com/ankit373/hydra/internal/workspace"
@@ -181,7 +182,13 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 		}
 
 		if vtmpl != "" {
-			vout, vrc := runValidatorCmd(vtmpl, req.File)
+			vout, vrc, verr := runValidatorCmd(ctx, vtmpl, req.File)
+			if verr != nil {
+				// Interrupted, so nothing was learned about this head. Recording
+				// it would teach the calibrator that a Ctrl+C is broken code.
+				rollback(req.File, origContent, origExisted, resolved.GitRoot, backup)
+				return nil, fmt.Errorf("validating %s: %w", req.File, verr)
+			}
 			recordValidationOutcome(dispResult.Head.ID, trust.DomainForFile(req.File), vrc == 0)
 			if vrc != 0 {
 				validatorPassed = false
@@ -464,7 +471,9 @@ func rollback(file, origContent string, origExisted bool, gitRoot, backup string
 
 // runValidatorCmd executes a validator template safely.
 // Splits around {file} so paths containing spaces are never fragmented by Fields.
-func runValidatorCmd(vtmpl, file string) (output string, exitCode int) {
+// A non-nil error means the run was cancelled, which is not an exit code: a
+// killed validator exits non-zero exactly like a failing one.
+func runValidatorCmd(ctx context.Context, vtmpl, file string) (output string, exitCode int, err error) {
 	var parts []string
 	if idx := strings.Index(vtmpl, "{file}"); idx >= 0 {
 		parts = append(strings.Fields(vtmpl[:idx]), file)
@@ -473,17 +482,20 @@ func runValidatorCmd(vtmpl, file string) (output string, exitCode int) {
 		parts = strings.Fields(vtmpl)
 	}
 	if len(parts) == 0 {
-		return "", 0
+		return "", 0, nil
 	}
-	c := exec.Command(parts[0], parts[1:]...)
-	out, err := c.CombinedOutput()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return string(out), exitErr.ExitCode()
+	c := sandbox.Harden(exec.CommandContext(ctx, parts[0], parts[1:]...))
+	out, runErr := c.CombinedOutput()
+	if runErr != nil {
+		if ctx.Err() != nil {
+			return string(out), 0, ctx.Err()
 		}
-		return string(out), 1
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			return string(out), exitErr.ExitCode(), nil
+		}
+		return string(out), 1, nil
 	}
-	return string(out), 0
+	return string(out), 0, nil
 }
 
 func tscTemplate(gitRoot string) string {

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -3,6 +3,7 @@
 package editor
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,11 +96,11 @@ func TestRunValidatorCmd(t *testing.T) {
 	}
 	absent := filepath.Join(dir, "absent.txt")
 
-	if _, rc := runValidatorCmd("test -f {file}", present); rc != 0 {
-		t.Errorf("validator on existing file: rc = %d, want 0", rc)
+	if _, rc, err := runValidatorCmd(context.Background(), "test -f {file}", present); rc != 0 || err != nil {
+		t.Errorf("validator on existing file: rc = %d, err = %v, want 0 and no error", rc, err)
 	}
-	if _, rc := runValidatorCmd("test -f {file}", absent); rc == 0 {
-		t.Errorf("validator on missing file: rc = 0, want non-zero")
+	if _, rc, err := runValidatorCmd(context.Background(), "test -f {file}", absent); rc == 0 || err != nil {
+		t.Errorf("validator on missing file: rc = %d, err = %v, want non-zero and no error", rc, err)
 	}
 }
 

--- a/internal/editor/validator_cancel_test.go
+++ b/internal/editor/validator_cancel_test.go
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package editor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+// A validator's exit code is ground truth about the head, and #738 wired
+// Ctrl+C through to the subprocess, so a killed validator now exits non-zero
+// exactly like a rejecting one. Recording that would teach the calibrator that
+// an interrupted run is a head writing broken code, which is a confident lie
+// about a model, written from a keystroke.
+func TestEdit_CancelledValidatorIsNotRecordedAsAFailedValidation(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}\n"))
+	tmpl, pidFile := hangingValidator(t)
+	writeWorkspaceYAML(t, repo, tmpl)
+
+	file := filepath.Join(repo, "a.go")
+	original := "package main\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The pid file is the synchronisation point, not a timer: the validator
+	// records its child before blocking, so cancelling on that is deterministic
+	// however long the head above it took.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	type outcome struct {
+		res *Result
+		err error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		res, err := Edit(ctx, Request{File: file, Enum: "MODERATE", Prompt: "x", Validate: true})
+		done <- outcome{res, err}
+	}()
+
+	helper := readHelperPID(t, pidFile)
+	cancel()
+
+	var got outcome
+	select {
+	case got = <-done:
+	case <-time.After(cancelBudget):
+		_ = syscall.Kill(helper, syscall.SIGKILL)
+		t.Fatalf("the edit did not return within %v of cancellation: the kill never reached the validator's process group", cancelBudget)
+	}
+
+	if !errors.Is(got.err, context.Canceled) {
+		t.Fatalf("err = %v (result %+v), want context.Canceled: an interrupted edit is not a verdict", got.err, got.res)
+	}
+	if raw, _ := os.ReadFile(file); string(raw) != original {
+		t.Errorf("the file was left in its unvalidated state: %q", raw)
+	}
+
+	cal, err := trust.New(trust.DefaultPath())
+	if err != nil {
+		return // nothing was written at all, which is the point
+	}
+	// Any domain, not just "go": what must not happen is an observation about
+	// this head at all, and pinning the domain would let a rename in
+	// trust.DomainForFile quietly make this assertion vacuous.
+	for _, s := range cal.Report() {
+		if s.Source == "cody" {
+			t.Errorf("a cancelled validator was recorded against the head: %+v", s)
+		}
+	}
+
+	if !processGone(helper, 5*time.Second) {
+		_ = syscall.Kill(helper, syscall.SIGKILL) // never leak it past the test
+		t.Errorf("helper %d outlived the validator that spawned it", helper)
+	}
+}
+
+// The unit contract the calibration guard rests on: cancellation is an error,
+// never an exit code, and the kill reaches the validator's children.
+func TestRunValidatorCmd_CancellationIsNotAnExitCode(t *testing.T) {
+	tmpl, pidFile := hangingValidator(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type result struct {
+		rc  int
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		_, rc, err := runValidatorCmd(ctx, tmpl, "ignored")
+		done <- result{rc, err}
+	}()
+
+	helper := readHelperPID(t, pidFile)
+	cancel()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(cancelBudget):
+		_ = syscall.Kill(helper, syscall.SIGKILL)
+		t.Fatalf("the validator did not return within %v of cancellation: the kill never reached its process group", cancelBudget)
+	}
+	if !errors.Is(got.err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled; a killed validator must not read as a verdict", got.err)
+	}
+	if got.rc != 0 {
+		t.Errorf("rc = %d alongside a cancellation, want 0: a non-zero code here is a rejection the validator never made", got.rc)
+	}
+	if !processGone(helper, 5*time.Second) {
+		_ = syscall.Kill(helper, syscall.SIGKILL)
+		t.Errorf("helper %d outlived the cancelled validator", helper)
+	}
+}
+
+// cancelBudget bounds how long a cancelled validator may take to return. The
+// process-group kill is immediate; without it CombinedOutput blocks until the
+// child the validator spawned closes the pipe, which is what this catches.
+const cancelBudget = 10 * time.Second
+
+// hangingValidator is a validator that records a child's pid and then blocks
+// for far longer than any test will wait, so "the child died" cannot be
+// confused with "the child finished".
+//
+// A script rather than an inline `sh -c`: the template is split on whitespace,
+// which would fragment a shell one-liner. Absolute paths and builtins only,
+// because the test sandbox strips PATH to its own bin directory and dash will
+// not resolve a bare `sleep` there (#738).
+func hangingValidator(t *testing.T) (template, pidFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile = filepath.Join(dir, "helper.pid")
+	script := filepath.Join(dir, "validate.sh")
+	body := "#!/bin/sh\n/bin/sleep 300 &\necho $! > " + pidFile + "\n/bin/sleep 300\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script + " {file}", pidFile
+}
+
+// readHelperPID waits for the validator to record its child, so a test never
+// races the process it is about to cancel.
+func readHelperPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if raw, err := os.ReadFile(path); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(raw))); err == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("the validator never ran: nothing recorded a pid to %s", path)
+	return 0
+}
+
+// processGone reports whether the pid has left the table. Signal 0 checks for
+// existence without delivering anything.
+func processGone(pid int, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if syscall.Kill(pid, 0) == syscall.ESRCH {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/parallel/edit_test.go
+++ b/internal/parallel/edit_test.go
@@ -636,22 +636,22 @@ func TestRunValidate_DoesNotFragmentPathsWithSpaces(t *testing.T) {
 	if err := os.WriteFile(spaced, []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if rc := runValidate("/bin/test -f {file}", spaced); rc != 0 {
-		t.Errorf("exit %d, the path was fragmented at its spaces", rc)
+	if rc, err := runValidate(context.Background(), "/bin/test -f {file}", spaced); rc != 0 || err != nil {
+		t.Errorf("exit %d (err %v), the path was fragmented at its spaces", rc, err)
 	}
 
-	if rc := runValidate("/usr/bin/false", "ignored"); rc == 0 {
-		t.Error("a failing validator reported success")
+	if rc, err := runValidate(context.Background(), "/usr/bin/false", "ignored"); rc == 0 || err != nil {
+		t.Errorf("a failing validator reported rc %d, err %v, want non-zero and no error", rc, err)
 	}
 	// A template naming a binary that does not exist is a failure, not a pass:
 	// treating "could not run the check" as "the check passed" is how an
 	// unvalidated edit ships.
-	if rc := runValidate("definitely-not-installed-anywhere", "x"); rc == 0 {
-		t.Error("a missing validator binary was treated as a pass")
+	if rc, err := runValidate(context.Background(), "definitely-not-installed-anywhere", "x"); rc == 0 || err != nil {
+		t.Errorf("a missing validator binary gave rc %d, err %v, want non-zero and no error", rc, err)
 	}
 	// An empty template means no validator is configured, which is a pass.
-	if rc := runValidate("", "x"); rc != 0 {
-		t.Errorf("an empty template returned %d, want 0 (no validator configured)", rc)
+	if rc, err := runValidate(context.Background(), "", "x"); rc != 0 || err != nil {
+		t.Errorf("an empty template returned %d, %v, want 0 and no error (no validator configured)", rc, err)
 	}
 }
 

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/runid"
 	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/sandbox"
 	"github.com/ankit373/hydra/internal/util"
 	"github.com/ankit373/hydra/internal/workspace"
 )
@@ -397,7 +398,23 @@ func runEditTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 			vtmpl = tscTemplate(resolved.GitRoot)
 		}
 		if vtmpl != "" {
-			if rc := runValidate(vtmpl, file); rc != 0 {
+			rc, verr := runValidate(ctx, vtmpl, file)
+			if verr != nil {
+				// The deadline is the policy stopping the validator, not the
+				// validator rejecting the edit, the same distinction the
+				// dispatch above draws (#424).
+				rollback(file, origContent, origExisted, resolved.GitRoot, backup)
+				reason := "validator_cancelled: " + verr.Error()
+				if errors.Is(verr, context.DeadlineExceeded) {
+					reason = fmt.Sprintf("max_wall_seconds_exceeded: policy allows %ds", fp.MaxWallSeconds)
+				}
+				return mustMarshal(EditResult{
+					Label: task.Label, Enum: task.Enum, Mode: "edit",
+					Status: "fail", File: file, Workspace: wsName, GitRoot: resolved.GitRoot,
+					RolledBack: true, Error: reason,
+				})
+			}
+			if rc != 0 {
 				rollback(file, origContent, origExisted, resolved.GitRoot, backup)
 				return mustMarshal(EditResult{
 					Label: task.Label, Enum: task.Enum, Mode: "edit",
@@ -586,7 +603,10 @@ func rollback(file, origContent string, origExisted bool, gitRoot, backup string
 
 // runValidate splits the validator template around {file} to prevent
 // paths-with-spaces from being fragmented by strings.Fields.
-func runValidate(vtmpl, file string) int {
+// A non-nil error means the run was cancelled or ran past max_wall_seconds,
+// which is not an exit code: a killed validator exits non-zero exactly like a
+// failing one.
+func runValidate(ctx context.Context, vtmpl, file string) (int, error) {
 	var parts []string
 	if idx := strings.Index(vtmpl, "{file}"); idx >= 0 {
 		parts = append(strings.Fields(vtmpl[:idx]), file)
@@ -595,16 +615,19 @@ func runValidate(vtmpl, file string) int {
 		parts = strings.Fields(vtmpl)
 	}
 	if len(parts) == 0 {
-		return 0
+		return 0, nil
 	}
-	c := exec.Command(parts[0], parts[1:]...)
+	c := sandbox.Harden(exec.CommandContext(ctx, parts[0], parts[1:]...))
 	if err := c.Run(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return exitErr.ExitCode()
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
 		}
-		return 1
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode(), nil
+		}
+		return 1, nil
 	}
-	return 0
+	return 0, nil
 }
 
 func tscTemplate(gitRoot string) string {

--- a/internal/parallel/validator_cancel_test.go
+++ b/internal/parallel/validator_cancel_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package parallel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// A validator killed mid-run exits non-zero exactly like a validator that
+// rejected the edit. Reporting the first as the second tells the operator the
+// model wrote bad code when the run was simply interrupted, the same
+// distinction the dispatch above it already draws for a deadline (#424).
+func TestEdit_CancelledValidatorIsNotAValidationFailure(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}\n"))
+	tmpl, pidFile := hangingValidator(t)
+	writeWorkspaceYAML(t, repo, tmpl)
+
+	file := filepath.Join(repo, "a.go")
+	original := "package main\n\nfunc main() {}\n"
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The pid file is the synchronisation point, not a timer: the validator
+	// records its child before blocking, so cancelling on that is deterministic
+	// however long the head above it took.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan []Result, 1)
+	go func() {
+		results, _ := Run(ctx, []Task{{Label: "cancel", Enum: "MODERATE", File: file, Prompt: "x"}}, Options{})
+		done <- results
+	}()
+
+	helper := readHelperPID(t, pidFile)
+	cancel()
+
+	var results []Result
+	select {
+	case results = <-done:
+	case <-time.After(cancelBudget):
+		_ = syscall.Kill(helper, syscall.SIGKILL)
+		t.Fatalf("the batch did not return within %v of cancellation: the kill never reached the validator's process group", cancelBudget)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	var got EditResult
+	if err := json.Unmarshal(results[0].raw, &got); err != nil {
+		t.Fatalf("result is not an EditResult: %v\n%s", err, results[0].raw)
+	}
+
+	if got.Error == "validation_failed" {
+		t.Fatalf("a cancelled validator was reported as a rejected edit: %+v", got)
+	}
+	if !strings.Contains(got.Error, "validator_cancelled") {
+		t.Fatalf("Error = %q, want it to name the cancellation", got.Error)
+	}
+	if !got.RolledBack {
+		t.Error("RolledBack = false; an unvalidated edit was left on disk")
+	}
+	if raw, _ := os.ReadFile(file); string(raw) != original {
+		t.Errorf("the file was left in its unvalidated state: %q", raw)
+	}
+	if !processGone(helper, 5*time.Second) {
+		_ = syscall.Kill(helper, syscall.SIGKILL) // never leak it past the test
+		t.Errorf("helper %d outlived the validator that spawned it", helper)
+	}
+}
+
+// The unit contract the reporting above rests on. Both cancellation shapes are
+// covered because the caller maps them to different answers: a deadline is
+// max_wall_seconds refusing, a cancel is the operator interrupting.
+func TestRunValidate_CancellationIsNotAnExitCode(t *testing.T) {
+	t.Run("cancel", func(t *testing.T) {
+		tmpl, pidFile := hangingValidator(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		type result struct {
+			rc  int
+			err error
+		}
+		done := make(chan result, 1)
+		go func() {
+			rc, err := runValidate(ctx, tmpl, "ignored")
+			done <- result{rc, err}
+		}()
+
+		helper := readHelperPID(t, pidFile)
+		cancel()
+
+		var got result
+		select {
+		case got = <-done:
+		case <-time.After(cancelBudget):
+			_ = syscall.Kill(helper, syscall.SIGKILL)
+			t.Fatalf("the validator did not return within %v of cancellation: the kill never reached its process group", cancelBudget)
+		}
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled; a killed validator must not read as a verdict", got.err)
+		}
+		if got.rc != 0 {
+			t.Errorf("rc = %d alongside a cancellation, want 0: a non-zero code here is a rejection the validator never made", got.rc)
+		}
+		if !processGone(helper, 5*time.Second) {
+			_ = syscall.Kill(helper, syscall.SIGKILL)
+			t.Errorf("helper %d outlived the cancelled validator", helper)
+		}
+	})
+
+	// Only the mapping here: the kill is the same code path the cancel case
+	// above already pins down, and reading the child's pid after the deadline
+	// has killed it races a validator that may not have started yet.
+	t.Run("deadline", func(t *testing.T) {
+		tmpl, _ := hangingValidator(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		rc, err := runValidate(ctx, tmpl, "ignored")
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("err = %v, want context.DeadlineExceeded; this is what the caller maps to max_wall_seconds_exceeded", err)
+		}
+		if rc != 0 {
+			t.Errorf("rc = %d past the deadline, want 0", rc)
+		}
+	})
+}
+
+// cancelBudget bounds how long a cancelled validator may take to return. The
+// process-group kill is immediate; without it Run blocks until the child the
+// validator spawned closes the pipe, which is what this catches.
+const cancelBudget = 10 * time.Second
+
+// hangingValidator is a validator that records a child's pid and then blocks
+// for far longer than any test will wait, so "the child died" cannot be
+// confused with "the child finished".
+//
+// A script rather than an inline `sh -c`: the template is split on whitespace,
+// which would fragment a shell one-liner. Absolute paths and builtins only,
+// because the test sandbox strips PATH to its own bin directory and dash will
+// not resolve a bare `sleep` there (#738).
+func hangingValidator(t *testing.T) (template, pidFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile = filepath.Join(dir, "helper.pid")
+	script := filepath.Join(dir, "validate.sh")
+	body := "#!/bin/sh\n/bin/sleep 300 &\necho $! > " + pidFile + "\n/bin/sleep 300\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script + " {file}", pidFile
+}
+
+// readHelperPID waits for the validator to record its child, so a test never
+// races the process it is about to cancel.
+func readHelperPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if raw, err := os.ReadFile(path); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(raw))); err == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("the validator never ran: nothing recorded a pid to %s", path)
+	return 0
+}
+
+// processGone reports whether the pid has left the table. Signal 0 checks for
+// existence without delivering anything.
+func processGone(pid int, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if syscall.Kill(pid, 0) == syscall.ESRCH {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/security/controls.go
+++ b/internal/security/controls.go
@@ -122,7 +122,8 @@ func filePolicyControl() Control {
 	c.Wired, c.Limited = true, true
 	c.Detail = fmt.Sprintf("%d rule(s) declared, and %d of %d policy fields take effect (%s) at %s: "+
 		"an over-large diff is rolled back, a head over the cost ceiling is refused before it runs, "+
-		"and the wall-clock limit deadlines the dispatch. The other %d are declared and read by "+
+		"and the wall-clock limit deadlines the dispatch and the validator after it. The other %d "+
+		"are declared and read by "+
 		"nothing. `hyctl edit` does not consult this policy at all, so even these apply to "+
 		"`hyctl parallel` only",
 		n, len(enforcedCaps), policyFieldCount(), strings.Join(enforcedCaps, ", "),


### PR DESCRIPTION
## Summary

#738 put heads and the oracle's verifier in process groups of their own.
Workspace validators were left out, and they are the same shape: a command from
the repo that Hydra runs after an edit and that spawns a tree of its own.

They could not simply be hardened, which is why this was a follow-up rather
than part of #738. `sandbox.Harden` sets `Setpgid` **and** a group-killing
`cmd.Cancel`, and `Cancel` is only ever called by `exec.CommandContext`.
Hardening a plain `exec.Command` would have taken the validator out of the
terminal's foreground group while giving nothing the ability to kill it: Ctrl+C
would stop reaching it and nothing else would. Strictly worse than before. So
the context goes in first, then the group.

## Wiring cancellation exposes the #738 bug one layer down

A killed validator exits non-zero exactly like a rejecting one, and both call
sites were reading that exit code as a verdict.

**`internal/editor` wrote it to calibration.** A Ctrl+C during `hyctl edit`
recorded `trust.OutcomeIncorrect` against the head, teaching the calibrator
that an interrupted run is a model writing broken code. The mutant for this is
worth reading, it is the pre-change behaviour verbatim:

```
Status:fail  Head:cody  ValidatorPassed:false  RolledBack:true
Error:validation_failed:
```

That is a keystroke, rendered as a verdict about a model, and then written to
the store the router reads.

**`internal/parallel` reported it as `validation_failed`** and rolled the file
back, so an operator reading the result saw a rejected edit where the policy
had simply run out of time.

Both now treat a non-nil error as cancellation rather than a verdict. The
editor returns it, which `cmd/hydra` already renders as `interrupted` and exit
130; parallel names it, keeping `max_wall_seconds_exceeded` apart from an
operator interrupting. That is the distinction the dispatch immediately above
it already drew (#424) and the validator did not.

Since `max_wall_seconds` now genuinely bounds the validator and not just the
dispatch, `hyctl security` says so.

## What is and is not proven

The full Ctrl+C chain is signal to context to subprocess. The first half is
already pinned by `TestInterrupt_KillsTheSubprocessAndExits130` from #738, which
drives a real binary and a real SIGINT. These tests pin the second half. The
join is `cmd.Context()`, which both `hyctl edit` and `hyctl parallel` use.

`ASI05` deliberately does **not** change. It says validator commands "run
unconfined at full user privilege", which is still true: a process group bounds
a subprocess's lifetime, not its privilege.

## Verification

Every claim mutation-tested, each mutation reverted by its inverse edit:

- [x] drop `sandbox.Harden` in editor → both editor tests fail
- [x] drop the `ctx.Err()` guard in editor → e2e fails with the mutant output above
- [x] drop `sandbox.Harden` in parallel → both parallel tests fail on a surviving helper
- [x] drop the call-site guard in parallel → e2e fails
- [x] `go test -race ./...` green, before and after the rebase onto #786

Two things caught while writing the tests, both of which would have shipped a
test that proved nothing:

- The first version passed with `Harden` removed. A helper sleeping 30s exits on
  its own, so "the child died" could not be told from "the child finished". The
  helper now outlives any test, and the wait is bounded, so a missing group kill
  fails in 10s instead of passing in 31s.
- Asserting `Domain == "go"` would have gone vacuous the moment
  `trust.DomainForFile` was renamed. It now asserts nothing at all was recorded
  against the head.

Tests are build-tagged `!windows` rather than skipped, so the covergate skip
budget is untouched at 38 of 40. Coverage: editor 90.4% (floor 86), parallel
92.0% (floor 87).

Closes #776
