### PR TITLE
test(ci): fail at PR time when a prerelease build names a tag it never creates

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -98,8 +98,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # GoReleaser resolves GORELEASER_CURRENT_TAG and reads that tag's
-      # contents, which --skip=validate does not skip. Annotated, not
-      # lightweight: %(contents) of a lightweight tag is empty too (#821).
+      # contents, which --skip=validate does not skip (#821). Annotated so the
+      # tag carries its own message; a lightweight one reads the commit's.
       #
       # A tag object carries a tagger, and the runner has no git identity: the
       # OS fallback derives an empty name there. -c rather than `git config`,

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -49,8 +49,8 @@ jobs:
           echo "semver=${RC_TAG#v}" >> "$GITHUB_OUTPUT"
 
       # GoReleaser resolves GORELEASER_CURRENT_TAG and reads that tag's
-      # contents, which --skip=validate does not skip. Annotated, not
-      # lightweight: %(contents) of a lightweight tag is empty too (#821).
+      # contents, which --skip=validate does not skip (#821). Annotated so the
+      # tag carries its own message; a lightweight one reads the commit's.
       #
       # A tag object carries a tagger, and the runner has no git identity: the
       # OS fallback derives an empty name there. -c rather than `git config`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -878,7 +878,8 @@ internal/build/build.go       ← version vars set by ldflags at build time
 internal/update/update.go     ← startup update checker (24h cache)
 .github/workflows/release.yml ← fires on tag push → goreleaser
 .github/workflows/edge.yml    ← fires on develop push → edge build
-.github/workflows/rc.yml      ← fires on release/v* push → RC pre-release
+.github/workflows/rc.yml      ← fires on release/v* push → RC pre-release. Both build from a
+                                branch, so they must tag HEAD themselves, see below.
 .github/workflows/publish.yml ← fans a release out to brew/npm/pip
 .github/workflows/release-please.yml ← fires on main push → release PR, then fans out to
                                        publish.yml and close-shipped-issues.yml
@@ -890,6 +891,15 @@ internal/update/update.go     ← startup update checker (24h cache)
                                        cannot merge (#670). Either way a red run means develop
                                        is behind main and a release cut will not merge cleanly.
 ```
+
+**A prerelease channel has to create the tag it names.** edge.yml and rc.yml build from a branch,
+so they invent a version and hand it to GoReleaser as `GORELEASER_CURRENT_TAG`. GoReleaser reads
+that tag's contents, and `--skip=validate` does not bypass that read, so naming a tag that does not
+exist fails the build in 0s on `couldn't get tag contents`. Both now tag HEAD before the build,
+local to the runner and never pushed, annotated with an explicit tagger because a runner has no git
+identity of its own. Every edge build failed this way from #761 until #822 and nobody saw it, since
+edge and RC gate no PR and nothing else reports them; `cmd/hydra/prerelease_naming_test.go` is what
+fails at PR time now instead (#793, #821).
 
 **The back-merge PR cannot merge itself, and needs one of your commits.** Two independent
 reasons, both invisible on the PR: it is opened by `github-actions[bot]`, whose events start no

--- a/cmd/hydra/prerelease_naming_test.go
+++ b/cmd/hydra/prerelease_naming_test.go
@@ -17,8 +17,9 @@ import (
 // Two invariants, checked against the workflow files, because that is where
 // they are actually decided.
 
-// prereleaseWorkflows are the channels built from a branch, with no tag on
-// HEAD. The stable release is tagged, so it never had this problem.
+// prereleaseWorkflows are the channels built from a branch, so nothing tags
+// HEAD for them and they have to do it themselves. The stable release runs on
+// a tag release-please already made.
 var prereleaseWorkflows = []string{"rc.yml", "edge.yml"}
 
 func workflowFile(t *testing.T, name string) string {
@@ -51,8 +52,8 @@ func TestPrereleaseWorkflows_DoNotBuildInSnapshotMode(t *testing.T) {
 					"0.0.0-SNAPSHOT and `hyctl version` cannot report the release: %s", name, args)
 			}
 			if !strings.Contains(args, "validate") {
-				t.Errorf("%s does not skip validate, and HEAD carries no tag here, so "+
-					"GoReleaser will refuse the build: %s", name, args)
+				t.Errorf("%s does not skip validate, so GoReleaser applies the git *state* "+
+					"checks to a tag the workflow made a moment ago: %s", name, args)
 			}
 		})
 	}
