### PR TITLE
fix(cost,swarm): a routing key that is not there, and spend that cannot find its span

### DIFF
--- a/internal/cost/cost.go
+++ b/internal/cost/cost.go
@@ -454,8 +454,8 @@ func RenderSummary(r *SummaryResult) {
 	fmt.Println()
 	fmt.Println("  Recent (last 5):")
 	for _, row := range r.Recent {
-		fmt.Printf("  %s  %s/%d  %s, %d+%d tok, $%.6f, %dms\n",
-			row.TS, row.Enum, row.Tier, row.Model,
+		fmt.Printf("  %s  %s  %s, %d+%d tok, $%.6f, %dms\n",
+			row.TS, routeKey(row.Enum, row.Tier), row.Model,
 			row.PromptTokens, row.ResponseTokens, row.EstCostUSD, row.WallMS)
 	}
 	fmt.Println()
@@ -564,14 +564,21 @@ func truncLabel(s string, max int) string {
 // RenderTail prints human-readable tail rows.
 func RenderTail(rows []Row) {
 	for _, r := range rows {
-		enum := r.Enum
-		if enum == "" {
-			enum = "?"
-		}
-		fmt.Printf("  %s  %s/%d  %s, %d+%d tok, $%.6f, %dms\n",
-			r.TS, enum, r.Tier, r.Model,
+		fmt.Printf("  %s  %s  %s, %d+%d tok, $%.6f, %dms\n",
+			r.TS, routeKey(r.Enum, r.Tier), r.Model,
 			r.PromptTokens, r.ResponseTokens, r.EstCostUSD, r.WallMS)
 	}
+}
+
+// routeKey says how a dispatch was routed: the enum that chose the tier, or
+// the tier itself when one was pinned. An absent enum is not unknown, a
+// --tier run has no routing key, and "%s/%d" over it printed a bare "/10" on
+// every row of a machine that routes that way (#794).
+func routeKey(enum string, tier int) string {
+	if enum == "" {
+		return fmt.Sprintf("tier %d", tier)
+	}
+	return fmt.Sprintf("%s/%d", enum, tier)
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/internal/cost/cost_log_test.go
+++ b/internal/cost/cost_log_test.go
@@ -663,12 +663,44 @@ func TestRenderers_HandleEmptyLongLabelsAndLargeNumbers(t *testing.T) {
 		t.Errorf("no total row:\n%s", out)
 	}
 
-	// A row with no enum must still print something, "?", rather than a gap
-	// that reads as a missing column.
+	// A --tier dispatch has no enum, so the field is not unknown and "?" was
+	// the wrong answer as surely as the bare "/3" the summary printed. Both
+	// render the same thing now, through routeKey.
 	tail := capture(t, func() {
 		RenderTail([]Row{{TS: "2026-08-01T00:00:00Z", Tier: 3, Model: "m", WallMS: 12}})
 	})
-	if !strings.Contains(tail, "?/3") {
-		t.Errorf("a row with no enum did not render a placeholder:\n%s", tail)
+	if !strings.Contains(tail, "tier 3") {
+		t.Errorf("a row with no enum does not say how it was routed:\n%s", tail)
+	}
+	if strings.Contains(tail, "/3") {
+		t.Errorf("a row with no enum still renders a routing key it does not have:\n%s", tail)
+	}
+}
+
+// One renderer forgot the placeholder the other had, which is how `hyctl cost`
+// came to print a bare "/10" on every row of a --tier-routed machine (#794).
+// Both call routeKey now, and this is what says so.
+func TestRouteKey_SaysHowARowWasRouted(t *testing.T) {
+	for _, c := range []struct {
+		enum string
+		tier int
+		want string
+	}{
+		{"STANDARD", 8, "STANDARD/8"},
+		{"", 10, "tier 10"},
+	} {
+		if got := routeKey(c.enum, c.tier); got != c.want {
+			t.Errorf("routeKey(%q, %d) = %q, want %q", c.enum, c.tier, got, c.want)
+		}
+	}
+
+	row := Row{TS: "2026-08-01T00:00:00Z", Tier: 10, Model: "m"}
+	summary := capture(t, func() {
+		RenderSummary(&SummaryResult{Recent: []Row{row}})
+	})
+	tail := capture(t, func() { RenderTail([]Row{row}) })
+	if !strings.Contains(summary, "tier 10") || !strings.Contains(tail, "tier 10") {
+		t.Errorf("the two renderers disagree about an enum-less row:\nsummary: %s\ntail: %s",
+			summary, tail)
 	}
 }

--- a/internal/cost/testdata/render_summary.golden
+++ b/internal/cost/testdata/render_summary.golden
@@ -17,4 +17,4 @@
     (cost is estimated: pricing × tokens, not billed)
 
   Recent (last 5):
-  <ts>  /8  gemini-flash, 400+120 tok, <usd>, <dur>
+  <ts>  tier 8  gemini-flash, 400+120 tok, <usd>, <dur>

--- a/internal/cost/writers_test.go
+++ b/internal/cost/writers_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+
+package cost
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"testing"
+)
+
+// Two packages append to cost.jsonl and neither knows what the other writes.
+// That is how span_id, added in #719 so spend joins the span that spent it,
+// reached only one of them: the swarm and SPRT rows, the ones where several
+// attempts share a task id and the join is the entire point, carried no span
+// at all (#794).
+//
+// Keys are compared rather than behaviour because a missing key is exactly
+// what neither writer can observe about the other. A key genuinely belonging
+// to one writer goes in exemptions, with the reason, so an omission has to be
+// argued rather than merely happen.
+var costWriterExemptions = map[string]string{
+	// A fan-out reports which mode ran and whether the attempt won it. A plain
+	// dispatch has no fan-out to describe.
+	"swarm_mode":   "swarm only: there is no mode on a single dispatch",
+	"swarm_winner": "swarm only: nothing to win",
+
+	// --enum reaches dispatch.Options and stops there; swarm.Options has no
+	// Enum field, so a swarm is never routed by an enum even when one was
+	// passed. Writing it here would record a routing key that did not route.
+	"enum": "dispatch only: an enum does not reach the swarm path at all",
+
+	// The dispatch log carries the preview on its own entry rather than on the
+	// cost row; swarm has one writer for both.
+	"prompt_preview": "swarm only: swarm has no separate dispatch-log entry",
+}
+
+func TestCostWriters_NeitherOmitsWhatTheOtherRecords(t *testing.T) {
+	dispatchKeys := costEntryKeys(t, "../dispatch/dispatch.go")
+	swarmKeys := costEntryKeys(t, "../swarm/cost.go")
+
+	if len(dispatchKeys) == 0 || len(swarmKeys) == 0 {
+		t.Fatalf("found %d dispatch keys and %d swarm keys; the entry is no longer "+
+			"a map literal carrying cost_source and this guard reads nothing",
+			len(dispatchKeys), len(swarmKeys))
+	}
+
+	for _, c := range []struct {
+		from, to   string
+		have, want map[string]bool
+	}{
+		{"internal/dispatch", "internal/swarm", dispatchKeys, swarmKeys},
+		{"internal/swarm", "internal/dispatch", swarmKeys, dispatchKeys},
+	} {
+		for _, k := range sortedKeys(c.have) {
+			if c.want[k] {
+				continue
+			}
+			if why, ok := costWriterExemptions[k]; ok {
+				t.Logf("%q is written by %s alone: %s", k, c.from, why)
+				continue
+			}
+			t.Errorf("%s writes %q to cost.jsonl and %s does not. Either write it "+
+				"there too, or record in costWriterExemptions why that row cannot "+
+				"carry it.", c.from, k, c.to)
+		}
+	}
+}
+
+// costEntryKeys returns the keys of the map literal a file writes to
+// cost.jsonl, identified by cost_source. est_cost_usd alone is not enough: a
+// runlog event's Meta carries it when a head is refused for exceeding a cost
+// ceiling, and this read that as a cost row.
+func costEntryKeys(t *testing.T, path string) map[string]bool {
+	t.Helper()
+
+	f, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := map[string]bool{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		keys := map[string]bool{}
+		for _, el := range lit.Elts {
+			kv, ok := el.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			if s, ok := kv.Key.(*ast.BasicLit); ok && s.Kind == token.STRING {
+				keys[mustUnquote(t, s.Value)] = true
+			}
+		}
+		if !keys["cost_source"] {
+			return true
+		}
+		for k := range keys {
+			out[k] = true
+		}
+		return true
+	})
+	return out
+}
+
+func mustUnquote(t *testing.T, s string) string {
+	t.Helper()
+	if len(s) < 2 {
+		t.Fatalf("not a quoted string: %s", s)
+	}
+	return s[1 : len(s)-1]
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/swarm/cost.go
+++ b/internal/swarm/cost.go
@@ -119,6 +119,7 @@ func logAttempts(attempts []Attempt, mode SwarmMode, opts Options, promptPreview
 			"swarm_winner":    a.Status == StatusOK && a.Rank == 1,
 			"task_id":         taskID,
 			"run_id":          runID,
+			"span_id":         attemptSpan(taskID, fanOutAgent(mode), a.Head.ID),
 			"prompt_preview":  promptPreview,
 			// 1 for both: a swarm runs the heads it fans out to rather than
 			// drawing one, so every attempt logged here was certain to appear.

--- a/internal/swarm/runlog.go
+++ b/internal/swarm/runlog.go
@@ -24,6 +24,22 @@ const (
 	sprtAgent  = "ensemble"
 )
 
+// fanOutAgent is the root a mode's attempts hang under.
+func fanOutAgent(mode SwarmMode) string {
+	if mode == ModeSPRT {
+		return sprtAgent
+	}
+	return swarmAgent
+}
+
+// attemptSpan is one head's span in a fan-out. The cost row and the run-log
+// event call this rather than each spelling the expression out, because a cost
+// row carries span_id so spend joins the span that spent it, and two heads on
+// one task cannot be told apart by task id (#794).
+func attemptSpan(taskID, agent, headID string) string {
+	return runlog.SpanIDFor(taskID + "/" + agent + "/" + headID)
+}
+
 // logRunEvents appends one runlog event per attempt so a swarm reads as N heads
 // working one task rather than a single opaque node.
 //
@@ -76,7 +92,7 @@ func logRunEvents(attempts []Attempt, mode SwarmMode, opts Options) {
 			// node rather than three.
 			Agent:        a.Head.ID,
 			Parent:       swarmAgent,
-			SpanID:       runlog.SpanIDFor(taskID + "/" + swarmAgent + "/" + a.Head.ID),
+			SpanID:       attemptSpan(taskID, swarmAgent, a.Head.ID),
 			ParentSpanID: rootSpan,
 			Head:         a.Head.ID,
 			Model:        a.Head.Name,
@@ -136,7 +152,7 @@ func logSamples(ledger []trust.Evidence, attempts []Attempt, opts Options) {
 			TaskID:       taskID,
 			Agent:        ev.Source,
 			Parent:       sprtAgent,
-			SpanID:       runlog.SpanIDFor(taskID + "/" + sprtAgent + "/" + ev.Source),
+			SpanID:       attemptSpan(taskID, sprtAgent, ev.Source),
 			ParentSpanID: rootSpan,
 			Head:         ev.Source,
 			CostUSD:      ev.CostUSD,

--- a/internal/swarm/span_join_test.go
+++ b/internal/swarm/span_join_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+
+package swarm
+
+import (
+	"testing"
+
+	"github.com/ankit373/hydra/internal/runlog"
+	"github.com/ankit373/hydra/internal/trust"
+)
+
+// cost.Row.SpanID exists so spend joins the span that spent it, which a task-id
+// join cannot do when one task made several attempts. That is exactly the
+// fan-out case, and it was the one writer that left the field empty (#794).
+//
+// Asserted by performing the join, not by checking the field is non-empty: a
+// span id derived independently on each side would pass that check and still
+// join to nothing, which is the failure worth catching.
+func TestLogAttempts_CostRowsJoinTheRunLogSpans(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		mode SwarmMode
+		emit func(attempts []Attempt, opts Options)
+	}{
+		{
+			name: "swarm",
+			mode: ModeBest,
+			emit: func(a []Attempt, o Options) { logRunEvents(a, ModeBest, o) },
+		},
+		{
+			// SPRT emits from the LLR ledger rather than the attempts, and keys
+			// its spans on a different root ("ensemble"), so a cost row that
+			// assumed the swarm root would join to nothing here.
+			name: "sprt",
+			mode: ModeSPRT,
+			emit: func(a []Attempt, o Options) { logSamples(sprtLedger(a), a, o) },
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			attempts := []Attempt{idAttempt("alpha"), idAttempt("beta")}
+			opts := Options{RunID: "run-" + c.name, TaskID: "task-" + c.name}
+
+			rows := costRows(t, func() {
+				c.emit(attempts, opts)
+				logAttempts(attempts, c.mode, opts, "p")
+			})
+			if len(rows) != len(attempts) {
+				t.Fatalf("wrote %d cost rows, want %d", len(rows), len(attempts))
+			}
+
+			events, err := runlog.Load(opts.RunID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			spanHead := map[string]string{}
+			for _, e := range events {
+				if e.SpanID != "" && e.Head != "" {
+					spanHead[e.SpanID] = e.Head
+				}
+			}
+
+			for _, r := range rows {
+				span, _ := r["span_id"].(string)
+				head, _ := r["head"].(string)
+				if span == "" {
+					t.Fatalf("cost row for %q carries no span_id, so its spend "+
+						"cannot be attributed to the attempt that incurred it", head)
+				}
+				got, ok := spanHead[span]
+				if !ok {
+					t.Errorf("cost row for %q names span %s, which no run-log event "+
+						"declares: the two sides derive it separately", head, span)
+					continue
+				}
+				if got != head {
+					t.Errorf("span %s is %q in the run log and %q in cost.jsonl", span, got, head)
+				}
+			}
+		})
+	}
+}
+
+// sprtLedger is the ledger shape logSamples reads: one entry per head that
+// voted, keyed by the same id the attempt carries.
+func sprtLedger(attempts []Attempt) []trust.Evidence {
+	out := make([]trust.Evidence, 0, len(attempts))
+	for _, a := range attempts {
+		out = append(out, trust.Evidence{Source: a.Head.ID, ConfidenceAfter: 0.8, Agreed: true})
+	}
+	return out
+}


### PR DESCRIPTION
## 1. A routing key that is not there

`hyctl cost` printed a bare `/10` wherever a dispatch had no enum, which on a `--tier`-routed machine is every row:

```
  2026-09-08T17:56:17Z  /10  Qwen2.5-Coder:7b, 34+2 tok, $0.000000, 5032ms
```

Two renderers format that field. Only one had thought about the empty case, and **its answer was wrong too**: `RenderTail` printed `?/3`, but a `--tier` run's routing key is not unknown, it does not have one.

Both go through `routeKey` now:

| enum | tier | renders |
|---|---|---|
| `STANDARD` | 8 | `STANDARD/8` |
| *(none)* | 10 | `tier 10` |

## 2. Spend that cannot find its span

`cost.Row.SpanID` was added in #719 so spend joins the span that spent it, which a task-id join cannot do when one task made several attempts. **The fan-out is exactly that case, and it was the one writer that left the field empty** — so on the only path where the join was the point, it could not be made. Mine from #718: I added the field and wired one of its two writers.

Both sides now derive the span through one `attemptSpan` rather than each spelling the expression out, and the mode picks the root: an ensemble hangs its attempts under `ensemble`, a swarm under `swarm`.

**The test performs the join rather than checking the field is non-empty.** Writing the swarm root for an SPRT run produces a perfectly well-formed span id that joins to nothing, and a non-empty check passes it. Mutation-tested:

```
attemptSpan(taskID, fanOutAgent(mode), …) → attemptSpan(taskID, swarmAgent, …)

--- FAIL: .../sprt
    cost row for "alpha" names span bedbf34927bbef35, which no run-log event declares
```

## 3. The guard, and what it found

`TestCostWriters_NeitherOmitsWhatTheOtherRecords` parses both writers and compares their key sets, so an omission has to be argued in `costWriterExemptions` with a reason rather than merely happen. Two packages append to `cost.jsonl` and neither can see what the other writes; a missing key is precisely what neither can observe.

It found a third omission on its first run (`limit_usd`, a false positive that made me tighten the discriminator from `est_cost_usd` to `cost_source`, since a runlog event's `Meta` carries the former when a head is refused for exceeding a cost ceiling).

And it answered its own question about `enum`. I was about to add it to the swarm row, and the guard made me check: **`--enum` reaches `dispatch.Options` and stops there.** `swarm.Options` has no `Enum` field, so `--enum SIMPLE --swarm` fans out over whatever `--tier` says and the enum is ignored entirely. Recording it on the cost row would log a routing key that did not route, so it is exempted with that reason and **filed separately** — the routing bug is #782's family, not this one's.

## Verification, from the built binary

```
$ hyctl cost
  2026-09-10T17:43:42Z  tier 10  Qwen2.5-Coder:7b, 34+2 tok, $0.000000, 6533ms

$ hyctl dispatch --swarm --swarm-mode all --local --swarm-max-heads 3 "…"
cost.jsonl                                  runs/*.jsonl
  ollama/Qwen2.5-Coder:7b 721cf119e21b93a3    721cf119e21b93a3
  ollama/qwen3:0.6b-q8_0  d90768f63f16d1e8    d90768f63f16d1e8
  ollama/qwen3:0.6b       a06d7fb38c1e4cee    a06d7fb38c1e4cee
```

`go test -race ./... -count=1` clean, `staticcheck` clean. The `render_summary.golden` fixture had captured the `/8` bug and is re-blessed.

Closes #794
