### PR TITLE
fix(executor): a provider that reports no usage is not a free call

### DIFF
--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -39,7 +39,7 @@ type Row struct {
 	EstCostUSD     float64 `json:"est_cost_usd"`
 	WallMS         int64   `json:"wall_ms"`
 	Source         string  `json:"source"`        // legacy, mirrors tokens_source
-	TokensSource   string  `json:"tokens_source"` // "actual" (provider) or "estimated" (agy char/4)
+	TokensSource   string  `json:"tokens_source"` // "actual" (provider) or "estimated" (char/4)
 	CostSource     string  `json:"cost_source"`   // always "estimated", cost is derived, never billed
 	TaskID         string  `json:"task_id"`
 	RunID          string  `json:"run_id"`
@@ -92,8 +92,9 @@ type SummaryResult struct {
 
 // SourceLabels returns the cost.jsonl provenance labels for a token count that
 // was either reported by the provider (estimated=false) or estimated by Hydra
-// (estimated=true, e.g. agy's char/4). It is the single source of truth for
-// these labels so the dispatch and swarm log paths cannot drift.
+// (estimated=true: the CLI heads that report no usage, and any HTTP provider
+// that answered without one, #802). It is the single source of truth for these
+// labels so the dispatch and swarm log paths cannot drift.
 //   - tokensSource: "actual" | "estimated"
 //   - costSource:   always "estimated" (est_cost_usd is pricing × tokens, never billed)
 //   - legacySource: "real" | "estimate", mirrors tokensSource for older readers
@@ -447,7 +448,7 @@ func RenderSummary(r *SummaryResult) {
 	renderTotals(r.AllTime, "    ")
 	if tot := r.ActualTokens + r.EstimatedTokens; tot > 0 {
 		estPct := float64(r.EstimatedTokens) * 100 / float64(tot)
-		fmt.Printf("    token source   %.0f%% actual · %.0f%% estimated (agy char/4)\n",
+		fmt.Printf("    token source   %.0f%% actual · %.0f%% estimated (Hydra's char/4)\n",
 			100-estPct, estPct)
 	}
 	fmt.Println("    (cost is estimated: pricing × tokens, not billed)")

--- a/internal/cost/testdata/render_summary.golden
+++ b/internal/cost/testdata/render_summary.golden
@@ -13,7 +13,7 @@
     tokens in/out  900000 / 250000
     est cost       <usd>
     wall time      <dur>
-    token source   87% actual · 13% estimated (agy char/4)
+    token source   87% actual · 13% estimated (Hydra's char/4)
     (cost is estimated: pricing × tokens, not billed)
 
   Recent (last 5):

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -1153,7 +1153,7 @@ func (d *Dispatcher) recordBudget(r *Result) {
 	if d.budget == nil || r.Response.InputTokens == 0 {
 		return
 	}
-	// Estimated tokens (agy char/4) must not be booked as measured usage.
+	// Tokens Hydra estimated must not be booked as measured usage.
 	source := "real"
 	if r.Response.TokensEstimated {
 		source = "estimate"
@@ -1267,7 +1267,7 @@ func (d *Dispatcher) logDispatch(r *Result, prompt string, opts Options, actProb
 	if r.Response.InputTokens > 0 || r.Response.OutputTokens > 0 {
 		// Provenance labels come from cost.SourceLabels so dispatch and swarm
 		// stay in lock-step: tokens_source reflects whether the provider
-		// reported usage or Hydra estimated it (agy char/4); cost_source is
+		// reported usage or Hydra estimated it (char/4); cost_source is
 		// always "estimated" (est_cost_usd is pricing × tokens, never billed);
 		// the legacy `source` field mirrors tokens_source for older readers.
 		tokensSource, costSource, legacySource := cost.SourceLabels(r.Response.TokensEstimated)

--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -152,13 +152,9 @@ func (e *HTTPExecutor) executeOpenAICompatible(ctx context.Context, req Request,
 		return nil, fmt.Errorf("http exec %s: empty response", req.Head.ID)
 	}
 
-	return &Response{
-		Output:       cr.Choices[0].Message.Content,
-		InputTokens:  cr.Usage.PromptTokens,
-		OutputTokens: cr.Usage.CompletionTokens,
-		Duration:     time.Since(start),
-		Model:        firstNonEmpty(cr.Model, cfg.Model),
-	}, nil
+	return httpResponse(req, cr.Choices[0].Message.Content,
+		firstNonEmpty(cr.Model, cfg.Model),
+		cr.Usage.PromptTokens, cr.Usage.CompletionTokens, start), nil
 }
 
 func (e *HTTPExecutor) executeAnthropic(ctx context.Context, req Request) (*Response, error) {
@@ -212,13 +208,9 @@ func (e *HTTPExecutor) executeAnthropic(ctx context.Context, req Request) (*Resp
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 
-	return &Response{
-		Output:       joinAnthropicBlocks(out.Content),
-		InputTokens:  out.Usage.InputTokens,
-		OutputTokens: out.Usage.OutputTokens,
-		Duration:     time.Since(start),
-		Model:        firstNonEmpty(out.Model, model),
-	}, nil
+	return httpResponse(req, joinAnthropicBlocks(out.Content),
+		firstNonEmpty(out.Model, model),
+		out.Usage.InputTokens, out.Usage.OutputTokens, start), nil
 }
 
 func (e *HTTPExecutor) executeGemini(ctx context.Context, req Request) (*Response, error) {
@@ -286,13 +278,9 @@ func (e *HTTPExecutor) executeGemini(ctx context.Context, req Request) (*Respons
 		return nil, fmt.Errorf("http exec %s: empty response", req.Head.ID)
 	}
 
-	return &Response{
-		Output:       joinGeminiParts(out.Candidates[0].Content.Parts),
-		InputTokens:  out.UsageMetadata.PromptTokenCount,
-		OutputTokens: out.UsageMetadata.CandidatesTokenCount,
-		Duration:     time.Since(start),
-		Model:        firstNonEmpty(out.ModelVersion, model),
-	}, nil
+	return httpResponse(req, joinGeminiParts(out.Candidates[0].Content.Parts),
+		firstNonEmpty(out.ModelVersion, model),
+		out.UsageMetadata.PromptTokenCount, out.UsageMetadata.CandidatesTokenCount, start), nil
 }
 
 func (e *HTTPExecutor) executeCohere(ctx context.Context, req Request) (*Response, error) {
@@ -346,13 +334,8 @@ func (e *HTTPExecutor) executeCohere(ctx context.Context, req Request) (*Respons
 		return nil, fmt.Errorf("http exec %s: decode: %w", req.Head.ID, err)
 	}
 
-	return &Response{
-		Output:       joinCohereBlocks(out.Message.Content),
-		InputTokens:  out.Usage.Tokens.InputTokens,
-		OutputTokens: out.Usage.Tokens.OutputTokens,
-		Duration:     time.Since(start),
-		Model:        model,
-	}, nil
+	return httpResponse(req, joinCohereBlocks(out.Message.Content), model,
+		out.Usage.Tokens.InputTokens, out.Usage.Tokens.OutputTokens, start), nil
 }
 
 func (e *HTTPExecutor) executeAzureOpenAI(ctx context.Context, req Request) (*Response, error) {
@@ -393,13 +376,9 @@ func (e *HTTPExecutor) executeAzureOpenAI(ctx context.Context, req Request) (*Re
 		return nil, fmt.Errorf("http exec %s: empty response", req.Head.ID)
 	}
 
-	return &Response{
-		Output:       out.Choices[0].Message.Content,
-		InputTokens:  out.Usage.PromptTokens,
-		OutputTokens: out.Usage.CompletionTokens,
-		Duration:     time.Since(start),
-		Model:        firstNonEmpty(out.Model, azureDeployment()),
-	}, nil
+	return httpResponse(req, out.Choices[0].Message.Content,
+		firstNonEmpty(out.Model, azureDeployment()),
+		out.Usage.PromptTokens, out.Usage.CompletionTokens, start), nil
 }
 
 func (e *HTTPExecutor) executeBedrock(ctx context.Context, req Request) (*Response, error) {
@@ -446,13 +425,9 @@ func (e *HTTPExecutor) executeBedrock(ctx context.Context, req Request) (*Respon
 		return nil, fmt.Errorf("http exec %s: empty response", req.Head.ID)
 	}
 
-	return &Response{
-		Output:       out.Choices[0].Message.Content,
-		InputTokens:  out.Usage.PromptTokens,
-		OutputTokens: out.Usage.CompletionTokens,
-		Duration:     time.Since(start),
-		Model:        firstNonEmpty(out.Model, cfg.Model),
-	}, nil
+	return httpResponse(req, out.Choices[0].Message.Content,
+		firstNonEmpty(out.Model, cfg.Model),
+		out.Usage.PromptTokens, out.Usage.CompletionTokens, start), nil
 }
 
 func (e *HTTPExecutor) executeReplicate(ctx context.Context, req Request) (*Response, error) {
@@ -518,11 +493,9 @@ func (e *HTTPExecutor) executeReplicate(ctx context.Context, req Request) (*Resp
 		return nil, fmt.Errorf("http exec %s: prediction ended with status %q", req.Head.ID, pred.Status)
 	}
 
-	return &Response{
-		Output:   stringifyAny(pred.Output),
-		Duration: time.Since(start),
-		Model:    model,
-	}, nil
+	// Replicate's prediction API reports no token usage at all, so this
+	// path logged every call as 0/0 and $0.00 measured.
+	return httpResponse(req, stringifyAny(pred.Output), model, 0, 0, start), nil
 }
 
 type replicatePrediction struct {
@@ -774,6 +747,33 @@ func firstEnv(keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// httpResponse assembles a dialect's reply and estimates whichever token count
+// the provider did not report, because cost is derived from the counts, so a
+// call that answered was logged as 0/0 and $0.00 *measured* (#802).
+//
+// Per side, not both-or-neither: a real count is never discarded, and a
+// provider reporting only its prompt tokens still gets an honest output figure.
+// TokensEstimated is how the cost report says the number is Hydra's, not the
+// provider's, so every path must come through here rather than build a Response
+// itself, which TestHTTPResponse_EveryDialectGoesThroughTheHelper enforces.
+func httpResponse(req Request, output, model string, in, out int, started time.Time) *Response {
+	estimated := false
+	if in == 0 && req.Prompt != "" {
+		in, estimated = EstimateTokens(req.Prompt), true
+	}
+	if out == 0 && output != "" {
+		out, estimated = EstimateTokens(output), true
+	}
+	return &Response{
+		Output:          output,
+		InputTokens:     in,
+		OutputTokens:    out,
+		Duration:        time.Since(started),
+		Model:           model,
+		TokensEstimated: estimated,
+	}
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/executor/http_stream.go
+++ b/internal/executor/http_stream.go
@@ -119,7 +119,6 @@ func (e *HTTPExecutor) streamOpenAILike(ctx context.Context, req Request, onDelt
 	sink := newDeltaSink(onDelta, start)
 	var gotModel string
 	var inTok, outTok int
-	var sawUsage bool
 
 	sc := bufio.NewScanner(io.LimitReader(resp.Body, int64(util.DefaultMaxBytes)+1))
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -146,7 +145,7 @@ func (e *HTTPExecutor) streamOpenAILike(ctx context.Context, req Request, onDelt
 			gotModel = chunk.Model
 		}
 		if chunk.Usage != nil {
-			inTok, outTok, sawUsage = chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens, true
+			inTok, outTok = chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens
 		}
 		for _, c := range chunk.Choices {
 			sink.write(c.Delta.Content)
@@ -165,24 +164,12 @@ func (e *HTTPExecutor) streamOpenAILike(ctx context.Context, req Request, onDelt
 	}
 
 	// A server that ignored stream_options, or a stream cut short, leaves no
-	// counts. Estimated and labelled beats reporting a call that answered as
-	// having cost nothing.
-	estimated := false
-	if !sawUsage || (inTok == 0 && outTok == 0) {
-		inTok, outTok = EstimateTokens(req.Prompt), EstimateTokens(out)
-		estimated = true
-	}
-
-	return &Response{
-		Output:          out,
-		InputTokens:     inTok,
-		OutputTokens:    outTok,
-		Duration:        time.Since(start),
-		Model:           firstNonEmpty(gotModel, model),
-		Truncated:       sink.truncated(),
-		TTFT:            sink.firstTokenAt(),
-		TokensEstimated: estimated,
-	}, nil
+	// counts. httpResponse estimates them, the same way the buffered dialects
+	// do, so the two cannot disagree about what a call with no usage cost.
+	answer := httpResponse(req, out, firstNonEmpty(gotModel, model), inTok, outTok, start)
+	answer.Truncated = sink.truncated()
+	answer.TTFT = sink.firstTokenAt()
+	return answer, nil
 }
 
 // azureStreamTarget mirrors executeAzureOpenAI's endpoint construction. Azure

--- a/internal/executor/http_usage_test.go
+++ b/internal/executor/http_usage_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Cost is derived from the token counts, so a provider that answers without a
+// usage block used to produce 0 in, 0 out, $0.00, labelled *measured*. Not
+// theoretical: the OpenAI-compatible path is what talks to llama.cpp, vLLM and
+// LM Studio, and a self-hosted server is free to omit usage (#802).
+func TestHTTPResponse_EstimatesWhatTheProviderDidNotReport(t *testing.T) {
+	const prompt = "a prompt long enough to estimate from"
+	const answer = "an answer long enough to estimate from"
+
+	for _, tc := range []struct {
+		name          string
+		in, out       int
+		wantEstimated bool
+		wantInZero    bool
+		wantOutZero   bool
+	}{
+		{name: "both reported", in: 31, out: 64},
+		{name: "no usage at all", wantEstimated: true},
+		// Per side, so a real count is never thrown away to fix the other one.
+		{name: "only the prompt side", in: 31, wantEstimated: true},
+		{name: "only the completion side", out: 64, wantEstimated: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := Request{Prompt: prompt}
+			got := httpResponse(req, answer, "stub-1", tc.in, tc.out, time.Now())
+
+			if got.TokensEstimated != tc.wantEstimated {
+				t.Errorf("TokensEstimated = %v, want %v", got.TokensEstimated, tc.wantEstimated)
+			}
+			if got.InputTokens == 0 || got.OutputTokens == 0 {
+				t.Errorf("counts %d/%d: a call that answered must never be logged as free",
+					got.InputTokens, got.OutputTokens)
+			}
+			if tc.in != 0 && got.InputTokens != tc.in {
+				t.Errorf("InputTokens = %d, want the reported %d kept", got.InputTokens, tc.in)
+			}
+			if tc.out != 0 && got.OutputTokens != tc.out {
+				t.Errorf("OutputTokens = %d, want the reported %d kept", got.OutputTokens, tc.out)
+			}
+		})
+	}
+}
+
+// An empty prompt or an empty answer is genuinely zero tokens, not a missing
+// measurement, so estimating one would invent spend rather than recover it.
+func TestHTTPResponse_EmptyTextIsNotEstimated(t *testing.T) {
+	got := httpResponse(Request{Prompt: ""}, "", "stub-1", 0, 0, time.Now())
+	if got.TokensEstimated {
+		t.Error("an empty call was labelled estimated; there was nothing to estimate")
+	}
+	if got.InputTokens != 0 || got.OutputTokens != 0 {
+		t.Errorf("counts %d/%d invented from no text", got.InputTokens, got.OutputTokens)
+	}
+}
+
+// The fallback has to be un-forgettable rather than remembered seven times.
+// It was already right on the streamed path and wrong on all seven buffered
+// ones, which is the shape of a rule that lives at the call sites.
+//
+// So: no dialect may build a Response itself. An eighth provider added by
+// copying its neighbour inherits the fallback, and one that does not fails
+// here rather than silently logging its calls as free.
+func TestHTTPResponse_EveryDialectGoesThroughTheHelper(t *testing.T) {
+	for _, file := range []string{"http.go", "http_stream.go"} {
+		t.Run(file, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, file, nil, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				lit, ok := n.(*ast.CompositeLit)
+				if !ok {
+					return true
+				}
+				id, ok := lit.Type.(*ast.Ident)
+				if !ok || id.Name != "Response" {
+					return true
+				}
+				// The helper is the one place allowed to build it.
+				if fn := enclosingFunc(f, fset, lit); fn == "httpResponse" {
+					return true
+				}
+				t.Errorf("%s builds a Response directly; use httpResponse so the "+
+					"zero-usage fallback cannot be skipped (#802)", fset.Position(lit.Pos()))
+				return true
+			})
+		})
+	}
+}
+
+func enclosingFunc(f *ast.File, fset *token.FileSet, n ast.Node) string {
+	for _, d := range f.Decls {
+		fn, ok := d.(*ast.FuncDecl)
+		if ok && fn.Pos() <= n.Pos() && n.End() <= fn.End() {
+			return fn.Name.Name
+		}
+	}
+	return ""
+}
+
+// End to end on the path that actually meets a server which omits usage: a
+// local OpenAI-compatible one. The unit test above pins the rule; this pins
+// that a real reply reaches it.
+func TestExecute_AServerThatReportsNoUsageIsNotFree(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"model":"stub-1","choices":[{"message":{"content":"an answer with real length"}}]}`)
+	}))
+	defer srv.Close()
+
+	req := Request{Prompt: "a prompt with real length", Head: compatHead(t, srv.URL)}
+	got, err := (&HTTPExecutor{client: srv.Client()}).Execute(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.InputTokens == 0 || got.OutputTokens == 0 {
+		t.Errorf("counts %d/%d: the call answered, so it did not cost nothing",
+			got.InputTokens, got.OutputTokens)
+	}
+	if !got.TokensEstimated {
+		t.Error("counts Hydra derived are labelled as the provider's own measurement")
+	}
+	if !strings.Contains(got.Output, "an answer") {
+		t.Errorf("output = %q", got.Output)
+	}
+}

--- a/internal/swarm/attempt.go
+++ b/internal/swarm/attempt.go
@@ -36,7 +36,7 @@ type Attempt struct {
 	Truncated       bool // true when output was capped by the accumulator
 	InputTokens     int
 	OutputTokens    int
-	TokensEstimated bool // true when tokens were estimated (agy char/4), not provider-reported
+	TokensEstimated bool // true when Hydra estimated the tokens, not provider-reported
 	Duration        time.Duration
 	EstCostUSD      float64
 	Err             error // original typed error, never stringified before display


### PR DESCRIPTION
## Summary

Every buffered HTTP dialect copied the provider's usage block into the `Response` without checking it was there:

```go
InputTokens:  cr.Usage.PromptTokens,      // 0 when the provider sent no usage
OutputTokens: cr.Usage.CompletionTokens,  // 0
// TokensEstimated stays false
```

Cost is derived from the counts, so a call that answered was logged as **0 in, 0 out, $0.00, labelled measured**, and `TokensEstimated`, which exists precisely to mark a count as Hydra's own, stayed false.

Not theoretical: the OpenAI-compatible path is what talks to llama.cpp, vLLM and LM Studio, and a self-hosted server is free to omit usage. Those are the local heads Hydra is built to prefer.

## Seven paths, not six

The issue lists six. **`executeReplicate` is the seventh and the worst**: it set no token count at all, so every Replicate call has always been logged as free. The audit missed it because it reads as an absence rather than as a wrong value.

## One helper, per-side

`httpResponse` is now the only place a dialect's reply is assembled. It estimates **per side**, not both-or-neither:

| provider reported | result |
|---|---|
| both counts | untouched, not labelled |
| neither | both estimated, labelled |
| prompt only | real prompt count **kept**, output estimated, labelled |
| completion only | real completion count kept, input estimated, labelled |

The both-or-neither form the streaming path used would have discarded a real count to fix the other one. Empty text stays at zero: that is genuinely no tokens rather than a missing measurement, and estimating it would invent spend instead of recovering it.

## Enforced structurally, not remembered

The rule was already right on the streamed path and wrong on all seven buffered ones, which is the shape of a rule that lives at its call sites.

`TestHTTPResponse_EveryDialectGoesThroughTheHelper` parses `http.go` and `http_stream.go` and fails on any `Response` composite literal outside the helper. An eighth dialect added by copying its neighbour inherits the fallback; one that does not fails the build rather than silently logging its calls as free.

This is deliberately instead of seven end-to-end stubs: those would need SigV4 for Bedrock, an endpoint and deployment for Azure, and Replicate's polling API, and would still say nothing about the eighth dialect. The decision itself is table-tested directly, and the compat path, the one that actually meets servers which omit usage, is covered end to end.

Both mutations fail:

```
a dialect builds Response itself  → http.go:337:10 builds a Response directly
drop the output-side estimate     → TokensEstimated = false, want true (×3 cases)
```

## A label that became false

Four comments and one printed line said estimation was `agy char/4`. That was already only mostly true (the CLI executor estimates too) and this makes it plainly false, so `hyctl cost` now reads `Hydra's char/4`. Golden updated.

## Verification

Against a local server that answers without a usage block:

```
$ hyctl dispatch --tier 10 "say something"
  ▶ nousage:7b (Ollama)  (3→23 tokens)  0ms      # was 0→0

$ hyctl cost
    token source   0% actual · 100% estimated (Hydra's char/4)
```

It still prices at $0.00 because the head is local and local is free. That is the correct arithmetic on a count that is no longer zero; the price side was never the bug, the tokens were.

`go test -race ./... -count=1` clean, `staticcheck ./...` clean. Coverage: executor 91.7% (floor 86), cost 94.3% (floor 91).

Closes #802
