### PR TITLE
fix(shellpath): assert the PATH merge against a shell the test controls

### DIFF
--- a/internal/shellpath/loginshell_test.go
+++ b/internal/shellpath/loginshell_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+
+package shellpath
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ankit373/hydra/internal/testutil"
+)
+
+// fakeShell puts a shell the test controls in $SHELL, so what loginPath does
+// with it is asserted the same way on all three platforms.
+//
+// The assertion these replace ran the developer's real interactive login shell
+// and was guarded on $SHELL being set, so it checked nothing wherever it was
+// not set, and where it was, it depended on that shell starting inside
+// loginPathTimeout. Under a full-suite run it sometimes did not, and the
+// timeout then read as the very bug the test was looking for (#816). Setting
+// SHELL here also means whatever a CI runner image happens to export cannot
+// make the check vacuous again.
+func fakeShell(t *testing.T, prints string) *testutil.Sandbox {
+	t.Helper()
+	sb := testutil.NewSandbox(t)
+	t.Setenv("SHELL", sb.FakeBinary(t, "fakeshell", testutil.EchoScript(prints)))
+	return sb
+}
+
+// script returns a shell body for this platform, since a .bat is not a .sh.
+func script(unix, batch string) string {
+	if runtime.GOOS == "windows" {
+		return "@echo off\r\n" + batch + "\r\n"
+	}
+	return "#!/bin/sh\n" + unix + "\n"
+}
+
+func TestLoginPath_ReadsWhatTheShellPrints(t *testing.T) {
+	want := sep("/opt/homebrew/bin", "/usr/bin")
+	fakeShell(t, want)
+
+	if got := loginPath(context.Background()); got != want {
+		t.Errorf("loginPath = %q, want %q", got, want)
+	}
+}
+
+// The invocation is the load-bearing detail: a plain login shell does not read
+// .zshrc, which is where a great many people set PATH, so it has to be
+// interactive as well. A fake shell can assert that. A real one cannot, it can
+// only be observed to have answered.
+func TestLoginPath_AsksForAnInteractiveLoginShell(t *testing.T) {
+	sb := testutil.NewSandbox(t)
+	argv := filepath.Join(t.TempDir(), "argv.txt")
+
+	t.Setenv("SHELL", sb.FakeBinary(t, "argvshell", script(
+		`printf '%s\n' "$@" > `+argv,
+		`echo %* > `+argv,
+	)))
+
+	loginPath(context.Background())
+
+	raw, err := os.ReadFile(argv)
+	if err != nil {
+		t.Fatalf("the shell was never invoked: %v", err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, "-ilc") {
+		t.Errorf("argv %q does not ask for an interactive login shell", got)
+	}
+	if !strings.Contains(got, "PATH") {
+		t.Errorf("argv %q does not ask the shell for its PATH", got)
+	}
+}
+
+// Three ways a shell can fail to answer. All three must leave PATH to the
+// caller rather than truncating it, which is what mergePath("") encodes.
+func TestLoginPath_SaysNothingRatherThanGuessing(t *testing.T) {
+	t.Run("no SHELL set", func(t *testing.T) {
+		testutil.NewSandbox(t)
+		t.Setenv("SHELL", "")
+		if got := loginPath(context.Background()); got != "" {
+			t.Errorf("loginPath = %q with no shell to ask", got)
+		}
+	})
+
+	t.Run("the shell exits non-zero", func(t *testing.T) {
+		sb := testutil.NewSandbox(t)
+		t.Setenv("SHELL", sb.FakeBinary(t, "brokenshell", script("exit 3", "exit /b 3")))
+		if got := loginPath(context.Background()); got != "" {
+			t.Errorf("loginPath = %q from a shell that exited non-zero", got)
+		}
+	})
+
+	// The real #816 failure, made deterministic: the shell outlives the
+	// deadline. Adopt must carry on with the PATH it has.
+	t.Run("the shell never answers", func(t *testing.T) {
+		sb := testutil.NewSandbox(t)
+		t.Setenv("SHELL", sb.FakeBinary(t, "hangingshell", script(
+			"sleep 30", "ping -n 30 127.0.0.1 > nul")))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		if got := loginPath(ctx); got != "" {
+			t.Errorf("loginPath = %q past its deadline", got)
+		}
+		// Bounded well below the shell's 30s sleep and well above the 100ms
+		// deadline, so it separates "the context was honoured" from "the sleep
+		// ran to completion" without racing a fork on a loaded machine.
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Errorf("waited %v: the deadline was not honoured", elapsed)
+		}
+	})
+}

--- a/internal/shellpath/shellpath.go
+++ b/internal/shellpath/shellpath.go
@@ -29,14 +29,21 @@ const loginPathTimeout = 3 * time.Second
 // Guarded on the PATH already being bare, because asking a shell costs about a
 // second and a process started from a terminal already has the answer.
 func Adopt() {
+	ctx, cancel := context.WithTimeout(context.Background(), loginPathTimeout)
+	defer cancel()
+	adopt(ctx)
+}
+
+// adopt is Adopt on the caller's deadline. A test asserts the merge through an
+// unbounded one, because forking any shell can outlast a fixed budget on a
+// loaded machine and the timeout then reads as the bug being looked for (#816).
+func adopt(ctx context.Context) {
 	if runtime.GOOS == "windows" {
 		return // PATH comes from the registry, not a shell profile
 	}
 	if !looksBare(os.Getenv("PATH")) {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), loginPathTimeout)
-	defer cancel()
 	if merged := mergePath(os.Getenv("PATH"), loginPath(ctx)); merged != "" {
 		os.Setenv("PATH", merged)
 	}

