### PR TITLE
fix(editor,policy): the file-policy caps reach hyctl edit, from one place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,12 +84,13 @@ registry/               ← Routing data, compiled into the binary via `go:embed
   domains.yaml          ← Domain → enum key routing (references routing.yaml).
   pricing.yaml          ← Tier pricing. Prices the CLI-agent heads that never appear in
                           OpenRouter's catalog, so it is load-bearing, not just an offline fallback.
-  policy.yaml           ← File-policy rules. Three of its fields take effect, and only in
-                          `hyctl parallel`: diff_size_cap_pct rolls an over-large edit back,
-                          max_cost_usd refuses a head before it runs, max_wall_seconds
-                          deadlines the dispatch (#424). The rest are declared and read by
-                          nothing, and `hyctl edit` does not consult the file at all (#769).
-                          `hyctl security` reports which, derived rather than hardcoded.
+  policy.yaml           ← File-policy rules. Three of its fields take effect, in both
+                          `hyctl edit` and `hyctl parallel`: diff_size_cap_pct rolls an
+                          over-large edit back, max_cost_usd refuses a head before it runs,
+                          max_wall_seconds deadlines the dispatch (#424, #769). All three are
+                          enforced from `internal/policy`'s caps.go, so a refusal reads the
+                          same whichever command hit it. The rest are declared and read by
+                          nothing. `hyctl security` reports which, derived rather than hardcoded.
   workspace.yaml        ← workspace roots + validators.
 logs/                   ← Dispatch log + state.json (claude_pct, claude_pct_history).
 ```
@@ -985,7 +986,7 @@ All Go source lives under `cmd/` and `internal/`. Key packages:
 | `internal/pricing` | Live cost DB: OpenRouter fetch + 24h cache + tier YAML fallback |
 | `internal/util` | Shared utilities: `Accumulator` (bounded io.Writer, 33 MB cap) |
 | `internal/cost` | Reads `cost.jsonl`, produces spend summaries |
