### PR TITLE
fix(egress): delete HasSecret, which has no callers

### DIFF
--- a/internal/egress/egress.go
+++ b/internal/egress/egress.go
@@ -316,20 +316,9 @@ func Summarize(parts []Part) Summary {
 	return s
 }
 
-// HasSecret reports whether any part classifies Secret, the question dispatch
-// asks before head selection so it can prefer a local head rather than
-// discovering the problem at the gate.
-func HasSecret(parts []Part) bool {
-	for _, p := range parts {
-		if p.Sens == Secret {
-			return true
-		}
-	}
-	return false
-}
-
 // Origins names the secret-classified parts, for the notice shown when a run
-// is rerouted to a local head.
+// is rerouted to a local head. Its emptiness is also the "is anything secret"
+// test dispatch reroutes on, so no separate predicate is needed.
 func Origins(parts []Part) []string {
 	var out []string
 	for _, p := range parts {


### PR DESCRIPTION
## Summary

`egress.HasSecret` was exported and documented as

> the question dispatch asks before head selection so it can prefer a local
> head rather than discovering the problem at the gate

Nothing called it. `grep -rn HasSecret` over `cmd/`, `internal/`, `registry/`,
`ci/`, `desktop/` and the docs returns the declaration and nothing else, which
is why it measured 0.0%.

Dispatch does ask that question, at
[dispatch.go:409](internal/dispatch/dispatch.go#L409), and answers it with
`len(egress.Origins(parts)) > 0`. That is not an oversight to fix by switching
the call over: dispatch needs the origin names anyway, for the notice shown when
a run is rerouted to a local head, so `Origins` is a call it has to make
regardless and `HasSecret` could only ever be a second walk of the same slice.

Two rules from CLAUDE.md, not one:

- "Exported symbols must be used. An exported function with no callers is noise
  that misleads the next engineer."
- "Dead code is a lie." The doc comment asserted a caller that does not exist,
  so the next person reading it goes looking for a call site nobody wrote.

`Origins`' own doc now says its emptiness is that test, so the predicate does
not get written a second time.

## A correction to what #808 says about this package

While setting egress's floor in #808 I read its 58% as "the enforcement path is
covered, the reporting surface is not". The first half is right, the second is
wrong, and the difference matters because it is a security control:

```
$ go test ./internal/dispatch/ -coverpkg=./internal/egress
ok  github.com/ankit373/hydra/internal/dispatch  coverage: 80.2% of statements in ./internal/egress

Summarize  100.0%
Origins    100.0%
String      75.0%
```

**egress is covered to 80.2%**, not 58%. `Summarize` and `Origins` read 0.0% in
the CI profile only because per-package coverage counts what a package's *own*
test binary executed, and those two are exercised by their caller's tests
instead. The 58% was a measurement artifact.

`HasSecret` was the one function that showed 0% in both readings, which is
exactly what a function with no callers looks like. #808's floors-file comment
is corrected to say this.

## Changes

- `internal/egress/egress.go`, `HasSecret` deleted, `Origins`' doc says what its
  emptiness means.

Net 13 lines out, 2 in.

## Verification

- `go build ./...`, `go vet ./internal/egress/` clean.
- `go test -race ./... -count=1` green across the module.
- `go -C desktop build ./api/` green, since the root suite does not cover that
  module.
- `grep -rn HasSecret .` returns nothing outside `.git`.
- Package coverage 58.0% to 60.4%.

## Why no floors edit

Deleting uncovered statements only raises the number, so the floor of 55 that
#808 sets continues to hold, and this PR touches no file #808 touches. The two
can land in either order without conflicting. Ratcheting egress up, and giving
its own tests the summary helpers so the per-package number stops understating
it, is separate work and not this PR.

Closes #806