--- a/internal/shellpath/shellpath_test.go
+++ b/internal/shellpath/shellpath_test.go
@@ -3,8 +3,10 @@
 package shellpath
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -48,10 +50,17 @@ func TestMergePath_NoLoginPathChangesNothing(t *testing.T) {
 // Exercised through a deliberately bare PATH, which is the only state Adopt
 // acts on: with this machine's real PATH the guard returns first and the test
 // would assert nothing while passing.
+//
+// Through adopt with no deadline, not Adopt with its 3s one. The budget is
+// right for startup and wrong for an assertion: a fork can outlast it on a
+// machine running the whole suite, and the timeout then looks like the missing
+// merge this is here to catch (#816).
 func TestAdopt_RecoversTheShellsPathFromABareOne(t *testing.T) {
+	fakeShell(t, sep("/opt/homebrew/bin", "/opt/only-the-shell-knows"))
+
 	bare := sep("/usr/bin", "/bin", "/usr/sbin", "/sbin")
 	t.Setenv("PATH", bare)
-	Adopt()
+	adopt(context.Background())
 
 	got := os.Getenv("PATH")
 	if got == "" {
@@ -62,7 +71,17 @@ func TestAdopt_RecoversTheShellsPathFromABareOne(t *testing.T) {
 			t.Errorf("Adopt dropped %q from PATH", dir)
 		}
 	}
-	if os.Getenv("SHELL") != "" && got == bare {
+
+	// On Windows PATH comes from the registry and Adopt returns before asking
+	// any shell. Asserted rather than skipped, so the platform difference is
+	// part of the contract instead of a hole in it.
+	if runtime.GOOS == "windows" {
+		if got != bare {
+			t.Errorf("PATH = %q, want it untouched: Adopt does not run on Windows", got)
+		}
+		return
+	}
+	if !strings.Contains(got, "/opt/only-the-shell-knows") {
 		t.Errorf("PATH = %q, want the shell's own entries merged in", got)
 	}
 }


### PR DESCRIPTION
## Summary

`TestAdopt_RecoversTheShellsPathFromABareOne` had two faults, and they hid each other.

**It asserted nothing where `$SHELL` was unset.** The merge check was written `if os.Getenv("SHELL") != "" && got == bare`, so on Windows, where `$SHELL -ilc` is not a thing, the one assertion that verifies the shell's entries were merged in evaluated to nothing and the test passed.

**Where `$SHELL` was set it raced a real shell against a 3s budget.** `loginPath` runs `$SHELL -ilc`, an *interactive login* shell, sourcing the user's whole config, against `loginPathTimeout`. Under a full-suite run that sometimes did not finish; `loginPath` returned `""`, `mergePath` correctly left PATH alone, and the assertion read that as the bug it was looking for. The original report's 3.47s runtime was the timeout firing.

## A fake shell alone was not the fix

The issue prescribed driving `loginPath` against a `FakeBinary`. That removes the profile-sourcing cost, and I confirmed it is **not sufficient**: with the fake shell in place the test still failed under `go test -race ./... -count=2`, at exactly 3.00s. Forking anything can outlast a fixed budget on a machine running the whole suite in parallel.

So `Adopt` now delegates to `adopt(ctx)`, and the test passes an unbounded context. The 3s budget is right for startup, where a slow shell costs only the heads it would have found, and wrong for an assertion. Guards stay on the one path, so `adopt` exercises the same `looksBare` and Windows checks `Adopt` does.

## What is asserted now, on all three platforms

The shell is a `testutil.FakeBinary` printing a known PATH, so the merge is deterministic everywhere, and setting `SHELL` ourselves means whatever a runner image happens to export cannot make the check vacuous again. Windows gets an assertion rather than a skip: `Adopt` returns before asking any shell there, so the test asserts PATH is untouched, and the platform difference becomes part of the contract instead of a hole in it.

Three new cases cover what a real shell could only be hoped to exercise:

| test | what it pins |
|---|---|
| `TestLoginPath_ReadsWhatTheShellPrints` | the happy path, no deadline, immune to load |
| `TestLoginPath_AsksForAnInteractiveLoginShell` | argv is `-ilc`, not `-lc`: a plain login shell does not read `.zshrc`, which is where a great many people set PATH |
| `TestLoginPath_SaysNothingRatherThanGuessing` | no `$SHELL`, a non-zero exit, and a shell that outlives its deadline each yield `""` rather than a truncated PATH |

**No `t.Skip` added**, so the 38/40 budget is unchanged.

## Verification

Both mutations fail the suite:

```
mergePath: drop add(login)   → TestMergePath_AddsWhatTheShellKnows + TestAdopt_... both fail
loginPath: "-ilc" → "-lc"    → argv "-lc\nprintf %s \"$PATH\"" does not ask for an interactive login shell
```

`go test -race ./... -count=1` clean. `-count=2`, the mode that exposed the flake, now passes `internal/shellpath` (it still fails `TestGlobalRegistry_IsPopulatedByInit` in `internal/provider`, which this branch does not touch and which cannot pass twice by construction; CI runs `-count=1`).

Coverage 92.3%, floor 84. `staticcheck` and `gofmt` clean.

## On the first acceptance criterion

"whether `SHELL` is set on each runner, established rather than assumed" is deliberately **not** answered. It stopped being load-bearing: the test sets `SHELL` itself, so the runner's value cannot affect what CI covers. Answering it would also be a fact with a shelf life, since a runner image bump could change it and silently re-open the same hole, which is the failure mode being closed here.

Closes #816
