### PR TITLE
fix(ci): give the edge and RC build tag a git identity

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -100,8 +100,15 @@ jobs:
       # GoReleaser resolves GORELEASER_CURRENT_TAG and reads that tag's
       # contents, which --skip=validate does not skip. Annotated, not
       # lightweight: %(contents) of a lightweight tag is empty too (#821).
+      #
+      # A tag object carries a tagger, and the runner has no git identity: the
+      # OS fallback derives an empty name there. -c rather than `git config`,
+      # so it stays out of the other steps that run git (#824).
       - name: Create the tag GoReleaser reads
-        run: git tag -a "${{ steps.ver.outputs.version }}" -m "edge ${{ steps.ver.outputs.sha }}"
+        run: |
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              tag -a "${{ steps.ver.outputs.version }}" -m "edge ${{ steps.ver.outputs.sha }}"
 
       - name: Build edge binaries
         uses: goreleaser/goreleaser-action@v7

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -51,8 +51,15 @@ jobs:
       # GoReleaser resolves GORELEASER_CURRENT_TAG and reads that tag's
       # contents, which --skip=validate does not skip. Annotated, not
       # lightweight: %(contents) of a lightweight tag is empty too (#821).
+      #
+      # A tag object carries a tagger, and the runner has no git identity: the
+      # OS fallback derives an empty name there. -c rather than `git config`,
+      # so it stays out of the other steps that run git (#824).
       - name: Create the tag GoReleaser reads
-        run: git tag -a "${{ steps.ver.outputs.tag }}" -m "RC ${{ steps.ver.outputs.sha }}"
+        run: |
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              tag -a "${{ steps.ver.outputs.tag }}" -m "RC ${{ steps.ver.outputs.sha }}"
 
       - name: Build RC binaries
         uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
## Summary

**#822 did not unbreak the edge build.** It moved the failure one step earlier,
to the step it added:

```
Run git tag -a "v1.4.3-edge.gce00e7a" -m "edge ce00e7a"
  Committer identity unknown
fatal: empty ident name (for <runner@runnervm...cloudapp.net>) not allowed
##[error]Process completed with exit code 128
```

A tag *object* carries a tagger, so `git tag -a` needs an identity. The runner
has none configured, and git's OS fallback derives an empty name there.

## Why #822's verification missed it, and what I changed about it

#822 A/B tested the tag mechanism against the real goreleaser 2.18.1 and it
passed. It passed because this machine has a git identity and git derived one
without saying so. **The mechanism was verified and the environment was not.**

`GIT_CONFIG_GLOBAL=/dev/null` does not reproduce it, the OS fallback still
supplies a name. The empty name has to be forced:

```
$ git -c user.name= -c user.email=runner@localhost tag -a t1 -m x
fatal: empty ident name (for <runner@localhost>) not allowed    ← the CI error
$ git tag -l t1
                                                                 ← no tag
```

So this PR is verified with the ambient identity forced empty, which is the
condition the runner is actually in:

```
$ git -c user.name= -c user.email=runner@localhost \
      -c user.name="github-actions[bot]" -c user.email="41898282+...@users.noreply.github.com" \
      tag -a v1.4.3-edge.gce00e7a -m "edge ce00e7a"
tag created despite empty ambient ident
tagger: github-actions[bot]

$ GORELEASER_CURRENT_TAG=v1.4.3-edge.gce00e7a goreleaser release --clean --skip=publish,sign,sbom,validate
  • release succeeded after 3s
  "version":"1.4.3-edge.gce00e7a"
```

## Changes

`-c` on the command rather than `git config`, so the identity stays out of the
other steps in these workflows that run git (`git push origin :refs/tags/edge`,
`git tag -d`). Applied to `edge.yml` and `rc.yml`, since #822 added the same
step to both and `rc.yml` has still never run.

The tag is local and never pushed, so `required_signatures` does not apply.

Both files parse (`yaml.safe_load`).

## Green CI here proves nothing

`Edge Build` only runs on `develop`, which is the whole reason this went 25 runs
without anyone noticing. So the acceptance check is after the merge, off the
real run and by reading the version back out of the **published asset**, not the
build log.

Closes #824