### PR TITLE
fix(ci): create the tag GoReleaser reads, so edge and RC builds run

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -97,6 +97,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # GoReleaser resolves GORELEASER_CURRENT_TAG and reads that tag's
+      # contents, which --skip=validate does not skip. Annotated, not
+      # lightweight: %(contents) of a lightweight tag is empty too (#821).
+      - name: Create the tag GoReleaser reads
+        run: git tag -a "${{ steps.ver.outputs.version }}" -m "edge ${{ steps.ver.outputs.sha }}"
+
       - name: Build edge binaries
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -104,8 +110,9 @@ jobs:
           # Not --snapshot: it computes its own 0.0.0-SNAPSHOT version and
           # ignores the tag, so every edge build shipped archives that could
           # not say which commit they came from (#759, and #705 for RC).
-          # Skipping validate is what makes a build work with no tag on HEAD,
-          # which is always the case here, and it keeps the version.
+          # It was also swallowing the missing-tag error, which is why dropping
+          # it turned this red; the tag above is what actually addresses that,
+          # not --skip=validate, which only skips the git *state* checks (#821).
           args: release --clean --skip=publish,sign,sbom,validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -48,21 +48,31 @@ jobs:
           # the archive filenames need this form and not the tag (#759).
           echo "semver=${RC_TAG#v}" >> "$GITHUB_OUTPUT"
 
+      # GoReleaser resolves GORELEASER_CURRENT_TAG and reads that tag's
+      # contents, which --skip=validate does not skip. Annotated, not
+      # lightweight: %(contents) of a lightweight tag is empty too (#821).
+      - name: Create the tag GoReleaser reads
+        run: git tag -a "${{ steps.ver.outputs.tag }}" -m "RC ${{ steps.ver.outputs.sha }}"
+
       - name: Build RC binaries
         uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           # --snapshot made GoReleaser compute its own 0.0.0-SNAPSHOT version
           # and ignore the tag, so every RC shipped CLI archives that could not
-          # say which release they stood for (#705). It was presumably there
-          # because a plain `release` refuses when HEAD carries no tag, which is
-          # always true here: the tag is created afterwards, by `gh release
-          # create`. Skipping validate is what actually addresses that, and it
-          # keeps GORELEASER_CURRENT_TAG as the version.
+          # say which release they stood for (#705). It was also swallowing the
+          # missing-tag error, which is why dropping it broke the build; the tag
+          # above is what addresses that, not --skip=validate, which only skips
+          # the git *state* checks (#821).
           args: release --clean --skip=publish,sign,sbom,validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.ver.outputs.version }}
+
+      # gh release create refuses a tag that exists locally but not on the
+      # remote, so the build-only tag goes before it creates the real one.
+      - name: Drop the local build tag
+        run: git tag -d "${{ steps.ver.outputs.tag }}"
 
       - name: Publish RC release
         run: |


### PR DESCRIPTION
## Summary

**Every edge build has failed since #761 landed. 24 consecutive runs**, last
success `254ce6d` at 2026-09-08T14:14Z:

```
⨯ release failed after 0s
  error=couldn't get tag contents: unexpected git tag output for "v1.4.3-edge.g9f6c644": ""
```

Nobody noticed because `Edge Build` is not a required check on any PR, so the
edge channel `CLAUDE.md` documents as a release channel has been dead all day
while every PR stayed green.

`rc.yml` has the identical invocation and is **latently broken the same way**.
No `release/v*` has been pushed since #761, so it has never run. It would have
failed on the next release cut.

## Cause

#761 was right to drop `--snapshot`: it stamped `0.0.0-SNAPSHOT-none` into every
edge and RC archive (#705, #759). It replaced it with `--skip=validate` on a
premise both workflows state as the resolution:

> a plain `release` refuses when HEAD carries no tag, which is always true here
> ... Skipping validate is what actually addresses that

**That is false.** `--skip=validate` skips the git *state* checks. Resolving
`GORELEASER_CURRENT_TAG` and reading that tag's contents is a separate step, and
it is fatal when the tag does not exist.

And `--snapshot` was never addressing the missing tag either. It was **swallowing
this exact error**, which is visible in the last good run's log once you look:

```
• ignoring errors because this is a snapshot
  error=couldn't get tag contents: unexpected git tag output for ...: ""
```

So #761 removed what was hiding the error without removing the cause. The
comment describing the wrong mechanism as the fix is how this passed review, so
it is corrected in both files rather than left to mislead the next person.

## Fix

Create the tag locally before GoReleaser runs, keeping non-snapshot mode so
#761's real version stamping survives.

- **`edge.yml`**: the GoReleaser tag (`v1.4.3-edge.g<sha>`) and the published tag
  (`edge`) are different names, so nothing else changes.
- **`rc.yml`**: the two are the **same** name (`v1.2.0-rc.1`), and `gh release
  create` refuses a tag that exists locally but not on the remote, which
  `edge.yml` already documents and deletes the `edge` tag for. So the build tag
  is dropped between the build and the publish.

**Annotated, not lightweight.** `git tag -l --format='%(contents)'` returns empty
for a lightweight tag, the same empty string the error reports, so a lightweight
tag would not fix it:

```
lightweight contents: []
annotated   contents: [edge build ...]
nonexistent contents: []
```

## Verification

Against **goreleaser 2.18.1**, the version CI resolves, replaying `edge.yml`'s
own version computation off `.release-please-manifest.json`:

| tag state | result | version stamped |
|---|---|---|
| no tag (current CI) | `couldn't get tag contents: ... "v1.4.3-edge.gc5760e8": ""` | none |
| annotated tag (this PR) | `release succeeded`, 6 archives | `1.4.3-edge.gc5760e8` |

Sample archive: `hydra_1.4.3-edge.gc5760e8_darwin_amd64.tar.gz`.

Also measured, for the record, the three states across versions:

| args | tag | result | version |
|---|---|---|---|
| `--snapshot ... ` (before #761) | none | succeeds | `0.0.0-SNAPSHOT-none` ← the #759 bug |
| `--clean --skip=...,validate` (now) | none | **fails** | none |
| `--clean --skip=...,validate` | annotated | succeeds | correct |

Local goreleaser **2.17.1 does not fail** on the missing tag, so reproducing this
needs the pinned 2.18.1 binary. Both workflows use `version: latest`.

Both files parse (`yaml.safe_load`).

## What I did not do

`version: latest` stays. It is precisely why a goreleaser release can change this
behaviour under us, and 2.17.1 vs 2.18.1 differing on this exact path is the
evidence. Pinning is a separate decision about how the pipeline tracks upstream,
not part of unbreaking it, so it is called out rather than bundled.

`rc.yml` cannot be exercised without cutting a release branch. Its GoReleaser
step is verified by the same mechanism as edge; the `gh release create` ordering
rests on the constraint `edge.yml` already documents and works around.

Closes #821