-| `internal/policy` | Allow/deny rules (PII local-only, etc.) |
+| `internal/policy` | Allow/deny rules (PII local-only, etc.), plus the three `policy.yaml` caps that take effect. `ForFile`/`Deadline`/`Bounded`/`DiffExceeded` are the one place they are enforced from: `hyctl edit` read the policy file nowhere at all, so every cap applied to `hyctl parallel` and nothing else (#769). `Bounded` reads the deadline off the **context**, not the dispatch error, because killing a CLI head's subprocess surfaces as "signal: killed" with no deadline for `errors.Is` to find, so an error-only check saw the timeout on HTTP heads and never on CLI ones. |
 | `internal/rank` | CapScore ranking helpers. `ByCapScore` dedupes non-local heads per **provider**, one entry per cloud vendor, except a head that names its own model (`Meta["model"]`), whose ID is its identity the way a local model's is: without that a three-model OpenRouter allowlist arrived as whichever scored highest and the rest were gone from probe, status and routing alike. `UITier` keeps tier 10 as the **free floor**, local-only, and floors paid heads at 9 (#752). |
 | `registry` | The routing YAML **and** the `go:embed` that compiles it into the binary. `registry.Read(home, name)` prefers `$HYDRA_HOME/registry/<name>` so operators can retune without a rebuild, and falls back to the embedded copy, which is what every brew/npm/pip/curl install uses, since none of them ship the files (#238). |
 | `internal/config` | Hydra config load/save (`~/.config/hydra/`); `Breadcrumb()`, SHA256 deployment-identity fingerprint over `registry/{routing,models,domains}.yaml`, auto-stamped into ledger/trust/cost log entries so they can be tied back to the exact routing rules in effect. It holds **no tier table**: a `[[tiers]]` block from an older `hyctl init` is left undecoded rather than rejected. Those CapScore bands (85/75/65/55/0) were a second routing table with no relation to the tier numbers, so `--tier simple` and `--enum SIMPLE` picked different heads, and which of the two cost money depended on what discovery happened to find (#782). |

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -11,11 +11,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/diff"
 	"github.com/ankit373/hydra/internal/dispatch"
+	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/sandbox"
 	"github.com/ankit373/hydra/internal/trust"
 	"github.com/ankit373/hydra/internal/util"
@@ -115,6 +117,29 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 		}
 	}
 
+	// ── Policy ────────────────────────────────────────────────────────────────
+	// Decided after the snapshot, so the line-count rules see the file's real
+	// shape rather than the zero value. Every cap below is enforced through
+	// internal/policy alongside `hyctl parallel`, so a refusal reads the same
+	// whichever command hit it (#769).
+	//
+	// Three of policy.yaml's fields take effect; the rest are declared and read
+	// by nothing, which `hyctl security` reports rather than this pretending
+	// otherwise. Of those three, atomic write, the extension validator and
+	// rollback-on-failure are editor-owned and unconditional: they are what
+	// `hyctl edit` *is*, so `atomic: false` does not turn off atomicity here
+	// and `--no-validate` remains the only way to skip validation.
+	enumTier, _ := strconv.Atoi(enumToTier(req.Enum))
+	fp := policy.ForFile(config.ScriptHome(), policy.Spec{
+		File:          req.File,
+		FileLines:     strings.Count(origContent, "\n") + 1,
+		FileCount:     1,
+		FileExtension: fileExt(req.File),
+		HasGit:        resolved.GitRoot != "",
+		EnumTier:      enumTier,
+		Workspace:     wsName,
+	})
+
 	// ── Build prompt ──────────────────────────────────────────────────────────
 	var ctxNote string
 	if origExisted {
@@ -135,16 +160,21 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 		cleanupBackup()
 		return failResult(req, wsName, resolved.GitRoot, "dispatcher init failed: "+err.Error()), nil
 	}
-	tierHint := enumToTier(req.Enum)
+	ctx, cancel := fp.Deadline(ctx)
+	defer cancel()
 	dispResult, err := d.Dispatch(ctx, editPrompt, dispatch.Options{
-		TierHint:  tierHint,
-		LocalOnly: req.LocalOnly,
-		RunID:     req.RunID,
-		TaskID:    req.TaskID,
-		Resource:  req.File,
+		TierHint:   enumToTier(req.Enum),
+		LocalOnly:  req.LocalOnly,
+		RunID:      req.RunID,
+		TaskID:     req.TaskID,
+		Resource:   req.File,
+		MaxCostUSD: fp.MaxCostUSD,
 	})
 	if err != nil {
 		cleanupBackup()
+		if fp.Bounded(ctx) {
+			return failResult(req, wsName, resolved.GitRoot, fp.WallExceeded()), nil
+		}
 		return failResult(req, wsName, resolved.GitRoot, "route_failed: "+err.Error()), nil
 	}
 
@@ -210,6 +240,21 @@ func Edit(ctx context.Context, req Request) (*Result, error) {
 
 	// ── Diff stats ────────────────────────────────────────────────────────────
 	added, removed := diffStats(req.File, origContent, resolved.GitRoot, backup, origExisted)
+
+	// ── Diff-size cap ─────────────────────────────────────────────────────────
+	// After the write, because the size of the change is only knowable once it
+	// exists, and before the run log, so a rolled-back edit is never recorded
+	// as an applied one.
+	if origExisted {
+		if why, over := fp.DiffExceeded(added, removed, strings.Count(origContent, "\n")+1); over {
+			rollback(req.File, origContent, origExisted, resolved.GitRoot, backup)
+			return &Result{
+				Status: "fail", File: req.File, Workspace: wsName,
+				GitRoot: resolved.GitRoot, Enum: req.Enum, Head: dispResult.Head.ID,
+				ValidatorPassed: validatorPassed, RolledBack: true, Error: why,
+			}, nil
+		}
+	}
 
 	// ── Run log ───────────────────────────────────────────────────────────────
 	// Emitted here, after validation, so a rolled-back edit is never recorded as

--- a/internal/editor/policy_caps_test.go
+++ b/internal/editor/policy_caps_test.go
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+
+package editor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// `hyctl edit` is the single-file command a person reaches for, and it
+// consulted registry/policy.yaml nowhere at all, so every cap in that file
+// applied to `hyctl parallel` and nothing else. An operator who set
+// diff_size_cap_pct to stop an agent rewriting a file wholesale got that
+// protection from the batch command and not from the one they were running
+// (#769).
+
+// writePolicyApply writes a policy.yaml whose single always-matching rule
+// applies whatever fields the caller names, so a test can trip one cap
+// without tripping the others.
+func writePolicyApply(t *testing.T, apply string) {
+	t.Helper()
+	dir := filepath.Join(os.Getenv("HYDRA_HOME"), "registry")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: \"1.0\"\nrules:\n  - name: test_caps\n    when:\n      always: true\n    apply:\n" + apply
+	if err := os.WriteFile(filepath.Join(dir, "policy.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The cap exists to stop a wholesale rewrite, so the file has to come back.
+func TestEdit_DiffSizeCapRollsBackAnOversizedEdit(t *testing.T) {
+	original := "package main\n\nfunc a() {}\nfunc b() {}\nfunc c() {}\nfunc d() {}\n"
+	repo := editSandbox(t, marked("package main\n\nfunc z() {}\n"))
+	writePolicyApply(t, "      diff_size_cap_pct: 10\n")
+
+	file := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "replace everything",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" {
+		t.Fatalf("status = %q, want fail: the edit rewrote the file past a 10%% cap", res.Status)
+	}
+	// The same string `hyctl parallel` reports, so a refusal reads the same
+	// whichever command hit it.
+	if !strings.Contains(res.Error, "diff_size_cap_exceeded") {
+		t.Errorf("error = %q, want diff_size_cap_exceeded", res.Error)
+	}
+	if !res.RolledBack {
+		t.Error("RolledBack = false on a refused edit")
+	}
+
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != original {
+		t.Errorf("file = %q, want the original restored: a cap that refuses but "+
+			"leaves the rewrite on disk is worse than no cap", raw)
+	}
+}
+
+// A generous cap must not refuse a legitimate edit, or the fix trades one
+// broken command for another.
+func TestEdit_DiffSizeCapAllowsAnOrdinaryEdit(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}\n"))
+	writePolicyApply(t, "      diff_size_cap_pct: 900\n")
+
+	file := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(file, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "add main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "ok" {
+		t.Fatalf("status = %q, error %q: a 900%% cap should refuse nothing", res.Status, res.Error)
+	}
+}
+
+// A new file has no percent of itself changed to measure. Creating one is a
+// 100% change by construction, so a cap below that would make `hyctl edit`
+// unable to create files at all.
+func TestEdit_DiffSizeCapDoesNotApplyToANewFile(t *testing.T) {
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}\n"))
+	writePolicyApply(t, "      diff_size_cap_pct: 1\n")
+
+	res, err := Edit(context.Background(), Request{
+		File: filepath.Join(repo, "created.go"), Enum: "MODERATE", Prompt: "create it",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "ok" {
+		t.Fatalf("status = %q, error %q: a 1%% cap blocked a file creation", res.Status, res.Error)
+	}
+}
+
+// max_cost_usd is refused by dispatch before the head runs, so the file is
+// never touched rather than touched and restored.
+//
+// The refusal string is asserted, not just the failure: with the ceiling
+// unwired the edit ran and tripped the *default* 90% diff cap instead, so the
+// status was "fail" and the file was back to its original either way. A test
+// that only checked those two passed under the bug it exists to catch.
+func TestEdit_CostCeilingRefusesBeforeTheFileIsTouched(t *testing.T) {
+	// Long enough that the model's reply is a modest change, so the diff cap
+	// cannot be what refuses and only the ceiling can.
+	original := "package main\n\nfunc a() {}\nfunc b() {}\nfunc c() {}\n" +
+		"func d() {}\nfunc e() {}\nfunc f() {}\nfunc g() {}\nfunc h() {}\n"
+	repo := editSandbox(t, marked(original+"func i() {}\n"))
+	// A ceiling no head can be under, so the refusal is the policy's and not
+	// a pricing accident.
+	writePolicyApply(t, "      max_cost_usd: 0.0000000001\n")
+
+	file := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "add one function",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" {
+		t.Fatalf("status = %q: a ceiling of $1e-10 refused nothing", res.Status)
+	}
+	if !strings.Contains(res.Error, "exceeds limit") {
+		t.Fatalf("error = %q, want the cost ceiling; something else refused this "+
+			"edit and the ceiling may still be unwired", res.Error)
+	}
+	// Nothing was written, so there was nothing to restore. A rolled-back
+	// refusal is a different mechanism reaching the same file content.
+	if res.RolledBack {
+		t.Error("RolledBack = true: the head ran and was undone, but the ceiling " +
+			"is meant to refuse it before it runs")
+	}
+
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != original {
+		t.Errorf("file = %q, want it untouched", raw)
+	}
+}
+
+// The wall-clock cap, fired by the policy's own number.
+//
+// Cancelling the context by hand proves nothing: the dispatch then fails on
+// the cancellation whether or not max_wall_seconds was ever read, and that
+// version of this test passed with fp.Deadline deleted. So the head is made
+// slower than the budget and the refusal string is asserted.
+//
+// The margin is one-directional: a 5s head against a 1s budget cannot finish
+// early, and a loaded machine that takes longer to start it only makes the
+// deadline fire more surely.
+func TestEdit_WallClockCapRefusesAndRestoresTheFile(t *testing.T) {
+	original := "package main\n"
+	repo := editSandbox(t, marked("package main\n\nfunc main() {}\n"))
+	slowHead(t, 5)
+	writePolicyApply(t, "      max_wall_seconds: 1\n")
+
+	file := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(file, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Edit(context.Background(), Request{
+		File: file, Enum: "MODERATE", Prompt: "add main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != "fail" {
+		t.Fatalf("status = %q: a 1s budget did not bound a 5s head", res.Status)
+	}
+	// The same string `hyctl parallel` reports. A deadline is the policy
+	// refusing, not the head failing, and the two want different answers.
+	if !strings.Contains(res.Error, "max_wall_seconds_exceeded") {
+		t.Fatalf("error = %q, want max_wall_seconds_exceeded: the dispatch was "+
+			"bounded by something other than the policy", res.Error)
+	}
+
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != original {
+		t.Errorf("file = %q, want it untouched", raw)
+	}
+}
+
+// slowHead replaces the sandbox's fake head with one that outlives a deadline.
+// Found through PATH, which is where editSandbox put it.
+func slowHead(t *testing.T, seconds int) {
+	t.Helper()
+	path, err := exec.LookPath("cody")
+	if err != nil {
+		t.Fatalf("the sandbox head is not on PATH: %v", err)
+	}
+	// Absolute paths: the sandbox empties PATH, so a bare `sleep` is not found
+	// and the head exits 127 instead of outliving the budget.
+	body := fmt.Sprintf("#!/bin/sh\n/bin/sleep %d\n", seconds)
+	if runtime.GOOS == "windows" {
+		body = fmt.Sprintf("@echo off\r\n%%SystemRoot%%\\System32\\ping.exe -n %d 127.0.0.1 > nul\r\n", seconds+1)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/parallel/edit_test.go
+++ b/internal/parallel/edit_test.go
@@ -12,12 +12,10 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/ankit373/hydra/internal/config"
 	"github.com/ankit373/hydra/internal/dispatch"
 	"github.com/ankit373/hydra/internal/ledger"
-	"github.com/ankit373/hydra/internal/policy"
 	"github.com/ankit373/hydra/internal/runlog"
 	"github.com/ankit373/hydra/internal/testutil"
 
@@ -1157,38 +1155,5 @@ func TestEdit_NoCapsDeclaredStillEdits(t *testing.T) {
 
 	if got.Status != "ok" {
 		t.Fatalf("result = %+v, want ok: no cap was declared, so nothing should refuse", got)
-	}
-}
-
-// The deadline's wiring, deterministically. An end-to-end timeout needs a head
-// slow enough to miss it, which means `sleep`, which is Unix-only and racy;
-// this asserts the policy's number reaches a real deadline, which is the part
-// that was missing entirely.
-func TestPolicyDeadline_AppliesMaxWallSeconds(t *testing.T) {
-	t.Run("a declared limit becomes a deadline", func(t *testing.T) {
-		ctx, cancel := policyDeadline(context.Background(), policy.FilePolicy{MaxWallSeconds: 30})
-		defer cancel()
-		dl, ok := ctx.Deadline()
-		if !ok {
-			t.Fatal("no deadline was set, so max_wall_seconds bounds nothing")
-		}
-		if d := time.Until(dl); d > 30*time.Second || d < 29*time.Second {
-			t.Errorf("deadline is %v out, want about 30s", d)
-		}
-	})
-
-	// An absent cap must not become a zero one: a context that has already
-	// expired would refuse every edit on a policy that declared no limit.
-	for _, v := range []int{0, -1} {
-		t.Run(fmt.Sprintf("no limit at %d", v), func(t *testing.T) {
-			ctx, cancel := policyDeadline(context.Background(), policy.FilePolicy{MaxWallSeconds: v})
-			defer cancel()
-			if _, ok := ctx.Deadline(); ok {
-				t.Error("a deadline was set with no limit declared")
-			}
-			if err := ctx.Err(); err != nil {
-				t.Errorf("ctx is already done: %v", err)
-			}
-		})
 	}
 }

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -224,16 +224,6 @@ func runTextTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 	})
 }
 
-// policyDeadline bounds a dispatch by policy.yaml's max_wall_seconds. Returns
-// ctx unchanged, with a no-op cancel, when no limit is declared, so an absent
-// cap is not a zero one.
-func policyDeadline(ctx context.Context, fp policy.FilePolicy) (context.Context, context.CancelFunc) {
-	if fp.MaxWallSeconds <= 0 {
-		return ctx, func() {}
-	}
-	return context.WithTimeout(ctx, time.Duration(fp.MaxWallSeconds)*time.Second)
-}
-
 // runEditTask performs an atomic file edit and returns the raw JSON result.
 // Self-contained port of edit.sh, its tests target this package's own
 // extractContent/diffStats/rollback, but shares the KindEdit emission with
@@ -278,19 +268,16 @@ func runEditTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 	// a Decide result that is only ever discarded is not a policy, and the
 	// Security view's own "file-policy caps declared but never run" finding
 	// traced to this exact line (#501).
-	fp := policy.FilePolicy{DiffSizeCapPct: 90} // matches defaultFilePolicy's cap if policy.yaml can't load
-	if eng, pErr := policy.LoadFilePolicy(config.ScriptHome()); pErr == nil {
-		enumTier, _ := strconv.Atoi(enumToTier(task.Enum))
-		fp = eng.Decide(policy.Spec{
-			File:          file,
-			FileLines:     strings.Count(origContent, "\n") + 1,
-			FileCount:     1,
-			FileExtension: fileExt(file),
-			HasGit:        resolved.GitRoot != "",
-			EnumTier:      enumTier,
-			Workspace:     wsName,
-		})
-	}
+	enumTier, _ := strconv.Atoi(enumToTier(task.Enum))
+	fp := policy.ForFile(config.ScriptHome(), policy.Spec{
+		File:          file,
+		FileLines:     strings.Count(origContent, "\n") + 1,
+		FileCount:     1,
+		FileExtension: fileExt(file),
+		HasGit:        resolved.GitRoot != "",
+		EnumTier:      enumTier,
+		Workspace:     wsName,
+	})
 
 	// Build prompt
 	ctxNote := "The file currently exists. Modify it per the instruction below."
@@ -311,7 +298,7 @@ func runEditTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 	// Both enforcement mechanisms already existed and were simply not handed
 	// the policy's numbers: dispatch refuses a candidate over MaxCostUSD
 	// before executing it, and a deadline is what bounds a slow head.
-	ctx, cancel := policyDeadline(ctx, fp)
+	ctx, cancel := fp.Deadline(ctx)
 	defer cancel()
 	dispResult, err := d.Dispatch(ctx, editPrompt, dispatch.Options{
 		TierHint:   enumToTier(task.Enum),
@@ -324,8 +311,8 @@ func runEditTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 		cleanupBackup()
 		// A deadline is the policy refusing, not the head failing, and the two
 		// want different answers from whoever reads the result.
-		if errors.Is(err, context.DeadlineExceeded) {
-			return failEdit(task, fmt.Sprintf("max_wall_seconds_exceeded: policy allows %ds", fp.MaxWallSeconds))
+		if fp.Bounded(ctx) {
+			return failEdit(task, fp.WallExceeded())
 		}
 		return failEdit(task, "route_failed: "+err.Error())
 	}
@@ -372,17 +359,14 @@ func runEditTask(ctx context.Context, d *dispatch.Dispatcher, dispatchErr error,
 	// doc comment calls it "reject edits changing > N% of file", and nothing
 	// rejected anything before this. A brand-new file has no "percent of
 	// itself changed" to measure, so the cap only applies to modifications.
-	if origExisted && fp.DiffSizeCapPct > 0 {
-		if total := strings.Count(origContent, "\n") + 1; total > 0 {
-			if pct := float64(added+removed) / float64(total) * 100; pct > float64(fp.DiffSizeCapPct) {
-				rollback(file, origContent, origExisted, resolved.GitRoot, backup)
-				return mustMarshal(EditResult{
-					Label: task.Label, Enum: task.Enum, Mode: "edit",
-					Status: "fail", File: file, Workspace: wsName, GitRoot: resolved.GitRoot,
-					RolledBack: true,
-					Error:      fmt.Sprintf("diff_size_cap_exceeded: changed %.0f%% of file (cap %d%%)", pct, fp.DiffSizeCapPct),
-				})
-			}
+	if origExisted {
+		if why, over := fp.DiffExceeded(added, removed, strings.Count(origContent, "\n")+1); over {
+			rollback(file, origContent, origExisted, resolved.GitRoot, backup)
+			return mustMarshal(EditResult{
+				Label: task.Label, Enum: task.Enum, Mode: "edit",
+				Status: "fail", File: file, Workspace: wsName, GitRoot: resolved.GitRoot,
+				RolledBack: true, Error: why,
+			})
 		}
 	}
 

--- a/internal/policy/caps.go
+++ b/internal/policy/caps.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// The three caps in policy.yaml that are enforced, and the one place they are
+// enforced from. `hyctl parallel` gained them in #424 and `hyctl edit`, the
+// single-file command a person actually reaches for, consulted the policy file
+// nowhere at all (#769). Two copies of a cap is two chances for a refusal to
+// read differently depending on which command hit it.
+
+// ForFile decides the policy governing one file edit.
+//
+// A policy file that cannot be read leaves the caps at their defaults rather
+// than unset: an unreadable policy must not read as "no limits", which is what
+// a zero FilePolicy would mean to every caller below.
+func ForFile(hydraHome string, spec Spec) FilePolicy {
+	eng, err := LoadFilePolicy(hydraHome)
+	if err != nil {
+		return defaultFilePolicy()
+	}
+	return eng.Decide(spec)
+}
+
+// Deadline bounds a dispatch by max_wall_seconds, or returns ctx unchanged
+// when the policy sets no ceiling.
+func (fp FilePolicy) Deadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	if fp.MaxWallSeconds <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, time.Duration(fp.MaxWallSeconds)*time.Second)
+}
+
+// Bounded reports whether ctx ended because this policy's wall-clock ceiling
+// fired, which is what separates the policy refusing from the head failing.
+//
+// Read off the context rather than the dispatch error: killing a CLI head's
+// subprocess surfaces as "signal: killed", which carries no deadline for
+// errors.Is to find, so an error-only check saw the timeout on HTTP heads and
+// never on CLI ones.
+func (fp FilePolicy) Bounded(ctx context.Context) bool {
+	return fp.MaxWallSeconds > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded)
+}
+
+// WallExceeded is what a caller reports when Bounded says the ceiling fired. A
+// deadline is the policy refusing rather than the head failing, and the two
+// want different answers from whoever reads the result.
+func (fp FilePolicy) WallExceeded() string {
+	return fmt.Sprintf("max_wall_seconds_exceeded: policy allows %ds", fp.MaxWallSeconds)
+}
+
+// DiffExceeded reports whether an edit breaches diff_size_cap_pct, and the
+// refusal to report when it does.
+//
+// origLines <= 0 is a new file, which has no "percent of itself changed" to
+// measure, so the cap applies to modifications only.
+func (fp FilePolicy) DiffExceeded(added, removed, origLines int) (string, bool) {
+	if fp.DiffSizeCapPct <= 0 || origLines <= 0 {
+		return "", false
+	}
+	pct := float64(added+removed) / float64(origLines) * 100
+	if pct <= float64(fp.DiffSizeCapPct) {
+		return "", false
+	}
+	return fmt.Sprintf("diff_size_cap_exceeded: changed %.0f%% of file (cap %d%%)",
+		pct, fp.DiffSizeCapPct), true
+}

--- a/internal/policy/caps_test.go
+++ b/internal/policy/caps_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+package policy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// The deadline's wiring, deterministically. An end-to-end timeout needs a head
+// slow enough to miss it, which means `sleep`, which is Unix-only and racy;
+// this asserts the policy's number reaches a real deadline, which is the part
+// that was missing entirely (#424), and now for `hyctl edit` too (#769).
+func TestDeadline_AppliesMaxWallSeconds(t *testing.T) {
+	t.Run("a declared limit becomes a deadline", func(t *testing.T) {
+		ctx, cancel := FilePolicy{MaxWallSeconds: 30}.Deadline(context.Background())
+		defer cancel()
+		dl, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("no deadline was set, so max_wall_seconds bounds nothing")
+		}
+		if d := time.Until(dl); d > 30*time.Second || d < 29*time.Second {
+			t.Errorf("deadline is %v out, want about 30s", d)
+		}
+	})
+
+	// An absent cap must not become a zero one: a context that has already
+	// expired would refuse every edit on a policy that declared no limit.
+	for _, v := range []int{0, -1} {
+		t.Run(fmt.Sprintf("no limit at %d", v), func(t *testing.T) {
+			ctx, cancel := FilePolicy{MaxWallSeconds: v}.Deadline(context.Background())
+			defer cancel()
+			if _, ok := ctx.Deadline(); ok {
+				t.Error("a deadline was set with no limit declared")
+			}
+			if err := ctx.Err(); err != nil {
+				t.Errorf("ctx is already done: %v", err)
+			}
+		})
+	}
+}
+
+func TestDiffExceeded_MeasuresTheChangeAgainstTheCap(t *testing.T) {
+	cap30 := FilePolicy{DiffSizeCapPct: 30}
+
+	for _, c := range []struct {
+		name                   string
+		fp                     FilePolicy
+		added, removed, origLn int
+		want                   bool
+	}{
+		{"under the cap", cap30, 10, 5, 100, false},
+		{"exactly at the cap is allowed", cap30, 30, 0, 100, false},
+		{"over the cap", cap30, 40, 0, 100, true},
+		{"a rewrite of a large file", cap30, 600, 600, 1000, true},
+
+		// A new file has no percent of itself changed to measure, so the cap
+		// cannot apply: every creation is a 100% change by construction.
+		{"a new file", cap30, 50, 0, 0, false},
+
+		// 0 is "unlimited" in policy.yaml, not "refuse everything".
+		{"no cap declared", FilePolicy{DiffSizeCapPct: 0}, 9999, 9999, 10, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			why, over := c.fp.DiffExceeded(c.added, c.removed, c.origLn)
+			if over != c.want {
+				t.Fatalf("DiffExceeded(%d, %d, %d) = %v, want %v",
+					c.added, c.removed, c.origLn, over, c.want)
+			}
+			if over && why == "" {
+				t.Error("a refusal with no reason: the caller prints this verbatim")
+			}
+			if !over && why != "" {
+				t.Errorf("a reason %q was given for an edit that is allowed", why)
+			}
+		})
+	}
+}
+
+// An unreadable policy must leave the caps at their defaults rather than
+// unset: a zero FilePolicy means "no limits" to every caller, which is the
+// opposite of what an operator with an unparseable policy file wants.
+func TestForFile_AnUnreadablePolicyStillCaps(t *testing.T) {
+	fp := ForFile(t.TempDir(), Spec{File: "/x/y.go", FileLines: 100})
+	if fp.DiffSizeCapPct <= 0 {
+		t.Error("no diff-size cap after a failed policy load; an unreadable " +
+			"policy reads as no policy")
+	}
+	if fp.MaxWallSeconds <= 0 {
+		t.Error("no wall-clock cap after a failed policy load")
+	}
+}

--- a/internal/security/controls.go
+++ b/internal/security/controls.go
@@ -85,7 +85,7 @@ func Controls(events []ledger.Event, audit PolicyAudit, chain ledger.ChainResult
 // That hand-sync is exactly what drifted: #501 made the caps apply and this
 // text kept saying "none are applied … discards the result", so the one
 // surface whose purpose is an honest posture was understating it (#424).
-const filePolicyEnforcementSite = "internal/parallel/parallel.go"
+const filePolicyEnforcementSite = "internal/policy/caps.go"
 
 // enforcedCaps are the FilePolicy fields something actually reads, by their
 // policy.yaml names, so the line names what an operator can rely on rather
@@ -122,10 +122,9 @@ func filePolicyControl() Control {
 	c.Wired, c.Limited = true, true
 	c.Detail = fmt.Sprintf("%d rule(s) declared, and %d of %d policy fields take effect (%s) at %s: "+
 		"an over-large diff is rolled back, a head over the cost ceiling is refused before it runs, "+
-		"and the wall-clock limit deadlines the dispatch and the validator after it. The other %d "+
-		"are declared and read by "+
-		"nothing. `hyctl edit` does not consult this policy at all, so even these apply to "+
-		"`hyctl parallel` only",
+		"and the wall-clock limit deadlines the dispatch and the validator after it. Both "+
+		"`hyctl edit` and `hyctl parallel` enforce them from there, so a refusal reads the same "+
+		"either way (#769). The other %d are declared and read by nothing",
 		n, len(enforcedCaps), policyFieldCount(), strings.Join(enforcedCaps, ", "),
 		filePolicyEnforcementSite, policyFieldCount()-len(enforcedCaps))
 	return c

--- a/internal/security/controls_test.go
+++ b/internal/security/controls_test.go
@@ -33,8 +33,9 @@ func findControl(t *testing.T, cs []Control, name string) Control {
 // two releases understating it. The expectation is changed on purpose, and the
 // caps it reports on are now enforced (#424).
 //
-// `limited`, not `active`: three of the twenty policy fields take effect, and
-// `hyctl edit` still does not consult the policy at all.
+// `limited`, not `active`: three of the twenty policy fields take effect. Both
+// edit commands enforce those three now (#769), so what remains limited is the
+// seventeen fields nothing reads, not which command they reach.
 func TestControls_FilePolicyIsEnforcedButPartial(t *testing.T) {
 	testutil.NewSandbox(t)
 
@@ -53,7 +54,13 @@ func TestControls_FilePolicyIsEnforcedButPartial(t *testing.T) {
 		t.Errorf("Detail = %q, want it to name the enforcing call site", c.Detail)
 	}
 	if !strings.Contains(c.Detail, "hyctl edit") {
-		t.Errorf("Detail = %q, want it to say the caps do not reach hyctl edit", c.Detail)
+		t.Errorf("Detail = %q, want it to name both commands the caps reach", c.Detail)
+	}
+	// The claim that made this control honest when the caps were unreachable
+	// is now itself the false one, and the control reports the source.
+	if strings.Contains(c.Detail, "does not consult") {
+		t.Errorf("Detail still says hyctl edit ignores the policy, which it no "+
+			"longer does: %s", c.Detail)
 	}
 	for _, cap := range enforcedCaps {
 		if !strings.Contains(c.Detail, cap) {


### PR DESCRIPTION
## Summary

`hyctl edit` referenced `internal/policy`'s file-policy engine **nowhere at all**, so every cap in `registry/policy.yaml` applied to `hyctl parallel` and to nothing else. An operator who set `diff_size_cap_pct: 30` to stop an agent rewriting a file wholesale got that protection from the batch command and not from the one they were actually running.

## One enforcement site, not two

The three caps that take effect now live in `internal/policy/caps.go` as `ForFile`, `Deadline`, `Bounded` and `DiffExceeded`, and **both** commands call them. Giving editor its own copy would have been two chances for a refusal to read differently depending on which command hit it, so `parallel` moved onto the shared helpers rather than editor growing a parallel implementation.

## Two tests that passed under the bug they exist to catch

Both found by mutation-testing rather than by reading them.

**The cost ceiling.** With `MaxCostUSD` unwired the test still passed: the edit ran and tripped the *default* 90% diff cap instead, so `Status == "fail"` and the file was back to its original either way.

```
DEBUG error = "diff_size_cap_exceeded: changed 150% of file (cap 90%)"
--- PASS
```

It asserts the refusal string and `RolledBack` now (a cost refusal never writes, so there is nothing to restore), and the fixture is long enough that only the ceiling can refuse it.

**The wall clock.** With `fp.Deadline` deleted the test still passed, because cancelling the context by hand fails the dispatch whether or not `max_wall_seconds` was ever read. Driving it with a head slower than the budget instead **exposed a real defect in #424's enforcement**:

```go
if errors.Is(err, context.DeadlineExceeded) {   // never true for a CLI head
```

Killing a CLI head's subprocess surfaces as `signal: killed`, which carries no deadline for `errors.Is` to find. So `hyctl parallel` reported `max_wall_seconds_exceeded` on HTTP heads and never on CLI ones:

```
error = "route_failed: all heads failed (tried 1): cli exec cody: signal: killed, stderr: "
```

`Bounded` reads the deadline off the **context** instead, and both commands get the fix.

## The fields editor already owns

Resolved explicitly rather than left ambiguous, which the issue called out as the part that could be done carelessly. Atomic write, the extension validator and rollback-on-failure are **editor-owned and unconditional**, because they are what `hyctl edit` *is*: `atomic: false` does not turn off atomicity and `--no-validate` stays the only way to skip validation. That is stated in the code beside the policy call.

## Verification

Every cap mutation-tested, each fails its own test:

| mutation | caught by |
|---|---|
| drop `MaxCostUSD` from the dispatch options | `status = "ok": a ceiling of $1e-10 refused nothing` |
| drop `fp.Deadline(ctx)` | `error = "empty_replacement", want max_wall_seconds_exceeded` |
| disable the diff-cap branch | `status = "ok", want fail: the edit rewrote the file past a 10% cap` |

`go test -race ./... -count=1` clean, `staticcheck` clean. Coverage: editor 91.6% (floor 86), policy 89.4% (88), parallel 91.9% (87).

`hyctl security --why` from the built binary:

```
LIMITED File-policy caps [source-derived]
  24 rule(s) declared, and 3 of 21 policy fields take effect (diff_size_cap_pct,
  max_cost_usd, max_wall_seconds) at internal/policy/caps.go: … Both `hyctl edit`
  and `hyctl parallel` enforce them from there, so a refusal reads the same either
  way (#769). The other 18 are declared and read by nothing
```

Still `limited`, correctly: what remains partial is the eighteen fields nothing reads, not which command they reach. `controls_test.go` now fails if the "does not consult" claim comes back.

Closes #769
