### PR TITLE
fix(executor): a first token too fast to measure is still a measurement

### DIFF
--- a/internal/executor/stream.go
+++ b/internal/executor/stream.go
@@ -76,6 +76,11 @@ type deltaSink struct {
 	onDelta OnDelta
 	started time.Time
 	ttft    time.Duration
+	// Separate from ttft because zero is a reachable measurement, not just an
+	// unset one: against a local server the first token can arrive inside the
+	// clock's granularity. Overloading zero as the sentinel let the *second*
+	// fragment record its own elapsed time as the time to the first (#810).
+	ttftSet bool
 }
 
 // newDeltaSink starts measuring from started, which must be when the request
@@ -101,8 +106,9 @@ func (s *deltaSink) write(delta string) {
 		return
 	}
 	s.mu.Lock()
-	if s.ttft == 0 && strings.TrimSpace(delta) != "" {
-		s.ttft = time.Since(s.started)
+	if !s.ttftSet && strings.TrimSpace(delta) != "" {
+		s.ttftSet = true
+		s.ttft = measured(time.Since(s.started))
 	}
 	truncated := s.acc.Truncated()
 	if !truncated {
@@ -142,6 +148,17 @@ func (s *deltaSink) truncated() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.acc.Truncated()
+}
+
+// measured reports an elapsed time a reader can tell apart from no reading at
+// all. Response.TTFT documents zero as "the provider does not report it", and
+// a first token can arrive inside the clock's granularity against a local
+// server, so the floor is the honest answer there (#810).
+func measured(d time.Duration) time.Duration {
+	if d == 0 {
+		return time.Nanosecond
+	}
+	return d
 }
 
 // firstTokenAt is the measured time to the first non-empty delta, or 0 when

--- a/internal/executor/stream_test.go
+++ b/internal/executor/stream_test.go
@@ -322,3 +322,41 @@ func TestStream_PrefersTheStreamingPath(t *testing.T) {
 		t.Errorf("got %d deltas, want 3: Stream fell back to Execute", n)
 	}
 }
+
+// #810: zero was both the sentinel and a reachable measurement, so a first
+// token that arrived inside the clock's granularity read as "the provider does
+// not report TTFT" and the next fragment then recorded its own elapsed time as
+// the time to the first. Windows against a local server is where that showed.
+func TestDeltaSink_TheFirstTokenKeepsTheTitle(t *testing.T) {
+	s := newDeltaSink(func(string) {}, time.Now())
+
+	s.write("a")
+	if s.firstTokenAt() == 0 {
+		t.Fatal("TTFT is zero for a token that demonstrably arrived")
+	}
+
+	// Stand in for a sub-granularity measurement, which is the state the old
+	// sentinel could not tell from "never measured". A later fragment must not
+	// be able to claim the title from it.
+	s.mu.Lock()
+	s.ttft = 0
+	s.mu.Unlock()
+
+	time.Sleep(2 * time.Millisecond)
+	s.write("b")
+
+	if got := s.firstTokenAt(); got != 0 {
+		t.Errorf("a later fragment recorded %v as the time to the first token", got)
+	}
+}
+
+// The floor itself: a reading of zero is a reading, and must not render as the
+// absence of one.
+func TestMeasured_ZeroIsReportedAsTheFloorNotAsUnknown(t *testing.T) {
+	if got := measured(0); got != time.Nanosecond {
+		t.Errorf("measured(0) = %v, want the floor: zero reads as 'not reported'", got)
+	}
+	if got := measured(3 * time.Millisecond); got != 3*time.Millisecond {
+		t.Errorf("measured(3ms) = %v, a real reading must pass through untouched", got)
+	}
+}


### PR DESCRIPTION
## Summary

`TestOllamaStream_RealTokenCountsSurviveTheStream` failed on `windows-latest`
on an unrelated PR (#804):

```
--- FAIL: TestOllamaStream_RealTokenCountsSurviveTheStream (0.00s)
    stream_test.go:226: TTFT is zero on a stream we watched arrive
```

The test was right and the code was wrong, so this is a fix rather than a
looser assertion.

## Zero was both the sentinel and a value

```go
if s.ttft == 0 && strings.TrimSpace(delta) != "" {
    s.ttft = time.Since(s.started)
}
```

Against a local server the first token can arrive inside the clock's
granularity. Two things then go wrong, and only the first one is visible:

1. **A token that arrived reads as one that was never reported.**
   `Response.TTFT` documents zero as "the provider does not report it".
2. **The next fragment silently claims the title.** Because the guard is
   `ttft == 0`, the *second* delta re-enters it and records its own elapsed
   time. TTFT then means "time to whichever fragment first measured non-zero",
   which is the first token on a slow stream and not on a fast one, with
   nothing saying which reading you have.

The second is the reason this mattered beyond a red Windows job: the number is
wrong in a way that looks entirely plausible, and TTFT is a latency figure
people compare heads on.

## Verification

Both halves mutation-tested:

- [x] restoring the `ttft == 0` guard fails `TestDeltaSink_TheFirstTokenKeepsTheTitle`
      with `a later fragment recorded 2.265625ms as the time to the first token`
- [x] dropping the floor fails `TestMeasured_ZeroIsReportedAsTheFloorNotAsUnknown`
- [x] `go test -race ./...` green

The regression test forces the sub-granularity state rather than waiting to be
lucky on a fast machine: a real zero cannot be arranged from `time.Since` on
demand, so it pins `ttft` back to zero and proves a later fragment cannot take
it. Without the fix that fails immediately, on every platform, not just the one
where the bug shows.

Closes #810