@@ -129,6 +130,80 @@ func TestPrereleaseWorkflows_InstallSnippetNamesAnAssetThatExists(t *testing.T) 
 			if !strings.Contains(body, `echo "semver=`) {
 				t.Errorf("%s uses outputs.semver but never writes it, so the filename "+
 					"interpolates to hydra__darwin_arm64.tar.gz", name)
+			}
+		})
+	}
+}
+
+// outputRef matches a ${{ steps.<id>.outputs.<name> }} reference, and
+// currentTagEnv the one a workflow hands GoReleaser as its tag.
+var (
+	outputRef     = regexp.MustCompile(`steps\.\w+\.outputs\.(\w+)`)
+	currentTagEnv = regexp.MustCompile(`GORELEASER_CURRENT_TAG:\s*\$\{\{\s*steps\.\w+\.outputs\.(\w+)\s*\}\}`)
+	outputAssign  = regexp.MustCompile(`echo "(\w+)=([^"]*)" >> "\$GITHUB_OUTPUT"`)
+)
+
+// A prerelease workflow invents its version, so the tag it names exists only
+// if the workflow makes one. --skip=validate does not bypass GoReleaser's read
+// of the tag's contents, so from #761 every edge build failed in 0s on
+// "couldn't get tag contents" while the tests above stayed green, because they
+// only ever checked that a tag was named (#793, #821).
+func TestPrereleaseWorkflows_CreateTheTagTheyName(t *testing.T) {
+	for _, name := range prereleaseWorkflows {
+		t.Run(name, func(t *testing.T) {
+			body := workflowFile(t, name)
+			m := currentTagEnv.FindStringSubmatch(body)
+			if m == nil {
+				t.Fatalf("%s hands GoReleaser no GORELEASER_CURRENT_TAG output; this "+
+					"test no longer checks what it thinks", name)
+			}
+			want := m[1]
+
+			// rc.yml tags outputs.tag but hands GoReleaser outputs.version, which
+			// works only because one shell expression writes both. Comparing the
+			// values rather than the names accepts that and still catches the two
+			// drifting apart.
+			value := map[string]string{}
+			for _, a := range outputAssign.FindAllStringSubmatch(body, -1) {
+				value[a[1]] = a[2]
+			}
+			isTag := func(s string) bool {
+				for _, r := range outputRef.FindAllStringSubmatch(s, -1) {
+					if r[1] == want || (value[want] != "" && value[r[1]] == value[want]) {
+						return true
+					}
+				}
+				return false
+			}
+
+			build := strings.Index(body, goreleaserArgs(t, body, name))
+			create, push, off := -1, -1, 0
+			for _, line := range strings.Split(body, "\n") {
+				// The one-line `run:` form, normalised to the block form.
+				s := strings.TrimPrefix(strings.TrimSpace(line), "run: ")
+				switch {
+				case !isTag(s):
+				case strings.Contains(s, "git push"):
+					push = off
+				case strings.Contains(s, "tag ") && !strings.Contains(s, " -d "):
+					if create < 0 {
+						create = off
+					}
+				}
+				off += len(line) + 1
+			}
+
+			switch {
+			case create < 0:
+				t.Errorf("%s hands GoReleaser outputs.%s but never creates that tag, so "+
+					"the build fails reading the tag's contents", name, want)
+			case create > build:
+				t.Errorf("%s creates outputs.%s only after the build that reads it, and "+
+					"steps run in file order", name, want)
+			}
+			if push >= 0 {
+				t.Errorf("%s pushes outputs.%s, putting a prerelease tag in the branch's "+
+					"own history, where git describe reaches it again (#759)", name, want)
 			}
 		})
 	}


### PR DESCRIPTION
**This PR no longer fixes the build.** #822 and #826 did that, from #821, which
is the same defect filed by a parallel session while I was verifying mine. I
have dropped my workflow fix and kept only what develop still lacks.

## What is still missing

The reason this ran for a day is not that the tag was wrong. It is that
**nothing failed when it was wrong.** `Edge Build` and `RC Build` gate no PR,
so the pipeline was red while every PR was green, and the file that should have
caught it, `prerelease_naming_test.go`, asserted only that a tag was *named*:

```go
if !strings.Contains(workflowFile(t, name), "GORELEASER_CURRENT_TAG:") {
```

That passes just as happily when the tag it names exists nowhere.

`TestPrereleaseWorkflows_CreateTheTagTheyName` checks that each prerelease
workflow **creates** the tag it hands GoReleaser, **before** the build that
reads it, and does **not** push it. Pushing would put a prerelease tag in
develop's own history, which is where `git describe` found the `edge` tag and
produced the `0.0.0` fallback #759 fixed.

One wrinkle it has to handle: `rc.yml` tags `outputs.tag` but hands GoReleaser
`outputs.version`. That works only because one shell expression writes both, so
the guard compares the **values** the names are assigned rather than the names,
and still fires when they drift apart.

### Mutation-tested against the workflows as merged

```
m1 (tag step deleted, the state #761 shipped):
  edge.yml hands GoReleaser outputs.version but never creates that tag, so the
  build fails reading the tag's contents
m2 (step moved after the build):
  edge.yml creates outputs.version only after the build that reads it, and
  steps run in file order
m3 (tag pushed to origin):
  edge.yml pushes outputs.version, putting a prerelease tag in the branch's own
  history, where git describe reaches it again (#759)
m4 (rc.yml's outputs.tag drifts from outputs.version):
  rc.yml hands GoReleaser outputs.version but never creates that tag
```

m4 is the one that matters: without it the value comparison could accept
anything, and it proves the guard survives the exact shape that shipped.

## One correction to the merged comment

```
# Annotated, not lightweight: %(contents) of a lightweight tag is empty too (#821).
```

This is not right, and it is what made `-a` look mandatory:

```
$ git tag v0.0.0-probe                       # lightweight, no -a, no -m
$ git tag -l --format='%(contents)' v0.0.0-probe
fix(ci): create the tag the edge and RC builds name (#793)
```

`%(contents)` of a lightweight tag resolves to the **commit message**, because
the ref points at a commit object. I also built from one: goreleaser **2.18.1**,
the version CI's `version: latest` resolves to, `release succeeded after 3s`,
with `hyctl --version` reporting `1.4.3-edge.g8784cf2` out of the archive.

That choice is what cost the extra red build. `-a` needs a tagger, a runner has
no git identity, and #826 then had to inject one. **I have not changed the
mechanism** — it is green and a release is waiting on it. Annotated is still
the better choice, for the weaker reason that the tag carries its own message.
Only the sentence is corrected.

## Also

The pipeline gotcha is now in CLAUDE.md beside the other release traps, since
"the workflow must create the tag it names" is not deducible from either file.

`go test -race ./... -count=1`, gofmt, `go vet` and staticcheck all clean.

Closes #793
